### PR TITLE
[Documentation] Update GSC documentation for Ubuntu 20.04 support

### DIFF
--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -299,8 +299,8 @@ in :file:`config.yaml.template`.
 
 .. describe:: Distro
 
-   Defines Linux distribution to be used to build Graphene in. Currently the
-   only supported value is ``ubuntu18.04``.
+   Defines Linux distribution to be used to build Graphene in. Currently tested
+   distros are Ubuntu 18.04 and Ubuntu 20.04. Default value is ``ubuntu18.04``.
 
 .. describe:: Graphene.Repository
 


### PR DESCRIPTION
GSC documentation is  updated to highlight Ubuntu 20.04 support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/70)
<!-- Reviewable:end -->
