### PR TITLE
[CI] Test apps in the SGX sanitizers configuration

### DIFF
--- a/.ci/linux-sgx-sanitizers.jenkinsfile
+++ b/.ci/linux-sgx-sanitizers.jenkinsfile
@@ -19,6 +19,7 @@ node('sgx_slave_2.6') {
         load '.ci/lib/stage-clean-check-prepare.jenkinsfile'
         load '.ci/lib/stage-build-sgx.jenkinsfile'
         load '.ci/lib/stage-test.jenkinsfile'
+        load '.ci/lib/stage-test-sgx.jenkinsfile'
         load '.ci/lib/stage-clean-check.jenkinsfile'
     }
 }

--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -17,6 +17,9 @@ GRAMINE_LOG_LEVEL = error
 CFLAGS += -O2
 endif
 
+CFLAGS += -fPIE
+LDFLAGS += -pie
+
 .PHONY: all
 all: app epid  # by default, only build EPID because it doesn't rely on additional (DCAP) libs
 
@@ -67,13 +70,13 @@ mbedtls/.mbedtls_configured: mbedtls/.mbedtls_downloaded
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
 CFLAGS += -I./mbedtls/include $(shell pkg-config --cflags mbedtls_gramine)
-LFLAGS += -ldl $(shell pkg-config --libs mbedtls_gramine)
+LDFLAGS += -ldl $(shell pkg-config --libs mbedtls_gramine)
 
 server: src/server.c mbedtls/.mbedtls_configured
-	$(CC) $< $(CFLAGS) $(LFLAGS) -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
 
 client: src/client.c mbedtls/.mbedtls_configured
-	$(CC) $< $(CFLAGS) $(LFLAGS) -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
 
 ############################### SERVER MANIFEST ###############################
 

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -17,6 +17,9 @@ GRAMINE_LOG_LEVEL = error
 CFLAGS += -O2
 endif
 
+CFLAGS += -fPIE
+LDFLAGS += -pie
+
 .PHONY: clients
 clients: secret_prov_min_client secret_prov_client secret_prov_pf_client
 
@@ -39,25 +42,25 @@ dcap: secret_prov_server_dcap
 
 CFLAGS += -Wall -std=c11 -I$(GRAMINEDIR)/Pal/src/host/Linux-SGX/tools/ra-tls \
           $(shell pkg-config --cflags mbedtls_gramine)
-LFLAGS += $(shell pkg-config --libs mbedtls_gramine)
+LDFLAGS += $(shell pkg-config --libs mbedtls_gramine)
 
 secret_prov_server_epid: src/secret_prov_server.c
-	$(CC) $< $(CFLAGS) $(LFLAGS) -lsecret_prov_verify_epid -pthread -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -lsecret_prov_verify_epid -pthread -o $@
 
 # linker option --no-as-needed is required because SGX DCAP library (libsgx_dcap_quoteverify.so)
 # does dlopen() instead of directly linking against libsgx_urts.so, and without this option
 # compilers remove the "seemingly unused" libsgx_urts.so
 secret_prov_server_dcap: src/secret_prov_server.c
-	$(CC) $< $(CFLAGS) $(LFLAGS) -Wl,--no-as-needed -lsgx_urts -lsecret_prov_verify_dcap -pthread -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -Wl,--no-as-needed -lsgx_urts -lsecret_prov_verify_dcap -pthread -o $@
 
 secret_prov_client: src/secret_prov_client.c
-	$(CC) $< $(CFLAGS) $(LFLAGS) -lsecret_prov_attest -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -lsecret_prov_attest -o $@
 
 secret_prov_min_client: src/secret_prov_min_client.c
-	$(CC) $< $(CFLAGS) $(LFLAGS) -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
 
 secret_prov_pf_client: src/secret_prov_pf_client.c
-	$(CC) $< $(CFLAGS) $(LFLAGS) -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
 
 ############################### CLIENT MANIFEST ###############################
 

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -249,8 +249,8 @@ static int execute_loadcmd(const struct loadcmd* c, ElfW(Addr) load_addr,
         }
 
         if ((ret = file->fs->fs_ops->mmap(file, &map_start, map_size, c->prot, map_flags,
-                                          c->map_off) < 0)) {
-            log_debug("%s: failed to map segment", __func__);
+                                          c->map_off)) < 0) {
+            log_debug("%s: failed to map segment: %d", __func__, ret);
             return ret;
         }
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This adds `CI-Examples` to the SGX sanitizers configuration. ASan and UBSan found no bugs, but the remote attestation examples did not work when compiled with Clang (because it doesn't default to PIE).

Also, I fixed a stupid bug that causes Gramine to continue after failing to map such executables (instead of exiting with a helpful message, which we already have!)

## How to test this PR? <!-- (if applicable) -->

CI should be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/197)
<!-- Reviewable:end -->
