### PR TITLE
[Pal/Linux-SGX] Map enclave pages with MAP_FIXED_NOREPLACE

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -143,9 +143,9 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
     uint64_t addr = DO_SYSCALL(mmap, request_mmap_addr, request_mmap_size,
                                PROT_NONE, /* newer DCAP driver requires such initial mmap */
 #ifdef SGX_DCAP
-                               MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+                               MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #else
-                               MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
+                               MAP_FIXED_NOREPLACE | MAP_SHARED, g_isgx_device, 0);
 #endif
 
     if (IS_PTR_ERR(addr)) {
@@ -312,7 +312,8 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
     }
 
     /* ask Intel SGX driver to actually mmap the added enclave pages */
-    uint64_t mapped = DO_SYSCALL(mmap, addr, size, prot, MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
+    uint64_t mapped = DO_SYSCALL(mmap, addr, size, prot, MAP_FIXED_NOREPLACE | MAP_SHARED,
+                                 g_isgx_device, 0);
     if (IS_PTR_ERR(mapped)) {
         ret = PTR_TO_ERR(mapped);
         log_error("Cannot map enclave pages %d", ret);


### PR DESCRIPTION
Discussed in #32.

The `mmap()` call should fail if something is mapped in the specified range already.

MAP_FIXED_NOREPLACE is available since Linux 4.17, so we had to wait until we dropped support for Ubuntu 16.04.

## How to test this PR? <!-- (if applicable) -->

Add an overlapping `mmap` to the beginning of main (`sgx_main.c`):

```c
DO_SYSCALL(mmap, (void*)0x1000, 0x1000, 0, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
```

Gramine invocation should fail:

```
error: ECREATE failed in allocating EPC memory: -17
error: Creating enclave failed: -17
error: load_enclave() failed with error -17
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/94)
<!-- Reviewable:end -->
