### PR TITLE
db_rtld: Allow EXEC (non-pie executable) PAL binaries

### DIFF
--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -40,7 +40,8 @@
  * Structure describing a loaded ELF object. Originally based on glibc link_map structure.
  */
 struct link_map {
-    /* Base address shared object is loaded at. */
+    /* Difference between the address in ELF file and the address in memory (for DYNs, base address
+     * where shared object is loaded at; for EXECs, 0x00). */
     ElfW(Addr) l_addr;
 
     /* Object identifier: file path, or PAL URI if path is unavailable. */
@@ -385,7 +386,9 @@ static struct link_map* map_elf_object(struct shim_handle* file, ElfW(Ehdr)* ehd
 
         l->l_addr = (ElfW(Addr))addr;
     } else {
-        l->l_addr = 0;
+        /* This is a non-pie shared object (EXEC, executable), so the difference between address in
+         * the ELF file and the actual address in memory is zero. */
+        l->l_addr = 0x00;
     }
     l->l_map_start = load_start + l->l_addr;
     l->l_map_end   = load_end + l->l_addr;

--- a/Pal/include/pal_rtld.h
+++ b/Pal/include/pal_rtld.h
@@ -15,11 +15,12 @@ enum elf_object_type { ELF_OBJECT_INTERNAL, ELF_OBJECT_EXEC, ELF_OBJECT_PRELOAD 
 
 /* Loaded shared object. */
 struct link_map {
-    ElfW(Addr)  l_addr;       /* Address shared object (its first LOAD segment) is loaded at. */
-    ElfW(Addr)  l_base;       /* Base address (0x0 for EXECs, same as l_addr for DYNs). */
-    const char* l_name;       /* Absolute file name object was found in. */
-    ElfW(Dyn)*  l_ld;         /* Dynamic section of the shared object. */
-    ElfW(Addr)  l_entry;      /* Entry point location (may be empty, e.g., for libs). */
+    ElfW(Addr)  l_addr;  /* Address shared object (its first LOAD segment) is loaded at. */
+    ElfW(Addr)  l_diff;  /* Diff between address in ELF file and address in memory
+                            (0x0 for EXECs, same as l_addr for DYNs). */
+    const char* l_name;  /* Absolute file name object was found in. */
+    ElfW(Dyn)*  l_ld;    /* Dynamic section of the shared object. */
+    ElfW(Addr)  l_entry; /* Entry point location (may be empty, e.g., for libs). */
 
     /* Chain of all shared objects loaded at startup. */
     struct link_map* l_next;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the common PAL loader assumed that the PAL binary is a shared object file (DYN). In some PAL implementations, the PAL binary may be an EXEC, and thus doesn't need relocations (in other words, its base address is `0x00`).

UPDATE: This PR is superseded by https://github.com/gramineproject/gramine/pull/255 and https://github.com/gramineproject/gramine/pull/264

## How to test this PR? <!-- (if applicable) -->

N/A. Technically, this PR is currently not needed, but I am implementing a new PAL that uses an EXEC PAL binary. So I decided to upstream this, since it doesn't hurt and it is the only change I needed in the common PAL code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/250)
<!-- Reviewable:end -->
