### PR TITLE
[CI-Examples,Docs] Add `helloworld` example

### DIFF
--- a/.ci/lib/stage-clean-check.jenkinsfile
+++ b/.ci/lib/stage-clean-check.jenkinsfile
@@ -13,6 +13,7 @@ stage('clean-check') {
         make -C Pal/regression clean
         make -C Scripts clean
 
+        make -C CI-Examples/helloworld clean
         make -C CI-Examples/python clean
         make -C CI-Examples/bash clean
         make -C CI-Examples/memcached distclean

--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -13,6 +13,13 @@ stage('test-direct') {
     }
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
+            cd CI-Examples/helloworld
+            make ${MAKEOPTS} all
+            make check
+        '''
+    }
+    timeout(time: 5, unit: 'MINUTES') {
+        sh '''
             cd CI-Examples/python
             make ${MAKEOPTS} all
             make check

--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -1,6 +1,13 @@
 stage('test-sgx') {
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
+            cd CI-Examples/helloworld
+            make ${MAKEOPTS}
+            make ${MAKEOPTS} check
+        '''
+    }
+    timeout(time: 5, unit: 'MINUTES') {
+        sh '''
             cd CI-Examples/python
             make ${MAKEOPTS}
             make ${MAKEOPTS} check

--- a/CI-Examples/helloworld/.gitignore
+++ b/CI-Examples/helloworld/.gitignore
@@ -1,0 +1,3 @@
+/helloworld
+/*.o
+/OUTPUT

--- a/CI-Examples/helloworld/Makefile
+++ b/CI-Examples/helloworld/Makefile
@@ -1,0 +1,59 @@
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+CFLAGS = -Wall -Wextra
+
+ifeq ($(DEBUG),1)
+GRAMINE_LOG_LEVEL = debug
+CFLAGS += -g
+else
+GRAMINE_LOG_LEVEL = error
+CFLAGS += -O3
+endif
+
+.PHONY: all
+all: helloworld helloworld.manifest
+ifeq ($(SGX),1)
+all: helloworld.manifest.sgx helloworld.sig helloworld.token
+endif
+
+helloworld: helloworld.o
+
+helloworld.o: helloworld.c
+
+helloworld.manifest: helloworld.manifest.template
+	gramine-manifest \
+		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
+		$< $@
+
+helloworld.manifest.sgx: helloworld.manifest helloworld
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
+	gramine-sgx-sign \
+		--key $(SGX_SIGNER_KEY) \
+		--manifest $< \
+		--output $@
+
+helloworld.sig: helloworld.manifest.sgx
+
+helloworld.token: helloworld.sig
+	gramine-sgx-get-token \
+		--output $@ --sig $<
+
+ifeq ($(SGX),)
+GRAMINE = gramine-direct
+else
+GRAMINE = gramine-sgx
+endif
+
+.PHONY: check
+check: all
+	$(GRAMINE) helloworld > OUTPUT
+	echo "Hello, world" | diff OUTPUT -
+	@echo "[ Success ]"
+
+.PHONY: clean
+clean:
+	$(RM) *.token *.sig *.manifest.sgx *.manifest helloworld.o helloworld OUTPUT
+
+.PHONY: distclean
+distclean: clean

--- a/CI-Examples/helloworld/README.md
+++ b/CI-Examples/helloworld/README.md
@@ -1,0 +1,27 @@
+# Hello World
+
+This directory contains a Makefile and a manifest template for running a simple
+"Hello World" program in Gramine. It can be used as a sanity test for your
+Gramine installation.
+
+# Building
+
+## Building for Linux
+
+Run `make` (non-debug) or `make DEBUG=1` (debug) in the directory.
+
+## Building for SGX
+
+Run `make SGX=1` (non-debug) or `make SGX=1 DEBUG=1` (debug) in the directory.
+
+# Run Hello World with Gramine
+
+Without SGX:
+```sh
+gramine-direct helloworld
+```
+
+With SGX:
+```sh
+gramine-sgx helloworld
+```

--- a/CI-Examples/helloworld/helloworld.c
+++ b/CI-Examples/helloworld/helloworld.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("Hello, world\n");
+    return 0;
+}

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -1,0 +1,21 @@
+# Hello World manifest file example
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "helloworld"
+loader.log_level = "{{ log_level }}"
+loader.argv0_override = "helloworld"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+
+sgx.debug = true
+sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:helloworld",
+  "file:{{ gramine.runtimedir() }}/",
+]

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -64,7 +64,6 @@ Building
 
 #. Build and run :program:`helloworld`::
 
-       cd LibOS/shim/test/regression
+       cd CI-Examples/helloworld
        make SGX=1
-       make SGX=1 sgx-tokens
        gramine-sgx helloworld

--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -49,9 +49,9 @@ After rebuilding Gramine with debug symbols, you need to re-sign the manifest of
 the application. For instance, if you want to debug the ``helloworld`` program,
 run the following commands::
 
-    cd LibOS/shim/test/regression
-    make SGX=1
-    make SGX=1 sgx-tokens
+    cd CI-Examples/helloworld
+    make SGX=1 clean
+    make SGX=1 DEBUG=1
 
 To run Gramine with GDB, use the Gramine loader (``gramine-sgx``) and specify
 ``GDB=1``::

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -30,7 +30,7 @@ Quick start without SGX support
 
 #. Build and run :program:`helloworld`::
 
-      cd LibOS/shim/test/regression
+      cd CI-Examples/helloworld
       make
       gramine-direct helloworld
 
@@ -92,9 +92,8 @@ descriptions in :doc:`building`.
 
 #. Build and run :program:`helloworld`::
 
-      cd LibOS/shim/test/regression
+      cd CI-Examples/helloworld
       make SGX=1
-      make SGX=1 sgx-tokens
       gramine-sgx helloworld
 
 Troubleshooting


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine's "quick start" guides recommended running the `helloworld` regression test, but this now requires an extra flag for Meson (`-Dtests=enabled`) that we do not want to recommend to first-time users. Instead, there's a standalone `helloworld` example.

Discussed in #187.

Fixes #205.

## How to test this PR? <!-- (if applicable) -->

Compile and run the example yourself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/188)
<!-- Reviewable:end -->
