### PR TITLE
[LibOS] Support umask

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -43,7 +43,8 @@ int init_process(int argc, const char** argv) {
 
     g_process.wait_queue = NULL;
 
-    g_process.umask = 0;
+    /* default Linux umask */
+    g_process.umask = 0022;
 
     struct shim_dentry* dent = NULL;
     int ret = path_lookupat(/*start=*/NULL, "/", LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &dent);

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -2446,9 +2446,6 @@ skip = yes
 [truncate03_64]
 skip = yes
 
-[umask01]
-skip = yes
-
 [umount01]
 skip = yes
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This change makes Gramine respect the process umask when creating new files using `open` and `mkdir`. It also initializes it correctly.

Fixes one of the issues in https://github.com/gramineproject/graphene/issues/2543.

## How to test this PR? <!-- (if applicable) -->

LTP test `umask01` (which this PR unskips) checks umask support in `open(O_CREAT)`. As far as I can tell, there's no corresponding LTP test for `mkdir`, but I'm not sure if this is important enough to add one of our own.

Anyway, a manual test (to be run with `python` example) looks like this:

```python
import os

for umask in [0o000, 0o022, 0o077]:
    if os.path.exists('dir'):
        os.rmdir('dir')
    os.umask(umask)
    os.mkdir('dir', 0o777)
    print(oct(os.stat('dir').st_mode))  # should print 0o40777, 0o40755, 0o40700
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/90)
<!-- Reviewable:end -->
