### PR TITLE
[Pal/Linux-SGX] Fix renaming issue with protected files

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -201,7 +201,8 @@ out:
 }
 
 /* Open a temporary PAL handle for a file (used by `rename`, `unlink` etc.) */
-static int chroot_temp_open(struct shim_dentry* dent, mode_t type, int pal_options ,PAL_HANDLE* out_palhdl) {
+static int chroot_temp_open(struct shim_dentry* dent, mode_t type, int pal_options,
+                            PAL_HANDLE* out_palhdl) {
     char* uri;
     int ret = chroot_dentry_uri(dent, type, &uri);
     if (ret < 0)

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -201,7 +201,7 @@ out:
 }
 
 /* Open a temporary PAL handle for a file (used by `rename`, `unlink` etc.) */
-static int chroot_temp_open(struct shim_dentry* dent, mode_t type, PAL_HANDLE* out_palhdl, int pal_options) {
+static int chroot_temp_open(struct shim_dentry* dent, mode_t type, int pal_options ,PAL_HANDLE* out_palhdl) {
     char* uri;
     int ret = chroot_dentry_uri(dent, type, &uri);
     if (ret < 0)
@@ -522,7 +522,7 @@ static int chroot_readdir(struct shim_dentry* dent, readdir_callback_t callback,
     char* buf = NULL;
     size_t buf_size = READDIR_BUF_SIZE;
 
-    ret = chroot_temp_open(dent, S_IFDIR, &palhdl, /*pal_options=*/0);
+    ret = chroot_temp_open(dent, S_IFDIR, /*pal_options=*/0, &palhdl);
     if (ret < 0)
         return ret;
 
@@ -584,7 +584,7 @@ static int chroot_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
     lock(&dent->lock);
 
     PAL_HANDLE palhdl;
-    ret = chroot_temp_open(dent, dent->type, &palhdl, /*pal_options=*/0);
+    ret = chroot_temp_open(dent, dent->type, /*pal_options=*/0, &palhdl);
     if (ret < 0)
         goto out;
 
@@ -638,7 +638,7 @@ static int chroot_rename(struct shim_dentry* old, struct shim_dentry* new) {
         goto out;
 
     PAL_HANDLE palhdl;
-    ret = chroot_temp_open(old, old->type, &palhdl, PAL_OPTION_RENAME);
+    ret = chroot_temp_open(old, old->type, PAL_OPTION_RENAME, &palhdl);
     if (ret < 0)
         goto out;
 
@@ -677,7 +677,7 @@ static int chroot_chmod(struct shim_dentry* dent, mode_t perm) {
     lock(&dent->inode->lock);
 
     PAL_HANDLE palhdl;
-    ret = chroot_temp_open(dent, dent->type, &palhdl, /*pal_options=*/0);
+    ret = chroot_temp_open(dent, dent->type, /*pal_options=*/0, &palhdl);
     if (ret < 0)
         goto out;
 

--- a/Pal/include/host/Linux-common/pal_flags_conv.h
+++ b/Pal/include/host/Linux-common/pal_flags_conv.h
@@ -57,7 +57,7 @@ static inline int PAL_CREATE_TO_LINUX_OPEN(int create) {
 }
 
 static inline int PAL_OPTION_TO_LINUX_OPEN(int options) {
-    assert(WITHIN_MASK(options, PAL_OPTION_CLOEXEC | PAL_OPTION_NONBLOCK));
+    assert(WITHIN_MASK(options, PAL_OPTION_CLOEXEC | PAL_OPTION_NONBLOCK | PAL_OPTION_RENAME));
     return (options & PAL_OPTION_CLOEXEC  ? O_CLOEXEC  : 0) |
            (options & PAL_OPTION_NONBLOCK ? O_NONBLOCK : 0);
 }

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -297,8 +297,9 @@ enum PAL_OPTION {
     PAL_OPTION_CLOEXEC       = 1,
     PAL_OPTION_EFD_SEMAPHORE = 2, /*!< specific to `eventfd` syscall */
     PAL_OPTION_NONBLOCK      = 4,
+    PAL_OPTION_RENAME        = 8, /*!<specific to `rename` syscall */
 
-    PAL_OPTION_MASK          = 7,
+    PAL_OPTION_MASK          = 15,
 };
 
 #define WITHIN_MASK(val, mask) (((val) | (mask)) == (mask))

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -297,7 +297,7 @@ enum PAL_OPTION {
     PAL_OPTION_CLOEXEC       = 1,
     PAL_OPTION_EFD_SEMAPHORE = 2, /*!< specific to `eventfd` syscall */
     PAL_OPTION_NONBLOCK      = 4,
-    PAL_OPTION_RENAME        = 8, /*!<specific to `rename` syscall */
+    PAL_OPTION_RENAME        = 8, /*!< specific to `rename` syscall */
 
     PAL_OPTION_MASK          = 15,
 };

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -800,7 +800,6 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     if (!new_path)
         return -PAL_ERROR_NOMEM;
 
-
     struct protected_file* pf = find_protected_file_handle(handle);
 
     /* TODO: Handle the case of renaming a file that has a file handle already open */

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -125,9 +125,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         /* The file is being opened for renaming. We will need to update the metadata in the file,
          * so open with RDWR mode with necessary share permissions. */
         if (pal_options & PAL_OPTION_RENAME) {
-            pal_share = PAL_SHARE_OWNER_R | PAL_SHARE_OWNER_W;
             pf_mode = PF_FILE_MODE_READ | PF_FILE_MODE_WRITE;
-            flags |= O_RDWR;
+            flags = O_RDWR;
         }
 
         if ((pf_mode & PF_FILE_MODE_WRITE) && pf->writable_fd >= 0) {

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -804,7 +804,6 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     struct protected_file* pf = find_protected_file_handle(handle);
 
     /* TODO: Handle the case of renaming a file that has a file handle already open */
-    struct protected_file* pf_new;
     if (pf) {
         size_t normpath_size = strlen(uri) + 1;
         char* new_normpath = (char*)calloc(1, normpath_size);
@@ -821,8 +820,7 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
             return -PAL_ERROR_DENIED;
         }
 
-        pf_new = get_protected_file(new_normpath);
-        if (!pf_new) {
+        if (!get_protected_file(new_normpath)) {
             log_warning("New path during rename is not specified in 'sgx.protected_files' (%s)", new_normpath);
             free(new_normpath);
             free(new_path);
@@ -854,11 +852,8 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
         return unix_to_pal_error(ret);
     }
 
-    /* TODO: Handle file_close for the source file during protected file rename works properly */
     if (pf) {
-        struct protected_file* tmp = pf;
-        pf = pf_new;
-        ret = pf_file_close(tmp, handle);
+        ret = pf_file_close(pf, handle);
         if (ret < 0) {
             log_warning("pf_file_close failed during rename");
         }

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -372,6 +372,15 @@ static bool ipf_init_new_file(pf_context_t* pf, const char* path) {
     return true;
 }
 
+static bool ipf_rename_file(pf_context_t* pf, const char* new_path) {
+    memset(&pf->encrypted_part_plain.path, 0, sizeof(pf->encrypted_part_plain.path));
+    memcpy(pf->encrypted_part_plain.path, new_path, strlen(new_path) + 1);
+
+    pf->need_writing = true;
+
+    return true;
+}
+
 static bool ipf_close(pf_context_t* pf) {
     void* data;
     bool retval = true;
@@ -1317,6 +1326,31 @@ pf_status_t pf_flush(pf_context_t* pf) {
 
     if (!ipf_internal_flush(pf))
         return pf->last_error;
+    return PF_STATUS_SUCCESS;
+}
+
+pf_status_t pf_rename(pf_context_t* pf, const char* new_path) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (!pf) {
+        DEBUG_PF("pf_rename(PF): PF not initialized\n");
+        return PF_STATUS_UNKNOWN_ERROR;
+    }
+
+    if (!new_path)
+        return PF_STATUS_INVALID_PATH;
+
+    if (strlen(new_path) > PATH_MAX_SIZE - 1) {
+        return PF_STATUS_PATH_TOO_LONG;
+    }
+
+    if (!ipf_rename_file(pf, new_path))
+        return pf->last_error;
+
+    if (!ipf_internal_flush(pf))
+        return pf->last_error;
+
     return PF_STATUS_SUCCESS;
 }
 

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -373,11 +373,6 @@ static bool ipf_init_new_file(pf_context_t* pf, const char* path) {
 }
 
 static bool ipf_rename_file(pf_context_t* pf, const char* new_path) {
-    if (!new_path) {
-        pf->last_error = PF_STATUS_INVALID_PATH;
-        return false;
-    }
-
     if (strlen(new_path) > PATH_MAX_SIZE - 1) {
         pf->last_error = PF_STATUS_PATH_TOO_LONG;
         return false;

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -373,6 +373,16 @@ static bool ipf_init_new_file(pf_context_t* pf, const char* path) {
 }
 
 static bool ipf_rename_file(pf_context_t* pf, const char* new_path) {
+    if (!new_path) {
+        pf->last_error = PF_STATUS_INVALID_PATH;
+        return false;
+    }
+
+    if (strlen(new_path) > PATH_MAX_SIZE - 1) {
+        pf->last_error = PF_STATUS_PATH_TOO_LONG;
+        return false;
+    }
+
     memset(&pf->encrypted_part_plain.path, 0, sizeof(pf->encrypted_part_plain.path));
     memcpy(pf->encrypted_part_plain.path, new_path, strlen(new_path) + 1);
 
@@ -1332,18 +1342,6 @@ pf_status_t pf_flush(pf_context_t* pf) {
 pf_status_t pf_rename(pf_context_t* pf, const char* new_path) {
     if (!g_initialized)
         return PF_STATUS_UNINITIALIZED;
-
-    if (!pf) {
-        DEBUG_PF("pf_rename(PF): PF not initialized\n");
-        return PF_STATUS_UNKNOWN_ERROR;
-    }
-
-    if (!new_path)
-        return PF_STATUS_INVALID_PATH;
-
-    if (strlen(new_path) > PATH_MAX_SIZE - 1) {
-        return PF_STATUS_PATH_TOO_LONG;
-    }
 
     if (!ipf_rename_file(pf, new_path))
         return pf->last_error;

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -275,4 +275,16 @@ pf_status_t pf_get_handle(pf_context_t* pf, pf_handle_t* handle);
  */
 pf_status_t pf_flush(pf_context_t* pf);
 
+/*!
+ * \brief Update the path in the metadata during a rename
+ *
+ * \param [in] pf PF context
+ * \param [in] new_path Renamed path
+ * \return PF status
+ * \details For protected files, the file name including the path is stored in the encrypted
+ *          metadata which is verified against the actual path during open. So, during a rename
+ *          we need to update the metadata with the new path.
+ */
+pf_status_t pf_rename(pf_context_t* pf, const char* new_path);
+
 #endif /* PROTECTED_FILES_H_ */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
With certain workloads involving Federated Learning, the frameworks create protected files and rename them as part of the flow. This does not work currently with protected files because every protected file maintains the path name in its metadata (stored when the file was first created) and which is checked during open to make sure the incoming path is the same as what is already stored in the metadata for this file.

This PR is to address this issue by handling rename for protected files. A normal rename call does not need the file to be open in RW mode, but since the metadata needs to be updated with the new path, we pass a special `PAL_OPTION_RENAME` flag to `DkStreamOpen` during rename and open the protected file in RW mode with required permissions, update the metadata with the new path and flush it. Then the flow goes through the one for normal file renaming. If the ocall to rename fails, we restore the metadata back to what it was earlier so the file remains usable still.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/31)
<!-- Reviewable:end -->
