### PR TITLE
[WIP][Pal/Linux] Add a seccomp policy to emulate inline syscalls

### DIFF
--- a/LibOS/shim/test/regression/syscall.c
+++ b/LibOS/shim/test/regression/syscall.c
@@ -2,13 +2,20 @@
 #include <err.h>
 #include <stdlib.h>
 #include <sys/syscall.h>
-#include <unistd.h>
 
 int main(int argc, char** argv) {
     const char buf[] = "Hello world\n";
-    long ret = syscall(__NR_write, 1, buf, sizeof(buf) - 1);
+    long ret = -1;
+#ifdef __x86_64__
+    __asm__ volatile (
+        "syscall"
+        : "=a"(ret)
+        : "0"(__NR_write), "D"(1), "S"(buf), "d"(sizeof(buf) - 1)
+        : "memory", "cc", "rcx", "r11"
+    );
+#endif
     if (ret < 0)
-        err(EXIT_FAILURE, "write syscall");
+        errx(EXIT_FAILURE, "write syscall: %ld", ret);
 
     return 0;
 }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -767,10 +767,6 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('TEST OK', stdout)
 
 class TC_31_Syscall(RegressionTestCase):
-    @unittest.skipUnless(HAS_SGX,
-        'This test is only meaningful on SGX PAL because only SGX catches raw '
-        'syscalls and redirects to Gramine\'s LibOS. If we will add seccomp to '
-        'Linux PAL, then we should allow this test on Linux PAL as well.')
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])
 

--- a/Pal/include/arch/x86_64/Linux/ucontext.h
+++ b/Pal/include/arch/x86_64/Linux/ucontext.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2020 Intel Corporation
  *                    Borys Popławski <borysp@invisiblethingslab.com>
+ * Copyright (C) 2021 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 #ifndef LINUX_X86_64_UCONTEXT_H_
 #define LINUX_X86_64_UCONTEXT_H_
