### PR TITLE
Optimize `sendfile`

### DIFF
--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -22,7 +22,7 @@
 #include "shim_utils.h"
 #include "stat.h"
 
-#define BUF_SIZE 4096 /* read/write in 4KB chunks for sendfile() */
+#define BUF_SIZE (64 * 1024) /* read/write in 64KB chunks for sendfile() */
 
 /* The kernel would look up the parent directory, and remove the child from the inode. But we are
  * working with the PAL, so we open the file, truncate and close it. */

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -24,7 +24,9 @@ int _DkEventCreate(PAL_HANDLE* handle_ptr, bool init_signaled, bool auto_clear) 
     }
 
     init_handle_hdr(HANDLE_HDR(handle), PAL_TYPE_EVENT);
+    spinlock_init(&handle->event.lock);
     handle->event.auto_clear = auto_clear;
+    handle->event.waiters_cnt = 0;
     __atomic_store_n(&handle->event.signaled, init_signaled ? 1 : 0, __ATOMIC_RELEASE);
 
     *handle_ptr = handle;
@@ -32,19 +34,26 @@ int _DkEventCreate(PAL_HANDLE* handle_ptr, bool init_signaled, bool auto_clear) 
 }
 
 void _DkEventSet(PAL_HANDLE handle) {
+    spinlock_lock(&handle->event.lock);
     __atomic_store_n(&handle->event.signaled, 1, __ATOMIC_RELEASE);
-    /* We could just use `FUTEX_WAKE`, but using `FUTEX_WAKE_BITSET` is more consistent with
-     * `FUTEX_WAIT_BITSET` in `_DkEventWait`. */
-    int ret = DO_SYSCALL(futex, &handle->event.signaled, FUTEX_WAKE_BITSET,
-                         handle->event.auto_clear ? 1 : INT_MAX, NULL, NULL,
-                         FUTEX_BITSET_MATCH_ANY);
-    __UNUSED(ret);
-    /* This `FUTEX_WAKE_BITSET` cannot really fail. */
-    assert(ret >= 0);
+    bool need_wake = handle->event.waiters_cnt > 0;
+    spinlock_unlock(&handle->event.lock);
+    if (need_wake) {
+        /* We could just use `FUTEX_WAKE`, but using `FUTEX_WAKE_BITSET` is more consistent with
+         * `FUTEX_WAIT_BITSET` in `_DkEventWait`. */
+        int ret = DO_SYSCALL(futex, &handle->event.signaled, FUTEX_WAKE_BITSET,
+                             handle->event.auto_clear ? 1 : INT_MAX, NULL, NULL,
+                             FUTEX_BITSET_MATCH_ANY);
+        __UNUSED(ret);
+        /* This `FUTEX_WAKE_BITSET` cannot really fail. */
+        assert(ret >= 0);
+    }
 }
 
 void _DkEventClear(PAL_HANDLE handle) {
+    spinlock_lock(&handle->event.lock);
     __atomic_store_n(&handle->event.signaled, 0, __ATOMIC_RELEASE);
+    spinlock_unlock(&handle->event.lock);
 }
 
 int _DkEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
@@ -53,6 +62,9 @@ int _DkEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
     if (timeout_us) {
         time_get_now_plus_ns(&timeout, *timeout_us * TIME_NS_IN_US);
     }
+
+    spinlock_lock(&handle->event.lock);
+    handle->event.waiters_cnt++;
 
     while (1) {
         bool needs_sleep = false;
@@ -67,14 +79,20 @@ int _DkEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
             break;
         }
 
+        spinlock_unlock(&handle->event.lock);
         /* Using `FUTEX_WAIT_BITSET` to have an absolute timeout. */
         ret = DO_SYSCALL(futex, &handle->event.signaled, FUTEX_WAIT_BITSET, 0,
                          timeout_us ? &timeout : NULL, NULL, FUTEX_BITSET_MATCH_ANY);
+        spinlock_lock(&handle->event.lock);
+
         if (ret < 0 && ret != -EAGAIN) {
             ret = unix_to_pal_error(ret);
             break;
         }
     }
+
+    handle->event.waiters_cnt--;
+    spinlock_unlock(&handle->event.lock);
 
     if (timeout_us) {
         int64_t diff = time_ns_diff_from_now(&timeout);

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "atomic.h"
+#include "spinlock.h"
 
 typedef struct {
     PAL_HDR hdr;
@@ -108,6 +108,8 @@ typedef struct pal_handle {
         } thread;
 
         struct {
+            spinlock_t lock;
+            uint32_t waiters_cnt;
             uint32_t signaled;
             bool auto_clear;
         } event;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

I looked into why the `sendfile` LTP test is so slow, and found two things:
* the buffer size is pretty small,
* `DkEventSet` in Linux PAL is pretty inefficient and always calls `futex` (Linux-SGX PAL has a waiters count, so it should be OK)

As a result, there is a lot of small `pread64` and `pwrite64` calls, each accompanied by several `futex` calls (releasing locks).

Here's a benchmark for `sendfile09` LTP test (which uses `sendfile` to copy 1 GB ranges), with `gramine-direct`, compiled in debug mode (but release numbers are pretty similar):

| version | time |
|---|---|
| Linux (no Gramine) | 1.07 s |
| master |  2.61 s |
| `DkEventSet` optimized | 1.86 s |
| 64KB buffer | 1.31 s |
| **`DkEventSet` optimized + 64KB buffer** | **1.25 s** |

(Benchmarks performed using [hyperfine](https://github.com/sharkdp/hyperfine), it's pretty neat).

## How to test this PR? <!-- (if applicable) -->

Please read the DkEventSet code carefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/245)
<!-- Reviewable:end -->
