### PR TITLE
[Pal/Linux-SGX] Fix user address range calculation

### DIFF
--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -417,21 +417,23 @@ int DkStreamMap(PAL_HANDLE handle, PAL_PTR* addr, pal_prot_flags_t prot, PAL_NUM
     assert(addr);
     void* map_addr = *addr;
 
-    /* TODO: we must not allow NULL addresses here, but sendfile() in LibOS does it -- it must be
-     *       re-written and then this function should enforce `map_addr != NULL` */
-
     if (!handle) {
         return -PAL_ERROR_INVAL;
     }
 
-    if (map_addr && !IS_ALLOC_ALIGNED_PTR(map_addr)) {
+    if (!map_addr) {
         return -PAL_ERROR_INVAL;
     }
+
+    if (!IS_ALLOC_ALIGNED_PTR(map_addr)) {
+        return -PAL_ERROR_INVAL;
+    }
+
     if (!size || !IS_ALLOC_ALIGNED(size) || !IS_ALLOC_ALIGNED(offset)) {
         return -PAL_ERROR_INVAL;
     }
 
-    if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
+    if (_DkCheckMemoryMappable(map_addr, size)) {
         return -PAL_ERROR_DENIED;
     }
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -416,7 +416,7 @@ static int pf_file_map(struct protected_file* pf, PAL_HANDLE handle, void** addr
               *addr, prot, offset, size);
 
     if (*addr == NULL) {
-        /* LibOS didn't provide address at which to map, can happen on sendfile() */
+        /* No address at which to map, can happen when called from `db_rtld.c` */
         allocated_enclave_pages = get_enclave_pages(/*addr=*/NULL, size, /*is_pal_internal=*/false);
         if (!allocated_enclave_pages)
             return -PAL_ERROR_NOMEM;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -47,9 +47,8 @@ void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     *end   = (PAL_PTR)g_pal_sec.heap_max;
 
     /* Keep some heap for internal PAL objects allocated at runtime (recall that LibOS does not keep
-     * track of PAL memory, so without this limit it could overwrite internal PAL memory). This
-     * relies on the fact that our memory management allocates memory from higher addresses to lower
-     * addresses (see also enclave_pages.c). */
+     * track of PAL memory, so without this limit it could overwrite internal PAL memory). See also
+     * `enclave_pages.c`. */
     *end = SATURATED_P_SUB(*end, g_pal_internal_mem_size, *start);
 
     if (*end <= *start) {

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -44,7 +44,7 @@ const size_t g_page_size = PRESET_PAGESIZE;
 
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     *start = (PAL_PTR)g_pal_sec.heap_min;
-    *end   = (PAL_PTR)get_enclave_heap_top();
+    *end   = (PAL_PTR)g_pal_sec.heap_max;
 
     /* Keep some heap for internal PAL objects allocated at runtime (recall that LibOS does not keep
      * track of PAL memory, so without this limit it could overwrite internal PAL memory). This

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -319,21 +319,3 @@ out:
     spinlock_unlock(&g_heap_vma_lock);
     return ret;
 }
-
-/* returns current highest available address on the enclave heap */
-void* get_enclave_heap_top(void) {
-    spinlock_lock(&g_heap_vma_lock);
-
-    void* addr = g_heap_top;
-    struct heap_vma* vma;
-    LISTP_FOR_EACH_ENTRY(vma, &g_heap_vma_list, list) {
-        if (vma->top < addr) {
-            goto out;
-        }
-        addr = vma->bottom;
-    }
-
-out:
-    spinlock_unlock(&g_heap_vma_lock);
-    return addr;
-}

--- a/Pal/src/host/Linux-SGX/enclave_pages.h
+++ b/Pal/src/host/Linux-SGX/enclave_pages.h
@@ -2,6 +2,5 @@
 #include <stddef.h>
 
 void init_enclave_pages(void);
-void* get_enclave_heap_top(void);
 void* get_enclave_pages(void* addr, size_t size, bool is_pal_internal);
 int free_enclave_pages(void* addr, size_t size);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Fixes the intermittent crashes after fork, introduced in #192. See commit message for more details.

Unfortunately LibOS allocation code still looks pretty brittle (we rely on the fact that in child process does roughly the same allocations as in parent, or at least less of them). But the crash should be gone now.

Fixes #215.

## How to test this PR? <!-- (if applicable) -->

The problem can be seen on the `fork_and_exec` example. Normally it appears rarely, but you can adjust the memory parameters to force it:

1. `cd LibOS/shim/test/regression; make fork_and_exec.manifest`
2. Edit `fork_and_exec.manifest`: set `sgx.enclave_size = "128M"` and `loader.pal_internal_mem_size = "40M"`.
3. Rebuild: `SGX=1 make fork_and_exec.token` (you'll need to repeat this step after rebuilding Gramine)
4. Run in a loop, e.g.: `while gramine-sgx fork_and_exec; do true; done`

With the manifest modifications, the code on `master` crashes pretty reliably on first try, with the following messages:

```
[::] warning: user app tried to free an internal vma!
[::] error: failed restoring checkpoint at vma (-13)
[::] error: Error during shim_init() in receive_checkpoint_and_restore (-13)
...
[P1:T1:fork_and_exec] debug: process 1 exited with status 1
debug: DkProcessExit: Returning exit code 1
```

After this fix, I've run it in a loop for 300+ iterations and it still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/214)
<!-- Reviewable:end -->
