### PR TITLE
[CI-Examples] Update examples to use TOML-array syntax for files

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -30,9 +30,13 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4
 
-sgx.trusted_files.execs = "file:{{ execdir }}/"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:{{ execdir }}/",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
-sgx.allowed_files.scripts = "file:scripts/"
+sgx.allowed_files = [
+  "file:scripts/",
+]

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -39,11 +39,13 @@ sys.stack.size = "8M"
 sgx.enclave_size = "2048M"
 sgx.thread_num = 64
 
-sgx.trusted_files.blender = "file:{{ blender_dir }}/blender"
-sgx.trusted_files.libGL = "file:{{ blender_dir }}/lib/"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:{{ blender_dir }}/blender",
+  "file:{{ blender_dir }}/lib/",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
 # INSECURE! These 3 lines are insecure by design and should never be used in production environments.
 # There is a lot of files that Blender uses (e.g. bundled Python) and listing them here would
@@ -52,6 +54,8 @@ sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
 # Additionally, Blender scenes could allow for code execution (e.g. via bundled scripts), so
 # running untrusted scenes should not be allowed. This can be achieved for example by adding scenes
 # to trusted files or uploading them to a running and attested enclave via secured connection.
-sgx.allowed_files.blender_dir = "file:{{ blender_dir }}/{{ blender_ver }}/"
-sgx.allowed_files.blender_input = "file:{{ data_dir }}/scenes/"
-sgx.allowed_files.blender_output = "file:{{ data_dir }}/images/"
+sgx.allowed_files = [
+  "file:{{ blender_dir }}/{{ blender_ver }}/",
+  "file:{{ data_dir }}/scenes/",
+  "file:{{ data_dir }}/images/",
+]

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -25,14 +25,18 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
-sgx.trusted_files.busybox = "file:busybox"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:busybox",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.localtime = "file:/etc/localtime"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/localtime",
+]

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -34,11 +34,12 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 3
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.install_dir = "file:{{ install_dir }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-
-sgx.trusted_files.conf = "file:lighttpd.conf"
-sgx.trusted_files.conf2 = "file:lighttpd-generic.conf"
-sgx.trusted_files.conf3 = "file:lighttpd-server.conf"
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ install_dir }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:lighttpd.conf",
+  "file:lighttpd-generic.conf",
+  "file:lighttpd-server.conf",
+]

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -35,14 +35,18 @@ sgx.thread_num = 16
 # issue in Memcached source code, not related to Graphene.
 sgx.enclave_size = "1024M"
 
-sgx.trusted_files.memcached = "file:memcached"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:memcached",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
-sgx.allowed_files.nsswitch  = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers    = "file:/etc/ethers"
-sgx.allowed_files.hosts     = "file:/etc/hosts"
-sgx.allowed_files.group     = "file:/etc/group"
-sgx.allowed_files.passwd    = "file:/etc/passwd"
-sgx.allowed_files.gaiconf   = "file:/etc/gai.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+]

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -41,16 +41,20 @@ sgx.thread_num = 4
 # Nginx benefits from Exitless. Uncomment the below line to use it.
 #sgx.rpc_thread_num = 4
 
-sgx.trusted_files.nginx = "file:{{ install_dir }}/sbin/nginx"
-sgx.trusted_files.conf_dir = "file:{{ install_dir }}/conf/"
-sgx.trusted_files.html_dir = "file:{{ install_dir }}/html/"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:{{ install_dir }}/sbin/nginx",
+  "file:{{ install_dir }}/conf/",
+  "file:{{ install_dir }}/html/",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
-sgx.allowed_files.logs = "file:{{ install_dir }}/logs"
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
+sgx.allowed_files = [
+  "file:{{ install_dir }}/logs",
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+]

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -43,22 +43,26 @@ sgx.enclave_size = "512M"
 sys.stack.size = "2M"
 sgx.thread_num = 32
 
-sgx.trusted_files.python = "file:{{ entrypoint }}"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.python_dir = "file:{{ python.stdlib }}/"
-sgx.trusted_files.dist = "file:{{ python.distlib }}/"
-sgx.trusted_files.scripts = "file:scripts/"
-sgx.trusted_files.mimetypes = "file:/etc/mime.types"
-sgx.trusted_files.defapport = "file:/etc/default/apport"
+sgx.trusted_files = [
+  "file:{{ entrypoint }}",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ python.stdlib }}/",
+  "file:{{ python.distlib }}/",
+  "file:scripts/",
+  "file:/etc/mime.types",
+  "file:/etc/default/apport",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.resolv = "file:/etc/resolv.conf"
-sgx.allowed_files.tmp = "file:/tmp"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+  "file:/etc/host.conf",
+  "file:/etc/resolv.conf",
+  "file:/tmp",
+]

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -31,19 +31,23 @@ sgx.remote_attestation = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4
 
