### PR TITLE
[Pal/Linux-SGX] Add "insecure__" prefix to "protected_files_key"

### DIFF
--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -406,10 +406,10 @@ environment variables if available:
 - ``SECRET_PROVISION_SET_PF_KEY`` (optional) -- set it to ``1/true/TRUE`` to
   indicate that the provisioned secret is a protected-files master key. The key
   must be a 32-char null-terminated AES-GCM encryption key in hex format,
-  similar to ``sgx.protected_files_key`` manifest option. This environment
-  variable is checked only if ``SECRET_PROVISION_CONSTRUCTOR`` is set. The
-  library puts the provisioned key into ``/dev/attestation/protected_files_key``
-  so that Gramine recognizes it.
+  similar to ``sgx.insecure__protected_files_key`` manifest option. This
+  environment variable is checked only if ``SECRET_PROVISION_CONSTRUCTOR`` is
+  set. The library puts the provisioned key into
+  ``/dev/attestation/protected_files_key`` so that Gramine recognizes it.
 
 - ``SECRET_PROVISION_SERVERS`` (optional) -- a comma, semicolon or space
   separated list of server names with ports to connect to for secret

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -524,7 +524,7 @@ Protected files
 
 ::
 
-    sgx.protected_files_key = "[16-byte hex value]"
+    sgx.insecure__protected_files_key = "[16-byte hex value]"
 
     sgx.protected_files = [
       "[URI]",
@@ -555,16 +555,16 @@ directory are automatically treated as protected.
 Note that path size of a protected file is limited to 512 bytes and filename
 size is limited to 260 bytes.
 
-``sgx.protected_files_key`` specifies the wrap (master) encryption key and must
-be used only for debugging purposes.
+``sgx.insecure__protected_files_key`` specifies the wrap (master) encryption key
+and must be used only for debugging purposes.
 
 .. warning::
-   ``sgx.protected_files_key`` hard-codes the key in the manifest. This option
-   is thus insecure and must not be used in production environments! Typically,
-   you want to provision the protected files wrap key using SGX local/remote
-   attestation, thus you should not specify the ``sgx.protected_files_key``
-   manifest option at all. Instead, use the Secret Provisioning interface (see
-   :doc:`attestation`).
+   ``sgx.insecure__protected_files_key`` hard-codes the key in the manifest.
+   This option is thus insecure and must not be used in production environments!
+   Typically, you want to provision the protected files wrap key using SGX
+   local/remote attestation, thus you should not specify the
+   ``sgx.insecure__protected_files_key`` manifest option at all. Instead, use
+   the Secret Provisioning interface (see :doc:`attestation`).
 
 There are three types of protected files:
 

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -41,7 +41,7 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/libgcc_s.so.1",
 ]
 
-sgx.protected_files_key = "ffeeddccbbaa99887766554433221100"
+sgx.insecure__protected_files_key = "ffeeddccbbaa99887766554433221100"
 sgx.protected_files = [
   "file:tmp/pf_input",
   "file:tmp/pf_output",

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -44,7 +44,7 @@ sgx.trusted_files = [
   "file:exec_victim",
 ]
 
-sgx.protected_files_key = "ffeeddccbbaa99887766554433221100"
+sgx.insecure__protected_files_key = "ffeeddccbbaa99887766554433221100"
 sgx.protected_files = [
   "file:tmp/pf/",
 ]

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -617,16 +617,16 @@ int init_protected_files(void) {
     /* if wrap key is not hard-coded in the manifest, assume that it was received from parent or
      * it will be provisioned after local/remote attestation; otherwise read it from manifest */
     char* protected_files_key_str = NULL;
-    ret = toml_string_in(g_pal_state.manifest_root, "sgx.protected_files_key",
+    ret = toml_string_in(g_pal_state.manifest_root, "sgx.insecure__protected_files_key",
                          &protected_files_key_str);
     if (ret < 0) {
-        log_error("Cannot parse 'sgx.protected_files_key'");
+        log_error("Cannot parse 'sgx.insecure__protected_files_key'");
         return -PAL_ERROR_INVAL;
     }
 
     if (protected_files_key_str) {
         if (strlen(protected_files_key_str) != PF_KEY_SIZE * 2) {
-            log_error("Malformed 'sgx.protected_files_key' value in the manifest");
+            log_error("Malformed 'sgx.insecure__protected_files_key' value in the manifest");
             free(protected_files_key_str);
             return -PAL_ERROR_INVAL;
         }
@@ -635,7 +635,7 @@ int init_protected_files(void) {
         for (size_t i = 0; i < strlen(protected_files_key_str); i++) {
             int8_t val = hex2dec(protected_files_key_str[i]);
             if (val < 0) {
-                log_error("Malformed 'sgx.protected_files_key' value in the manifest");
+                log_error("Malformed 'sgx.insecure__protected_files_key' value in the manifest");
                 free(protected_files_key_str);
                 return -PAL_ERROR_INVAL;
             }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
It's clearly described as insecure and debug feature, but the name missed the usual prefix we give such options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/123)
<!-- Reviewable:end -->
