### PR TITLE
[LibOS,Pal] Properly report crash location in vDSO

### DIFF
--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -756,6 +756,7 @@ static int vdso_map_init(void) {
         return pal_to_unix_errno(ret);
     }
 
+    append_r_debug("file:[vdso_libos]", addr);
     vdso_addr = addr;
     return 0;
 }

--- a/Pal/src/host/Linux-common/debug_map.c
+++ b/Pal/src/host/Linux-common/debug_map.c
@@ -114,8 +114,8 @@ static int debug_map_init_callback(struct proc_maps_range* r, void* arg) {
     if (!r->name)
         return 0;
 
-    /* [vvar], [vdso] etc. */
-    if (r->name[0] != '/')
+    /* [vvar] etc. */
+    if (r->name[0] != '/' && strcmp(r->name, "[vdso]"))
         return 0;
 
     /* /dev/sgx etc. */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit adds both system vDSO and Gramine's vDSO to debug maps. As aresult, crash location inside these objects will be properly reported.

~~In addition, we attribute crashes inside Gramine's vDSO to Gramine, instead of delivering a signal to the application.~~

## How to test this PR? <!-- (if applicable) -->

* Try running LibOS regression tests without SGX. I have Linux 5.11.4, and e.g. the `proc_common` test crashes inside vDSO on current master, becase the seccomp policy does not allow syscalls inside vDSO, and recent kernels issue such syscalls (this was broken in commit ae352efbc7f2b7bf6a959689801b8f6ed718cdd3).

  The issue with seccomp will be fixed separately, but this commit reports the crash properly (I see `[vdso]+0xb1b`, instead of `libsysdb.so+(bogus offset)` on master).

* ~~Try producing a crash inside Gramine's vDSO: add something like a divide-by-0 in Gramine's `vdso.c:__vdso_gettimeofday` and run the `gettimeofday` regression test. This crash should get reported as `[vdso_libos]+offset`, instead of the signal being delivered to application.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/177)
<!-- Reviewable:end -->
