### PR TITLE
[Pal/Linux-SGX] Change log level of "unknown files" message to "warning"

### DIFF
--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -2,6 +2,8 @@ loader.preload = "file:{{ gramine.libos }}"
 libos.entrypoint = "file_check_policy"
 loader.argv0_override = "file_check_policy"
 
+loader.log_level = "warning"
+
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -2,6 +2,8 @@ loader.preload = "file:{{ gramine.libos }}"
 libos.entrypoint = "file_check_policy"
 loader.argv0_override = "file_check_policy"
 
+loader.log_level = "warning"
+
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -78,15 +78,15 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     struct trusted_file* tf   = get_trusted_or_allowed_file(hdl->file.realpath);
 
     if (!pf && !tf && get_file_check_policy() != FILE_CHECK_POLICY_ALLOW_ALL_BUT_LOG) {
-        log_error("Disallowing access to file '%s'; file is not protected, trusted or allowed.",
-                  hdl->file.realpath);
+        log_warning("Disallowing access to file '%s'; file is not protected, trusted or allowed.",
+                    hdl->file.realpath);
         ret = -PAL_ERROR_DENIED;
         goto fail;
     }
 
     if (!pf && !tf) {
-        log_always("Allowing access to unknown file '%s' due to file_check_policy settings.",
-                   hdl->file.realpath);
+        log_warning("Allowing access to unknown file '%s' due to file_check_policy settings.",
+                    hdl->file.realpath);
 
         fd = ocall_open(uri, flags, pal_share);
         if (fd < 0) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

In some workloads (especially Python workloads that try to access .pyc files), there are tons of  "Disallowing access ..." and "Allowing access ..." messages. Previously, they were printed even at the "error" level. To decrease verbosity of the output, this commit forces these messages to be printed starting from the "warning" level.

## How to test this PR? <!-- (if applicable) -->

Two LibOS tests now have `loader.log_level = "warning"` to verify this.

Also, manually check GSC's example of Python helloworld example: https://gramine-gsc.readthedocs.io/en/latest/#example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/144)
<!-- Reviewable:end -->
