### PR TITLE
[Docs] Fix broken Marblerun links; improve `sgx.enclave_size` explanation

### DIFF
--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -507,7 +507,8 @@ secrets from the Coordinator, patches command-line arguments, environment
 variables and files with these secrets, and only then starts the main Gramine
 application. This "premain" executable together with the Gramine application is
 referred to as a Marble. For more details, see `Marblerun docs on Gramine
-integration <https://www.marblerun.sh/docs/building-services/graphene>`__.
+integration
+<https://docs.edgeless.systems/marblerun/#/building-services/gramine>`__.
 
 The Coordinator serves as a centralized service for remote attestation of
 Marbles and provisioning of secrets to them. The Coordinator verifies the
@@ -527,5 +528,5 @@ Coordinator acts as a Certificate Authority (CA) for these connections.
 For more information, refer to official Marblerun resources:
 
 - `Official website <https://www.marblerun.sh>`__
-- `Marblerun documentation <https://www.marblerun.sh/docs/introduction>`__
+- `Marblerun documentation <https://docs.edgeless.systems/marblerun/#/>`__
 - `GitHub repository <https://github.com/edgelesssys/marblerun>`__

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -420,13 +420,14 @@ The PAL and library OS code/data count towards this size value, as well as the
 application memory itself: application's code, stack, heap, loaded application
 libraries, etc. The application cannot allocate memory that exceeds this limit.
 
-Be careful when setting the enclave size to large values: SGX |~| v1 hardware
-(i.e., without the :term:`EDMM` hardware feature) not only reserves
+Be careful when setting the enclave size to large values: on systems where the
+:term:`EDMM` feature is not enabled, Gramine not only reserves
 ``sgx.enclave_size`` bytes of virtual address space but also *commits* them to
-the backing store (RAM + swap file). For example, if ``sgx.enclave_size =
-"4G"``, then 4GB of RAM will be immediately allocated to back the enclave
-memory. Thus, if your system has 4GB of backing store or less, then the host
-Linux kernel will fail to start the SGX enclave and will typically print the
+the backing store (EPC, RAM and/or swap file). For example, if
+``sgx.enclave_size = "4G"``, then 4GB of EPC/RAM will be immediately allocated
+to back the enclave memory (recall that :term:`EPC` is the SGX-protected part of
+RAM). Thus, if your system has 4GB of backing store or less, then the host Linux
+kernel will fail to start the SGX enclave and will typically print the
 ``Killed`` message. If you encounter this situation, you can try the following:
 
 - If possible, decrease ``sgx.enclave_size`` to a value less than the amount of


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Two commits:

- [Docs] Improve explanation for `sgx.enclave_size` manifest option

 From the previous explanation, it looked like it is enough to enable  EDMM feature only in hardware, and the behavior of Gramine would change automatically. In fact, the EDMM feature must be enabled in all components of the hardware/software stack (including Gramine).

Also, it was confusing to readers to jump straight to RAM, without a mention of SGX-specific EPC. This looked like EPC was some memory separate from RAM.

- [Docs] Fix broken links for Marblerun attestation

## How to test this PR? <!-- (if applicable) -->

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/256)
<!-- Reviewable:end -->
