### PR TITLE
[Pal/Linux-SGX] Add a message on `sgx.debug = true` on GDB attach

### DIFF
--- a/Pal/src/host/Linux-SGX/gdb_integration/gramine_sgx_gdb.py
+++ b/Pal/src/host/Linux-SGX/gdb_integration/gramine_sgx_gdb.py
@@ -20,6 +20,9 @@ def main():
         path = os.path.join(os.path.dirname(__file__), filename)
         gdb.execute('source ' + path)
 
+    print('[%s] For SGX enclave debugging, don\'t forget to specify `sgx.debug=true`.' %
+              os.path.basename(__file__))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

I forgot to add `sgx.debug = true` in the manifest file before starting my GDB sessions on a production-ready app. This made my GDB hang, and I spent some time figuring out what's going on. Then I remembered that `sgx.debug` is false by default (this was flipped starting from Gramine v1.0).

## How to test this PR? <!-- (if applicable) -->

Run GDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/217)
<!-- Reviewable:end -->
