### PR TITLE
[LibOS] Add UID and GID to manifest

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -196,6 +196,20 @@ are "consumed" by ``insecure__use_host_env``).
    because it's inherently insecure (doesn't provide any real security).
    Gramine loudly fails if ``passthrough = false`` manifest options are set.
 
+User ID and Group ID
+^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   loader.uid = [NUM]
+   loader.gid = [NUM]
+   (Default: 0)
+
+This specifies the initial, Gramine emulated user/group ID and effective
+user/group ID. It must be non-negative. By default Gramine emulates the
+user/group ID and effective user/group ID as the root user (uid = gid = 0).
+
+
 Disabling ASLR
 ^^^^^^^^^^^^^^
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -114,5 +114,6 @@
 /tcp_msg_peek
 /tmp
 /udp
+/uid_gid
 /unix
 /vfork_and_exec

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -96,6 +96,7 @@ c_executables = \
 	tcp_ipv6_v6only \
 	tcp_msg_peek \
 	udp \
+	uid_gid \
 	unix \
 	vfork_and_exec \
 	$(c_executables-$(ARCH))

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -144,6 +144,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('Local Address in Executable: 0x', stdout)
         self.assertIn('argv[0] = bootstrap_pie', stdout)
 
+    def test_108_uid_and_gid(self):
+        stdout, _ = self.run_binary(['uid_gid'])
+        self.assertIn('TEST OK', stdout)
+
     @unittest.skipUnless(ON_X86, "x86-specific")
     def test_110_basic_bootstrapping_cpp(self):
         stdout, _ = self.run_binary(['bootstrap_cpp'])

--- a/LibOS/shim/test/regression/uid_gid.c
+++ b/LibOS/shim/test/regression/uid_gid.c
@@ -1,0 +1,24 @@
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    uid_t uid = getuid();
+    uid_t euid = geteuid();
+
+    if (uid != 1338 || euid != 1338) {
+        errx(EXIT_FAILURE, "UID/effective UID are not equal to the value in the manifest");
+    }
+
+    uid_t gid = getgid();
+    uid_t egid = getegid();
+
+    if (gid != 1337 || egid != 1337) {
+        errx(EXIT_FAILURE, "GID/effective GID are not equal to the value in the manifest");
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/uid_gid.manifest.template
+++ b/LibOS/shim/test/regression/uid_gid.manifest.template
@@ -1,0 +1,19 @@
+loader.preload = "file:{{ gramine.libos }}"
+libos.entrypoint = "uid_gid"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+loader.argv0_override = "uid_gid"
+
+loader.uid = 1338
+loader.gid = 1337
+
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+
+sgx.nonpie_binary = true
+sgx.debug = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.runtimedir() }}/",
+  "file:uid_gid",
+]


### PR DESCRIPTION
This implementation enables Gramine to run an executable with another user than root.
This becomes very handy in case of executables, which shouldn't run with the root user.
The implementation of this feature sets also the effective uid/gid to the value,
which is defined in the manifest for the directive loader.uid/gid

This topic has been discussed in the issue [2632](https://github.com/gramineproject/graphene/issues/2632)

Signed-off-by: Denis Zygann <denis@zygann.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/37)
<!-- Reviewable:end -->
