### PR TITLE
[PAL] Initialize ret variable to avoid incorrect return value

### DIFF
--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -160,6 +160,8 @@ static ssize_t handle_serialize(PAL_HANDLE handle, void** data) {
         memcpy(buffer + hdlsz, d1, dsz1);
     if (dsz2)
         memcpy(buffer + hdlsz + dsz1, d2, dsz2);
+
+    ret = 0;
 out:
     if (free_d1)
         free((void*)d1);


### PR DESCRIPTION
Signed-off-by: aneessahib <anees.a.sahib@intel.com>

Fixes a Klocwork sighting. The function could return negative incorrectly even when there are no failures due to uninitialized return variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/93)
<!-- Reviewable:end -->
