### PR TITLE
[Pal,LibOS] Disable sysfs topology by default

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -368,6 +368,21 @@ Start (current working) directory
 This syntax specifies the start (current working) directory. If not specified,
 then Gramine sets the root directory as the start directory (see ``fs.root``).
 
+Experimental sysfs topology support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    fs.experimental__enable_sysfs_topology = [true|false]
+    (Default: false)
+
+This syntax enables sysfs topology feature in Gramine: pseudo-files under
+``/sys/devices/system/cpu`` and ``/sys/devices/system/node``.
+
+.. warning::
+   This feature is still under development and may contain security
+   vulnerabilities. This is temporary; the feature will be enabled in future
+   after thorough validation and this syntax will be removed then.
 
 SGX syntax
 ----------

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -151,10 +151,12 @@ static int __mount_sys(void) {
         return ret;
     }
 
-    log_debug("Mounting special sys filesystem: /sys");
-    if ((ret = mount_fs("pseudo", "sys", "/sys")) < 0) {
-        log_error("Mounting sys filesystem failed (%d)", ret);
-        return ret;
+    if (g_pal_control->enable_sysfs_topology) {
+        log_debug("Mounting special sys filesystem: /sys");
+        if ((ret = mount_fs("pseudo", "sys", "/sys")) < 0) {
+            log_error("Mounting sys filesystem failed (%d)", ret);
+            return ret;
+        }
     }
 
     return 0;

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -151,6 +151,9 @@ static void init_node_dir(struct pseudo_node* node) {
 }
 
 int init_sysfs(void) {
+    if (!g_pal_control->enable_sysfs_topology)
+        return 0;
+
     struct pseudo_node* root = pseudo_add_root_dir("sys");
     struct pseudo_node* devices = pseudo_add_dir(root, "devices");
     struct pseudo_node* system = pseudo_add_dir(devices, "system");

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -26,6 +26,7 @@ fs.mount.tmp.type = "chroot"
 fs.mount.tmp.path = "/tmp"
 fs.mount.tmp.uri = "file:/tmp"
 
+fs.experimental__enable_sysfs_topology = true
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/sysfs_common.manifest.template
+++ b/LibOS/shim/test/regression/sysfs_common.manifest.template
@@ -1,0 +1,18 @@
+loader.preload = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.argv0_override = "{{ entrypoint }}"
+
+fs.mount.gramine_lib.type = "chroot"
+fs.mount.gramine_lib.path = "/lib"
+fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir() }}"
+
+fs.experimental__enable_sysfs_topology = true
+
+sgx.nonpie_binary = true
+sgx.debug = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ entrypoint }}",
+]

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -167,6 +167,7 @@ typedef struct PAL_CONTROL_ {
     PAL_CPU_INFO cpu_info; /*!< CPU information (only required ones) */
     PAL_MEM_INFO mem_info; /*!< memory information (only required ones) */
     PAL_TOPO_INFO topo_info; /*!< Topology information (only required ones) */
+    bool enable_sysfs_topology;
 } PAL_CONTROL;
 
 const PAL_CONTROL* DkGetPalControl(void);

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -567,6 +567,16 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     }
     g_pal_control.mem_info.mem_total = _DkMemoryQuota();
 
+    /* TODO: temporary measure, remove it once sysfs topology is thoroughly validated */
+    bool enable_sysfs_topology;
+    ret = toml_bool_in(g_pal_state.manifest_root, "fs.experimental__enable_sysfs_topology",
+                       /*defaultval=*/false, &enable_sysfs_topology);
+    if (ret < 0) {
+        INIT_FAIL_MANIFEST(PAL_ERROR_INVAL, "Cannot parse 'fs.experimental__enable_sysfs_topology' "
+                                            "(the value must be `true` or `false`)");
+    }
+    g_pal_control.enable_sysfs_topology = enable_sysfs_topology;
+
     if (_DkGetTopologyInfo(&g_pal_control.topo_info) < 0) {
         goto out_fail;
     }

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -790,6 +790,12 @@ out_vendor_id:
 }
 
 int _DkGetTopologyInfo(PAL_TOPO_INFO* topo_info) {
+    if (!g_pal_control.enable_sysfs_topology) {
+        /* TODO: temporary measure, remove it once sysfs topology is thoroughly validated */
+        memset(topo_info, 0, sizeof(*topo_info));
+        return 0;
+    }
+
     topo_info->num_online_nodes = g_pal_sec.topo_info.num_online_nodes;
     topo_info->num_cache_index  = g_pal_sec.topo_info.num_cache_index;
     topo_info->core_topology    = g_pal_sec.topo_info.core_topology;
@@ -797,7 +803,6 @@ int _DkGetTopologyInfo(PAL_TOPO_INFO* topo_info) {
     COPY_ARRAY(topo_info->online_logical_cores, g_pal_sec.topo_info.online_logical_cores);
     COPY_ARRAY(topo_info->possible_logical_cores, g_pal_sec.topo_info.possible_logical_cores);
     COPY_ARRAY(topo_info->online_nodes, g_pal_sec.topo_info.online_nodes);
-
     return 0;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commit disables sysfs feature by default but exposes a new manifest option `fs.experimental__enable_sysfs_topology`
to turn on the feature for experimental purposes.

As a part of this commit, sysfs regression test is also disabled.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>


## How to test this PR? <!-- (if applicable) -->
Although sysfs regression test is disabled, one can add the `fs.experimental__enable_sysfs_topology` manifest option and run the `sysfs_common` test manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/135)
<!-- Reviewable:end -->
