### PR TITLE
ASan improvements

### DIFF
--- a/LibOS/shim/test/fs/test_pf.py
+++ b/LibOS/shim/test/fs/test_pf.py
@@ -172,15 +172,21 @@ class TC_50_ProtectedFiles(test_fs.TC_00_FileSystem):
                                          timeout=timeout)
         self.verify_copy(stdout, stderr, self.ENCRYPTED_DIR, executable)
 
+    # TODO: `mmap` on protected files is broken, because we fail to properly register that memory is
+    # unmapped. The `copy_mmap*` tests technically work, but trigger AddressSanitizer.
+
     # overrides TC_00_FileSystem to not skip this on SGX
+    @unittest.skipIf(os.environ.get('ASAN') == '1', 'mapping protected files is broken')
     def test_204_copy_dir_mmap_whole(self):
         self.do_copy_test('copy_mmap_whole', 30)
 
     # overrides TC_00_FileSystem to not skip this on SGX
+    @unittest.skipIf(os.environ.get('ASAN') == '1', 'mapping protected files is broken')
     def test_205_copy_dir_mmap_seq(self):
         self.do_copy_test('copy_mmap_seq', 60)
 
     # overrides TC_00_FileSystem to not skip this on SGX
+    @unittest.skipIf(os.environ.get('ASAN') == '1', 'mapping protected files is broken')
     def test_206_copy_dir_mmap_rev(self):
         self.do_copy_test('copy_mmap_rev', 60)
 

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -26,6 +26,9 @@ static void handler(bool is_in_pal, PAL_NUM arg, PAL_CONTEXT* context) {
 #endif
 }
 
