### PR TITLE
[Docs] Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+python:
+    install:
+        - requirements: Documentation/requirements.txt
+build:
+    apt_packages:
+        - doxygen


### PR DESCRIPTION
After merging this to master, docs should be fixed on https://gramine.rtfd.io/.

How to test: https://gramine.readthedocs.io/en/woju-rtfd-yaml/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/45)
<!-- Reviewable:end -->
