### PR TITLE
[Pal] Reduce the 64MB static buffer

### DIFF
--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -244,7 +244,7 @@ int _DkSetProtectedFilesKey(PAL_PTR pf_key_hex);
         _DkProcessExit(exitcode);                                      \
     } while (0)
 
-void init_slab_mgr(void);
+void init_slab_mgr(char* mem_pool, size_t mem_pool_size);
 void* malloc(size_t size);
 void* malloc_copy(const void* mem, size_t size);
 void* calloc(size_t nmem, size_t size);
@@ -277,5 +277,9 @@ const char* pal_event_name(enum PAL_EVENT event);
         _DkProcessExit(PAL_ERROR_NOMEM);       \
     } while (0)
 #include "uthash.h"
+
+/* Size of PAL memory available before parsing the manifest; `loader.pal_internal_mem_size` does not
+ * include this memory */
+#define PAL_INITIAL_MEM_SIZE (64 * 1024 * 1024)
 
 #endif

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -69,8 +69,10 @@ int main(int argc, char** argv, char** envp) {
             pal_printf("Memory Deallocation OK\n");
     }
 
+    /* TODO: This does not take into account `pal_control.preloaded_ranges`; we are not allowed to
+     * ask for memory overlapping with these ranges */
     void* mem3 = (void*)pal_control.user_address.start;
-    void* mem4 = (void*)pal_control.user_address.end - UNIT;
+    void* mem4 = (void*)pal_control.user_address.start + UNIT;
 
     int ret2 = DkVirtualMemoryAlloc(&mem3, UNIT, 0, PAL_PROT_READ | PAL_PROT_WRITE);
     ret = DkVirtualMemoryAlloc(&mem4, UNIT, 0, PAL_PROT_READ | PAL_PROT_WRITE);


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This change reduces the initial 64MB buffer to a much smaller size, and allocates 64MB of memory after PAL startup instead (by making that the default value for `loader.pal_internal_mem_size`).

While the memory still has to be explicitely zeroed, this makes calculating the enclave measurement much faster (`gramine-sgx-sign` on test binaries takes 50% less time, because we can omit hashing 64MB worth of zeroes.

## How to test this PR? <!-- (if applicable) -->

CI should be enough, but keep in mind this is a breaking change if existing manifests define `loader.pal_internal_mem_size`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/192)
<!-- Reviewable:end -->
