### PR TITLE
[LibOS] Make sure LibOS doesn't have executable stack flag

### DIFF
--- a/LibOS/shim/src/meson.build
+++ b/LibOS/shim/src/meson.build
@@ -121,6 +121,7 @@ vdso_data_o = custom_target('vdso-data.o',
     command: [
         cc.cmd_array(),
         cflags_libos,
+        '-Wa,--noexecstack',
         '-DVDSO_SO_FULL_PATH="@0@"'.format(vdso_so.full_path()),
         '-c',
         '@INPUT@',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This ensures that the LibOS binary (`libsysdb.so`) is not incorrectly marked as requiring executable stack.

As mentioned in the commit, it doesn't actually change anything for Gramine, at least right now. It just makes the `libsysdb.so` library look less suspicious. :)

## How to test this PR? <!-- (if applicable) -->

The only difference is in ELF metadata. You can check that:

* using checksec: `checksec --file=libsysdb.so` (should say "NX enabled")
* using readelf: `readelf -l libsysdb.so` (the `GNU_STACK` section should say `RW`, not `RWX`)

If you're curious about the `.o` files, they should all have the `.note.GNU-stack` section (which you can check using `readelf -S`). `vdso-data.o` did not have that section before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/116)
<!-- Reviewable:end -->
