### PR TITLE
[LibOS] Get rid of `FDTYPE` and replace it with `uint32_t`

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -162,7 +162,7 @@ struct shim_tmpfs_handle {
 DEFINE_LIST(shim_epoll_item);
 DEFINE_LISTP(shim_epoll_item);
 struct shim_epoll_item {
-    FDTYPE fd;
+    int fd;
     uint64_t data;
     unsigned int events;
     unsigned int revents;
@@ -259,16 +259,16 @@ int set_handle_nonblocking(struct shim_handle* hdl, bool on);
 
 /* file descriptor table */
 struct shim_fd_handle {
-    FDTYPE vfd; /* virtual file descriptor */
-    int flags;  /* file descriptor flags, only FD_CLOEXEC */
+    uint32_t vfd; /* virtual file descriptor */
+    int flags;    /* file descriptor flags, only FD_CLOEXEC */
 
     struct shim_handle* handle;
 };
 
 struct shim_handle_map {
     /* the top of created file descriptors */
-    FDTYPE fd_size;
-    FDTYPE fd_top;
+    uint32_t fd_size;
+    uint32_t fd_top;
 
     /* refrence count and lock */
     REFTYPE ref_count;
@@ -279,11 +279,11 @@ struct shim_handle_map {
 };
 
 /* allocating file descriptors */
-#define FD_NULL                     ((FDTYPE)-1)
+#define FD_NULL                     UINT32_MAX
 #define HANDLE_ALLOCATED(fd_handle) ((fd_handle) && (fd_handle)->vfd != FD_NULL)
 
-struct shim_handle* __get_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map* map);
-struct shim_handle* get_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map* map);
+struct shim_handle* __get_fd_handle(uint32_t fd, int* flags, struct shim_handle_map* map);
+struct shim_handle* get_fd_handle(uint32_t fd, int* flags, struct shim_handle_map* map);
 
 /*!
  * \brief Assign new fd to a handle.
@@ -296,13 +296,13 @@ struct shim_handle* get_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map*
  * Uses the lowest, non-negative available number for the new fd.
  */
 int set_new_fd_handle(struct shim_handle* hdl, int fd_flags, struct shim_handle_map* map);
-int set_new_fd_handle_by_fd(FDTYPE fd, struct shim_handle* hdl, int fd_flags,
+int set_new_fd_handle_by_fd(uint32_t fd, struct shim_handle* hdl, int fd_flags,
                             struct shim_handle_map* map);
-int set_new_fd_handle_above_fd(FDTYPE fd, struct shim_handle* hdl, int fd_flags,
+int set_new_fd_handle_above_fd(uint32_t fd, struct shim_handle* hdl, int fd_flags,
                                struct shim_handle_map* map);
 struct shim_handle* __detach_fd_handle(struct shim_fd_handle* fd, int* flags,
                                        struct shim_handle_map* map);
-struct shim_handle* detach_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map* map);
+struct shim_handle* detach_fd_handle(uint32_t fd, int* flags, struct shim_handle_map* map);
 
 /* manage handle mapping */
 int dup_handle_map(struct shim_handle_map** new_map, struct shim_handle_map* old_map);

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -338,8 +338,6 @@ typedef Elf64_auxv_t elf_auxv_t;
 /* typedef for shim internal types */
 typedef uint32_t IDTYPE;
 #define IDTYPE_MAX UINT32_MAX
-typedef uint16_t FDTYPE;
-#define FDTYPE_MAX UINT16_MAX
 typedef uint64_t HASHTYPE;
 
 #define FILE_OFF_MAX INT64_MAX

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -230,7 +230,7 @@ int proc_thread_tid_list_names(struct shim_dentry* parent, readdir_callback_t ca
 bool proc_thread_fd_name_exists(struct shim_dentry* parent, const char* name) {
     __UNUSED(parent);
     unsigned long fd;
-    if (pseudo_parse_ulong(name, FDTYPE_MAX, &fd) < 0)
+    if (pseudo_parse_ulong(name, UINT32_MAX, &fd) < 0)
         return false;
 
     struct shim_handle_map* handle_map = get_thread_handle_map(NULL);
@@ -253,7 +253,7 @@ int proc_thread_fd_list_names(struct shim_dentry* parent, readdir_callback_t cal
     lock(&handle_map->lock);
 
     int ret = 0;
-    for (int i = 0; i <= handle_map->fd_top; i++)
+    for (uint32_t i = 0; i <= handle_map->fd_top; i++)
         if (handle_map->map[i] && handle_map->map[i]->handle) {
             char name[11];
             snprintf(name, sizeof(name), "%u", i);
@@ -288,7 +288,7 @@ static char* describe_handle(struct shim_handle* hdl) {
 
 int proc_thread_fd_follow_link(struct shim_dentry* dent, char** out_target) {
     unsigned long fd;
-    if (pseudo_parse_ulong(dent->name, FDTYPE_MAX, &fd) < 0)
+    if (pseudo_parse_ulong(dent->name, UINT32_MAX, &fd) < 0)
         return -ENOENT;
 
     struct shim_handle_map* handle_map = get_thread_handle_map(NULL);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, LibOS used `typedef uint16_t FDTYPE`. This was unnecessary and hard-to-read. Moreover, it led to a bug in `__enlarge_handle_map()`: the new size was of 64-bit type `size_t` but it was assigned to `fd_size` field of 16-bit type `FDTYPE`, which led to silent truncation. This resulted in failing asserts, because active FDs suddenly became greater than the limit in the FD map.

This commit fixes this bug by changing the type from 16-bit to 32-bit, and also removes the opaque and confusing `FDTYPE`.

Fixes https://github.com/gramineproject/gramine/issues/28

## How to test this PR? <!-- (if applicable) -->

Current tests should be sufficient. I don't think we want a regression test that opens 64 thousand FDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/41)
<!-- Reviewable:end -->
