### PR TITLE
[Pal/Linux-SGX] Restructure sgx_quote_t to split signature from body

### DIFF
--- a/LibOS/shim/test/regression/attestation.c
+++ b/LibOS/shim/test/regression/attestation.c
@@ -226,20 +226,20 @@ static int test_quote_interface(void) {
     }
 
     /* 3. verify report data read from `quote` */
-    if ((size_t)bytes < sizeof(sgx_quote_t)) {
+    if ((size_t)bytes < sizeof(sgx_quote_body_t)) {
         fprintf(stderr, "obtained SGX quote is too small: %ldB (must be at least %ldB)\n", bytes,
-                sizeof(sgx_quote_t));
+                sizeof(sgx_quote_body_t));
         return FAILURE;
     }
 
-    sgx_quote_t* typed_quote = (sgx_quote_t*)g_quote;
+    sgx_quote_body_t* quote_body = (sgx_quote_body_t*)g_quote;
 
-    if (typed_quote->version != /*EPID*/2 && typed_quote->version != /*DCAP*/3) {
+    if (quote_body->version != /*EPID*/2 && quote_body->version != /*DCAP*/3) {
         fprintf(stderr, "version of SGX quote is not EPID (2) and not ECDSA/DCAP (3)\n");
         return FAILURE;
     }
 
-    int ret = memcmp(typed_quote->report_body.report_data.d, user_report_data.d,
+    int ret = memcmp(quote_body->report_body.report_data.d, user_report_data.d,
                      sizeof(user_report_data));
     if (ret) {
         fprintf(stderr, "comparison of report data in SGX quote failed\n");

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -44,11 +44,7 @@ typedef struct _sgx_basename_t {
     uint8_t name[32];
 } sgx_basename_t;
 
-/* TODO: IAS returns an IAS report object that contains a truncated SGX quote inside, without
- * `signature_len` and `signature` fields. This is called "SGX quote body". We must split the
- * current `sgx_quote_t` struct into two structs, and use the "SGX quote body" in all relevant
- * functions instead of the full `sgx_quote_t` (otherwise it will blow up someday). */
-typedef struct _sgx_quote_t {
+typedef struct _sgx_quote_body_t {
     uint16_t version;
     uint16_t sign_type;
     sgx_epid_group_id_t epid_group_id;
@@ -57,11 +53,13 @@ typedef struct _sgx_quote_t {
     uint32_t xeid;
     sgx_basename_t basename;
     sgx_report_body_t report_body;
-    uint32_t signature_len;
+} sgx_quote_body_t;
+
+typedef struct _sgx_quote_t {
+    sgx_quote_body_t body;
+    uint32_t signature_size;
     uint8_t signature[];
 } sgx_quote_t;
-
-#define SGX_QUOTE_BODY_SIZE (offsetof(sgx_quote_t, signature_len))
 
 typedef uint8_t sgx_spid_t[16];
 typedef uint8_t sgx_quote_nonce_t[16];

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -305,7 +305,7 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
     /* Intel SGX SDK implementation of the Quoting Enclave always sets `quote.len` to user-provided
      * `getreq.buf_size` (see above) instead of the actual size. We calculate the actual size here
      * by peeking into the quote and determining the size of the signature. */
-    size_t actual_quote_size = sizeof(sgx_quote_t) + actual_quote->signature_len;
+    size_t actual_quote_size = sizeof(sgx_quote_t) + actual_quote->signature_size;
     if (actual_quote_size > SGX_QUOTE_MAX_SIZE) {
         log_error("Size of the obtained SGX quote exceeds %d", SGX_QUOTE_MAX_SIZE);
         goto out;

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.h
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.h
@@ -23,13 +23,6 @@
 void display_quote(const void* quote_data, size_t quote_size);
 
 /*!
- *  \brief Display internal SGX report body structure (sgx_report_body_t).
- *
- *  \param[in] body Buffer with report body data.
- */
-void display_report_body(const sgx_report_body_t* body);
-
-/*!
  *  \brief Verify IAS attestation report. Also extract the SGX quote contained in IAS report:
  *         allocate enough memory to hold the quote and pass it to the user.
  *
@@ -54,10 +47,9 @@ int verify_ias_report_extract_quote(const uint8_t* ias_report, size_t ias_report
                                     size_t* out_quote_size);
 
 /*!
- *  \brief Verify that the provided SGX quote contains expected values.
+ *  \brief Verify that the provided SGX quote body contains expected values.
  *
- *  \param[in] quote_data      Quote to verify.
- *  \param[in] quote_size      Size of \a quote_data in bytes.
+ *  \param[in] quote_body      Quote body to verify.
  *  \param[in] mr_signer       (Optional) Expected mr_signer quote field.
  *  \param[in] mr_enclave      (Optional) Expected mr_enclave quote field.
  *  \param[in] isv_prod_id     (Optional) Expected isv_prod_id quote field.
@@ -72,18 +64,18 @@ int verify_ias_report_extract_quote(const uint8_t* ias_report, size_t ias_report
  *
  *  \return 0 on successful verification, negative value on error.
  */
-int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signer,
-                 const char* mr_enclave, const char* isv_prod_id, const char* isv_svn,
-                 const char* report_data, bool expected_as_str);
+int verify_quote_body(const sgx_quote_body_t* quote_body, const char* mr_signer,
+                      const char* mr_enclave, const char* isv_prod_id, const char* isv_svn,
+                      const char* report_data, bool expected_as_str);
 
 /*!
- *  \brief Verify enclave attributes of the provided SGX quote.
+ *  \brief Verify enclave attributes of the provided SGX quote body.
  *
- *  \param[in] quote                Quote to verify.
+ *  \param[in] quote_body           Quote body to verify.
  *  \param[in] allow_debug_enclave  If true, then SGXREPORT.ATTRIBUTES.DEBUG can be 1.
  *
  *  \return 0 on successful verification, negative value on error.
  */
-int verify_quote_enclave_attributes(sgx_quote_t* quote, bool allow_debug_enclave);
+int verify_quote_body_enclave_attributes(sgx_quote_body_t* quote_body, bool allow_debug_enclave);
 
 #endif /* ATTESTATION_H */

--- a/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
@@ -92,11 +92,11 @@ static int report(struct ias_context_t* ias, const char* quote_path, const char*
     }
 
     sgx_quote_t* quote = (sgx_quote_t*)quote_data;
-    if ((size_t)quote_size < sizeof(sgx_quote_t) + quote->signature_len) {
+    if ((size_t)quote_size < sizeof(sgx_quote_t) + quote->signature_size) {
         ERROR("Quote is too small\n");
         goto out;
     }
-    quote_size = sizeof(sgx_quote_t) + quote->signature_len;
+    quote_size = sizeof(sgx_quote_t) + quote->signature_size;
 
     ret = ias_verify_quote(ias, quote_data, quote_size, nonce, report_path, sig_path, cert_path,
                            advisory_path);

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls.h
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls.h
@@ -54,7 +54,7 @@ __attribute__ ((visibility("hidden")))
 int cmp_crt_pk_against_quote_report_data(mbedtls_x509_crt* crt, sgx_quote_t* quote);
 
 __attribute__ ((visibility("hidden")))
-int verify_quote_against_envvar_measurements(const void* quote, size_t quote_size);
+int verify_quote_body_against_envvar_measurements(const sgx_quote_body_t* quote_body);
 
 /*!
  * \brief Callback for user-specific verification of measurements in SGX quote.

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_common.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_common.c
@@ -166,7 +166,7 @@ int cmp_crt_pk_against_quote_report_data(mbedtls_x509_crt* crt, sgx_quote_t* quo
     if (ret < 0)
         return ret;
 
-    ret = memcmp(quote->report_body.report_data.d, sha, SHA256_DIGEST_SIZE);
+    ret = memcmp(quote->body.report_body.report_data.d, sha, SHA256_DIGEST_SIZE);
     if (ret)
         return MBEDTLS_ERR_X509_SIG_MISMATCH;
 
@@ -197,7 +197,7 @@ out:
     return ret;
 }
 
-int verify_quote_against_envvar_measurements(const void* quote, size_t quote_size) {
+int verify_quote_body_against_envvar_measurements(const sgx_quote_body_t* quote_body) {
     int ret;
 
     sgx_measurement_t expected_mrsigner;
@@ -217,12 +217,11 @@ int verify_quote_against_envvar_measurements(const void* quote, size_t quote_siz
     if (ret < 0)
         return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
 
-    ret = verify_quote(quote, quote_size,
-                       validate_mrsigner ? (char*)&expected_mrsigner : NULL,
-                       validate_mrenclave ? (char*)&expected_mrenclave : NULL,
-                       validate_isv_prod_id ? (char*)&expected_isv_prod_id : NULL,
-                       validate_isv_svn ? (char*)&expected_isv_svn : NULL,
-                       /*report_data=*/NULL, /*expected_as_str=*/false);
+    ret = verify_quote_body(quote_body, validate_mrsigner ? (char*)&expected_mrsigner : NULL,
+                            validate_mrenclave ? (char*)&expected_mrenclave : NULL,
+                            validate_isv_prod_id ? (char*)&expected_isv_prod_id : NULL,
+                            validate_isv_svn ? (char*)&expected_isv_svn : NULL,
+                            /*report_data=*/NULL, /*expected_as_str=*/false);
     if (ret < 0)
         return MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
 

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_dcap.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_dcap.c
@@ -163,8 +163,10 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
             break;
     }
 
-    /* verify enclave attributes from the SGX quote */
-    ret = verify_quote_enclave_attributes(quote, allow_debug_enclave);
+    sgx_quote_body_t* quote_body = &quote->body;
+
+    /* verify enclave attributes from the SGX quote body */
+    ret = verify_quote_body_enclave_attributes(quote_body, allow_debug_enclave);
     if (ret < 0) {
         ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
         goto out;
@@ -173,13 +175,13 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
     /* verify other relevant enclave information from the SGX quote */
     if (g_verify_measurements_cb) {
         /* use user-supplied callback to verify measurements */
-        ret = g_verify_measurements_cb((const char*)&quote->report_body.mr_enclave,
-                                       (const char*)&quote->report_body.mr_signer,
-                                       (const char*)&quote->report_body.isv_prod_id,
-                                       (const char*)&quote->report_body.isv_svn);
+        ret = g_verify_measurements_cb((const char*)&quote_body->report_body.mr_enclave,
+                                       (const char*)&quote_body->report_body.mr_signer,
+                                       (const char*)&quote_body->report_body.isv_prod_id,
+                                       (const char*)&quote_body->report_body.isv_svn);
     } else {
         /* use default logic to verify measurements */
-        ret = verify_quote_against_envvar_measurements(quote, quote_size);
+        ret = verify_quote_body_against_envvar_measurements(quote_body);
     }
     if (ret < 0) {
         ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
SGX quote returned by IAS does not contain signature and signature length fields. This might result in a buffer overflow if we accidentally end up using these fields as part of the quote. To avoid such an issue, this commit splits sgx_quote structure into sgx_quote_body and signature.

Also, modified `attestation` LibOS regression to incorporate the new sgx_quote structural change.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

Fixes #113 

## How to test this PR? <!-- (if applicable) -->
Please run LibOS regression tests. One can also run the `ra-tls-mbedtls` test as part of our CI-Examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/219)
<!-- Reviewable:end -->
