### PR TITLE
[CI-Examples] Increase enclave size to 512MB for Nginx

### DIFF
--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -36,7 +36,7 @@ fs.mount.cwd.uri = "file:{{ install_dir }}"
 
 sgx.debug = true
 sgx.nonpie_binary = true
-sgx.enclave_size = "256M"
+sgx.enclave_size = "512M"
 sgx.thread_num = 4
 
 # Nginx benefits from Exitless. Uncomment the below line to use it.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

On some systems (namely CentOS/RHEL), the previous enclave size of 256MB was barely enough for Nginx worker processes. Intermittently, these worker processes failed with `Out-of-memory in library OS` error. Increasing the size to 512MB fixes this error.

## How to test this PR? <!-- (if applicable) -->

Nginx CI test should still work. Also, CentOS and RHEL tests should now work all the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/125)
<!-- Reviewable:end -->
