### PR TITLE
[Pal/Linux] Assign an ephemeral port if port 0 was specified in `udp_bind`

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1901,7 +1901,7 @@ timeout = 60
 [sendfile09_64]
 timeout = 60
 
-# EINVAL from native sendmsg()
+# uses recvmmsg(timeout) but timeout is unsupported in Gramine
 [sendmmsg01]
 skip = yes
 

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -609,6 +609,13 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
         }
     }
 
+    /* call getsockname to get socket address */
+    ret = DO_SYSCALL(getsockname, fd, bind_addr, &bind_addrlen);
+    if (ret < 0) {
+        ret = unix_to_pal_error(ret);
+        goto failed;
+    }
+
     *handle = socket_create_handle(PAL_TYPE_UDPSRV, fd, options, bind_addr, bind_addrlen, NULL, 0);
 
     if (!(*handle)) {


### PR DESCRIPTION
Signed-off-by: Sonali Saha <sonali.saha@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Fixed the issue of an ephemeral port is not allocated when port number in a socket address is specified as 0 when calling bind.
Fixes gramineproject/graphene#2291

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Follow the steps to reproduce mentioned in issue gramineproject/graphene#2291.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/76)
<!-- Reviewable:end -->
