### PR TITLE
[Pal/Linux] Add vDSO as allowed range in seccomp policy

### DIFF
--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -127,40 +127,51 @@ static void handle_async_signal(int signum, siginfo_t* info, struct ucontext* uc
     perform_signal_handling(event, ADDR_IN_PAL_OR_VDSO(rip), /*addr=*/0, uc);
 }
 
-static int setup_seccomp(void) {
+#define BPF_GENERATE_ALLOWED_RANGE(range_begin_low, range_begin_high,                           \
+                                   range_end_low, range_end_high)                               \
+    /* 0: A = ip >> 32 */                                                                       \
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4), \
+    /* 1: A >= range_begin_high ? 0 : NEXT */                                                   \
+    BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, (range_begin_high), 0, /*NEXT*/9),                      \
+    /* 2: A == range_begin_high ? 0 : CMP_END */                                                \
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, (range_begin_high), 0, /*CMP_END*/2),                   \
+    /* 3: A = ip & (2**32 - 1) */                                                               \
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),     \
+    /* 4: A >= range_begin_low ? CMP_END : NEXT */                                              \
+    BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, (range_begin_low), /*CMP_END*/0, /*NEXT*/6),            \
+    /* 5: CMP_END: A = ip >> 32 */                                                              \
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4), \
+    /* 6: A > range_end_high ? NEXT : 0 */                                                      \
+    BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, (range_end_high), /*NEXT*/4, 0),                        \
+    /* 7: A == range_end_high ? 0 : ALLOW */                                                    \
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, (range_end_high), 0, /*ALLOW*/2),                       \
+    /* 8: A = ip & (2**32 - 1) */                                                               \
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),     \
+    /* 9: A >= range_end_low ? NEXT : ALLOW */                                                  \
+    BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, (range_end_low), /*NEXT*/1, 0),                         \
+                                                                                                \
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)
+
+static int setup_seccomp(uintptr_t vdso_start, uintptr_t vdso_end) {
     int ret = DO_SYSCALL(prctl, PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
     if (ret < 0) {
         log_error("prctl(PR_SET_NO_NEW_PRIVS, 1) failed: %d", ret);
         return -1;
     }
 
-    uint32_t syscalls_code_begin_low = (uintptr_t)gramine_raw_syscalls_code_begin & 0xffffffffu;
+    uint32_t syscalls_code_begin_low = (uintptr_t)gramine_raw_syscalls_code_begin;
     uint32_t syscalls_code_begin_high = (uintptr_t)gramine_raw_syscalls_code_begin >> 32;
-    uint32_t syscalls_code_end_low = (uintptr_t)gramine_raw_syscalls_code_end & 0xffffffffu;
+    uint32_t syscalls_code_end_low = (uintptr_t)gramine_raw_syscalls_code_end;
     uint32_t syscalls_code_end_high = (uintptr_t)gramine_raw_syscalls_code_end >> 32;
-    struct sock_filter filter[] = {
-        /* 0: A = ip >> 32 */
-        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4),
-        /* 1: A >= syscalls_code_begin_high ? 0 : TRAP */
-        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, syscalls_code_begin_high, 0, /*TRAP*/9),
-        /* 2: A == syscalls_code_begin_high ? 0 : CMP_END */
-        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, syscalls_code_begin_high, 0, /*CMP_END*/2),
-        /* 3: A = ip & (2**32 - 1) */
-        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
-        /* 4: A >= syscalls_code_begin_low ? CMP_END : TRAP */
-        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, syscalls_code_begin_low, /*CMP_END*/0, /*TRAP*/6),
-        /* 5: CMP_END: A = ip >> 32 */
-        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4),
-        /* 6: A > syscalls_code_end_high ? TRAP : 0 */
-        BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, syscalls_code_end_high, /*TRAP*/4, 0),
-        /* 7: A == syscalls_code_end_high ? 0 : ALLOW */
-        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, syscalls_code_end_high, 0, /*ALLOW*/2),
-        /* 8: A = ip & (2**32 - 1) */
-        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
-        /* 9: A >= syscalls_code_end_low ? TRAP : ALLOW */
-        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, syscalls_code_end_low, /*TRAP*/1, 0),
+    uint32_t vdso_begin_low = vdso_start;
+    uint32_t vdso_begin_high = vdso_start >> 32;
+    uint32_t vdso_end_low = vdso_end;
+    uint32_t vdso_end_high = vdso_end >> 32;
 
-        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    struct sock_filter filter[] = {
+        BPF_GENERATE_ALLOWED_RANGE(syscalls_code_begin_low, syscalls_code_begin_high,
+                                   syscalls_code_end_low, syscalls_code_end_high),
+        BPF_GENERATE_ALLOWED_RANGE(vdso_begin_low, vdso_begin_high, vdso_end_low, vdso_end_high),
         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP),
     };
 
@@ -176,7 +187,7 @@ static int setup_seccomp(void) {
     return 0;
 }
 
-void signal_setup(bool is_first_process) {
+void signal_setup(bool is_first_process, uintptr_t vdso_start, uintptr_t vdso_end) {
     int ret;
 
     /* SIGPIPE and SIGCHLD are emulated completely inside LibOS */
@@ -217,7 +228,7 @@ void signal_setup(bool is_first_process) {
     }
 
     if (is_first_process) {
-        ret = setup_seccomp();
+        ret = setup_seccomp(vdso_start, vdso_end);
         if (ret < 0) {
             INIT_FAIL(PAL_ERROR_DENIED, "Setting up seccomp for inline syscall handling failed");
         }

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -300,7 +300,8 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
             INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
         }
     } else {
-        log_warning("vdso address range not preloaded, is your system missing vdso?!");
+        INIT_FAIL(PAL_ERROR_DENIED, "vdso address range not preloaded, is your system missing "
+                                    "vdso?!");
     }
     if (vvar_start || vvar_end) {
         ret = add_preloaded_range(vvar_start, vvar_end, "vvar");
@@ -335,7 +336,9 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     }
     assert(manifest);
 
-    signal_setup(first_process);
+    /* This depends on `g_vdso_start` and `g_vdso_end`, so it must be called only after they were
+     * initialized. */
+    signal_setup(first_process, g_vdso_start, g_vdso_end);
 
     g_pal_state.raw_manifest_data = manifest;
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -73,7 +73,7 @@ void init_child_process(int parent_pipe_fd, PAL_HANDLE* parent, char** manifest_
 
 void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[]);
 int block_async_signals(bool block);
-void signal_setup(bool is_first_process);
+void signal_setup(bool is_first_process, uintptr_t vdso_start, uintptr_t vdso_end);
 
 extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_START ((void*)(&__text_start))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
In some cases vDSO stubs may fallback to raw syscalls, which we now allow in our seccomp filter.

Fixes #176

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/178)
<!-- Reviewable:end -->
