### PR TITLE
[Pal/Linux-SGX] Improve SGX driver header configuration

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -158,7 +158,8 @@ and EINITTOKENs (``.token`` files).
 Then install Gramine (recall that "direct" means non-SGX version)::
 
    meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=enabled \
-       -Dsgx_driver=<driver> -Dsgx_driver_path=<path-to-sgx-driver-sources>
+       -Dsgx_driver=<driver> \
+       -Dsgx_driver_include_path=<path-to-sgx-driver-sources>
    ninja -C build/
    sudo ninja -C build/ install
 
@@ -174,11 +175,11 @@ The ``-Dsgx_driver`` parameter controls which SGX driver to use:
 * ``dcap1.10`` for Intel DCAP version 1.10 or higher,
 * ``oot`` for non-DCAP, out-of-tree version of the driver.
 
-The ``-Dsgx_driver_path`` parameter must point to the absolute path where the
-SGX driver was downloaded or installed in the previous step. For example, for
-the DCAP version 33 of the SGX driver, you must specify
-``-Dsgx_driver-path="/usr/src/sgx-1.33/"``. If this parameter is omitted,
-Gramine's build system will try to determine the right path.
+The ``-Dsgx_driver_include_path`` parameter must point to the absolute path
+where the SGX driver was downloaded or installed in the previous step. For
+example, for the DCAP version 1.41 of the SGX driver, you must specify
+``-Dsgx_driver_include_path="/usr/src/sgx-1.41/include/"``. If this parameter is
+omitted, Gramine's build system will try to determine the right path.
 
 .. note::
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -3,6 +3,8 @@ Quick start
 
 .. highlight:: sh
 
+The following guide assumes you're using Ubuntu 18.04 or 20.04.
+
 Quick start without SGX support
 -------------------------------
 
@@ -41,7 +43,8 @@ Quick start with SGX support
 Gramine requires several features from your system:
 
 - the FSGSBASE feature of recent processors must be enabled in the Linux kernel,
-- the Intel SGX driver must be built in the Linux kernel,
+- the Intel SGX driver must be built in the Linux kernel, and Linux headers for
+  your kernel (``linux-headers-*`` package) must be installed,
 - Intel SGX SDK/PSW and (optionally) Intel DCAP must be installed.
 
 If your system doesn't meet these requirements, please refer to more detailed
@@ -73,10 +76,14 @@ descriptions in :doc:`building`.
       python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       make
       make SGX=1
-      # this assumes Linux 5.11+
       meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=enabled
       ninja -C build/
       sudo ninja -C build/ install
+
+   In case of a non-standard SGX driver configuration (different SGX driver, or
+   different kernel headers path) you might need to also pass ``-Dsgx_driver``
+   and ``-Dsgx_driver_include_path`` options to Meson. See :doc:`building` for
+   details.
 
 #. Set ``vm.mmap_min_addr=0`` in the system (*only required for the legacy SGX
    driver and not needed for newer DCAP/in-kernel drivers*)::

--- a/meson.build
+++ b/meson.build
@@ -76,47 +76,67 @@ if sgx
     if sgx_driver == 'upstream'
         # upstream in-kernel driver (Linux 5.11+)
         conf_sgx.set('CONFIG_SGX_DRIVER_UPSTREAM', true)
-        sgx_driver_header = 'uapi/asm/sgx.h'
-        sgx_driver_include_path_default = '/usr/src/linux-headers-@0@/arch/x86/include'.format(
-            run_command('uname', '-r').stdout().strip())
+        sgx_driver_header = 'asm/sgx.h'
+        sgx_driver_include_path_defaults = [
+            '/usr/include/',
+            # Ubuntu `linux-headers` package
+            '/usr/src/linux-headers-@0@/arch/x86/include/uapi'.format(
+                run_command('uname', '-r').stdout().strip()),
+        ]
         sgx_driver_device_default = '/dev/sgx_enclave'
     elif sgx_driver == 'oot'
         # old non-DCAP driver (https://github.com/intel/linux-sgx-driver)
         conf_sgx.set('CONFIG_SGX_DRIVER_OOT', true)
         sgx_driver_header = 'sgx_user.h'
-        sgx_driver_include_path_default = '/opt/intel/linux-sgx-driver'
         sgx_driver_device_default = '/dev/isgx'
+        sgx_driver_include_path_defaults = ['/opt/intel/linux-sgx-driver']
     elif sgx_driver == 'dcap1.6'
         # DCAP 1.6+ but below 1.10 (https://github.com/intel/SGXDataCenterAttestationPrimitives)
         conf_sgx.set('CONFIG_SGX_DRIVER_DCAP_1_6', true)
         sgx_driver_header = 'uapi/asm/sgx_oot.h'
         sgx_driver_device_default = '/dev/sgx/enclave'
-        sgx_driver_include_path_default = \
-            '/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux/include'
+        sgx_driver_include_path_defaults = [
+            '/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux/include',
+        ]
     elif sgx_driver == 'dcap1.10'
         # DCAP 1.10+ (https://github.com/intel/SGXDataCenterAttestationPrimitives)
         conf_sgx.set('CONFIG_SGX_DRIVER_DCAP_1_10', true)
         sgx_driver_header = 'sgx_user.h'
         sgx_driver_device_default = '/dev/sgx/enclave'
-        sgx_driver_include_path_default = \
-            '/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux/include'
+        sgx_driver_include_path_defaults = [
+            '/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux/include',
+        ]
     else
         error('Unknown sgx_driver value')
-    endif
-
-    if sgx_driver_include_path == ''
-        sgx_driver_include_path = sgx_driver_include_path_default
     endif
 
     if sgx_driver_device == ''
         sgx_driver_device = sgx_driver_device_default
     endif
 
+    if sgx_driver_include_path == ''
+        foreach path : sgx_driver_include_path_defaults
+            sgx_driver_header_abspath = ''
+            if cc.has_header(join_paths(path, sgx_driver_header))
+                sgx_driver_include_path = path
+                break
+            endif
+        endforeach
+
+        if sgx_driver_include_path == ''
+            error('Invalid SGX driver configuration (-Dsgx_driver and/or ' +
+                  '-Dsgx_driver_include_path); searched for "@0@" under directories: @1@'.format(
+                      sgx_driver_header, sgx_driver_include_path_defaults))
+        endif
+    endif
+
+
     sgx_driver_header_abspath = join_paths(sgx_driver_include_path, sgx_driver_header)
 
     if not cc.has_header(sgx_driver_header_abspath)
         error('Invalid SGX driver configuration (-Dsgx_driver and/or -Dsgx_driver_include_path); ' +
-             'expected "@0@" to exist'.format(sgx_driver_header_abspath))
+              'expected "@0@" to exist under "@1@"'.format(
+                  sgx_driver_header, sgx_driver_include_path))
     endif
 
     conf_sgx.set('CONFIG_SGX_DRIVER_HEADER_ABSPATH', sgx_driver_header_abspath)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This change improves support for building on systems other than Ubuntu:

- Use `asm/sgx.h` (not `uapi/asm/sgx.h`). Previously, `uapi` was always appended to the provided include path, so it wasn't possible to configure Gramine when the userspace kernel headers were installed without `uapi` prefix.

- Try out the `/usr/include` path. Ubuntu doesn't install kernel headers there, but many other distributions (e.g. Fedora, CentOS) do.

- Clarify in the quick start guide that it is for Ubuntu, and add a hint in case of configuration problems.

Closes #120.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->


<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Try building on a system with 5.11+ kernel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/121)
<!-- Reviewable:end -->
