### PR TITLE
[Pal/Linux-SGX] Always open Protected Files in RW mode

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -129,6 +129,10 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
             goto fail_pf_unlock;
         }
 
+        /* Protected files sometimes needs to be read and written (e.g. to read or save some
+         * metadata), regardless of the requested open mode. */
+        flags = (flags & ~O_ACCMODE) | O_RDWR;
+
         fd = ocall_open(uri, flags, pal_share);
         if (fd < 0) {
             ret = unix_to_pal_error(fd);


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
A Protected File sometimes needs to be read or written, regardless of the actual open mode that was requested (e.g. to read or write some metadata).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/78)
<!-- Reviewable:end -->
