### PR TITLE
[LibOS] Remove __kernel_itimerspec

### DIFF
--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -58,13 +58,6 @@ struct __kernel_timespec {
 };
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
-struct __kernel_itimerspec {
-    struct __kernel_timespec it_interval; /* timer period */
-    struct __kernel_timespec it_value;    /* timer expiration */
-};
-#endif
-
 struct __kernel_timeval {
     __kernel_time_t tv_sec;       /* seconds */
     __kernel_suseconds_t tv_usec; /* microsecond */


### PR DESCRIPTION
This is unused and breaks with RHEL8 kernels, which are nominally 4.18,
but provide this struct anyway.

## How to test this PR?

Compile on RHEL8-compatible distro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/183)
<!-- Reviewable:end -->
