### PR TITLE
[Pal/Linux-SGX] Add `sgx.protected_mr{enclave,signer}_files` manifest options

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -525,7 +525,18 @@ Protected files
 ::
 
     sgx.protected_files_key = "[16-byte hex value]"
+
     sgx.protected_files = [
+      "[URI]",
+      "[URI]",
+    ]
+
+    sgx.protected_mrenclave_files = [
+      "[URI]",
+      "[URI]",
+    ]
+
+    sgx.protected_mrsigner_files = [
       "[URI]",
       "[URI]",
     ]
@@ -554,6 +565,21 @@ be used only for debugging purposes.
    attestation, thus you should not specify the ``sgx.protected_files_key``
    manifest option at all. Instead, use the Secret Provisioning interface (see
    :doc:`attestation`).
+
+There are three types of protected files:
+
+* ``sgx.protected_files`` are encrypted using the wrap (master) encryption key;
+  they are well-suited for input files encrypted by the user and sent to the
+  deployment platform as well as for output files sent back to the user and
+  decrypted at the user side.
+
+* ``sgx.protected_mrenclave_files`` are encrypted using the SGX sealing key
+  based on the MRENCLAVE identity of the enclave; they are useful to allow only
+  the same enclave (on the same platform) to unseal files.
+
+* ``sgx.protected_mrsigner_files`` are encrypted using the SGX sealing key based
+  on the MRSIGNER identity of the enclave; they are useful to allow all enclaves
+  signed with the same key (and on the same platform) to unseal files.
 
 File check policy
 ^^^^^^^^^^^^^^^^^

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -1,3 +1,4 @@
+/*.dat
 /*.manifest
 /*.xml
 
@@ -92,6 +93,8 @@
 /run_test
 /sched
 /sched_set_get_affinity
+/sealed_file
+/sealed_file_mod
 /select
 /send_handle
 /shared_object

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -77,6 +77,8 @@ c_executables = \
 	run_test \
 	sched \
 	sched_set_get_affinity \
+	sealed_file \
+	sealed_file_mod \
 	select \
 	send_handle \
 	shared_object \
@@ -166,10 +168,23 @@ else
 CFLAGS-openmp = -fopenmp
 endif
 
-proc_common: proc_common.o dump.o
+attestation: attestation.c rw_file.c
 	$(call cmd,cmulti)
 
-sysfs_common: sysfs_common.o dump.o
+file_size: file_size.c rw_file.c
+	$(call cmd,cmulti)
+
+proc_common: proc_common.c dump.c
+	$(call cmd,cmulti)
+
+sealed_file: sealed_file.c rw_file.c
+	$(call cmd,cmulti)
+
+CFLAGS-sealed_file_mod += -DMODIFY_MRENCLAVE  # see comment in the test's source
+sealed_file_mod: sealed_file.c rw_file.c
+	$(call cmd,cmulti)
+
+sysfs_common: sysfs_common.c dump.c
 	$(call cmd,cmulti)
 
 %: %.c
@@ -190,6 +205,7 @@ libos-regression.xml: test_libos.py $(call expand_target_to_token,$(target))
 clean-tmp:
 	$(RM) -r \
 		*.cached \
+		*.dat \
 		*.manifest \
 		*.manifest.sgx \
 		*.sig \

--- a/LibOS/shim/test/regression/attestation.c
+++ b/LibOS/shim/test/regression/attestation.c
@@ -13,6 +13,7 @@
 #include "mbedtls/base64.h"
 #include "mbedtls/cmac.h"
 
+#include "rw_file.h"
 #include "sgx_api.h"
 #include "sgx_arch.h"
 #include "sgx_attest.h"
@@ -23,105 +24,8 @@ char user_report_data_str[] = "This is user-provided report data";
 
 enum { SUCCESS = 0, FAILURE = -1 };
 
-ssize_t (*rw_file_f)(const char* path, char* buf, size_t bytes, bool do_write);
-
-static ssize_t rw_file_posix(const char* path, char* buf, size_t bytes, bool do_write) {
-    ssize_t rv = 0;
-    ssize_t ret = 0;
-
-    int fd = open(path, do_write ? O_WRONLY : O_RDONLY);
-    if (fd < 0) {
-        fprintf(stderr, "opening %s failed\n", path);
-        return fd;
-    }
-
-    while (bytes > rv) {
-        if (do_write)
-            ret = write(fd, buf + rv, bytes - rv);
-        else
-            ret = read(fd, buf + rv, bytes - rv);
-
-        if (ret > 0) {
-            rv += ret;
-        } else if (ret == 0) {
-            /* end of file */
-            if (rv == 0)
-                fprintf(stderr, "%s failed: unexpected end of file\n", do_write ? "write" : "read");
-            break;
-        } else {
-            if (ret < 0 && (errno == EAGAIN || errno == EINTR)) {
-                continue;
-            } else {
-                fprintf(stderr, "%s failed: %s\n", do_write ? "write" : "read", strerror(errno));
-                goto out;
-            }
-        }
-    }
-
-out:
-    if (ret < 0) {
-        /* error path */
-        close(fd);
-        return ret;
-    }
-
-    ret = close(fd);
-    if (ret < 0) {
-        fprintf(stderr, "closing %s failed\n", path);
-        return ret;
-    }
-    return rv;
-}
-
-static ssize_t rw_file_stdio(const char* path, char* buf, size_t bytes, bool do_write) {
-    size_t rv = 0;
-    size_t ret = 0;
-
-    FILE* f = fopen(path, do_write ? "wb" : "rb");
-    if (!f) {
-        fprintf(stderr, "opening %s failed\n", path);
-        return -1;
-    }
-
-    while (bytes > rv) {
-        if (do_write)
-            ret = fwrite(buf + rv, /*size=*/1, /*nmemb=*/bytes - rv, f);
-        else
-            ret = fread(buf + rv, /*size=*/1, /*nmemb=*/bytes - rv, f);
-
-        if (ret > 0) {
-            rv += ret;
-        } else {
-            if (feof(f)) {
-                if (rv) {
-                    /* read some bytes from file, success */
-                    break;
-                }
-                assert(rv == 0);
-                fprintf(stderr, "%s failed: unexpected end of file\n", do_write ? "write" : "read");
-                fclose(f);
-                return -1;
-            }
-
-            assert(ferror(f));
-
-            if (errno == EAGAIN || errno == EINTR) {
-                continue;
-            }
-
-            fprintf(stderr, "%s failed: %s\n", do_write ? "write" : "read", strerror(errno));
-            fclose(f);
-            return -1;
-        }
-    }
-
-    int close_ret = fclose(f);
-    if (close_ret) {
-        fprintf(stderr, "closing %s failed\n", path);
-        return -1;
-    }
-    return rv;
-}
+ssize_t (*file_read_f)(const char* path, char* buf, size_t bytes);
+ssize_t (*file_write_f)(const char* path, char* buf, size_t bytes);
 
 /*!
  * \brief Verify the signature on `report`.
@@ -137,7 +41,7 @@ static int verify_report_mac(sgx_report_t* report) {
     /* setup key request structure */
     __sgx_mem_aligned sgx_key_request_t key_request;
     memset(&key_request, 0, sizeof(key_request));
