### PR TITLE
[Pal/Linux-SGX] Detect signal stack overflow in "enclave_entry.S"

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -384,6 +384,16 @@ enclave_entry:
 	addq $STACK_FRAME_SUB, %rax
 	subq %rax, %rsi
 
+	# Disallow too many nested exceptions. In normal Gramine flow, this should never happen.
+	# Since addresses need to be canonical, this addition does not overflow.
+	movq %gs:SGX_SIG_STACK_HIGH, %rax
+	addq %gs:SGX_SIG_STACK_LOW, %rax
+	shrq $1, %rax
+	cmp %rax, %rsi
+	jae .Lno_signal_stack_overflow
+	FAIL_LOOP
+.Lno_signal_stack_overflow:
+
 	# Align xsave area to 64 bytes after sgx_cpu_context_t
 	andq $~(PAL_XSTATE_ALIGN - 1), %rsi
 	subq $SGX_CPU_CONTEXT_XSTATE_ALIGN_SUB, %rsi


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Creating a frame with CPU context on signal stack when handling an exception was done without any bound checks. Malicious host could generate any amount of signals and cause these frames to overflow the stack. This commit fixes it by adding bound checks, effectively disallowing more than ~9 nested exceptions (which should be more than enough in normal case).

## How to test this PR? <!-- (if applicable) -->
Try running in Gramine with SGX:
```c
#define _GNU_SOURCE
#include <err.h>
#include <sched.h>

int main(void) {
     while (1) {
         if (sched_yield() < 0) {
             err(1, "sched_yield");
         }
     }
}
```
and concurrently `timeout 4 bash -c 'while true; do kill -SIGCONT pid_of_above_program; done'`. This will cause weird behavior on the current master (most likely a crash) and with this PR the process will hang in newly added `FAIL_LOOP`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/108)
<!-- Reviewable:end -->
