### PR TITLE
[*] Fix indentation in manifest templates

### DIFF
--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -40,11 +40,11 @@ sgx.enclave_size = "2048M"
 sgx.thread_num = 64
 
 sgx.trusted_files = [
-  "file:{{ blender_dir }}/blender",
-  "file:{{ blender_dir }}/lib/",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
+    "file:{{ blender_dir }}/blender",
+    "file:{{ blender_dir }}/lib/",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
 ]
 
 # INSECURE! These 3 lines are insecure by design and should never be used in production environments.
@@ -55,7 +55,7 @@ sgx.trusted_files = [
 # running untrusted scenes should not be allowed. This can be achieved for example by adding scenes
 # to trusted files or uploading them to a running and attested enclave via secured connection.
 sgx.allowed_files = [
-  "file:{{ blender_dir }}/{{ blender_ver }}/",
-  "file:{{ data_dir }}/scenes/",
-  "file:{{ data_dir }}/images/",
+    "file:{{ blender_dir }}/{{ blender_ver }}/",
+    "file:{{ data_dir }}/scenes/",
+    "file:{{ data_dir }}/images/",
 ]

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -26,17 +26,17 @@ fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
 sgx.trusted_files = [
-  "file:busybox",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
+    "file:busybox",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/localtime",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/localtime",
 ]

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -35,11 +35,11 @@ sgx.enclave_size = "256M"
 sgx.thread_num = 3
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ install_dir }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:lighttpd.conf",
-  "file:lighttpd-generic.conf",
-  "file:lighttpd-server.conf",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ install_dir }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:lighttpd.conf",
+    "file:lighttpd-generic.conf",
+    "file:lighttpd-server.conf",
 ]

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -36,17 +36,17 @@ sgx.thread_num = 16
 sgx.enclave_size = "1024M"
 
 sgx.trusted_files = [
-  "file:memcached",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
+    "file:memcached",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
 ]

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -42,19 +42,19 @@ sgx.thread_num = 4
 #sgx.rpc_thread_num = 4
 
 sgx.trusted_files = [
-  "file:{{ install_dir }}/sbin/nginx",
-  "file:{{ install_dir }}/conf/",
-  "file:{{ install_dir }}/html/",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
+    "file:{{ install_dir }}/sbin/nginx",
+    "file:{{ install_dir }}/conf/",
+    "file:{{ install_dir }}/html/",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
 ]
 
 sgx.allowed_files = [
-  "file:{{ install_dir }}/logs",
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
+    "file:{{ install_dir }}/logs",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
 ]

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -44,25 +44,25 @@ sys.stack.size = "2M"
 sgx.thread_num = 32
 
 sgx.trusted_files = [
-  "file:{{ entrypoint }}",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:{{ python.stdlib }}/",
-  "file:{{ python.distlib }}/",
-  "file:scripts/",
-  "file:/etc/mime.types",
-  "file:/etc/default/apport",
+    "file:{{ entrypoint }}",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:{{ python.stdlib }}/",
+    "file:{{ python.distlib }}/",
+    "file:scripts/",
+    "file:/etc/mime.types",
+    "file:/etc/default/apport",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
-  "file:/etc/host.conf",
-  "file:/etc/resolv.conf",
-  "file:/tmp",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
+    "file:/etc/host.conf",
+    "file:/etc/resolv.conf",
+    "file:/tmp",
 ]

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -32,22 +32,22 @@ sgx.enclave_size = "256M"
 sgx.thread_num = 4
 
 sgx.trusted_files = [
-  "file:client",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:./libs/",
+    "file:client",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:./libs/",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/host.conf",
-  "file:/etc/resolv.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
-  "file:/etc/ssl/certs/ca-certificates.crt",
-  "file:/etc/sgx_default_qcnl.conf",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/host.conf",
+    "file:/etc/resolv.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
+    "file:/etc/ssl/certs/ca-certificates.crt",
+    "file:/etc/sgx_default_qcnl.conf",
 ]

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -27,18 +27,18 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
 sgx.trusted_files = [
-  "file:server",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:./libs/",
+    "file:server",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:./libs/",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
 ]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -25,21 +25,21 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
 sgx.trusted_files = [
-  "file:secret_prov_client",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:./libs/",
-  "file:certs/test-ca-sha256.crt",
+    "file:secret_prov_client",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:./libs/",
+    "file:certs/test-ca-sha256.crt",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
-  "file:/etc/resolv.conf",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/host.conf",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
+    "file:/etc/resolv.conf",
 ]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -29,21 +29,21 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
 sgx.trusted_files = [
-  "file:secret_prov_min_client",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:./libs/",
-  "file:certs/test-ca-sha256.crt",
+    "file:secret_prov_min_client",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:./libs/",
+    "file:certs/test-ca-sha256.crt",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
-  "file:/etc/resolv.conf",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/host.conf",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
+    "file:/etc/resolv.conf",
 ]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -30,25 +30,25 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
 sgx.trusted_files = [
-  "file:secret_prov_pf_client",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-  "file:./libs/",
-  "file:certs/test-ca-sha256.crt",
+    "file:secret_prov_pf_client",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
+    "file:./libs/",
+    "file:certs/test-ca-sha256.crt",
 ]
 
 sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
