### PR TITLE
[LibOS] Correct RDTSC instruction drift with system clock more often

### DIFF
--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -28,7 +28,11 @@
 #include "spinlock.h"
 #include "toml.h"
 
-#define TSC_REFINE_INIT_TIMEOUT_USECS 10000000
+/* The timeout of 50ms was found to be a safe TSC drift correction periodicity based on results
+ * from multiple systems. Any higher or lower could pose risks of negative time drift or
+ * performance hit respectively.
+ */
+#define TSC_REFINE_INIT_TIMEOUT_USECS 50000
 
 uint64_t g_tsc_hz = 0; /* TSC frequency for fast and accurate time ("invariant TSC" HW feature) */
 static uint64_t g_start_tsc = 0;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
On some systems - the RDTSC and the system clock drifts away from each other significantly, that at higher gaps (above 100ms), rdtsc falls behind, and this gets flagged by LTP. Currently the correction is done every 10 seconds ```#define TSC_REFINE_INIT_TIMEOUT_USECS 10000000``` .  The timeout is now reduced to 50ms. This satisfies LTP drift thresholds, and does not impact performance either(tested with SPECpower and Redis).
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
Fixes https://github.com/gramineproject/graphene/issues/2666 

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/38)
<!-- Reviewable:end -->
