### PR TITLE
[LibOS,Pal] Fix operations on files without permissions

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -219,22 +219,6 @@ skip = yes
 [dirtyc0w]
 skip = yes
 
-# Subtest 4 tries to unlink a file which is not readable. See
-# https://github.com/oscarlab/graphene/issues/1248.
-[dup07]
-must-pass =
-    1
-    2
-    3
-
-# Subtest 4 tries to unlink a file which is not readable. See
-# https://github.com/oscarlab/graphene/issues/1248.
-[dup202]
-must-pass =
-    1
-    2
-    3
-
 # complex test, not all of its checking is implemented in Graphene
 [epoll01]
 skip = yes
@@ -427,15 +411,6 @@ skip = yes
 
 [fcntl26_64]
 skip = yes
-
-# 2. unlink in /tmp fails with EACCES
-[fcntl28]
-must-pass =
-    1
-
-[fcntl28_64]
-must-pass =
-    1
 
 # no F_GETPIPE_SZ
 [fcntl30]

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -777,7 +777,7 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
 static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int fd  = handle->file.fd;
-    int ret = ocall_fchmod(fd, attr->share_flags | PERM_rw_______);
+    int ret = ocall_fchmod(fd, attr->share_flags);
     if (ret < 0)
         return unix_to_pal_error(ret);
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -248,7 +248,7 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int fd = handle->generic.fds[0], ret;
 
-    ret = DO_SYSCALL(fchmod, fd, attr->share_flags | PERM_rw_______);
+    ret = DO_SYSCALL(fchmod, fd, attr->share_flags);
     if (ret < 0)
         return unix_to_pal_error(ret);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit fixes the problem in which the user is not allowed to manipulate (unlink, chmod) files without read permissions. Because PAL requires us to open such files, we override the host mode in order to be able to open them.

Fixes https://github.com/gramineproject/graphene/issues/1248.

## How to test this PR? <!-- (if applicable) -->

The tests should pass; I also unskipped the LTP tests that fail due to this problem.

The same failure started appearing for a newly added `rename14` test ([link to Jenkins](https://leeroy.cs.unc.edu/job/graphene-direct-sanitizers/59/testReport/junit/apps/LTP/test_direct___rename14/)) so that should be fixed as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/39)
<!-- Reviewable:end -->
