### PR TITLE
[LibOS] Fix filesystem corner cases 

### DIFF
--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -237,7 +237,7 @@ int64_t _DkStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* 
 
 int DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buffer, PAL_PTR source,
                  PAL_NUM size) {
-    if (!handle || !buffer) {
+    if (!handle) {
         return -PAL_ERROR_INVAL;
     }
 
@@ -279,7 +279,7 @@ int64_t _DkStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const
 }
 
 int DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buffer, PAL_STR dest) {
-    if (!handle || !buffer) {
+    if (!handle) {
         return -PAL_ERROR_INVAL;
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes various small corner cases in filesystem code. As mentioned in #29, our test runner failed to detect these because the LTP test cases actually returned 0.

The LTP runner is also fixed so that this doesn't happen again.

Fixes #29.

The LTP tests fixed are `pwrite02`, `pwrite03` and `ftruncate03`.

## How to test this PR? <!-- (if applicable) -->

Jenkins should pass, you can also run the above tests manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/33)
<!-- Reviewable:end -->
