### PR TITLE
[Pal/Linux-SGX] Add `libsgx_dcap_quoteverify.so` dependency to DCAP-based libs

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/.gitignore
+++ b/CI-Examples/ra-tls-mbedtls/.gitignore
@@ -3,4 +3,3 @@
 /client
 /mbedtls
 /server
-/libs/

--- a/CI-Examples/ra-tls-mbedtls/README.md
+++ b/CI-Examples/ra-tls-mbedtls/README.md
@@ -12,10 +12,10 @@ to verify the server RA-TLS certificate via `ra_tls_verify_callback()`.
 
 This example uses the RA-TLS libraries `ra_tls_attest.so` for server and
 `ra_tls_verify_epid.so`/ `ra_tls_verify_dcap.so` for client. These libraries are
-found under `Pal/src/host/Linux-SGX/tools/ra-tls`. Additionally, mbedTLS
-libraries are required to correctly run RA-TLS, the client, and the server. For
-ECDSA/DCAP attestation, the DCAP software infrastructure must be installed and
-work correctly on the host.
+installed together with Graphene (for DCAP version, you need `meson setup ...
+-Ddcap=enabled`). Additionally, mbedTLS libraries are required to correctly run
+RA-TLS, the client, and the server. For ECDSA/DCAP attestation, the DCAP
+software infrastructure must be installed and work correctly on the host.
 
 The current example works with both EPID (IAS) and ECDSA (DCAP) remote
 attestation schemes. For more documentation, refer to
@@ -55,15 +55,6 @@ four additional command-line arguments (see the source code for details).
 
 # Quick Start
 
-First, start with adding the library directory to `LD_LIBRARY_PATH`:
-
-```sh
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./libs
-```
-
-Remember to undo this change after finishing the tutorial (or just do everything
-in a subshell).
-
 - Normal non-RA-TLS flows; without SGX and without Graphene:
 
 ```sh
@@ -97,9 +88,6 @@ kill %%
 - RA-TLS flows with SGX and with Graphene, ECDSA-based (DCAP) attestation:
 
 ```sh
-# make sure RA-TLS DCAP libraries are built in Graphene via:
-#   cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap
-
 # replace dummy values with your MRENCLAVE, MRSIGNER, etc!
 make clean
 make app dcap

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -4,7 +4,7 @@ loader.preload = "file:{{ graphene.libos }}"
 libos.entrypoint = "server"
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
 loader.insecure__use_cmdline_argv = true
 

