### PR TITLE
[Glibc] Fix the build of Glibc with default prefix `/usr/local`

### DIFF
--- a/subprojects/packagefiles/glibc-2.34/compile.sh
+++ b/subprojects/packagefiles/glibc-2.34/compile.sh
@@ -42,6 +42,7 @@ mkdir -p "$BUILDDIR"
         --with-tls \
         --without-gd \
         --without-selinux \
+        --disable-sanity-checks \
         --disable-test \
         --disable-nscd
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

if Gramine is built with the default prefix `/usr/local`, Glibc requires the option `--disable-sanity-checks` otherwise it complains like this:

"On GNU/Linux systems the GNU C Library should not be installed into /usr/local since this might make your system totally unusable. We strongly advise to use a different prefix."

Note that `--disable-sanity-checks` simply silences this warning -- we actually install Glibc under `gramine/runtime/glibc`.

Fixes #97.

## How to test this PR? <!-- (if applicable) -->

Try to build with default prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/98)
<!-- Reviewable:end -->
