### PR TITLE
[Doc] Fix wrong formatting

### DIFF
--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -35,7 +35,7 @@ library OS running inside an enclave (using a normal GDB will only debug the
 execution *outside* the enclave).
 
 To build Gramine with debug symbols, the source code needs to be compiled with
-``--buildtype=debug``:
+``--buildtype=debug``::
 
     meson setup build-debug/ --buildtype=debug -Dsgx=enabled
     ninja -C build-debug/


### PR DESCRIPTION
Signed-off-by: Denis Zygann <denis@zygann.de>

Fix to correct the formatting of the documentation. 

![image](https://user-images.githubusercontent.com/74046675/136455728-2cde3b39-9609-4089-ae04-1256243b9889.png)


