### PR TITLE
[Pal/Linux] Exit process in case of errors in `setup_asan`

### DIFF
--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -152,8 +152,12 @@ static void setup_asan(void) {
     int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED;
     void* addr = (void*)DO_SYSCALL(mmap, (void*)ASAN_SHADOW_START, ASAN_SHADOW_LENGTH, prot, flags,
                                    /*fd=*/-1, /*offset=*/0);
-    if (IS_PTR_ERR(addr))
+    if (IS_PTR_ERR(addr)) {
+        /* We are super early in the init sequence, TCB is not yet set, we probably should not call
+         * any logging functions. */
+        DO_SYSCALL(exit_group, PAL_ERROR_NOMEM);
         die_or_inf_loop();
+    }
 }
 #endif
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously, if mapping ASAN shadow memory failed, process would just enter an infinite loop. This commit makes it exit the whole process instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/124)
<!-- Reviewable:end -->
