### PR TITLE
[LibOS] Make `get_new_id` immediately move ID ownership if needed

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -143,14 +143,15 @@ static inline bool is_internal(struct shim_thread* thread) {
 /*!
  * \brief Allocates new ID
  *
- * \param remove_from_owned if `true`, ID is removed from owned and locally tracked IDs
+ * \param move_ownership_to VMID of the process to pass ownership of ID to; if set, ID is removed
+ *                          from owned and locally tracked IDs
  *
  * \returns new ID on success, `0` on failure (`0` is an invalid ID)
  *
- * If \p remove_from_owned is `true`, the returned ID cannot be freed with #release_id since it's
- * no longer locally tracked. You probably want to call #ipc_change_id_owner afterwards.
+ * If \p move_ownership_to is set, the returned ID should not be freed with #release_id since it's
+ * no longer locally tracked and the current process no longer owns it.
  */
-IDTYPE get_new_id(bool remove_from_owned);
+IDTYPE get_new_id(IDTYPE move_ownership_to);
 /*!
  * \brief Releases (frees) previously allocated ID
  *

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -141,7 +141,7 @@ static int init_main_thread(void) {
         return -ENOMEM;
     }
 
-    cur_thread->tid = get_new_id(/*remove_from_owned=*/false);
+    cur_thread->tid = get_new_id(/*move_ownership_to=*/0);
     if (!cur_thread->tid) {
         log_error("Cannot allocate pid for the initial thread!");
         put_thread(cur_thread);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -456,13 +456,15 @@ noreturn void* shim_init(int argc, void* args) {
             DkProcessExit(1);
         }
 
-        /* This has also a (very much desired) side effect of the IPC leader making a connection to
-         * this process, so that it's included in all broadcast messages. */
-        ret = ipc_change_id_owner(g_process.pid, g_process_ipc_ids.self_vmid);
+        /* Send a dummy request causing the IPC leader to connect to this process, so that it is
+         * included in all broadcast messages. */
+        IDTYPE dummy = 0;
+        ret = ipc_get_id_owner(/*id=*/0, /*out_owner=*/&dummy);
         if (ret < 0) {
-            log_debug("shim_init: failed to change child process PID ownership: %d", ret);
+            log_debug("shim_init: failed to get a connection from IPC leader to us: %d", ret);
             DkProcessExit(1);
         }
+        assert(dummy == 0); // Nobody should own ID `0`.
 
         /* Notify the parent process we are done. */
         char dummy_c = 0;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously allocating ID for a new process did not immediately change the ownership of this ID (it happened later in the child process). This could cause a issues when one thread issues a `fork` syscall and another exits, releasing its own thread ID - IPC leader might get notified to release an ID range, which it thinks is a part of a bigger one, since it was not yet notified about the ID ownership change.
This commit causes allocating a new ID to also immediately notify IPC leader about ownership change, atomically w.r.t. other threads in the current process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/109)
<!-- Reviewable:end -->