-  "file:/etc/resolv.conf",
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/host.conf",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    "file:/etc/gai.conf",
+    "file:/etc/resolv.conf",
 ]
 
 sgx.protected_files = [
-  "file:files/input.txt",
+    "file:files/input.txt",
 ]

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -114,10 +114,10 @@ sgx.nonpie_binary = true
 # If hashes match, this file is trusted and allowed to be loaded and used. Note
 # that this happens on the client machine.
 sgx.trusted_files = [
-  "file:redis-server",
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
+    "file:redis-server",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/",
+    "file:/usr/{{ arch_libdir }}/",
 ]
 
 
@@ -128,15 +128,15 @@ sgx.trusted_files = [
 # measure their hashes). This may pose a security risk!
 
 sgx.allowed_files = [
-  # Name Service Switch (NSS) files. Glibc reads these files as part of name-
-  # service information gathering. For more info, see 'man nsswitch.conf'.
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-
-  # getaddrinfo(3) configuration file. Glibc reads this file to correctly find
-  # network addresses. For more info, see 'man gai.conf'.
-  "file:/etc/gai.conf",
+    # Name Service Switch (NSS) files. Glibc reads these files as part of name-
+    # service information gathering. For more info, see 'man nsswitch.conf'.
+    "file:/etc/nsswitch.conf",
+    "file:/etc/ethers",
+    "file:/etc/hosts",
+    "file:/etc/group",
+    "file:/etc/passwd",
+    
+    # getaddrinfo(3) configuration file. Glibc reads this file to correctly find
+    # network addresses. For more info, see 'man gai.conf'.
+    "file:/etc/gai.conf",
 ]

--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -181,3 +181,11 @@ Meson
    tied to the script name (see :file:`meson.build` there). The scripts should
    be written in Python except for things that clearly benefit from being
    written in ``sh``.
+
+TOML
+----
+
+#. 4-space indent, no tabs. Wrap lines at ~80-100 columns except for unbreakable
+   things like URLs.
+
+#. No space inside parenthesis.

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -12,10 +12,10 @@ fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 sgx.nonpie_binary = true
 
 sgx.allowed_files = [
-  "file:argv_test_input",
+    "file:argv_test_input",
 ]
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:bootstrap",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:bootstrap",
 ]

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -20,6 +20,6 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:attestation",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:attestation",
 ]

