### PR TITLE
[tests] Skip some flaky and unreliable LTP tests

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -152,6 +152,11 @@ must-pass =
     13
     14
 
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[clock_nanosleep02]
+skip = yes
+
 # kernel config
 [clock_nanosleep03]
 skip = yes
@@ -225,6 +230,11 @@ skip = yes
 
 # tries to open /proc/1/stat, which is not implemented in Graphene
 [epoll_pwait01]
+skip = yes
+
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[epoll_wait02]
 skip = yes
 
 # test requires libaio
@@ -592,6 +602,11 @@ skip = yes
 
 # flaky, see https://github.com/oscarlab/graphene/pull/180#issuecomment-368970338.
 [futex_wait03]
+skip = yes
+
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[futex_wait05]
 skip = yes
 
 # opens /proc/2/task
@@ -1206,6 +1221,11 @@ skip = yes
 [munlockall01]
 skip = yes
 
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[nanosleep01]
+skip = yes
+
 # reports TBROK due to lack of reported results (no shared memory in Graphene)
 [nanosleep02]
 must-pass =
@@ -1353,7 +1373,7 @@ skip = yes
 [pipe2_02]
 skip = yes
 
-# fails to set O_NONBLOCK by using pipe2(fds, O_NONBLOCK)
+# requires support for F_SETPIPE_SZ in fcntl
 [pipe2_04]
 skip = yes
 
@@ -1362,6 +1382,11 @@ skip = yes
 
 # no pkey_alloc()
 [pkey*]
+skip = yes
+
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[poll02]
 skip = yes
 
 [posix_fadvise01]
@@ -1492,6 +1517,16 @@ skip = yes
 skip = yes
 
 [prot_hsymlinks]
+skip = yes
+
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[pselect01]
+skip = yes
+
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
+[pselect01_64]
 skip = yes
 
 # no ptrace()
@@ -1813,7 +1848,9 @@ skip = yes
 [sched_setscheduler03]
 skip = yes
 
-# relies on shared mmap (see tst_test.c:setup_ipc)
+# Relies on shared mmap (see tst_test.c:setup_ipc).
+# Requires disabling C-states through /dev/cpu_dma_latency to work reliably. See
+# https://github.com/linux-test-project/ltp/issues/862.
 [select04]
 skip = yes
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We aren't gonna require root and make invasive changes to the test machines to test Graphene, so unfortunately we have to disable these.

Closes gramineproject/graphene#2297, closes gramineproject/graphene#2479.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/61)
<!-- Reviewable:end -->
