### PR TITLE
[Format] Apply clang-format to a few files

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -128,6 +128,8 @@ Conventions and high-level style
    implementation details in comments within a |~| function. Only tricky or
    unintuitive code should be commented.
 
+#. Inline comments should be separated from code (or macros) with one space.
+
 #. Magic numbers (e.g. buffer sizes) shouldn’t be hardcoded in the
    implementation. Use ``#define``.
 

--- a/LibOS/shim/include/arch/x86_64/gramine_entry_api.h
+++ b/LibOS/shim/include/arch/x86_64/gramine_entry_api.h
@@ -15,7 +15,7 @@
 #define GRAMINE_ENTRY_API_H_
 
 /* Offsets for GS register at which entry vectors can be found */
-#define GRAMINE_SYSCALL_OFFSET         24
+#define GRAMINE_SYSCALL_OFFSET 24
 
 #ifdef __ASSEMBLER__
 
@@ -27,7 +27,7 @@ jmpq *%gs:GRAMINE_SYSCALL_OFFSET
 
 #else /* !__ASSEMBLER__ */
 
-#define GRAMINE_STR(x) #x
+#define GRAMINE_STR(x)  #x
 #define GRAMINE_XSTR(x) GRAMINE_STR(x)
 
 __asm__(
@@ -67,7 +67,6 @@ static inline int gramine_register_library(const char* name, unsigned long load_
 static inline int gramine_run_test(const char* test_name) {
     return gramine_call(GRAMINE_CALL_RUN_TEST, (unsigned long)test_name, 0);
 }
-
 
 #endif /* __ASSEMBLER__ */
 

--- a/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
@@ -3,17 +3,17 @@
 #ifndef _SHIM_INTERNAL_ARCH_H_
 #define _SHIM_INTERNAL_ARCH_H_
 
-#define CALL_ELF_ENTRY(ENTRY, ARGP)           \
-    do {                                      \
-        __asm__ volatile(                     \
-            "pushq $0\r\n"                    \
-            "popfq\r\n"                       \
-            "movq %%rbx, %%rsp\r\n"           \
-            "jmp *%%rax\r\n"                  \
-            :                                 \
-            : "a"(ENTRY), "b"(ARGP), "d"(0)   \
-            : "memory", "cc");                \
-        __builtin_unreachable();              \
+#define CALL_ELF_ENTRY(ENTRY, ARGP)         \
+    do {                                    \
+        __asm__ volatile(                   \
+            "pushq $0\r\n"                  \
+            "popfq\r\n"                     \
+            "movq %%rbx, %%rsp\r\n"         \
+            "jmp *%%rax\r\n"                \
+            :                               \
+            : "a"(ENTRY), "b"(ARGP), "d"(0) \
+            : "memory", "cc");              \
+        __builtin_unreachable();            \
     } while(0)
 
 #define SHIM_ELF_HOST_MACHINE EM_X86_64

--- a/LibOS/shim/include/arch/x86_64/shim_syscalls.h
+++ b/LibOS/shim/include/arch/x86_64/shim_syscalls.h
@@ -52,4 +52,4 @@
 #ifndef __NR_syscalls
 #define __NR_syscalls 428
 #endif
-#endif  /* SHIM_SYSCALLS_H_ */
+#endif /* SHIM_SYSCALLS_H_ */


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Apply clang-format rules to a few files, which should be uncontroversial.  This is mostly to "denoise" output while working on issues where we don't like what clang-format does, although I may have misjudged something (i.e., the review may still be useful to catch format changes that are unappealing).

Unless people object, I'll probably do a slow trickle of these sorts of PRs, or updates to this one.

I did manually disable formatting around some inline assembly, which I assume will be uncommon to need.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

N/A: No functional change to the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/223)
<!-- Reviewable:end -->