-    key_request.key_name = REPORT_KEY;
+    key_request.key_name = SGX_REPORT_KEY;
     memcpy(&key_request.key_id, &report->key_id, sizeof(key_request.key_id));
 
     /* retrieve key via EGETKEY instruction leaf */
@@ -186,18 +90,17 @@ static int test_local_attestation(void) {
 
     /* 1. read `my_target_info` file */
     sgx_target_info_t target_info;
-    bytes = rw_file_f("/dev/attestation/my_target_info", (char*)&target_info, sizeof(target_info),
-                      /*do_write=*/false);
+    bytes = file_read_f("/dev/attestation/my_target_info", (char*)&target_info,
+                        sizeof(target_info));
     if (bytes != sizeof(target_info)) {
-        /* error is already printed by rw_file_f() */
+        /* error is already printed by file_read_f() */
         return FAILURE;
     }
 
     /* 2. write data from `my_target_info` to `target_info` file */
-    bytes = rw_file_f("/dev/attestation/target_info", (char*)&target_info, sizeof(target_info),
-                      /*do_write=*/true);
+    bytes = file_write_f("/dev/attestation/target_info", (char*)&target_info, sizeof(target_info));
     if (bytes != sizeof(target_info)) {
-        /* error is already printed by rw_file_f() */
+        /* error is already printed by file_write_f() */
         return FAILURE;
     }
 
@@ -208,19 +111,18 @@ static int test_local_attestation(void) {
 
     memcpy((void*)&user_report_data, (void*)user_report_data_str, sizeof(user_report_data_str));
 
-    bytes = rw_file_f("/dev/attestation/user_report_data", (char*)&user_report_data,
-                      sizeof(user_report_data), /*do_write=*/true);
+    bytes = file_write_f("/dev/attestation/user_report_data", (char*)&user_report_data,
+                         sizeof(user_report_data));
     if (bytes != sizeof(user_report_data)) {
-        /* error is already printed by rw_file_f() */
+        /* error is already printed by file_write_f() */
         return FAILURE;
     }
 
     /* 4. read `report` file */
     sgx_report_t report;
-    bytes = rw_file_f("/dev/attestation/report", (char*)&report, sizeof(report),
-                      /*do_write=*/false);
+    bytes = file_read_f("/dev/attestation/report", (char*)&report, sizeof(report));
     if (bytes != sizeof(report)) {
-        /* error is already printed by rw_file_f() */
+        /* error is already printed by file_read_f() */
         return FAILURE;
     }
 
@@ -287,18 +189,17 @@ static int test_quote_interface(void) {
 
     memcpy((void*)&user_report_data, (void*)user_report_data_str, sizeof(user_report_data_str));
 
-    bytes = rw_file_f("/dev/attestation/user_report_data", (char*)&user_report_data,
-                      sizeof(user_report_data), /*do_write=*/true);
+    bytes = file_write_f("/dev/attestation/user_report_data", (char*)&user_report_data,
+                         sizeof(user_report_data));
     if (bytes != sizeof(user_report_data)) {
-        /* error is already printed by rw_file_f() */
+        /* error is already printed by file_write_f() */
         return FAILURE;
     }
 
     /* 2. read `quote` file */
-    bytes = rw_file_f("/dev/attestation/quote", (char*)&g_quote, sizeof(g_quote),
-                      /*do_write=*/false);
+    bytes = file_read_f("/dev/attestation/quote", (char*)&g_quote, sizeof(g_quote));
     if (bytes < 0) {
-        /* error is already printed by rw_file_f() */
+        /* error is already printed by file_read_f() */
         return FAILURE;
     }
 
@@ -327,10 +228,13 @@ static int test_quote_interface(void) {
 }
 
 int main(int argc, char** argv) {
-    rw_file_f = rw_file_posix;
+    file_read_f  = posix_file_read;
+    file_write_f = posix_file_write;
+
     if (argc > 1) {
         /* simple trick to test stdio-style interface to pseudo-files in our tests */
-        rw_file_f = rw_file_stdio;
+        file_read_f  = stdio_file_read;
+        file_write_f = stdio_file_write;
     }
 
     printf("Test local attestation... %s\n",

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -48,3 +48,13 @@ sgx.protected_files_key = "ffeeddccbbaa99887766554433221100"
 sgx.protected_files = [
   "file:tmp/pf/",
 ]
+
+# for sealed_file_mrenclave* tests
+sgx.protected_mrenclave_files = [
+  "file:sealed_file_mrenclave.dat",
+]
+
+# for sealed_file_mrsigner test
+sgx.protected_mrsigner_files = [
+  "file:sealed_file_mrsigner.dat",
+]

--- a/LibOS/shim/test/regression/rw_file.c
+++ b/LibOS/shim/test/regression/rw_file.c
@@ -1,0 +1,161 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
+#include "rw_file.h"
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static ssize_t posix_fd_rw(int fd, char* buf, size_t count, bool do_write) {
+    ssize_t transferred = 0;
+    while (transferred < count) {
+        ssize_t ret = do_write ? write(fd, buf + transferred, count - transferred) :
+                                 read(fd, buf + transferred, count - transferred);
+
+        if (ret < 0) {
+            int ret_errno = errno;
+            if (ret_errno == EINTR)
+                continue;
+            warn("%s", do_write ? "write" : "read");
+            errno = ret_errno;
+            return -1;
+        }
+
+        if (ret == 0) {
+            /* end of file */
+            break;
+        }
+
+        transferred += ret;
+    }
+
+    return transferred;
+}
+
+static ssize_t stdio_fd_rw(FILE* f, char* buf, size_t count, bool do_write) {
+    ssize_t transferred = 0;
+    while (transferred < count) {
+        size_t ret = do_write ? fwrite(buf + transferred, 1, count - transferred, f) :
+                                fread(buf + transferred, 1, count - transferred, f);
+
+        if (ret == 0) {
+            /* end of file or error */
+            if (ferror(f)) {
+                int ret_errno = errno;
+                if (ret_errno == EINTR)
+                    continue;
+                warn("%s", do_write ? "write" : "read");
+                errno = ret_errno;
+                return -1;
+            }
+
+            assert(feof(f));
+            break;
+        }
+
+        transferred += ret;
+    }
+
+    return transferred;
+}
+
+static ssize_t posix_file_rw(const char* path, char* buf, size_t count, bool do_write) {
+    int fd = open(path, do_write ? O_WRONLY : O_RDONLY);
+    if (fd < 0) {
+        int ret_errno = errno;
+        warn("open");
+        errno = ret_errno;
+        return -1;
+    }
+
+    ssize_t transferred = posix_fd_rw(fd, buf, count, do_write);
+    if (transferred < 0) {
+        int ret_errno = errno;
+        int close_ret = close(fd);
+        if (close_ret < 0)
+            warn("close (during error handling)");
+        errno = ret_errno;
+        return -1;
+    }
+
+    int close_ret = close(fd);
+    if (close_ret < 0) {
+        int ret_errno = errno;
+        warn("close");
+        errno = ret_errno;
+        return -1;
+    }
+
+    return transferred;
+}
+
+static ssize_t stdio_file_rw(const char* path, char* buf, size_t count, bool do_write) {
+    FILE* f = fopen(path, do_write ? "w" : "r");
+    if (!f) {
+        int ret_errno = errno;
+        warn("open");
+        errno = ret_errno;
+        return -1;
+    }
+
+    ssize_t transferred = stdio_fd_rw(f, buf, count, do_write);
+    if (transferred < 0) {
+        int ret_errno = errno;
+        int close_ret = fclose(f);
+        if (close_ret < 0)
+            warn("close (during error handling)");
+        errno = ret_errno;
+        return -1;
+    }
+
+    int close_ret = fclose(f);
+    if (close_ret < 0) {
+        int ret_errno = errno;
+        warn("close");
+        errno = ret_errno;
+        return -1;
+    }
+
+    return transferred;
+}
+
+
+ssize_t posix_file_read(const char* path, char* buf, size_t count) {
+    return posix_file_rw(path, buf, count, /*do_write=*/false);
+}
+
+ssize_t posix_file_write(const char* path, char* buf, size_t count) {
+    return posix_file_rw(path, buf, count, /*do_write=*/true);
+}
+
+
+ssize_t stdio_file_read(const char* path, char* buf, size_t count) {
+    return stdio_file_rw(path, buf, count, /*do_write=*/false);
+}
+
+ssize_t stdio_file_write(const char* path, char* buf, size_t count) {
+    return stdio_file_rw(path, buf, count, /*do_write=*/true);
+}
+
+ssize_t posix_fd_read(int fd, char* buf, size_t count) {
+    return posix_fd_rw(fd, buf, count, /*do_write=*/false);
+}
+
+ssize_t posix_fd_write(int fd, char* buf, size_t count) {
+    return posix_fd_rw(fd, buf, count, /*do_write=*/true);
+}
+
+ssize_t stdio_fd_read(FILE* f, char* buf, size_t count) {
+    return stdio_fd_rw(f, buf, count, /*do_write=*/false);
+}
+
+ssize_t stdio_fd_write(FILE* f, char* buf, size_t count) {
+    return stdio_fd_rw(f, buf, count, /*do_write=*/true);
+}

--- a/LibOS/shim/test/regression/rw_file.h
+++ b/LibOS/shim/test/regression/rw_file.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
+#ifndef RW_FILE_H_
+#define RW_FILE_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+/* All functions below return the number of bytes read/written on success or -1 (with set errno) on
+ * failure. All functions restart read/write syscall in case of EINTR. */
+
+/* Opens file `path`, reads/writes at most `count` bytes into/from buffer `buf` and closes the
+ * file. Uses POSIX functions: open, read/write, close. */
+ssize_t posix_file_read(const char* path, char* buf, size_t count);
+ssize_t posix_file_write(const char* path, char* buf, size_t count);
+
+/* Opens file `path`, reads/writes at most `count` bytes into/from buffer `buf` and closes the
+ * file. Uses stdio functions: fopen, fread/fwrite, fclose. */
+ssize_t stdio_file_read(const char* path, char* buf, size_t count);
+ssize_t stdio_file_write(const char* path, char* buf, size_t count);
+
+/* Reads/writes at most `count` bytes into/from buffer `buf`. Uses POSIX functions: read/write. */
+ssize_t posix_fd_read(int fd, char* buf, size_t count);
+ssize_t posix_fd_write(int fd, char* buf, size_t count);
+
+/* Reads/writes at most `count` bytes into/from buffer `buf`. Uses stdio functions: fread/fwrite. */
+ssize_t stdio_fd_read(FILE* f, char* buf, size_t count);
+ssize_t stdio_fd_write(FILE* f, char* buf, size_t count);
+
+#endif /* RW_FILE_H_ */

--- a/LibOS/shim/test/regression/sealed_file.c
+++ b/LibOS/shim/test/regression/sealed_file.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "rw_file.h"
+
+#define SECRETSTRING "Secret string\n"
+#define SECRETSTRING_LEN (sizeof(SECRETSTRING) - 1)
+
+int main(int argc, char** argv) {
+    int ret;
+    ssize_t bytes;
+
+    if (argc != 2)
+        errx(EXIT_FAILURE, "Usage: %s <protected file to create/validate>", argv[0]);
+
+    ret = access(argv[1], F_OK);
+    if (ret < 0) {
+        if (errno == ENOENT) {
+            /* file is not yet created, create with secret string */
+            bytes = stdio_file_write(argv[1], SECRETSTRING, SECRETSTRING_LEN);
+            if (bytes < 0) {
+                /* error is already printed by stdio_file_write() */
+                return EXIT_FAILURE;
+            }
+
+            if (bytes != SECRETSTRING_LEN)
+                errx(EXIT_FAILURE, "Wrote %ld instead of expected %ld", bytes, SECRETSTRING_LEN);
+
+            printf("CREATION OK\n");
+            return 0;
+        }
+        err(EXIT_FAILURE, "access failed");
+    }
+
+    char buf[SECRETSTRING_LEN];
+    bytes = stdio_file_read(argv[1], buf, sizeof(buf));
+    if (bytes < 0) {
+        /* error is already printed by stdio_file_read() */
+        return EXIT_FAILURE;
+    }
+
+    if (bytes != SECRETSTRING_LEN)
+        errx(EXIT_FAILURE, "Read %ld instead of expected %ld", bytes, SECRETSTRING_LEN);
+
+    if (memcmp(SECRETSTRING, buf, SECRETSTRING_LEN))
+        errx(EXIT_FAILURE, "Read wrong content (expected '%s')\n", SECRETSTRING);
+
+#ifdef MODIFY_MRENCLAVE
+    /* The build system adds MODIFE_MRENCLAVE macro to produce a slightly different executable (due
+     * to the below different string), which in turn produces a different MRENCLAVE SGX measurement.
+     * This trick is to test `protected_mrsigner_files` functionality. */
+    printf("READING FROM MODIFIED ENCLAVE OK\n");
+#else
+    printf("READING OK\n");
+#endif
+    return 0;
+}

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -14,6 +14,14 @@
 #include "spinlock.h"
 #include "toml.h"
 
+/* SGX-specific keys for protected files, used for SGX sealing. The former key is bound to the
+ * MRENCLAVE measurement of the SGX enclave (only the same enclave can unseal secrets). The latter
+ * key is bound to the MRSIGNER measurement (all enclaves from the same signer can unseal secrets).
+ * We don't use synchronization on them since they are only set during initialization where Gramine
+ * runs single-threaded. */
+pf_key_t g_pf_mrenclave_key = {0};
+pf_key_t g_pf_mrsigner_key = {0};
+
 /* Wrap key for protected files, either hard-coded in manifest, provisioned during attestation, or
  * inherited from the parent process. We don't use synchronization on them since they are only set
  * during initialization where Gramine runs single-threaded. */
@@ -222,7 +230,8 @@ out:
     return ret;
 }
 
-static int register_protected_path(const char* path, struct protected_file** new_pf);
+static int register_protected_path(const char* path, enum pf_key_type key_type,
+                                   struct protected_file** new_pf);
 
 /* Return a registered PF that matches specified path
    (or the path that is contained in a registered PF directory) */
@@ -235,7 +244,7 @@ struct protected_file* get_protected_file(const char* path) {
     if (pf) {
         /* path not registered but matches registered dir */
         log_debug("get_pf: registering new PF '%s' in dir '%s'", path, pf->path);
-        int ret = register_protected_path(path, &pf);
+        int ret = register_protected_path(path, pf->key_type, &pf);
         __UNUSED(ret);
         assert(ret == 0);
         /* return newly registered PF */
@@ -281,7 +290,7 @@ out:
 }
 
 /* Register all files from the given directory recursively */
-static int register_protected_dir(const char* path) {
+static int register_protected_dir(const char* path, enum pf_key_type key_type) {
     int fd = -1;
     int ret = -PAL_ERROR_NOMEM;
     size_t bufsize = 1024;
@@ -325,7 +334,7 @@ static int register_protected_dir(const char* path) {
                 goto out;
 
             snprintf(sub_path, sub_path_size, URI_PREFIX_FILE "%s/%s", path, dir->d_name);
-            ret = register_protected_path(sub_path, NULL);
+            ret = register_protected_path(sub_path, key_type, NULL);
             if (ret != 0) {
                 free(sub_path);
                 goto out;
@@ -345,7 +354,8 @@ out:
 }
 
 /* Register a single PF (if it's a directory, recursively) */
-static int register_protected_path(const char* path, struct protected_file** new_pf) {
+static int register_protected_path(const char* path, enum pf_key_type key_type,
+                                   struct protected_file** new_pf) {
     int ret = -PAL_ERROR_NOMEM;
     struct protected_file* new = NULL;
 
@@ -378,6 +388,8 @@ static int register_protected_path(const char* path, struct protected_file** new
         goto out;
     }
 
+    new->key_type = key_type;
+
     new->path_len = strlen(path);
     /* This is never freed but so isn't the whole struct, PFs persist for the whole lifetime
        of the process. */
@@ -399,7 +411,7 @@ static int register_protected_path(const char* path, struct protected_file** new
     log_debug("register_protected_path: [%s] %s = %p", is_dir ? "dir" : "file", path, new);
 
     if (is_dir)
-        register_protected_dir(path);
+        register_protected_dir(path, key_type);
 
     pf_lock();
 
@@ -425,13 +437,29 @@ out:
     return ret;
 }
 
-static int register_protected_files_from_toml_table(void) {
+static const char* toml_table_name_from_key_type(enum pf_key_type key_type) {
+    assert(key_type == PROTECTED_FILE_KEY_WRAP || key_type == PROTECTED_FILE_KEY_MRENCLAVE ||
+           key_type == PROTECTED_FILE_KEY_MRSIGNER);
+    switch (key_type) {
+        case PROTECTED_FILE_KEY_WRAP:
+            return "protected_files";
+        case PROTECTED_FILE_KEY_MRENCLAVE:
+            return "protected_mrenclave_files";
+        case PROTECTED_FILE_KEY_MRSIGNER:
+            return "protected_mrsigner_files";
+    }
+    return NULL; /* unreachable */
+}
+
+static int register_protected_files_from_toml_table(enum pf_key_type key_type) {
     int ret;
     toml_table_t* manifest_sgx = toml_table_in(g_pal_state.manifest_root, "sgx");
     if (!manifest_sgx)
         return 0;
 
-    toml_table_t* toml_pfs = toml_table_in(manifest_sgx, "protected_files");
+    const char* table_name = toml_table_name_from_key_type(key_type);
+
+    toml_table_t* toml_pfs = toml_table_in(manifest_sgx, table_name);
     if (!toml_pfs)
         return 0;
 
@@ -467,7 +495,7 @@ static int register_protected_files_from_toml_table(void) {
             goto out;
         }
 
-        ret = register_protected_path(toml_pf_str, NULL);
+        ret = register_protected_path(toml_pf_str, key_type, NULL);
         if (ret < 0)
             goto out;
 
@@ -484,13 +512,15 @@ out:
     return ret;
 }
 
-static int register_protected_files_from_toml_array(void) {
+static int register_protected_files_from_toml_array(enum pf_key_type key_type) {
     int ret;
     toml_table_t* manifest_sgx = toml_table_in(g_pal_state.manifest_root, "sgx");
     if (!manifest_sgx)
         return 0;
 
-    toml_array_t* toml_pfs = toml_array_in(manifest_sgx, "protected_files");
+    const char* table_name = toml_table_name_from_key_type(key_type);
+
+    toml_array_t* toml_pfs = toml_array_in(manifest_sgx, table_name);
     if (!toml_pfs)
         return 0;
 
@@ -523,7 +553,7 @@ static int register_protected_files_from_toml_array(void) {
             goto out;
         }
 
-        ret = register_protected_path(toml_pf_str, NULL);
+        ret = register_protected_path(toml_pf_str, key_type, NULL);
         if (ret < 0)
             goto out;
 
@@ -537,11 +567,11 @@ out:
     return ret;
 }
 
-static int register_protected_files(void) {
+static int register_protected_files(enum pf_key_type key_type) {
     int ret;
 
     /* first try legacy manifest syntax with TOML tables, i.e. `sgx.protected_files.key = "file"` */
-    ret = register_protected_files_from_toml_table();
+    ret = register_protected_files_from_toml_table(key_type);
     if (ret < 0) {
         log_error("Reading protected files (in TOML-table syntax) from the manifest failed: %s",
                   pal_strerror(ret));
@@ -549,7 +579,7 @@ static int register_protected_files(void) {
     }
 
     /* use new manifest syntax with TOML arrays, i.e. `sgx.protected_files = ["file1", ..]` */
-    ret = register_protected_files_from_toml_array();
+    ret = register_protected_files_from_toml_array(key_type);
     if (ret < 0) {
         log_error("Reading protected files (in TOML-array syntax) from the manifest failed: %s",
                   pal_strerror(ret));
@@ -571,6 +601,18 @@ int init_protected_files(void) {
 
     pf_set_callbacks(cb_read, cb_write, cb_truncate, cb_aes_cmac, cb_aes_gcm_encrypt,
                      cb_aes_gcm_decrypt, cb_random, debug_callback);
+
+    ret = sgx_get_seal_key(SGX_KEYPOLICY_MRENCLAVE, &g_pf_mrenclave_key);
+    if (ret < 0) {
+        log_error("Cannot obtain MRENCLAVE-bound protected files key");
+        return ret;
+    }
+
+    ret = sgx_get_seal_key(SGX_KEYPOLICY_MRSIGNER, &g_pf_mrsigner_key);
+    if (ret < 0) {
+        log_error("Cannot obtain MRSIGNER-bound protected files key");
+        return ret;
+    }
 
     /* if wrap key is not hard-coded in the manifest, assume that it was received from parent or
      * it will be provisioned after local/remote attestation; otherwise read it from manifest */
@@ -604,8 +646,22 @@ int init_protected_files(void) {
         g_pf_wrap_key_set = true;
     }
 
-    if (register_protected_files() < 0) {
+    ret = register_protected_files(PROTECTED_FILE_KEY_WRAP);
+    if (ret < 0) {
         log_error("Malformed protected files found in manifest");
+        return ret;
+    }
+
+    ret = register_protected_files(PROTECTED_FILE_KEY_MRENCLAVE);
+    if (ret < 0) {
+        log_error("Malformed MRENCLAVE-bound protected files found in manifest");
+        return ret;
+    }
+
+    ret = register_protected_files(PROTECTED_FILE_KEY_MRSIGNER);
+    if (ret < 0) {
+        log_error("Malformed MRSIGNER-bound protected files found in manifest");
+        return ret;
     }
 
     return 0;
@@ -614,13 +670,28 @@ int init_protected_files(void) {
 /* Open/create a PF */
 static int open_protected_file(const char* path, struct protected_file* pf, pf_handle_t handle,
                                uint64_t size, pf_file_mode_t mode, bool create) {
-    if (!g_pf_wrap_key_set) {
-        log_error("pf_open(%d, %s) failed: wrap key was not provided", *(int*)handle, path);
-        return -PAL_ERROR_DENIED;
+    pf_key_t* pf_key = NULL;
+    switch (pf->key_type) {
+        case PROTECTED_FILE_KEY_WRAP:
+            if (!g_pf_wrap_key_set) {
+                log_error("pf_open failed: wrap key was not provided");
+                return -PAL_ERROR_DENIED;
+            }
+            pf_key = &g_pf_wrap_key;
+            break;
+        case PROTECTED_FILE_KEY_MRENCLAVE:
+            pf_key = &g_pf_mrenclave_key;
+            break;
+        case PROTECTED_FILE_KEY_MRSIGNER:
+            pf_key = &g_pf_mrsigner_key;
+            break;
+        default:
+            log_error("Invalid key type when opening a protected file!");
+            return -PAL_ERROR_DENIED;
     }
 
     pf_status_t pfs;
-    pfs = pf_open(handle, path, size, mode, create, &g_pf_wrap_key, &pf->context);
+    pfs = pf_open(handle, path, size, mode, create, pf_key, &pf->context);
     if (PF_FAILURE(pfs)) {
         log_warning("pf_open(%d, %s) failed: %s", *(int*)handle, path, pf_strerror(pfs));
         return -PAL_ERROR_DENIED;

--- a/Pal/src/host/Linux-SGX/enclave_pf.h
+++ b/Pal/src/host/Linux-SGX/enclave_pf.h
@@ -44,6 +44,12 @@ DEFINE_LISTP(pf_map);
 /* List of PF map buffers; this list is traversed on PF flush (on file close) */
 extern LISTP_TYPE(pf_map) g_pf_map_list;
 
+enum pf_key_type {
+    PROTECTED_FILE_KEY_WRAP,
+    PROTECTED_FILE_KEY_MRENCLAVE,
+    PROTECTED_FILE_KEY_MRSIGNER,
+};
+
 /* Data of a protected file */
 struct protected_file {
     UT_hash_handle hh;
@@ -52,6 +58,7 @@ struct protected_file {
     pf_context_t* context; /* NULL until PF is opened */
     int64_t refcount; /* used for deciding when to call unload_protected_file() */
     int writable_fd; /* fd of underlying file for writable PF, -1 if no writable handles are open */
+    enum pf_key_type key_type;
 };
 
 /* Take ownership of the global PF lock */

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -125,6 +125,18 @@ int sgx_get_report(const sgx_target_info_t* target_info, const sgx_report_data_t
                    sgx_report_t* report);
 
 /*!
+ * \brief Obtain an enclave/signer-bound key via EGETKEY(SGX_SEAL_KEY) for secret migration/sealing
+ * of files.
+ *
+ * \param[in]  key_policy  Must be SGX_KEYPOLICY_MRENCLAVE or SGX_KEYPOLICY_MRSIGNER. Binds the
+ *                         sealing key to MRENCLAVE (only the same enclave can unseal secrets) or
+ *                         to MRSIGNER (all enclaves from the same signer can unseal secrets).
+ * \param[out] seal_key    Output buffer to store the sealing key.
+ * \return 0 on success, negative error code otherwise.
+ */
+int sgx_get_seal_key(uint16_t key_policy, sgx_key_128bit_t* seal_key);
+
+/*!
  * \brief Verify the peer enclave during SGX local attestation.
  *
  * Verifies that the SGX information of the peer enclave is the same as ours (all Gramine enclaves

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -27,6 +27,8 @@ typedef uint8_t pf_mac_t[PF_MAC_SIZE];
 typedef uint8_t pf_key_t[PF_KEY_SIZE];
 typedef uint8_t pf_keyid_t[32]; /* key derivation material */
 
+extern pf_key_t g_pf_mrenclave_key;
+extern pf_key_t g_pf_mrsigner_key;
 extern pf_key_t g_pf_wrap_key;
 extern bool g_pf_wrap_key_set;
 

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -419,14 +419,16 @@ typedef uint8_t sgx_key_128bit_t[16];
 #define EGETKEY 1
 #define EEXIT   4
 
-#define LAUNCH_KEY         0
-#define PROVISION_KEY      1
-#define PROVISION_SEAL_KEY 2
-#define REPORT_KEY         3
-#define SEAL_KEY           4
+#define SGX_LAUNCH_KEY         0
+#define SGX_PROVISION_KEY      1
+#define SGX_PROVISION_SEAL_KEY 2
+#define SGX_REPORT_KEY         3
+#define SGX_SEAL_KEY           4
 
-#define KEYPOLICY_MRENCLAVE 1
-#define KEYPOLICY_MRSIGNER  2
+/* KEYREQUEST.KEYPOLICY field is a 16-bit bitmask, currently we use only bits 0 (use MRENCLAVE
+ * measurement) and 1 (use MRSIGNER measurement) */
+#define SGX_KEYPOLICY_MRENCLAVE 0x1
+#define SGX_KEYPOLICY_MRSIGNER  0x2
 
 #define XSAVE_SIZE 512
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, only `sgx.protected_files` were available in the manifest. This kind of protected files needs a provisioned master (wrap) key. But sometimes it is enough to seal files on the same platform for later usage by the same enclave or by enclaves of the same signer: this is the SGX sealing feature.

This commit adds two more options to support SGX sealing: `sgx.protected_mrenclave_files` and `sgx.protected_mrsigner_files`.
Similarly to `sgx.protected_files`, these new options specify lists of files that are encrypted by the SGX key generated via SGX instruction `EGETKEY(SEAL_KEY)`, bound to the MRENCLAVE/MRSIGNER enclave measurement (so that only instances of the same enclave/only enclaves with the same signer may decrypt protected files).

References:
- https://github.com/gramineproject/graphene/pull/2484 -- same PR from the old repo (note that this current PR is slightly updated wrt to that old PR)
- Section 37.18 of the Intel SDM
- https://github.com/gramineproject/gramine/blob/5c505d44ab6ffa6d303cde51b4ccf922c3eaab88/Pal/src/host/Linux-SGX/sgx_arch.h#L395

## How to test this PR? <!-- (if applicable) -->

A corresponding LibOS test is added and documentation is updated to reflect this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/101)
<!-- Reviewable:end -->
