### PR TITLE
[LibOS] Return from read/write early with 0 if count is zero

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -401,6 +401,9 @@ static ssize_t chroot_read(struct shim_handle* hdl, void* buf, size_t count) {
     if (count > SSIZE_MAX)
         return -EFBIG;
 
+    if (count == 0)
+        return 0;
+
     struct shim_inode* inode = hdl->inode;
     lock(&hdl->lock);
 
@@ -437,6 +440,9 @@ static ssize_t chroot_write(struct shim_handle* hdl, const void* buf, size_t cou
 
     if (count > SSIZE_MAX)
         return -EFBIG;
+
+    if (count == 0)
+        return 0;
 
     struct shim_inode* inode = hdl->inode;
     lock(&hdl->lock);


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Return from read/write early with 0 if count is zero.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/207)
<!-- Reviewable:end -->
