### PR TITLE
Merge missing AKS documentation from Graphene docs

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -65,3 +65,129 @@ Building
        make SGX=1
        make SGX=1 sgx-tokens
        gramine-sgx helloworld
+
+Azure Kubernetes Services (AKS)
+-------------------------------
+
+Azure Kubernetes Service (AKS) offers a popular deployment technique relying on
+Azure's cloud resources. AKS hosts Kubernetes pods in Azure confidential compute
+VMs and exposes the underlying confidential compute hardware. In particular,
+`Gramine Shielded Containers (GSC)
+<https://gramine-gsc.readthedocs.io/en/latest>`__ translate
+existing Docker images to graminized Docker images, which can be deployed in
+AKS. Graminized Docker images execute the application inside an Intel SGX
+enclave using the Gramine Library OS, thus enabling confidential containers
+functions on AKS.
+
+This section describes the workflow to create an AKS cluster with confidential
+compute VMs, graminize a simple application, and deploy the graminized Docker
+image in an AKS cluster.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Follow the instructions on the `AKS Confidential Computing Quick Start guide
+<https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-get-started>`__
+to provision an AKS cluster with Intel SGX enabled worker nodes.
+
+Follow the `instructions
+<https://gramine-gsc.readthedocs.io/en/latest>`__ to set up
+Gramine Shielded Containers and create your own enclave key.
+
+Graminizing Python Docker image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This section demonstrate how to translate the Python Docker Hub image to a
+graminized image, which is ready to deploy in a confidential compute AKS
+cluster.
+
+.. warning::
+
+   This example relies on insecure arguments provided at runtime and should not
+   be used production. To use trusted arguments, please see the `manpage of GSC
+   <https://gramine-gsc.readthedocs.io/en/latest/#using-gramine-s-trusted-command-line-arguments>`__.
+
+#. Pull Python image::
+
+       docker pull python
+
+#. Configure GSC to build graminized images for AKS with the
+   `Gramine Docker Image for AKS from Docker Hub
+   <https://hub.docker.com/r/graphenelibos/aks>`__ by creating the following
+   configuration file :file:`config.aks.yaml`::
+
+       Distro: ubuntu18.04
+       Gramine:
+              Image: graphenelibos/aks:latest
+
+#. Create the application-specific Manifest file :file:`python.manifest`::
+
+       sgx.enclave_size = "256M"
+       sgx.thread_num = 4
+
+#. Graminize the Python image and allow insecure runtime arguments::
+
+       ./gsc build --insecure-args -c config.aks.yaml python python.manifest
+
+#. Sign the graminized image with your enclave signing key::
+
+       ./gsc sign-image python enclave-key.pem
+
+#. Push resulting image to Docker Hub or your preferred registry::
+
+       docker tag gsc-python <dockerhubusername>/python:gsc-aks
+       docker push <dockerhubusername>/python:gsc-aks
+
+Deploying a "HelloWorld" Python Application in a confidential compute AKS cluster
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This example first created an AKS cluster capable to create Intel SGX enclaves
+and then, created a graminized Docker image of Python. The goal of this section
+is to combine both by deploying the Python application in the AKS cluster.
+
+#. Create job deployment file :file:`gsc-aks-python.yaml` for AKS. It specifies
+   the underlying Docker image and the insecure arguments (in this case Python
+   code to print "HelloWorld!")::
+
+       apiVersion: batch/v1
+       kind: Job
+       metadata:
+          name: gsc-aks-python
+          labels:
+             app: gsc-aks-python
+       spec:
+          template:
+             metadata:
+                labels:
+                   app: gsc-aks-python
+             spec:
+                containers:
+                - name: gsc-aks-python
+                  image:  index.docker.io/<dockerhubusername>/python:gsc-aks
+                  imagePullPolicy: Always
+                  args: ["-c", "print('HelloWorld!')"]
+                  resources:
+                     limits:
+                        kubernetes.azure.com/sgx_epc_mem_in_MiB: 25
+                restartPolicy: Never
+          backoffLimit: 0
+
+#. You may need to follow this
+   `guide <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/>`__
+   to pull from a private registry.
+
+#. Deploy `gsc-aks-python` job::
+
+       kubectl apply -f gsc-aks-python.yaml
+
+#. Test job status::
+
+       kubectl get jobs -l app=gsc-aks-python
+
+#. Receive logs of job::
+
+       kubectl logs -l app=gsc-aks-python
+
+#. Delete job after completion::
+
+       kubectl delete -f gsc-aks-python.yaml

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -81,7 +81,8 @@ functions on AKS.
 
 This section describes the workflow to create an AKS cluster with confidential
 compute VMs, graminize a simple application, and deploy the graminized Docker
-image in an AKS cluster.
+image in an AKS cluster. This section will shortly be enhanced to include
+DCAP attestation support.
 
 Prerequisites
 ^^^^^^^^^^^^^


### PR DESCRIPTION
There are two changes here
1) Merge the missing AKS documentation from https://graphene.readthedocs.io/en/latest/cloud-deployment.html. 
2) Add a note on the upcoming DCAP attestation support. This was requested by the CSP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/141)
<!-- Reviewable:end -->
