### PR TITLE
[Docs] Make Python TOML package a dependency for non-SGX Gramine

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -43,7 +43,7 @@ Run the following command on Ubuntu LTS to install dependencies::
     sudo apt-get install -y build-essential \
         autoconf bison gawk ninja-build python3 python3-click python3-jinja2 \
         wget
-    python3 -m pip install 'meson>=0.55'
+    python3 -m pip install 'meson>=0.55' 'toml>=0.10'
 
 You can also install Meson from apt instead of pip, but only if your distro is
 new enough to have Meson >= 0.55 (Debian 11, Ubuntu 20.10).
@@ -72,7 +72,6 @@ Run the following commands on Ubuntu to install SGX-related dependencies::
 
     sudo apt-get install -y libcurl4-openssl-dev libprotobuf-c-dev \
         protobuf-c-compiler python3-pip python3-protobuf
-    python3 -m pip install toml>=0.10
 
 2. Upgrade to the Linux kernel patched with FSGSBASE
 """"""""""""""""""""""""""""""""""""""""""""""""""""

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -30,7 +30,7 @@ Update and install the required packages for Gramine::
        libcurl4-openssl-dev libprotobuf-c-dev meson protobuf-c-compiler \
        python3 python3-click python3-jinja2 python3-pip python3-protobuf \
        wget
-   python3 -m pip install toml>=0.10
+   python3 -m pip install 'meson>=0.55' 'toml>=0.10'
 
 Gramine requires the kernel to support FSGSBASE x86 instructions. Older Azure
 Confidential Compute VMs may not contain the required kernel patches and need to

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -22,7 +22,7 @@ Quick start without SGX support
       sudo apt-get install -y build-essential \
           autoconf bison gawk ninja-build python3 python3-click python3-jinja2 \
           wget
-      python3 -m pip install 'meson>=0.55'
+      python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       cd gramine
       make
       meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=disabled


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Our documentation is wrong currently. We need `toml` everywhere in Gramine.

## How to test this PR? <!-- (if applicable) -->

N/A.