### PR TITLE
[Pal/Linux-SGX] Fix SGX driver path

### DIFF
--- a/Pal/src/host/Linux-SGX/gsgx.h.in
+++ b/Pal/src/host/Linux-SGX/gsgx.h.in
@@ -22,7 +22,7 @@
 
 #mesondefine CONFIG_SGX_DRIVER_DEVICE
 
-#if defined(CONFIG_SGX_DRIVER_DCAP_1_6) || defined(CONFIG_SGX_DRIVER_DCAP_1_10)
+#if !defined(CONFIG_SGX_DRIVER_OOT)
 #define SGX_DCAP 1
 #endif
 

--- a/Pal/src/host/Linux-SGX/gsgx.h.in
+++ b/Pal/src/host/Linux-SGX/gsgx.h.in
@@ -13,7 +13,7 @@
 #include <linux/stddef.h>
 #include <linux/types.h>
 
-#include <@CONFIG_SGX_DRIVER_HEADER@>
+#include <@CONFIG_SGX_DRIVER_HEADER_ABSPATH@>
 
 #mesondefine CONFIG_SGX_DRIVER_UPSTREAM
 #mesondefine CONFIG_SGX_DRIVER_DCAP_1_6

--- a/Pal/src/host/Linux-SGX/meson.build
+++ b/Pal/src/host/Linux-SGX/meson.build
@@ -17,7 +17,6 @@ sgx_inc = [
         '../../../include/arch/@0@/Linux'.format(host_machine.cpu_family()),
         '../../../include/host/Linux-common',
         'protected-files',
-        sgx_driver_include_path,
     ),
 ]
 
@@ -36,7 +35,6 @@ cflags_pal_sgx = [
 sgx_inc_i = [
     '-I@0@'.format(meson.current_source_dir()),
     '-I@0@'.format(meson.current_build_dir()),
-    '-I@0@'.format(sgx_driver_include_path),
     '-I@0@'.format(join_paths(meson.current_source_dir(),
                               'protected-files')),
     '-I@0@'.format(join_paths(meson.current_source_dir(),

--- a/meson.build
+++ b/meson.build
@@ -112,19 +112,14 @@ if sgx
         sgx_driver_device = sgx_driver_device_default
     endif
 
-    # Check if the directory and header exist. We could run only `has_header`, but then
-    # `include_directories` would fail with a less helpful message if the directory does not exist.
-    fs = import('fs')
-    if (not fs.is_dir(sgx_driver_include_path) or
-        not cc.has_header(sgx_driver_header,
-                          include_directories: include_directories(sgx_driver_include_path)))
+    sgx_driver_header_abspath = join_paths(sgx_driver_include_path, sgx_driver_header)
 
+    if not cc.has_header(sgx_driver_header_abspath)
         error('Invalid SGX driver configuration (-Dsgx_driver and/or -Dsgx_driver_include_path); ' +
-             'expected "@0@" header to exist under "@1@"'.format(
-                 sgx_driver_header, sgx_driver_include_path))
+             'expected "@0@" to exist'.format(sgx_driver_header_abspath))
     endif
 
-    conf_sgx.set('CONFIG_SGX_DRIVER_HEADER', sgx_driver_header)
+    conf_sgx.set('CONFIG_SGX_DRIVER_HEADER_ABSPATH', sgx_driver_header_abspath)
     conf_sgx.set_quoted('CONFIG_SGX_DRIVER_DEVICE', sgx_driver_device)
 endif
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

When rewriting `gsgx.h` generation to Meson, we started adding the SGX driver include path to `-I`. This breaks the build process when the path points to kernel headers.

Instead, we should include only the SGX header file (by absolute path), like we did before.

## How to test this PR? <!-- (if applicable) -->

Gramine should compile with the in-kernel driver correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/117)
<!-- Reviewable:end -->