@@ -98,6 +100,19 @@ static inline uint64_t ucontext_get_ip(ucontext_t* uc) {
 
 static inline void ucontext_set_ip(ucontext_t* uc, uint64_t ip) {
     uc->uc_mcontext.rip = ip;
+}
+
+static inline void ucontext_revert_syscall(ucontext_t* uc, unsigned int arch, int syscall_nr,
+                                           void* syscall_addr) {
+    __UNUSED(arch);
+    /* man seccomp(2) says that "si_call_addr will show the address of the system call instruction",
+     * which is not true - it points to the next instruction past "syscall". */
+    uc->uc_mcontext.rip = (uint64_t)syscall_addr - 2;
+    uc->uc_mcontext.rax = syscall_nr;
+
+    uint8_t* rip = (uint8_t*)uc->uc_mcontext.rip;
+    assert(rip[0] == 0x0f && rip[1] == 0x05);
+    __UNUSED(rip);
 }
 
 #endif /* LINUX_X86_64_UCONTEXT_H_ */

--- a/Pal/include/host/Linux-common/syscall.h
+++ b/Pal/include/host/Linux-common/syscall.h
@@ -9,6 +9,8 @@ long do_syscall(long nr, ...);
 long clone(int (*f)(void*), void* stack, int flags, void* arg, void* parent_tid, void* tls,
            void* child_tid, void (*exit_func)(int));
 long vfork(void) __attribute__((returns_twice));
+void syscalls_range_begin(void);
+void syscalls_range_end(void);
 
 noreturn void _DkThreadExit_asm_stub(uint32_t* thread_stack_spinlock, int* clear_child_tid);
 

--- a/Pal/src/host/Linux-common/arch/x86_64/syscall.S
+++ b/Pal/src/host/Linux-common/arch/x86_64/syscall.S
@@ -6,6 +6,12 @@
 #define __ASSEMBLY__
 #include <asm/unistd.h>
 
+.global syscalls_range_begin
+.global syscalls_range_end
+.type syscalls_range_begin, @function
+.type syscalls_range_end, @function
+syscalls_range_begin:
+
 .global do_syscall
 .type do_syscall, @function
 .align 0x10
@@ -107,3 +113,5 @@ _DkThreadExit_asm_stub:
     ud2
     jmp .Lskip_clear_child_tid
     .cfi_endproc
+
+syscalls_range_end:

--- a/Pal/src/host/Linux-common/debug_map.c
+++ b/Pal/src/host/Linux-common/debug_map.c
@@ -170,6 +170,7 @@ out:
 
 /* Example output: "func_name at source_file.c:123" */
 static int run_addr2line(const char* name, uintptr_t offset, char* buf, size_t buf_size) {
+    return -1; // TODO: FIX
     char addr_buf[20];
     snprintf(addr_buf, sizeof(addr_buf), "0x%lx", offset);
 

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -1,13 +1,18 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University
  *               2020 Intel Labs
+ * Copyright (C) 2021 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
 /*
- * This file contains APIs to set up signal handlers.
+ * This file contains APIs to set up signal handlers and seccomp.
  */
 
 #include <stddef.h> /* needed by <linux/signal.h> for size_t */
+#include <linux/filter.h>
+#include <linux/prctl.h>
+#include <linux/seccomp.h>
 #include <linux/signal.h>
 
 #include "api.h"
@@ -80,6 +85,10 @@ static void perform_signal_handling(int event, bool is_in_pal, PAL_NUM addr, uco
 }
 
 static void handle_sync_signal(int signum, siginfo_t* info, struct ucontext* uc) {
+    if (info->si_signo == SIGSYS && info->si_code == SYS_SECCOMP) {
+        ucontext_revert_syscall(uc, info->si_arch, info->si_syscall, info->si_call_addr);
+    }
+
     int event = get_pal_event(signum);
     assert(event > 0);
 
@@ -113,7 +122,58 @@ static void handle_async_signal(int signum, siginfo_t* info, struct ucontext* uc
     perform_signal_handling(event, ADDR_IN_PAL_OR_VDSO(rip), /*addr=*/0, uc);
 }
 
-void signal_setup(void) {
+static int setup_seccomp(void) {
+    int ret = DO_SYSCALL(prctl, PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    if (ret < 0) {
+        log_error("prctl(PR_SET_NO_NEW_PRIVS, 1) failed: %d", ret);
+        return -1;
+    }
+
+    uint32_t syscalls_range_begin_low = (uintptr_t)syscalls_range_begin & 0xffffffffu;
+    uint32_t syscalls_range_begin_high = (uintptr_t)syscalls_range_begin >> 32;
+    uint32_t syscalls_range_end_low = (uintptr_t)syscalls_range_end & 0xffffffffu;
+    uint32_t syscalls_range_end_high = (uintptr_t)syscalls_range_end >> 32;
+    struct sock_filter filter[] = {
+        /* A = ip >> 32 */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4),
+        /* A >= syscalls_range_begin_high ? 0 : GOTO_TRAP */
+        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, syscalls_range_begin_high, 0, /*GOTO_TRAP*/9),
+        /* A == syscalls_range_begin_high ? 0 : GOTO_CMP_END */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, syscalls_range_begin_high, 0, /*GOTO_CMP_END*/2),
+        /* A = ip & (2**32 - 1) */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
+        /* A >= syscalls_range_begin_low ? GOTO_CMP_END : GOTO_TRAP */
+        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, syscalls_range_begin_low, 0, /*GOTO_TRAP*/6),
+        /* CMP_END: */
+        /* A = ip >> 32 */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4),
+        /* A > syscalls_range_end_high ? GOTO_TRAP : 0 */
+        BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, syscalls_range_end_high, /*GOTO_TRAP*/4, 0),
+        /* A == syscalls_range_end_high ? 0 : GOTO_ALLOW */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, syscalls_range_end_high, 0, /*GOTO_ALLOW*/2),
+        /* A = ip & (2**32 - 1) */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
+        /* A > syscalls_range_end_low ? GOTO_TRAP : GOTO_ALLOW */
+        BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, syscalls_range_end_low, /*GOTO_TRAP*/1, 0),
+
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP),
+    };
+    static_assert(ARRAY_SIZE(filter) == 12, "jumps in filter will fail");
+
+    struct sock_fprog seccomp_filter = {
+        .len = ARRAY_SIZE(filter),
+        .filter = filter,
+    };
+    ret = DO_SYSCALL(prctl, PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &seccomp_filter);
+    if (ret < 0) {
+        log_error("Setting seccomp filter failed: %d", ret);
+        return -1;
+    }
+    return 0;
+}
+
+void signal_setup(bool is_first_process) {
     int ret;
 
     /* SIGPIPE and SIGCHLD are emulated completely inside LibOS */
@@ -151,6 +211,13 @@ void signal_setup(void) {
         ret = set_signal_handler(ASYNC_SIGNALS[i], handle_async_signal);
         if (ret < 0)
             goto err;
+    }
+
+    if (is_first_process) {
+        ret = setup_seccomp();
+        if (ret < 0) {
+            INIT_FAIL(PAL_ERROR_DENIED, "Setting up seccomp for inline syscall handling failed");
+        }
     }
 
     return;

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -337,7 +337,7 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     }
     assert(manifest);
 
-    signal_setup();
+    signal_setup(first_process);
 
     g_pal_state.raw_manifest_data = manifest;
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -75,7 +75,7 @@ void init_child_process(int parent_pipe_fd, PAL_HANDLE* parent, char** manifest_
 
 void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[]);
 int block_async_signals(bool block);
-void signal_setup(void);
+void signal_setup(bool is_first_process);
 
 extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_START ((void*)(&__text_start))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commits adds a seccomp policy which traps inline syscalls made by user application and redirects them to LibOS so they can be properly emulated.

## How to test this PR? <!-- (if applicable) -->
Enabled a test which does inline `syscall` instruction.
