### PR TITLE
Change the default from `sgx.debug = true` to `sgx.debug = false`

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -26,6 +26,7 @@ fs.mount.bin.type = "chroot"
 fs.mount.bin.path = "{{ execdir }}"
 fs.mount.bin.uri = "file:{{ execdir }}"
 
+sgx.debug = true
 sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -34,6 +34,7 @@ fs.mount.blender.type = "chroot"
 fs.mount.blender.path = "/blender"
 fs.mount.blender.uri = "file:{{ blender_dir }}"
 
+sgx.debug = true
 sgx.nonpie_binary = true
 sys.stack.size = "8M"
 sgx.enclave_size = "2048M"

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -25,6 +25,8 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
+
 sgx.trusted_files = [
   "file:busybox",
   "file:{{ gramine.runtimedir() }}/",

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -30,6 +30,7 @@ fs.mount.var_tmp.type = "tmpfs"
 fs.mount.var_tmp.path = "/var/tmp"
 fs.mount.var_tmp.uri = "file:dummy-unused-by-tmpfs-uri"
 
+sgx.debug = true
 sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 3

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -26,6 +26,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.nonpie_binary = true
 sgx.thread_num = 16
 

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -34,6 +34,7 @@ fs.mount.cwd.type = "chroot"
 fs.mount.cwd.path = "{{ install_dir_abspath }}"
 fs.mount.cwd.uri = "file:{{ install_dir }}"
 
+sgx.debug = true
 sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -38,6 +38,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sys.stack.size = "2M"

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -27,6 +27,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.remote_attestation = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -26,6 +26,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -24,6 +24,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -28,6 +28,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -29,6 +29,7 @@ fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"
 
+sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -69,6 +69,11 @@ fs.mount.etc.uri = "file:/etc"
 
 ############################### SGX: GENERAL ##################################
 
+# Create a debug SGX enclave (with SIGSTRUCT.ATTRIBUTES.DEBUG bit set to 1).
+# This allows to debug Gramine with the application using GDB, read perf
+# counters and enable SGX statistics. Note that this option is *insecure*!
+sgx.debug = true
+
 # Set enclave size (somewhat arbitrarily) to 1024MB. Recall that SGX v1 requires
 # to specify enclave size at enclave creation time. If Redis exhausts these
 # 1024MB then it will start failing with random errors. Greater enclave sizes

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -23,6 +23,7 @@ fs.mount.sqlite3.type = "chroot"
 fs.mount.sqlite3.path = "{{ execdir }}/sqlite3"
 fs.mount.sqlite3.uri = "file:{{ execdir }}/sqlite3"
 
+sgx.debug = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -367,7 +367,7 @@ Debug/production enclave
 ::
 
     sgx.debug = [true|false]
-    (Default: true)
+    (Default: false)
 
 This syntax specifies whether the enclave can be debugged. Set it to ``true``
 for a |~| debug enclave and to ``false`` for a |~| production enclave.

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -28,6 +28,7 @@ fs.mount.tmpfs.path = "/mnt-tmpfs"
 fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 sgx.thread_num = 16
 
 sgx.allowed_files = [

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -29,6 +29,7 @@ fs.mount.tmp.uri = "file:/tmp"
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.allowed_files = [
   "file:/tmp",

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -10,6 +10,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.allowed_files = [
   "file:argv_test_input",

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -14,6 +14,7 @@ fs.mount.bin.path = "/bin"
 fs.mount.bin.uri = "file:/bin"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 sgx.remote_attestation = true
 
 sgx.ra_client_spid = "{{ ra_client_spid }}"

--- a/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
+++ b/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
@@ -20,6 +20,7 @@ fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
 
 sgx.thread_num = 8
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/debug_log_file.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_file.manifest.template
@@ -11,6 +11,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/debug_log_inline.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest.template
@@ -10,6 +10,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/device_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/device_passthrough.manifest.template
@@ -12,6 +12,7 @@ fs.mount.dev.path = "/dev/host-zero"
 fs.mount.dev.uri = "dev:/dev/zero"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -9,6 +9,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 # this tests the old syntax for allowed_files (TOML table)
 sgx.allowed_files.env = "file:env_test_input"

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -10,6 +10,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/env_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/env_passthrough.manifest.template
@@ -15,6 +15,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -10,6 +10,8 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
+
 sgx.file_check_policy = "allow_all_but_log"
 
 sgx.trusted_files = [

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -10,6 +10,8 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
+
 sgx.file_check_policy = "strict"
 
 sgx.trusted_files = [

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -13,6 +13,7 @@ fs.mount.gramine_lib.path = "/lib"
 fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -14,6 +14,7 @@ fs.mount.test.path = "/test"
 fs.mount.test.uri = "file:I_DONT_EXIST"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -9,6 +9,7 @@ fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 # this is an impossible combination of options, LibOS must fail very early in init process
 sgx.enclave_size = "256M"

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -14,6 +14,7 @@ fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
 sgx.enclave_size = "8G"
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.allowed_files = [
   "file:testfile",

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -28,6 +28,7 @@ fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
 
 sgx.thread_num = 16
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.allowed_files = [
   "file:tmp/",

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -11,6 +11,7 @@ fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 sgx.thread_num = 8
 
 sgx.nonpie_binary = true
+sgx.debug = true
 sgx.enable_stats = true
 
 sgx.trusted_files = [

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -12,6 +12,7 @@ sgx.thread_num = 8
 sgx.rpc_thread_num = 8
 
 sgx.nonpie_binary = true
+sgx.debug = true
 sgx.enable_stats = true
 
 sgx.trusted_files = [

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -27,6 +27,7 @@ fs.mount.usrlib.uri = "file:/usr/{{ arch_libdir }}"
 
 sgx.thread_num = 32
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",

--- a/Pal/regression/Bootstrap3.manifest
+++ b/Pal/regression/Bootstrap3.manifest
@@ -5,3 +5,4 @@ loader.argv0_override = "Bootstrap3"
 
 sgx.trusted_files.entrypoint = "file:Bootstrap3"
 sgx.nonpie_binary = true
+sgx.debug = true

--- a/Pal/regression/Bootstrap6.manifest
+++ b/Pal/regression/Bootstrap6.manifest
@@ -7,5 +7,6 @@ fs.mount.root.uri = "file:"
 
 sgx.enclave_size = "8192M"
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files.entrypoint = "file:Bootstrap"

--- a/Pal/regression/Bootstrap7.manifest
+++ b/Pal/regression/Bootstrap7.manifest
@@ -3,6 +3,7 @@ loader.argv0_override = "Bootstrap7"
 
 sgx.trusted_files.entrypoint = "file:Bootstrap7"
 sgx.nonpie_binary = true
+sgx.debug = true
 
 loader.env.key1 = "na"
 loader.env.key2 = "na"

--- a/Pal/regression/File.manifest
+++ b/Pal/regression/File.manifest
@@ -5,6 +5,7 @@ loader.log_level = "debug"
 fs.mount.root.uri = "file:"
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.allowed_files.tmp1 = "file:File"
 sgx.allowed_files.tmp2 = "file:../regression/File"

--- a/Pal/regression/Process3.manifest
+++ b/Pal/regression/Process3.manifest
@@ -4,5 +4,6 @@ loader.preload = "file:Preload1.so,file:Preload2.so"
 loader.insecure__use_cmdline_argv = true
 
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files.entrypoint = "file:Process3"

--- a/Pal/regression/Thread2.manifest
+++ b/Pal/regression/Thread2.manifest
@@ -4,5 +4,6 @@ loader.argv0_override = "Thread2"
 sgx.thread_num = 2
 sgx.enable_stats = true
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files.entrypoint = "file:Thread2"

--- a/Pal/regression/Thread2_exitless.manifest
+++ b/Pal/regression/Thread2_exitless.manifest
@@ -5,5 +5,6 @@ sgx.thread_num = 2
 sgx.rpc_thread_num = 2
 sgx.enable_stats = true
 sgx.nonpie_binary = true
+sgx.debug = true
 
 sgx.trusted_files.entrypoint = "file:Thread2"

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -2,6 +2,8 @@ pal.entrypoint = "file:{{ entrypoint }}"
 loader.log_level = "debug"
 loader.insecure__use_cmdline_argv = true
 
+sgx.debug = true
+
 # PAL tests use `DkVirtualMemoryAlloc(PAL_ALLOC_INTERNAL)` which must allocate in the PAL-internal
 # part of the Gramine memory
 loader.pal_internal_mem_size = "64M"

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -701,7 +701,7 @@ def read_manifest(path):
     sgx.setdefault('isvprodid', 0)
     sgx.setdefault('isvsvn', 0)
     sgx.setdefault('remote_attestation', False)
-    sgx.setdefault('debug', True)
+    sgx.setdefault('debug', False)
     sgx.setdefault('require_avx', False)
     sgx.setdefault('require_avx512', False)
     sgx.setdefault('require_mpx', False)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

From now on, Gramine creates manifest files with `sgx.debug = false` by default, i.e., Gramine creates production enclaves by default.

All tests and examples that we frequently use for debugging are augmented with `sgx.debug = true` for ease of debugging.

## How to test this PR? <!-- (if applicable) -->

All tests should still pass (some tests explicitly depend on `sgx.debug = true`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/105)
<!-- Reviewable:end -->
