### PR TITLE
[python] Skip inaccessible files in manifest trusted files expansion

### DIFF
--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -10,6 +10,7 @@ Gramine manifest management and rendering
 """
 
 import hashlib
+import os
 import pathlib
 import sys
 
@@ -58,7 +59,9 @@ def append_trusted_dir_or_file(trusted_files, val):
         if not uri.endswith('/'):
             raise ManifestError(f'Directory URI ({uri}) does not end with "/"')
         for sub_path in sorted(filter(pathlib.Path.is_file, path.rglob('*'))):
-            append_tf(trusted_files, f'file:{sub_path}', hash_file_contents(sub_path))
+            # Skip inaccessible files
+            if os.access(sub_path, os.R_OK):
+                append_tf(trusted_files, f'file:{sub_path}', hash_file_contents(sub_path))
     else:
         assert path.is_file()
         append_tf(trusted_files, uri, hash_file_contents(path))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Fixes https://github.com/gramineproject/graphene/issues/2624

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Add a directory to trusted files which contains unreadable file (e.g. owned by different user without read permission for others)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/167)
<!-- Reviewable:end -->
