### PR TITLE
Suggest sudo python3 -m pip

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -43,7 +43,7 @@ Run the following command on Ubuntu LTS to install dependencies::
     sudo apt-get install -y build-essential \
         autoconf bison gawk ninja-build python3 python3-click python3-jinja2 \
         wget
-    python3 -m pip install 'meson>=0.55' 'toml>=0.10'
+    sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
 
 You can also install Meson and python3-toml from apt instead of pip, but only if
 your distro is new enough to have Meson >= 0.55 and python3-toml >= 0.10 (Debian

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -34,7 +34,7 @@ Update and install the required packages for Gramine::
        autoconf bison gawk libcurl4-openssl-dev libprotobuf-c-dev ninja-build \
        protobuf-c-compiler python3 python3-click python3-jinja2 python3-pip \
        python3-protobuf wget
-   python3 -m pip install 'meson>=0.55' 'toml>=0.10'
+   sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
 
 Gramine requires the kernel to support FSGSBASE x86 instructions. Older Azure
 Confidential Compute VMs may not contain the required kernel patches and need to

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -22,7 +22,7 @@ Quick start without SGX support
       sudo apt-get install -y build-essential \
           autoconf bison gawk ninja-build python3 python3-click python3-jinja2 \
           wget
-      python3 -m pip install 'meson>=0.55' 'toml>=0.10'
+      sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       cd gramine
       meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=disabled
       ninja -C build/
@@ -72,7 +72,7 @@ descriptions in :doc:`building`.
           autoconf bison gawk libcurl4-openssl-dev libprotobuf-c-dev \
           ninja-build protobuf-c-compiler python3 python3-click python3-jinja2 \
           python3-pip python3-protobuf wget
-      python3 -m pip install 'meson>=0.55' 'toml>=0.10'
+      sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       # this assumes Linux 5.11+
       meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=enabled
       ninja -C build/


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

If you install meson from pip without sudo, then `sudo ninja install` will fail.

https://mesonbuild.com/Getting-meson.html#installing-meson-with-pip

## How to test this PR? <!-- (if applicable) -->

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/148)
<!-- Reviewable:end -->
