### PR TITLE
Fixes for problems found by GCC 11.2.0

### DIFF
--- a/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.c
+++ b/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.c
@@ -564,7 +564,7 @@ long int ptrace(enum __ptrace_request request, ...) {
         }
 
         case PTRACE_PEEKUSER: {
-            if ((size_t)addr >= sizeof(struct user)) {
+            if ((size_t)addr + sizeof(long) > sizeof(struct user)) {
                 errno = EINVAL;
                 return -1;
             }
@@ -572,7 +572,7 @@ long int ptrace(enum __ptrace_request request, ...) {
             if (!in_enclave)
                 return host_ptrace(PTRACE_PEEKUSER, tid, addr, data);
 
-            if ((size_t)addr >= sizeof(struct user_regs_struct))
+            if ((size_t)addr + sizeof(long) > sizeof(struct user_regs_struct))
                 return host_ptrace(PTRACE_PEEKUSER, tid, addr, NULL);
 
             ret = peek_user(memdev, tid, ei, &userdata);
@@ -581,16 +581,16 @@ long int ptrace(enum __ptrace_request request, ...) {
                 return -1;
             }
 
-            return *(long int*)((void*)&userdata + (off_t)addr);
+            return *(long*)((void*)&userdata + (off_t)addr);
         }
 
         case PTRACE_POKEUSER: {
-            if ((size_t)addr >= sizeof(struct user)) {
+            if ((size_t)addr + sizeof(long) > sizeof(struct user)) {
                 errno = EINVAL;
                 return -1;
             }
 
-            if (!in_enclave || (size_t)addr >= sizeof(struct user_regs_struct))
+            if (!in_enclave || (size_t)addr + sizeof(long) > sizeof(struct user_regs_struct))
                 return host_ptrace(PTRACE_POKEUSER, tid, addr, data);
 
             ret = peek_user(memdev, tid, ei, &userdata);
@@ -599,7 +599,7 @@ long int ptrace(enum __ptrace_request request, ...) {
                 return -1;
             }
 
-            *(long int*)((void*)&userdata + (off_t)addr) = (long int)data;
+            *(long*)((void*)&userdata + (off_t)addr) = (long)data;
 
             ret = poke_user(memdev, tid, ei, &userdata);
             if (ret < 0) {

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -142,7 +142,7 @@ out:
         ssize_t close_ret = pd_close(g_perf_data);
         if (close_ret < 0)
             log_error("sgx_profile_init: pd_close failed: %ld", close_ret);
-            g_perf_data = NULL;
+        g_perf_data = NULL;
     }
     return ret;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Still emits a warning under 11.2.0, but I'm not sure how to fix it (looks like false positive?) and it's probably not urgent:

```
../Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.c:584:20: error: ‘userdata’ may be used uninitialized [-Werror=maybe-uninitialized]
  584 |             return *(long*)((void*)&userdata + (off_t)addr);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/220)
<!-- Reviewable:end -->
