### PR TITLE
Fix argument for SGX client

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/README.md
+++ b/CI-Examples/ra-tls-mbedtls/README.md
@@ -166,11 +166,15 @@ kill %%
 
 ```sh
 make clean
-make app client_dcap.manifest.sgx
+make app dcap
 
 gramine-sgx ./server dcap &
 
-gramine-sgx ./client_dcap dcap
+RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 gramine-sgx \
+    ./client_dcap dcap \
+    1234567890123456789012345678901234567890123456789012345678901234 \
+    1234567890123456789012345678901234567890123456789012345678901234 \
+    0 0
 
 # client will successfully connect to the server via RA-TLS/DCAP flows
 kill %%


### PR DESCRIPTION
## Description of the changes
When compiling for running DCAP client in SGX, should make with options
as: make app dcap, previously one is not correct.

When running DCAP client in SGX, should add the arguments in cmd.

## How to test this PR?
N/A: No functional change to the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/225)
<!-- Reviewable:end -->