--- a/CI-Examples/ra-tls-secret-prov/.gitignore
+++ b/CI-Examples/ra-tls-secret-prov/.gitignore
@@ -1,9 +1,6 @@
 /*.tar.gz
 /OUTPUT
 /files/input.txt
-/libs/
-/mbedtls
-/pf_crypt
 /secret_prov_client
 /secret_prov_min_client
 /secret_prov_pf_client

--- a/CI-Examples/ra-tls-secret-prov/README.md
+++ b/CI-Examples/ra-tls-secret-prov/README.md
@@ -5,8 +5,8 @@ minimal server and clients written against the Secret Provisioning library.
 
 This example uses the Secret Provisioning libraries `secret_prov_attest.so` for
 clients and `secret_prov_verify_epid.so`/`secret_prov_verify_dcap.so` for
-server. These libraries can be found under
-`Pal/src/host/Linux-SGX/tools/ra-tls`. Additionally, mbedTLS libraries are
+server. These libraries are installed together with Graphene (for DCAP version,
+you need `meson setup ... -Ddcap=enabled`). Additionally, mbedTLS libraries are
 required. For ECDSA/DCAP attestation, the DCAP software infrastructure must be
 installed and work correctly on the host.
 
@@ -54,18 +54,6 @@ build time.
 
 # Quick Start
 
-Please make sure that the corresponding RA-TLS libraries (EPID or DCAP versions)
-are built.
-
-First, start with adding the library directory to `LD_LIBRARY_PATH`:
-
-```sh
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./libs
-```
-
-Remember to undo this change after finishing the tutorial (or just do everything
-in a subshell).
-
 - Secret Provisioning flows, EPID-based (IAS) attestation:
 
 ```sh
@@ -89,9 +77,6 @@ kill %%
 - Secret Provisioning flows, ECDSA-based (DCAP) attestation:
 
 ```sh
-# make sure RA-TLS DCAP libraries are built in Graphene via:
-#   cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap
-
 make app dcap files/input.txt
 
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 ./secret_prov_server_dcap &

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -4,7 +4,7 @@ loader.preload = "file:{{ graphene.libos }}"
 libos.entrypoint = "secret_prov_client"
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
 loader.insecure__use_cmdline_argv = true
 
@@ -13,8 +13,12 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
 fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "/lib/x86_64-linux-gnu"
-fs.mount.lib2.uri = "file:/lib/x86_64-linux-gnu"
+fs.mount.lib2.path = "{{ arch_libdir }}"
+fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+
+fs.mount.lib3.type = "chroot"
+fs.mount.lib3.path = "/usr{{ arch_libdir }}"
+fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
 
 fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -4,7 +4,7 @@ loader.preload = "file:{{ graphene.libos }}"
 libos.entrypoint = "secret_prov_min_client"
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 loader.env.LD_PRELOAD = "libsecret_prov_attest.so"
 loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
 loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "certs/test-ca-sha256.crt"
@@ -17,8 +17,12 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
 fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "/lib/x86_64-linux-gnu"
-fs.mount.lib2.uri = "file:/lib/x86_64-linux-gnu"
+fs.mount.lib2.path = "{{ arch_libdir }}"
+fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+
+fs.mount.lib3.type = "chroot"
+fs.mount.lib3.path = "/usr{{ arch_libdir }}"
+fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
 
 fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -4,7 +4,7 @@ loader.preload = "file:{{ graphene.libos }}"
 libos.entrypoint = "secret_prov_pf_client"
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 loader.env.LD_PRELOAD = "libsecret_prov_attest.so"
 loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
 loader.env.SECRET_PROVISION_SET_PF_KEY = "1"
@@ -18,8 +18,12 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
 fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "/lib/x86_64-linux-gnu"
-fs.mount.lib2.uri = "file:/lib/x86_64-linux-gnu"
+fs.mount.lib2.path = "{{ arch_libdir }}"
+fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+
+fs.mount.lib3.type = "chroot"
+fs.mount.lib3.path = "/usr{{ arch_libdir }}"
+fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
 
 fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/meson.build
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/meson.build
@@ -91,6 +91,7 @@ if dcap
         args: ra_tls_args,
         include_directories: sgx_inc,
         dependencies: [
+            sgx_dcap_quoteverify_dep,
             sgx_util_dep,
             mbedtls_dep,
         ],
@@ -111,6 +112,7 @@ if dcap
         args: ra_tls_args,
         include_directories: sgx_inc,
         dependencies: [
+            sgx_dcap_quoteverify_dep,
             sgx_util_dep,
             mbedtls_dep,
         ],
@@ -134,6 +136,7 @@ if dcap
         include_directories: sgx_inc,
         dependencies: [
             threads_dep,
+            sgx_dcap_quoteverify_dep,
             sgx_util_dep,
             mbedtls_dep,
         ],


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

This PR adds `libsgx_dcap_quoteverify.so` dependency to DCAP-based libs. This was missed in the `[Pal/Linux-SGX] Compile SGX tools with Meson` commit, even though the dependency was already baked in one of the meson files.

As an aside, the `ra-tls-mbedtls` and `ra-tls-secret-prov` examples got a bit stale, so I updated them as well. Surprisingly, we had the bug with `LD_LIBRARY_PATH` in those manifests for a long time, and noone noticed.

## How to test this PR? <!-- (if applicable) -->

CI is enough for `ra-tls` examples.

Unfortunately, we don't have DCAP-enabled SGX machines in our Jenkins CI, so we can't test DCAP-based libraries (that's why the bug was missed in the previous commits). If you want to test, do it manually on a DCAP-enabled machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/75)
<!-- Reviewable:end -->
