### PR TITLE
[LibOS] Add UID and GID to manifest

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -176,6 +176,21 @@ provided at runtime from an external (trusted) source.
 If the same variable is set in both, then ``loader.env.[ENVIRON]`` takes
 precedence.
 
+Add User ID and Group ID
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   loader.uid = [NUM]
+   loader.gid = [NUM]
+   (Default: 0)
+
+This specifies the user/group ID which will be used to run the executable in Gramine.
+These specified values are also used for the effective user/group ID. By default the
+executable is running as root user (0). If the value is < 0 Gramine stops with an
+"Invalid Argument" error.
+
+
 Disabling ASLR
 ^^^^^^^^^^^^^^
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -152,6 +152,27 @@ static int init_main_thread(void) {
 
     /* Default user and group ids are `0` and already set. */
 
+    int64_t uid_int64;
+    ret = toml_int_in(g_manifest_root, "loader.uid", /*defaultval=*/0, &uid_int64);
+    if (ret < 0) {
+        log_error("Cannot parse 'loader.uid'");
+        put_thread(cur_thread);
+        return -EINVAL;
+    }
+
+    int64_t gid_int64;
+    ret = toml_int_in(g_manifest_root, "loader.gid", /*defaultval=*/0, &gid_int64);
+    if (ret < 0) {
+        log_error("Cannot parse 'loader.gid'");
+        put_thread(cur_thread);
+        return -EINVAL;
+    }
+
+    cur_thread -> uid = uid_int64;
+    cur_thread -> euid = uid_int64;
+    cur_thread -> gid = gid_int64;
+    cur_thread -> egid = gid_int64;
+
     cur_thread->signal_dispositions = alloc_default_signal_dispositions();
     if (!cur_thread->signal_dispositions) {
         put_thread(cur_thread);

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -110,5 +110,6 @@
 /tcp_msg_peek
 /tmp
 /udp
+/uid_gid
 /unix
 /vfork_and_exec

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -94,6 +94,7 @@ c_executables = \
 	tcp_ipv6_v6only \
 	tcp_msg_peek \
 	udp \
+	uid_gid \
 	unix \
 	vfork_and_exec \
 	$(c_executables-$(ARCH))

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -3,6 +3,10 @@ libos.entrypoint = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.insecure__use_cmdline_argv = true
 
+# for uid_gid test
+loader.uid = 80085
+loader.gid = 1337
+
 # for eventfd test
 sys.insecure__allow_eventfd = true
 

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -105,6 +105,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         finally:
             os.remove('env_test_input')
 
+    def test_105_uid_and_gid_from_file(self):
+        stdout, _ = self.run_binary(['uid_gid.c'])
+        self.assertIn('TEST OK', stdout)
+
     @unittest.skipUnless(HAS_SGX,
         'This test is only meaningful on SGX PAL because only SGX catches raw '
         'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '

--- a/LibOS/shim/test/regression/uid_gid.c
+++ b/LibOS/shim/test/regression/uid_gid.c
@@ -1,0 +1,24 @@
+#include <err.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    uid_t uid = getuid();
+    uid_t euid = geteuid();
+
+    if(uid != 80085 && euid != 80085) {
+        errx(EXIT_FAILURE, "UID is not equal to the value in the the manifest");
+    }
+
+    uid_t gid = getgid();
+    uid_t egid = getegid();
+
+    if(gid != 1337 && egid != 1337) {
+        errx(EXIT_FAILURE, "GID is not equal to the value in the the manifest");
+    }
+
+    puts("TEST OK");
+    return 0;
+}


### PR DESCRIPTION
This implementation enables Gramine to run an executable with another user than root. This becomes very handy in case of executables, which shouldn't run with the root user. The implementation of this feature also sets the effective uid/gid to the value, which is defined in the manifest for the directive loader.uid/gid

This topic has been discussed in the issue [2632](https://github.com/gramineproject/graphene/issues/2632)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/36)
<!-- Reviewable:end -->
