### PR TITLE
[Pal/Linux] Fix vDSO range retrieval

### DIFF
--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -237,8 +237,8 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
         INIT_FAIL(-ret, "getting vdso and vvar ranges failed");
     }
 
-    if (!g_vdso_start && !g_vdso_end) {
-        /* We did not get vdso address from the auxiliary vector. */
+    if (vdso_start || vdso_end) {
+        /* Override the range retrieved by parsing vdso: the actual mapped range might be bigger. */
         g_vdso_start = vdso_start;
         g_vdso_end = vdso_end;
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This change causes PAL to report the vDSO range based on `/proc/self/maps`, instead of parsing the ELF mapped there and
processing PT_LOAD commands.

On my system, the former method returns 1 page, even though according to `/proc/self/maps` vDSO occupies 2 pages. As a result, under some circumstances (Docker and ASLR disabled) LibOS tries to map memory over vDSO.

## How to test this PR? <!-- (if applicable) -->

I found this while investigating #89, which actually breaks on my system (and this PR fixes it).

(With ASLR disabled, Linux maps vDSO _below_ the range occupied by PAL, so it is part of the "user address range" passed to LibOS. LibOS gets also notified of "preloaded ranges" including vDSO, but the computed length is wrong, so it ends up believing vDSO only occupies one page instead of two).

I also verified this change manually using GDB:

```
$ GDB=1 graphene-direct helloworld
(gdb) break shim_init
(gdb) run
Breakpoint 1, shim_init (argc=39, args=0x7fffa86f95a0) at ../LibOS/shim/src/shim_init.c:374
374	noreturn void* shim_init(int argc, void* args) {

(gdb) info proc mappings
...
      0x7fffa8711000     0x7fffa8713000     0x2000        0x0 [vdso]
...

(gdb) p/x g_vdso_start
$2 = 0x7fffa8711000

(gdb) p/x g_vdso_end
$3 = 0x7fffa8713000
```

Without this PR, `g_vdso_end` is only `0x1000` larger than `g_vdso_start`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/96)
<!-- Reviewable:end -->
