### PR TITLE
[tests] Fix `has_debug()` invocation

### DIFF
--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -30,7 +30,7 @@ class TC_00_Unittests(RegressionTestCase):
     @unittest.skipUnless(os.environ.get('ASAN') == '1', 'test only enabled with ASAN=1')
     def test_021_asan(self):
         expected_list = ['asan: heap-buffer-overflow']
-        if self.has_debug:
+        if self.has_debug():
             expected_list.append('asan: location: run_test_asan_buffer_overflow at shim_call.c')
         self._test_abort('asan_buffer_overflow', expected_list)
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`self.has_debug` -> `self.has_debug()`

This bug caused the ASan test to fail when running in release mode.

This is one of the issues described in #208.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

* Build with ASan and release mode: `CC=clang CXX=clang++ AS=clang meson --buildtype=release -Ddirect=enabled -Dtests=enabled -Dasan=enabled`.
* Run the ASan test in `LibOS/shim/tests/regression`:
```
make run_test run_test.manifest
ASAN=1 ../../../../Scripts/run-pytest -k test_021_asan
```

It should fail on `master` and pass on this branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/212)
<!-- Reviewable:end -->
