### PR TITLE
[LTP] Increase timeouts when running with ASan

### DIFF
--- a/.ci/lib/config-asan.jenkinsfile
+++ b/.ci/lib/config-asan.jenkinsfile
@@ -1,1 +1,2 @@
 env.ASAN = '1'
+env.LTP_TIMEOUT_FACTOR = '2'

--- a/LibOS/shim/test/ltp/Makefile
+++ b/LibOS/shim/test/ltp/Makefile
@@ -15,6 +15,10 @@ ifeq ($(BUILD_VERBOSE),1)
 	RUNLTPOPTS += -v
 endif
 
+ifneq ($(LTP_TIMEOUT_FACTOR),)
+	RUNLTPOPTS += -T $(LTP_TIMEOUT_FACTOR)
+endif
+
 $(SRCDIR)/Makefile:
 	$(error "$(SRCDIR) is empty. Please run `git submodule update --init $(SRCDIR)` or download the LTP source code (https://github.com/linux-test-project/ltp) into $(SRCDIR).")
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->


Gramine compiled with ASan builds is 2x slower, and some tests like
`sendfile09` often fail because of that.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Jenkins will, hopefully, pass :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/118)
<!-- Reviewable:end -->
