### PR TITLE
[Pal/Linux-SGX] Add uniform message on using insecure manifest options

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,8 @@ https://groups.google.com/g/gramine-users
 Please verify that your change doesn't introduce any insecure-by-default
 functionality. If an option allows users to introduce a security risk, the
 option should have a name prefixed with ``insecure__`` and be disabled by
-default.
+default. All new insecure options must be added to the Linux-SGX PAL function
+``print_warnings_on_insecure_configs()``.
 
 Simple bugfixes need not have advance discussion, but we welcome queries from
 newcomers.

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -467,13 +467,7 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
                                              "(the value must be `true` or `false`)");
     }
 
-    if (use_cmdline_argv) {
-        /* Warn only in the first process. */
-        if (!parent_process) {
-            log_error("Using insecure argv source. Gramine will continue application execution, "
-                      "but this configuration must not be used in production!");
-        }
-    } else {
+    if (!use_cmdline_argv) {
         char* argv_src_file = NULL;
 
         ret = toml_string_in(g_pal_state.manifest_root, "loader.argv_src_file", &argv_src_file);
@@ -507,15 +501,6 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     if (ret < 0) {
         INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot parse 'loader.insecure__use_host_env' "
                                              "(the value must be `true` or `false`)");
-    }
-
-    if (use_host_env) {
-        /* Warn only in the first process. */
-        if (!parent_process) {
-            log_error("Forwarding host environment variables to the app is enabled. Gramine will "
-                      "continue application execution, but this configuration must not be used in "
-                      "production!");
-        }
     }
 
     char* env_src_file = NULL;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -20,6 +20,7 @@
 
 void* g_enclave_base;
 void* g_enclave_top;
+bool g_allowed_files_warn = false;
 
 static int register_file(const char* uri, const char* checksum_str, bool check_duplicates);
 
@@ -760,13 +761,8 @@ out:
 }
 
 static void maybe_warn_about_allowed_files_usage(void) {
-    static bool g_allowed_files_warned = false;
-
-    if (!g_pal_state.parent_process && !g_allowed_files_warned) {
-        log_always("WARNING! \"allowed_files\" is an insecure feature designed for debugging and "
-                   "prototyping, it must never be used in production!");
-        g_allowed_files_warned = true;
-    }
+    if (!g_pal_state.parent_process)
+        g_allowed_files_warn = true;
 }
 
 static int init_allowed_files_from_toml_table(void) {


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, all insecure-manifest-option messages were scattered. Some insecure manifest options were not warned about at all (e.g. `sgx.debug`). This commit adds a uniform message with all insecure manifest options detected, and only prints this message for the SGX PAL.

## How to test this PR? <!-- (if applicable) -->

Run smth manually. E.g.:
```
$ gramine-sgx ./helloworld
---------------------------------------------------------------------------------------------------
Gramine detected the following insecure configurations:

    - sgx.debug = true                             (this is a debug enclave)
    - loader.insecure__use_cmdline_argv = true     (forwarding command-line args to the app)
    - sys.insecure__allow_eventfd = true           (host-based eventfd is enabled)
    - sgx.allowed_files = [ ... ]                  (some files allowed for unrestricted access)

Gramine will continue application execution, but this configuration must not be used in production!
---------------------------------------------------------------------------------------------------

Hello world!
```

Note that the non-SGX version doesn't print warnings anymore (which I consider correct behavior):
```
$ gramine-direct ./helloworld
Hello world!
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/103)
<!-- Reviewable:end -->
