### PR TITLE
[LibOS] Assign UID and GID to stat fields in chroot

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -208,7 +208,8 @@ User ID and Group ID
 This specifies the initial, Gramine emulated user/group ID and effective
 user/group ID. It must be non-negative. By default Gramine emulates the
 user/group ID and effective user/group ID as the root user (uid = gid = 0).
-The user/group ID affects also the stat members for ``tmpfs`` and ``chroot``.
+The user and group IDs are also reflected in the information about ``tmpfs``
+and ``chroot`` files returned via ``stat()``.
 
 
 Disabling ASLR

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -208,6 +208,7 @@ User ID and Group ID
 This specifies the initial, Gramine emulated user/group ID and effective
 user/group ID. It must be non-negative. By default Gramine emulates the
 user/group ID and effective user/group ID as the root user (uid = gid = 0).
+The user/group ID affects also the stat members for ``tmpfs`` and ``chroot``.
 
 
 Disabling ASLR

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -341,11 +341,14 @@ out:
 }
 
 static int chroot_istat(struct shim_inode* inode, struct stat* buf) {
+    struct shim_thread* cur_thread = get_cur_thread();
     memset(buf, 0, sizeof(*buf));
 
     lock(&inode->lock);
     buf->st_mode = inode->type | inode->perm;
     buf->st_size = inode->size;
+    buf->st_uid = cur_thread->uid;
+    buf->st_gid = cur_thread->gid;
     /*
      * Pretend `nlink` is 2 for directories (to account for "." and ".."), 1 for other files.
      *

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -22,6 +22,7 @@
 #include "shim_handle.h"
 #include "shim_internal.h"
 #include "shim_lock.h"
+#include "shim_thread.h"
 #include "shim_utils.h"
 #include "stat.h"
 
@@ -151,6 +152,8 @@ static int tmpfs_stat(struct shim_dentry* dent, struct stat* buf) {
     if (ret < 0)
         goto out;
 
+    struct shim_thread* cur_thread = get_cur_thread();
+
     memset(buf, 0, sizeof(*buf));
     buf->st_mode  = dent->perm | dent->type;
     buf->st_size  = data->mem.size;
@@ -158,6 +161,8 @@ static int tmpfs_stat(struct shim_dentry* dent, struct stat* buf) {
     buf->st_ctime = data->ctime;
     buf->st_mtime = data->mtime;
     buf->st_atime = data->atime;
+    buf->st_uid   = cur_thread->uid;
+    buf->st_gid   = cur_thread->gid;
     ret = 0;
 
 out:

--- a/LibOS/shim/test/regression/uid_gid.c
+++ b/LibOS/shim/test/regression/uid_gid.c
@@ -1,22 +1,42 @@
 #include <err.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+
 int main(int argc, char** argv) {
-    uid_t uid = getuid();
+    int r;
+    struct stat buffer;
+    struct stat* buf = &buffer;
+
+    uid_t uid  = getuid();
     uid_t euid = geteuid();
 
     if (uid != 1338 || euid != 1338) {
         errx(EXIT_FAILURE, "UID/effective UID are not equal to the value in the manifest");
     }
 
-    uid_t gid = getgid();
+    uid_t gid  = getgid();
     uid_t egid = getegid();
 
     if (gid != 1337 || egid != 1337) {
         errx(EXIT_FAILURE, "GID/effective GID are not equal to the value in the manifest");
+    }
+
+    // check stat uid and gid
+    r = stat(argv[0], buf);
+    if (r != 0) {
+        errx(EXIT_FAILURE, "Something unexpected went wrong in stat function. Error code: %d", r);
+    }
+
+    if (buf->st_uid != 1338) {
+        errx(EXIT_FAILURE, "UID is not equal to the value in the manifest");
+    }
+
+    if (buf->st_gid != 1337) {
+        errx(EXIT_FAILURE, "GID is not equal to the value in the manifest");
     }
 
     puts("TEST OK");

--- a/LibOS/shim/test/regression/uid_gid.c
+++ b/LibOS/shim/test/regression/uid_gid.c
@@ -5,11 +5,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-
 int main(int argc, char** argv) {
-    int r;
-    struct stat buffer;
-    struct stat* buf = &buffer;
+    int ret;
+    struct stat buf;
 
     uid_t uid  = getuid();
     uid_t euid = geteuid();
@@ -25,18 +23,17 @@ int main(int argc, char** argv) {
         errx(EXIT_FAILURE, "GID/effective GID are not equal to the value in the manifest");
     }
 
-    // check stat uid and gid
-    r = stat(argv[0], buf);
-    if (r != 0) {
-        errx(EXIT_FAILURE, "Something unexpected went wrong in stat function. Error code: %d", r);
+    ret = stat(argv[0], &buf);
+    if (ret < 0) {
+        err(EXIT_FAILURE, "stat failed");
     }
 
-    if (buf->st_uid != 1338) {
-        errx(EXIT_FAILURE, "UID is not equal to the value in the manifest");
+    if (buf.st_uid != 1338) {
+        errx(EXIT_FAILURE, "UID from stat() is not equal to the value in the manifest");
     }
 
-    if (buf->st_gid != 1337) {
-        errx(EXIT_FAILURE, "GID is not equal to the value in the manifest");
+    if (buf.st_gid != 1337) {
+        errx(EXIT_FAILURE, "GID from stat() is not equal to the value in the manifest");
     }
 
     puts("TEST OK");

--- a/LibOS/shim/test/regression/uid_gid.c
+++ b/LibOS/shim/test/regression/uid_gid.c
@@ -1,4 +1,5 @@
 #include <err.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -25,15 +26,34 @@ int main(int argc, char** argv) {
 
     ret = stat(argv[0], &buf);
     if (ret < 0) {
-        err(EXIT_FAILURE, "stat failed");
+        err(EXIT_FAILURE, "chroot stat failed");
     }
 
     if (buf.st_uid != 1338) {
-        errx(EXIT_FAILURE, "UID from stat() is not equal to the value in the manifest");
+        errx(EXIT_FAILURE, "UID from chroot stat() is not equal to the value in the manifest");
     }
 
     if (buf.st_gid != 1337) {
-        errx(EXIT_FAILURE, "GID from stat() is not equal to the value in the manifest");
+        errx(EXIT_FAILURE, "GID from chroot stat() is not equal to the value in the manifest");
+    }
+
+    char file[] = "/tmp/file1";
+    ret = open(file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (ret < 0) {
+        err(EXIT_FAILURE, "open failed");
+    }
+
+    ret = stat(file, &buf);
+    if (ret < 0) {
+        err(EXIT_FAILURE, "tmpfs stat failed");
+    }
+
+    if (buf.st_uid != 1338) {
+        errx(EXIT_FAILURE, "UID from tmpfs stat() is not equal to the value in the manifest");
+    }
+
+    if (buf.st_gid != 1337) {
+        errx(EXIT_FAILURE, "GID from tmpfs stat() is not equal to the value in the manifest");
     }
 
     puts("TEST OK");

--- a/LibOS/shim/test/regression/uid_gid.manifest.template
+++ b/LibOS/shim/test/regression/uid_gid.manifest.template
@@ -10,10 +10,18 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
+fs.mount.tmp.type = "chroot"
+fs.mount.tmp.path = "/tmp"
+fs.mount.tmp.uri = "file:/tmp"
+
 sgx.nonpie_binary = true
 sgx.debug = true
 
 sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:uid_gid",
+]
+
+sgx.allowed_files = [
+  "file:/tmp/file1",
 ]


### PR DESCRIPTION
Set the UID and GID in the chroot function to the one defined in the manifest
by using the `loader.uid` and `loader.gid` options. Otherwise, a check fails
from the wrapped application, because the UID/GID is set to 0 and the application
expects another one.

This topic has been discussed in the issue [2632](https://github.com/gramineproject/graphene/issues/2632)

Signed-off-by: Denis Zygann <denis@zygann.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/150)
<!-- Reviewable:end -->
