### PR TITLE
[Docs] Add a note on a separate repo/documentation site for GSC

### DIFF
--- a/Documentation/gsc.rst
+++ b/Documentation/gsc.rst
@@ -1,0 +1,8 @@
+GSC (Gramine Shielded Containers)
+=================================
+
+.. note ::
+   GSC (Gramine Shielded Containers) tool was split from the core Gramine
+   repository to a new repository: https://github.com/gramineproject/gsc.
+   Similarly, GSC documentation was split from the core Gramine documentation
+   and is now hosted here: https://gramine.readthedocs.io/projects/gsc.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -22,10 +22,16 @@ External documentation
 
 This website contains the official documentation of Gramine. For external
 contributions and additional resources, please visit
-https://gramine-contrib.readthedocs.io/en/latest/. Note that this link contains
-unofficial documents; these documents are not guaranteed to always be up-to-date
-and correct.
+https://gramine-contrib.readthedocs.io. Note that this link contains unofficial
+documents; these documents are not guaranteed to always be up-to-date and
+correct.
 
+
+GSC documentation
+=================
+
+For GSC (Gramine Shielded Containers) documentation please visit
+https://gramine.readthedocs.io/projects/gsc.
 
 Building and running Gramine
 ============================
@@ -59,6 +65,7 @@ Table of Contents
    manifest-syntax
    attestation
    cloud-deployment
+   gsc
    sgx-intro
    glossary
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Many people are confused where GSC went in the new Gramine repository and documentation web-site. We need to give them a hint.

## How to test this PR? <!-- (if applicable) -->

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/160)
<!-- Reviewable:end -->