--- a/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
+++ b/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
@@ -22,10 +22,10 @@ sgx.thread_num = 8
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ arch_libdir }}/libgcc_s.so.1",
-  "file:/usr{{ arch_libdir }}/libstdc++.so.6",
-  "file:/usr{{ arch_libdir }}/libunwind.so.8",
-  "file:{{ arch_libdir }}/liblzma.so.5",
-  "file:bootstrap_cpp",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ arch_libdir }}/libgcc_s.so.1",
+    "file:/usr{{ arch_libdir }}/libstdc++.so.6",
+    "file:/usr{{ arch_libdir }}/libunwind.so.8",
+    "file:{{ arch_libdir }}/liblzma.so.5",
+    "file:bootstrap_cpp",
 ]

--- a/LibOS/shim/test/regression/debug_log_file.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_file.manifest.template
@@ -13,6 +13,6 @@ fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:bootstrap",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:bootstrap",
 ]

--- a/LibOS/shim/test/regression/debug_log_inline.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest.template
@@ -12,6 +12,6 @@ fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:bootstrap",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:bootstrap",
 ]

--- a/LibOS/shim/test/regression/device_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/device_passthrough.manifest.template
@@ -14,6 +14,6 @@ fs.mount.dev.uri = "dev:/dev/zero"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:device_passthrough",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:device_passthrough",
 ]

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -14,6 +14,6 @@ sgx.nonpie_binary = true
 sgx.allowed_files.env = "file:env_test_input"
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:bootstrap",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:bootstrap",
 ]

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -12,6 +12,6 @@ fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:bootstrap",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:bootstrap",
 ]

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -13,7 +13,7 @@ sgx.nonpie_binary = true
 sgx.file_check_policy = "allow_all_but_log"
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
+    "file:{{ graphene.runtimedir() }}/",
 ]
 
 # below entry in sgx.trusted_files is to test TOML-table syntax without `sha256`

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -13,7 +13,7 @@ sgx.nonpie_binary = true
 sgx.file_check_policy = "strict"
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
+    "file:{{ graphene.runtimedir() }}/",
 ]
 
 # below entry in sgx.trusted_files is to test TOML-table syntax without `sha256`

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -15,6 +15,6 @@ fs.mount.graphene_lib.uri = "file:{{ graphene.runtimedir() }}"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:{{ env.PWD }}/host_root_fs",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:{{ env.PWD }}/host_root_fs",
 ]

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -16,6 +16,6 @@ fs.mount.test.uri = "file:I_DONT_EXIST"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:init_fail",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:init_fail",
 ]

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -15,6 +15,6 @@ sgx.enclave_size = "256M"
 sys.brk.max_size = "512M"
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:init_fail",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:init_fail",
 ]

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -16,10 +16,10 @@ sgx.enclave_size = "8G"
 sgx.nonpie_binary = true
 
 sgx.allowed_files = [
-  "file:testfile",
+    "file:testfile",
 ]
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:large_mmap",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:large_mmap",
 ]

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -14,6 +14,6 @@ sgx.nonpie_binary = true
 sgx.enable_stats = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:multi_pthread",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:multi_pthread",
 ]

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -15,6 +15,6 @@ sgx.nonpie_binary = true
 sgx.enable_stats = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:multi_pthread",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:multi_pthread",
 ]

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -29,7 +29,7 @@ sgx.thread_num = 32
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
-  "file:{{ graphene.runtimedir() }}/",
-  "file:openmp",
-  "file:/usr{{ arch_libdir }}/libgomp.so.1",
+    "file:{{ graphene.runtimedir() }}/",
+    "file:openmp",
+    "file:/usr{{ arch_libdir }}/libgomp.so.1",
 ]


### PR DESCRIPTION
Signed-off-by: Wojtek Porczyk <woju@invisiblethingslab.com>

## Description of the changes <!-- (reasons and measures) -->

TOML should be indented to 4 spaces like everything else, so we won't have to maintain per-filetype editor config.

## How to test this PR? <!-- (if applicable) -->

jenkins

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/73)
<!-- Reviewable:end -->