+/* Disable AddressSanitizer: this code tries to trigger a memory fault by accessing memory that's
+ * supposed to be inaccessible, but SGX PAL poisons such memory. */
+__attribute_no_sanitize_address
 int main(int argc, char** argv, char** envp) {
     volatile int c;
     DkSetExceptionHandler(handler, PAL_EVENT_MEMFAULT);

--- a/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.h
+++ b/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.h
@@ -2,12 +2,14 @@
 
 #define MAX_DBG_THREADS 1024
 
-/* This address is shared between our GDB and Gramine-SGX and must
- * reside in non-enclave memory. Gramine-SGX puts an enclave_dbginfo
- * object at this address and periodically updates it. Our GDB
- * reads the object from this address to update its internal structs
- * and learn about enclave layout, active threads, etc. */
-#define DBGINFO_ADDR 0x100000000000
+/*
+ * Pre-defined address at which Gramine-SGX writes the `enclave_dbginfo` object, and periodically
+ * updates it. The object is being read by the GDB integration (`sgx_gdb.c`) using `ptrace`.
+ *
+ * The address should be in untrusted memory (outside of enclave), and should not overlap with the
+ * ASan shadow memory area (see `asan.h`).
+ */
+#define DBGINFO_ADDR 0x10000000000ULL /* 1 TB */
 
 /* This struct is read using PTRACE_PEEKDATA in 8B increments
  * therefore it is aligned as uint64_t. */

--- a/common/include/asan.h
+++ b/common/include/asan.h
@@ -80,7 +80,8 @@
 
 /*
  * Parameters of the shadow memory area. Each byte of shadow memory corresponds to ASAN_SHADOW_ALIGN
- * (by default 8) bytes of user memory.
+ * (by default 8) bytes of user memory. The shadow map length is 1 << 45 to cover the whole 48-bit
+ * user address space: Linux sometimes maps `vvar` and `vdso` just above 0x800000000000 (= 1 << 47).
  *
  * Note that we override the address of shadow memory area (ASAN_SHADOW_START). We want the shadow
  * memory to begin at a high address, because the default for x86_64 (0x7fff8000, just before 2 GB)
@@ -91,7 +92,7 @@
  * (BEWARE when changing ASAN_SHADOW_START: the value should not be a power of two. For powers of
  * two, LLVM tries to optimize the generated code by emitting bitwise OR instead of addition in the
  * mem-to-shadow conversion. As a result, low values (such as 1 TB) will not work correctly. A value
- * at least as high as the shadow map length (1 << 44) should work, but it's probably better to stay
+ * at least as high as the shadow map length (1 << 45) should work, but it's probably better to stay
  * closer to the default configuration and not use a power of two.)
  *
  * The shadow memory bytes have the following meaning:
@@ -105,7 +106,7 @@
  */
 #define ASAN_SHADOW_START 0x18000000000ULL /* 1.5 TB */
 #define ASAN_SHADOW_SHIFT 3
-#define ASAN_SHADOW_LENGTH (1ULL << 44)
+#define ASAN_SHADOW_LENGTH (1ULL << 45)
 #define ASAN_SHADOW_ALIGN (1 << ASAN_SHADOW_SHIFT)
 #define ASAN_SHADOW_MASK ((1 << ASAN_SHADOW_SHIFT) - 1)
 

--- a/common/include/asan.h
+++ b/common/include/asan.h
@@ -114,9 +114,12 @@
 #define ASAN_MEM_TO_SHADOW(addr) (((addr) >> ASAN_SHADOW_SHIFT) + ASAN_SHADOW_START)
 #define ASAN_SHADOW_TO_MEM(addr) (((addr) - ASAN_SHADOW_START) << ASAN_SHADOW_SHIFT)
 
-/* Magic values to mark different kinds of inaccessible memory. */
+/* Magic values to mark different kinds of inaccessible memory. These are the same as in LLVM's
+ * AddressSanitizer (`asan_internal.h`), because LLVM's instrumentation often writes them
+ * directly instead of calling our callbacks. */
 #define ASAN_POISON_HEAP_LEFT_REDZONE     0xfa
 #define ASAN_POISON_HEAP_AFTER_FREE       0xfd
+#define ASAN_POISON_USER                  0xf7  /* currently used for unallocated SGX memory */
 
 /* Poison a memory region. `addr` must be aligned to ASAN_SHADOW_ALIGN, and `size` is rounded up to
  * ASAN_SHADOW_ALIGN. */

--- a/common/src/asan.c
+++ b/common/src/asan.c
@@ -88,6 +88,9 @@ static void asan_find_problem(uintptr_t addr, size_t size, uintptr_t* out_bad_ad
         case ASAN_POISON_HEAP_AFTER_FREE:
             bug_type = "heap-use-after-free";
             break;
+        case ASAN_POISON_USER:
+            bug_type = "use-after-poison (unallocated SGX memory?)";
+            break;
         default:
             bug_type = "unknown-crash";
             break;
@@ -134,6 +137,7 @@ static void asan_dump(uintptr_t bad_addr) {
     log_error("asan: %22s %02x..%02x", "partially addressable:", 1, ASAN_SHADOW_ALIGN - 1);
     log_error("asan: %22s %02x", "heap left redzone:", ASAN_POISON_HEAP_LEFT_REDZONE);
     log_error("asan: %22s %02x", "freed heap region:", ASAN_POISON_HEAP_AFTER_FREE);
+    log_error("asan: %22s %02x", "user-poisoned:", ASAN_POISON_USER);
 }
 
 /* Display full report for the user */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

A few changes related to ASan. The "Fix shadow memory size" commit fixes one of the problems described in #208.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

* This fixes `gramine-direct` hanging on some new Linux systems (I reproduced this on Linux 5.11, over at #208 people also reproduced it on 5.13) which like to map vvar/vdso above 0x800000000000 (I'm not sure why that happens, though).
* Accessing "invalid" enclave memory should now trigger ASan (which is why I had to disable it for some PAL tests).
* Overflowing the LibOS stack (you can try adding a big array in `shim_emulate_syscall`) also triggers ASan, because we hit the stack guard page.
  
  However, the user experience is not very good, as ASan then gets triggered recursively when trying to format the report, and the actual report we see is for memory *below* the stack guard page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/228)
<!-- Reviewable:end -->
