### PR TITLE
[LibOS] Fix dup2 and dup3 as per the spec

### DIFF
--- a/LibOS/shim/src/sys/shim_dup.c
+++ b/LibOS/shim/src/sys/shim_dup.c
@@ -31,9 +31,6 @@ long shim_do_dup(unsigned int fd) {
 }
 
 long shim_do_dup2(unsigned int oldfd, unsigned int newfd) {
-    if (oldfd == newfd)
-        return -EINVAL;
-
     if (newfd >= get_rlimit_cur(RLIMIT_NOFILE))
         return -EBADF;
 
@@ -43,6 +40,11 @@ long shim_do_dup2(unsigned int oldfd, unsigned int newfd) {
     struct shim_handle* hdl = get_fd_handle(oldfd, NULL, handle_map);
     if (!hdl)
         return -EBADF;
+
+    if (oldfd == newfd) {
+        put_handle(hdl);
+        return newfd;
+    }
 
     struct shim_handle* new_hdl = detach_fd_handle(newfd, NULL, handle_map);
 


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
As per the man [page](https://man7.org/linux/man-pages/man2/dup.2.html), `dup2` must return `newfd` if `oldfd` and `newfd` have the same values.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
Fixes #180 

## How to test this PR? <!-- (if applicable) -->
LTP tests haven't been upgraded yet. Please follow the steps listed in #180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/249)
<!-- Reviewable:end -->