-sgx.trusted_files.client = "file:client"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.libs = "file:./libs/"
+sgx.trusted_files = [
+  "file:client",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:./libs/",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.resolvconf = "file:/etc/resolv.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
-sgx.allowed_files.cacerts = "file:/etc/ssl/certs/ca-certificates.crt"
-sgx.allowed_files.sgx_default_qcnl = "file:/etc/sgx_default_qcnl.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/host.conf",
+  "file:/etc/resolv.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+  "file:/etc/ssl/certs/ca-certificates.crt",
+  "file:/etc/sgx_default_qcnl.conf",
+]

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -26,15 +26,19 @@ sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
-sgx.trusted_files.server = "file:server"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.libs = "file:./libs/"
+sgx.trusted_files = [
+  "file:server",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:./libs/",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -24,18 +24,22 @@ sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
-sgx.trusted_files.secret_prov_client = "file:secret_prov_client"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.libs = "file:./libs/"
-sgx.trusted_files.cachain = "file:certs/test-ca-sha256.crt"
+sgx.trusted_files = [
+  "file:secret_prov_client",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:./libs/",
+  "file:certs/test-ca-sha256.crt",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
-sgx.allowed_files.resolv = "file:/etc/resolv.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/host.conf",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+  "file:/etc/resolv.conf",
+]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -28,18 +28,22 @@ sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
-sgx.trusted_files.secret_prov_min_client = "file:secret_prov_min_client"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.libs = "file:./libs/"
-sgx.trusted_files.cachain = "file:certs/test-ca-sha256.crt"
+sgx.trusted_files = [
+  "file:secret_prov_min_client",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:./libs/",
+  "file:certs/test-ca-sha256.crt",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
-sgx.allowed_files.resolv = "file:/etc/resolv.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/host.conf",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+  "file:/etc/resolv.conf",
+]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -29,20 +29,26 @@ sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
-sgx.trusted_files.secret_prov_pf_client = "file:secret_prov_pf_client"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.libs = "file:./libs/"
-sgx.trusted_files.cachain = "file:certs/test-ca-sha256.crt"
+sgx.trusted_files = [
+  "file:secret_prov_pf_client",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:./libs/",
+  "file:certs/test-ca-sha256.crt",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
-sgx.allowed_files.resolv = "file:/etc/resolv.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/host.conf",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+  "file:/etc/resolv.conf",
+]
 
-sgx.protected_files.input = "file:files/input.txt"
+sgx.protected_files = [
+  "file:files/input.txt",
+]

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -97,32 +97,29 @@ sgx.nonpie_binary = true
 
 ############################# SGX: TRUSTED FILES ###############################
 
-# Specify all files used by Redis and its dependencies (including all
-# libraries which can be loaded at runtime via dlopen). The paths to files
-# are host-OS paths. These files will be searched for in in-Graphene visible
-# paths according to mount points above.
+# Specify all files used by Redis and its dependencies (including all libraries
+# which can be loaded at runtime via dlopen), as well as other static read-only
+# files (like configuration files).
 #
-# As part of the build process, Graphene-SGX script (`graphene-sgx-sign`) finds each
-# specified file, measures its hash, and outputs the hash in auto-generated
-# entry 'sgx.trusted_checksum.xxx' in auto-generated redis-server.manifest.sgx.
+# The paths to files are host-OS paths. These files will be searched for in
+# in-Graphene visible paths according to mount points above.
+#
+# As part of the build process, Graphene-SGX script (`graphene-sgx-sign`) finds
+# each specified file, measures its hash, and adds it to the manifest entry for
+# that file (converting each entry to a table with "uri" and "sha256" keys).
 # Note that this happens on the developer machine or a build server.
 #
-# At runtime, during loading of each "trusted file", Graphene-SGX measures its hash
-# and compares with the one specified in 'sgx.trusted_checksum.xxx'. If hashes
-# match, this file is trusted and allowed to be loaded and used. Note that
-# this happens on the client machine.
-sgx.trusted_files.redis-server = "file:redis-server"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+# At runtime, during loading of each "trusted file", Graphene-SGX measures its
+# hash and compares with the "sha256" value in the corresponding manifest entry.
+# If hashes match, this file is trusted and allowed to be loaded and used. Note
+# that this happens on the client machine.
+sgx.trusted_files = [
+  "file:redis-server",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
-# Trusted no-library files include configuration files, read-only files, and
-# other static files. It is useful to specify such files here to make sure
-# they are not maliciously modified (modifications will be detected as hash
-# mismatch by Graphene-SGX).
-#
-# Redis by default does not use configuration files, so this section is empty.
-# sgx.trusted_files.config = "file:<important-configuration-file>"
 
 ############################# SGX: ALLOWED FILES ###############################
 
@@ -130,14 +127,16 @@ sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
 # Graphene-SGX but their integrity is not verified (Graphene-SGX does not
 # measure their hashes). This may pose a security risk!
 
-# Name Service Switch (NSS) files. Glibc reads these files as part of name-
-# service information gathering. For more info, see 'man nsswitch.conf'.
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
+sgx.allowed_files = [
+  # Name Service Switch (NSS) files. Glibc reads these files as part of name-
+  # service information gathering. For more info, see 'man nsswitch.conf'.
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
 
-# getaddrinfo(3) configuration file. Glibc reads this file to correctly find
-# network addresses. For more info, see 'man gai.conf'.
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
+  # getaddrinfo(3) configuration file. Glibc reads this file to correctly find
+  # network addresses. For more info, see 'man gai.conf'.
+  "file:/etc/gai.conf",
+]

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -26,8 +26,12 @@ fs.mount.sqlite3.uri = "file:{{ execdir }}/sqlite3"
 sgx.enclave_size = "256M"
 sgx.thread_num = 4
 
-sgx.trusted_files.sqlite3 = "file:{{ execdir }}/sqlite3"
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:{{ execdir }}/sqlite3",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+]
 
-sgx.allowed_files.scripts = "file:scripts/"
+sgx.allowed_files = [
+  "file:scripts/",
+]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

All example manifests now use the TOML-array syntax for `sgx.trusted_files`, `sgx.allowed_files`, `sgx.protected_files`.

## How to test this PR? <!-- (if applicable) -->

All examples should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/66)
<!-- Reviewable:end -->
