### PR TITLE
[Docs] Fix docs compilation

### DIFF
--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -67,7 +67,7 @@ RUN python3 -m pip install \
     asv \
     recommonmark \
     'Sphinx==1.8' \
-    sphinx_rtd_theme \
+    'sphinx_rtd_theme<1' \
     toml>=0.10
 
 # Add the user UID:1001, GID:1001, home at /leeroy

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,3 @@ version: 2
 python:
     install:
         - requirements: Documentation/requirements.txt
-build:
-    apt_packages:
-        - doxygen

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==1.8.0
 breathe<4.13.0
 recommonmark
-sphinx_rtd_theme
+sphinx_rtd_theme<1


### PR DESCRIPTION
Currently docs are failing because of this commit: readthedocs/sphinx_rtd_theme@3693d4c, which got into released version 2 days ago: https://github.com/readthedocs/sphinx_rtd_theme/releases/tag/1.0.0

Test: docs job in jenkins and also:
- https://gramine.readthedocs.io/en/woju-sphinx-from-repo/
- https://readthedocs.org/api/v2/build/14721879.txt

Branch name has no bearing on the content, initially I wanted to `apt-get install` things in rtfd container, but [the documented solution](https://docs.readthedocs.io/en/stable/config-file/v2.html#python-system-packages) doesn't work on several important packages like sphinx and sphinx-rtd-theme, which are installed from pip anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/62)
<!-- Reviewable:end -->
