### PR TITLE
Mock ocall in sgx_pthread.edl for in-enclave RA verifier

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_dcap_urts.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_dcap_urts.c
@@ -17,9 +17,13 @@
 DUMMY_FUNCTION(sgx_create_enclave)
 DUMMY_FUNCTION(sgx_destroy_enclave)
 DUMMY_FUNCTION(sgx_ecall)
-/* ocalls in sgx_tstdc.edl */
+/* see https://github.com/intel/linux-sgx/blob/sgx_2.14/common/inc/sgx_tstdc.edl */
 DUMMY_FUNCTION(sgx_oc_cpuidex)
 DUMMY_FUNCTION(sgx_thread_set_untrusted_event_ocall)
 DUMMY_FUNCTION(sgx_thread_setwait_untrusted_events_ocall)
 DUMMY_FUNCTION(sgx_thread_set_multiple_untrusted_events_ocall)
 DUMMY_FUNCTION(sgx_thread_wait_untrusted_event_ocall)
+/* see https://github.com/intel/linux-sgx/blob/sgx_2.14/common/inc/sgx_pthread.edl */
+DUMMY_FUNCTION(pthread_wait_timeout_ocall)
+DUMMY_FUNCTION(pthread_create_ocall)
+DUMMY_FUNCTION(pthread_wakeup_ocall)


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->
Per as https://github.com/intel/SGXDataCenterAttestationPrimitives/pull/193,  some thread related `ocall` were added.  we here mock those APIs for graphene `ra-tls`.
## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/65)
<!-- Reviewable:end -->
