### PR TITLE
[LibOS] Report back the default permissions of a file consistently

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -199,9 +199,7 @@ static int chroot_lookup(struct shim_dentry* dent) {
             BUG();
     }
 
-    mode_t perm = (pal_attr.readable ? S_IRUSR : 0) |
-                  (pal_attr.writable ? S_IWUSR : 0) |
-                  (pal_attr.runnable ? S_IXUSR : 0);
+    mode_t perm = pal_attr.share_flags;
 
     file_off_t size = (type == S_IFREG ? pal_attr.pending_size : 0);
 

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -167,7 +167,7 @@ static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* att
         attr->readable     = stataccess(&stat_buf, ACCESS_R);
         attr->writable     = stataccess(&stat_buf, ACCESS_W);
         attr->runnable     = stataccess(&stat_buf, ACCESS_X);
-        attr->share_flags  = stat_buf.st_mode;
+        attr->share_flags  = stat_buf.st_mode & PAL_SHARE_MASK;
         attr->pending_size = stat_buf.st_size;
 
         ocall_close(fd);
@@ -199,7 +199,7 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
         attr->readable     = stataccess(&stat_buf, ACCESS_R);
         attr->writable     = stataccess(&stat_buf, ACCESS_W);
         attr->runnable     = stataccess(&stat_buf, ACCESS_X);
-        attr->share_flags  = stat_buf.st_mode;
+        attr->share_flags  = stat_buf.st_mode & PAL_SHARE_MASK;
         attr->pending_size = stat_buf.st_size;
     }
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -649,7 +649,7 @@ static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
     attr->readable     = stataccess(stat, ACCESS_R);
     attr->writable     = stataccess(stat, ACCESS_W);
     attr->runnable     = stataccess(stat, ACCESS_X);
-    attr->share_flags  = stat->st_mode;
+    attr->share_flags  = stat->st_mode & PAL_SHARE_MASK;
     attr->pending_size = stat->st_size;
 }
 

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -160,7 +160,7 @@ static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* att
         attr->readable     = stataccess(&stat_buf, ACCESS_R);
         attr->writable     = stataccess(&stat_buf, ACCESS_W);
         attr->runnable     = stataccess(&stat_buf, ACCESS_X);
-        attr->share_flags  = stat_buf.st_mode;
+        attr->share_flags  = stat_buf.st_mode & PAL_SHARE_MASK;
         attr->pending_size = stat_buf.st_size;
     }
 
@@ -190,7 +190,7 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
         attr->readable     = stataccess(&stat_buf, ACCESS_R);
         attr->writable     = stataccess(&stat_buf, ACCESS_W);
         attr->runnable     = stataccess(&stat_buf, ACCESS_X);
-        attr->share_flags  = stat_buf.st_mode;
+        attr->share_flags  = stat_buf.st_mode & PAL_SHARE_MASK;
         attr->pending_size = stat_buf.st_size;
     }
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -209,7 +209,7 @@ static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
     attr->readable     = stataccess(stat, ACCESS_R);
     attr->writable     = stataccess(stat, ACCESS_W);
     attr->runnable     = stataccess(stat, ACCESS_X);
-    attr->share_flags  = stat->st_mode;
+    attr->share_flags  = stat->st_mode & PAL_SHARE_MASK;
     attr->pending_size = stat->st_size;
 }
 


### PR DESCRIPTION
Signed-off-by: Sonali Saha <sonali.saha@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Graphene created the file with default permissions (0755), but it reported different permissions 0700 as it includes only user permissions to the returned permissions. This fix includes group and other permissions to the file permissions returned.

Fixes gramineproject/graphene#2543

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Create a file with mode set as 0777 the permissions of this newly generated file will be 0755. Use stat to report back the file permissions it should report 0755 instead of 0700.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/10)
<!-- Reviewable:end -->
