### PR TITLE
[Docs] quickstart: Add missing `-Dtests=enabled`

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -58,11 +58,11 @@ Building
 
 #. Build Gramine::
 
-       meson setup build/ --buildtype=release -Dsgx=enabled -Ddirect=disabled
+       meson setup build/ --buildtype=release -Dsgx=enabled -Dtests=enabled
        ninja -C build/
        sudo ninja -C build/ install
 
-#. Build and run :program:`helloworld`::
+#. Build test manifests and run :program:`helloworld`::
 
        cd LibOS/shim/test/regression
        make SGX=1

--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -47,7 +47,8 @@ GDB integration also requires pyelftools Python package::
 
 After rebuilding Gramine with debug symbols, you need to re-sign the manifest of
 the application. For instance, if you want to debug the ``helloworld`` program,
-run the following commands::
+run the following commands (note that you need to also pass ``-Dtests=enabled``
+to Meson in order to build test binaries)::
 
     cd LibOS/shim/test/regression
     make SGX=1

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -24,7 +24,8 @@ Quick start without SGX support
           wget
       sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       cd gramine
-      meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=disabled
+      meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=disabled \
+          -Dtests=enabled
       ninja -C build/
       sudo ninja -C build/ install
 
@@ -74,7 +75,8 @@ descriptions in :doc:`building`.
           python3-pip python3-protobuf wget
       sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       # this assumes Linux 5.11+
-      meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=enabled
+      meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=enabled \
+          -Dtests=enabled
       ninja -C build/
       sudo ninja -C build/ install
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -24,12 +24,11 @@ Quick start without SGX support
           wget
       sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
       cd gramine
-      meson setup build/ --buildtype=release -Ddirect=enabled -Dsgx=disabled \
-          -Dtests=enabled
+      meson setup build/ --buildtype=release -Ddirect=enabled -Dtests=enabled
       ninja -C build/
       sudo ninja -C build/ install
 
-#. Build and run :program:`helloworld`::
+#. Build test manifests and run :program:`helloworld`::
 
       cd LibOS/shim/test/regression
       make
@@ -92,7 +91,7 @@ descriptions in :doc:`building`.
 
    Note that this is an inadvisable configuration for production systems.
 
-#. Build and run :program:`helloworld`::
+#. Build test manifests and run :program:`helloworld`::
 
       cd LibOS/shim/test/regression
       make SGX=1


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The quickstart guide says to run `helloworld`, so we need to enable building tests.

## How to test this PR? <!-- (if applicable) -->

Following the quickstart guide should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/187)
<!-- Reviewable:end -->
