### PR TITLE
[python] Restore old trusted files syntax support

### DIFF
--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -11,6 +11,7 @@ Gramine manifest renderer
 
 import hashlib
 import pathlib
+import sys
 
 import toml
 
@@ -82,15 +83,31 @@ class Manifest:
         loader = manifest.setdefault('loader', {})
         loader.setdefault('preload', '')
 
+        # TODO: uncomment once we drop the old syntax support completely.
+        #if not isinstance(sgx['trusted_files'], list):
+        #    raise ValueError("Unsupported trusted files syntax, more info: " +
+        #        "https://gramine.readthedocs.io/en/latest/manifest-syntax.html#trusted-files")
+
         # Current toml versions (< 1.0) do not support non-homogeneous arrays
         trusted_files = []
-        for tf in sgx['trusted_files']:
-            if isinstance(tf, dict):
-                trusted_files.append(tf)
-            elif isinstance(tf, str):
-                append_tf(trusted_files, tf, None)
-            else:
-                raise ValueError(f'Unknown trusted file format: {tf!r}')
+        if isinstance(sgx['trusted_files'], dict):
+            # Old, deprecated syntax "sgx.trusted_files.key = value".
+            print("This trusted files syntax is deprecated, please move to the new one: " +
+                  "https://gramine.readthedocs.io/en/latest/manifest-syntax.html#trusted-files",
+                  file=sys.stderr)
+            for _, tf in sgx['trusted_files'].items():
+                if isinstance(tf, str):
+                    append_tf(trusted_files, tf, None)
+                else:
+                    raise ValueError(f'Unknown trusted file format: {tf!r}')
+        else:
+            for tf in sgx['trusted_files']:
+                if isinstance(tf, dict) and 'uri' in tf:
+                    trusted_files.append(tf)
+                elif isinstance(tf, str):
+                    append_tf(trusted_files, tf, None)
+                else:
+                    raise ValueError(f'Unknown trusted file format: {tf!r}')
 
         sgx['trusted_files'] = trusted_files
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
"sgx.trusted_files.key = value" syntax is deprecated, but still supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/119)
<!-- Reviewable:end -->
