### PR TITLE
[LibOS] Remove unused canary in shim_tcb

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_entry_api.h
+++ b/LibOS/shim/include/arch/x86_64/shim_entry_api.h
@@ -15,8 +15,8 @@
 #define SHIM_ENTRY_API_H_
 
 /* Offsets for GS register at which entry vectors can be found */
-#define SHIM_SYSCALLDB_OFFSET         32
-#define SHIM_CALL_OFFSET              40
+#define SHIM_SYSCALLDB_OFFSET         24
+#define SHIM_CALL_OFFSET              32
 
 #ifdef __ASSEMBLER__
 

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -9,8 +9,6 @@
 #include "shim_entry_api.h"
 #include "shim_tcb-arch.h"
 
-#define SHIM_TCB_CANARY 0xdeadbeef
-
 struct shim_context {
     PAL_CONTEXT* regs;
     long syscall_nr;
@@ -19,7 +17,6 @@ struct shim_context {
 
 typedef struct shim_tcb shim_tcb_t;
 struct shim_tcb {
-    uint64_t            canary;
     shim_tcb_t*         self;
 
     /* Function pointers for patched code calling into Graphene. */
@@ -46,7 +43,6 @@ static_assert(
     "SHIM_CALL_OFFSET must match");
 
 static inline void __shim_tcb_init(shim_tcb_t* shim_tcb) {
-    shim_tcb->canary = SHIM_TCB_CANARY;
     shim_tcb->self = shim_tcb;
     shim_tcb->syscalldb = &syscalldb;
     shim_tcb->handle_call = &handle_call;
@@ -66,10 +62,6 @@ static inline void shim_tcb_init(void) {
 
 static inline shim_tcb_t* shim_get_tcb(void) {
     return SHIM_TCB_GET(self);
-}
-
-static inline bool shim_tcb_check_canary(void) {
-    return SHIM_TCB_GET(canary) == SHIM_TCB_CANARY;
 }
 
 #endif /* _SHIM_H_ */


### PR DESCRIPTION
## Description of the changes

Just removing some unused code.

We should ping @stefanberger after merging this, he'll probably need analogous change in his port.

~Caveat: We probably shouldn't merge it before the build system rewrite, as it changes a file which is incorrectly dep-tracked and only `git clean -dfx` helps.~

// This is a migration of https://github.com/gramineproject/graphene/pull/2494 to the new repo. Now as we changed the repo, everyone will most likely be building everything from scratch, so we should be able to merge it safely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1)
<!-- Reviewable:end -->
