### PR TITLE
[LibOS] Return correct AF_UNIX-socket name in `getsockname/getpeername`

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -122,7 +122,8 @@ struct shim_sock_handle {
         struct addr_unix {
             struct shim_dentry* dentry;
             char name[PIPE_URI_SIZE];
-            char sun_path[SOCK_URI_SIZE]; /* Path name.  */
+            /* Linux stores user-supplied name as-is; we do the same */
+            char sun_path[SOCK_URI_SIZE];
         } un;
     } addr;
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -122,7 +122,7 @@ struct shim_sock_handle {
         struct addr_unix {
             struct shim_dentry* dentry;
             char name[PIPE_URI_SIZE];
-            char sun_path[108]; /* Path name.  */
+            char sun_path[SOCK_URI_SIZE]; /* Path name.  */
         } un;
     } addr;
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -122,6 +122,7 @@ struct shim_sock_handle {
         struct addr_unix {
             struct shim_dentry* dentry;
             char name[PIPE_URI_SIZE];
+            char sun_path[108]; /* Path name.  */
         } un;
     } addr;
 

--- a/LibOS/shim/test/regression/unix.c
+++ b/LibOS/shim/test/regression/unix.c
@@ -118,7 +118,6 @@ static int server(void) {
         perror("getsockname");
         exit(1);
     }
-    /* Gramine returns absolute path, whereas native Linux returns non-normalized path */
     if (strcmp(sockname_addr.sun_path, "u") != 0) {
         printf("Returned wrong socket name: %s\n", sockname_addr.sun_path);
         exit(1);
@@ -170,7 +169,6 @@ static int client(void) {
         perror("getpeername");
         exit(1);
     }
-    /* Gramine returns absolute path, whereas native Linux returns non-normalized path */
     if (strcmp(peer_addr.sun_path, "u") != 0) {
         printf("returned wrong peer name: %s\n", peer_addr.sun_path);
         exit(1);

--- a/LibOS/shim/test/regression/unix.c
+++ b/LibOS/shim/test/regression/unix.c
@@ -118,7 +118,7 @@ static int server(void) {
         perror("getsockname");
         exit(1);
     }
-    if (strcmp(sockname_addr.sun_path, "u") != 0) {
+    if (strcmp(sockname_addr.sun_path, SUN_PATH) != 0) {
         printf("Returned wrong socket name: %s\n", sockname_addr.sun_path);
         exit(1);
     }
@@ -169,7 +169,7 @@ static int client(void) {
         perror("getpeername");
         exit(1);
     }
-    if (strcmp(peer_addr.sun_path, "u") != 0) {
+    if (strcmp(peer_addr.sun_path, SUN_PATH) != 0) {
         printf("returned wrong peer name: %s\n", peer_addr.sun_path);
         exit(1);
     }
@@ -217,14 +217,19 @@ int main(int argc, char** argv) {
         return client();
     } else {
         int ret = server();
+        if (ret)
+            return ret;
         int status;
         pid_t pid = wait(&status);
         if (pid != child_pid) {
             perror("wait failed");
             return 1;
         }
-        if (WIFEXITED(status))
+        if (!WIFEXITED(status)){
             printf("child exited with status: %d\n", WEXITSTATUS(status));
-        return ret;
+            return 1;
+        }
+
+        return 0;
     }
 }

--- a/LibOS/shim/test/regression/unix.c
+++ b/LibOS/shim/test/regression/unix.c
@@ -225,7 +225,7 @@ int main(int argc, char** argv) {
             perror("wait failed");
             return 1;
         }
-        if (!WIFEXITED(status)){
+        if (!WIFEXITED(status)) {
             printf("child exited with status: %d\n", WEXITSTATUS(status));
             return 1;
         }


### PR DESCRIPTION
Signed-off-by: Jitender Kumar <jitender.kumar@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Current implementation of `shim_do_getsockname` and `shim_do_getpeername` functions handles only
 AF_INET and AF_INET6 domain type sockets but misses UNIX domain type socket. This PR 
 adds functionality to handle UNIX domain type sockets inside `shim_do_getsockname` and 
 `shim_do_getpeername` functions.

Fixes gramineproject/graphene#2393.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Follow below commands to execute unix regression test:

`cd LibOS/shim/test/regression`
`make SGX=1`
`make SGX=1 sgx-tokens`
`graphene-sgx unix fork`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/74)
<!-- Reviewable:end -->
