### PR TITLE
[Pal/Linux-SGX] Accept NULL in `write`/`pwrite` ocalls

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -505,19 +505,19 @@ ssize_t ocall_write(int fd, const void* buf, size_t count) {
             /* buf is too big and may overflow untrusted stack, so use untrusted heap */
             retval = ocall_mmap_untrusted_cache(ALLOC_ALIGN_UP(count), &obuf, &need_munmap);
             if (retval < 0) {
-                sgx_reset_ustack(old_ustack);
-                return retval;
+                goto out;
             }
             memcpy(obuf, buf, count);
             ms_buf = obuf;
         } else {
             ms_buf = sgx_copy_to_ustack(buf, count);
+            if (!ms_buf) {
+                retval = -EPERM;
+                goto out;
+            }
         }
     } else {
         /* buf is partially in/out of enclave memory */
-        ms_buf = NULL;
-    }
-    if (!ms_buf) {
         retval = -EPERM;
         goto out;
     }
@@ -629,19 +629,19 @@ ssize_t ocall_pwrite(int fd, const void* buf, size_t count, off_t offset) {
             /* buf is too big and may overflow untrusted stack, so use untrusted heap */
             retval = ocall_mmap_untrusted_cache(ALLOC_ALIGN_UP(count), &obuf, &need_munmap);
             if (retval < 0) {
-                sgx_reset_ustack(old_ustack);
-                return retval;
+                goto out;
             }
             memcpy(obuf, buf, count);
             ms_buf = obuf;
         } else {
             ms_buf = sgx_copy_to_ustack(buf, count);
+            if (!ms_buf) {
+                retval = -EPERM;
+                goto out;
+            }
         }
     } else {
         /* buf is partially in/out of enclave memory */
-        ms_buf = NULL;
-    }
-    if (!ms_buf) {
         retval = -EPERM;
         goto out;
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Fixes #67.

NULL is a valid parameter for these system calls, as long as count is 0 (and otherwise, they will fail with -EFAULT anyway).

This fixes Gramine's own `write`/`pwrite`, which recently have been modified not to specialcase 0, and started failing with -EPERM because of the ocall wrapper.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

As mentioned in #67, you can run `pwrite03` and `write02` LTP tests manually under SGX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/69)
<!-- Reviewable:end -->
