### PR TITLE
[Pal] Partially remove `PAL_PTR` type

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -105,8 +105,15 @@ nitpicky = True
 nitpick_ignore = [
     ('c:type', 'bool'),
     ('c:type', 'toml_table_t'),
+    ('c:type', 'uint8_t'),
+    ('c:type', 'uint16_t'),
     ('c:type', 'uint32_t'),
     ('c:type', 'uint64_t'),
+    ('c:type', 'int8_t'),
+    ('c:type', 'int16_t'),
+    ('c:type', 'int32_t'),
+    ('c:type', 'int64_t'),
+    ('c:type', 'uintptr_t'),
     ('c:type', 'union'),
     ('c:type', 'enum'), # parsing of these seems to be broken:
                         #     WARNING: c:type reference target not found: enum

--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -143,18 +143,18 @@ struct shim_xstate {
         }                                                               \
     } while (0)
 
-static inline void set_tls(unsigned long tls) {
-    DkSegmentBaseSet(PAL_SEGMENT_FS, (PAL_PTR)tls);
+static inline void set_tls(uintptr_t tls) {
+    DkSegmentBaseSet(PAL_SEGMENT_FS, tls);
 }
 
 static inline void set_default_tls(void) {
     set_tls(0);
 }
 
-static inline unsigned long get_tls(void) {
-    void* addr = NULL;
+static inline uintptr_t get_tls(void) {
+    uintptr_t addr = 0;
     (void)DkSegmentBaseGet(PAL_SEGMENT_FS, &addr);
-    return (unsigned long)addr;
+    return addr;
 }
 
 #endif /* _SHIM_TCB_ARCH_H_ */

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -138,7 +138,7 @@ long shim_do_sched_get_priority_max(int policy);
 long shim_do_sched_get_priority_min(int policy);
 long shim_do_sched_rr_get_interval(pid_t pid, struct timespec* interval);
 long shim_do_rt_sigsuspend(const __sigset_t* mask, size_t setsize);
-long shim_do_arch_prctl(int code, void* addr);
+long shim_do_arch_prctl(int code, unsigned long addr);
 long shim_do_setrlimit(int resource, struct __kernel_rlimit* rlim);
 long shim_do_chroot(const char* filename);
 long shim_do_sethostname(char* name, int len);

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -12,7 +12,7 @@
 struct shim_context {
     PAL_CONTEXT* regs;
     long syscall_nr;
-    unsigned long tls; /* Used only in clone. */
+    uintptr_t tls; /* Used only in clone. */
 };
 
 typedef struct shim_tcb shim_tcb_t;

--- a/LibOS/shim/src/arch/x86_64/shim_arch_prctl.c
+++ b/LibOS/shim/src/arch/x86_64/shim_arch_prctl.c
@@ -12,14 +12,14 @@
 #include "shim_table.h"
 #include "shim_tcb.h"
 
-long shim_do_arch_prctl(int code, void* addr) {
+long shim_do_arch_prctl(int code, unsigned long addr) {
     switch (code) {
         case ARCH_SET_FS:
-            set_tls((unsigned long)addr);
+            set_tls(addr);
             return 0;
 
         case ARCH_GET_FS:
-            return pal_to_unix_errno(DkSegmentBaseGet(PAL_SEGMENT_FS, addr));
+            return pal_to_unix_errno(DkSegmentBaseGet(PAL_SEGMENT_FS, (unsigned long*)addr));
 
         default:
             log_warning("Not supported flag (0x%x) passed to arch_prctl", code);

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -275,7 +275,7 @@ static int pfkey_save(struct shim_dentry* dent, const char* data, size_t size) {
     char buffer[sizeof(g_pf_key_hex) + 1];
     memcpy(buffer, data, sizeof(g_pf_key_hex));
     buffer[sizeof(g_pf_key_hex)] = '\0';
-    int ret = DkSetProtectedFilesKey(&buffer);
+    int ret = DkSetProtectedFilesKey(buffer);
     if (ret < 0)
         return -EACCES;
 

--- a/LibOS/shim/src/ipc/shim_ipc_worker.c
+++ b/LibOS/shim/src/ipc/shim_ipc_worker.c
@@ -357,7 +357,7 @@ out_die:
     DkProcessExit(1);
 }
 
-static void ipc_worker_wrapper(void* arg) {
+static int ipc_worker_wrapper(void* arg) {
     __UNUSED(arg);
     assert(g_worker_thread);
 

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -139,10 +139,10 @@ int init_async_worker(void) {
     return 0;
 }
 
-static void shim_async_worker(void* arg) {
+static int shim_async_worker(void* arg) {
     struct shim_thread* self = (struct shim_thread*)arg;
     if (!arg)
-        return;
+        return -1;
 
     shim_tcb_init();
     set_cur_thread(self);

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -915,7 +915,7 @@ noreturn void execute_elf_object(struct link_map* exec_map, void* argp, ElfW(aux
     ElfW(Addr) auxp_extra = (ElfW(Addr))&auxp[8];
 
     ElfW(Addr) random = auxp_extra; /* random 16B for AT_RANDOM */
-    ret = DkRandomBitsRead((PAL_PTR)random, 16);
+    ret = DkRandomBitsRead((void*)random, 16);
     if (ret < 0) {
         log_error("execute_elf_object: DkRandomBitsRead failed: %d", ret);
         DkProcessExit(1);

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -48,12 +48,13 @@ struct shim_clone_args {
  * 7.In the wrapper function ,we just do the stack switch to user
  *   Provided stack and execute the user Provided function.
  */
-static int clone_implementation_wrapper(struct shim_clone_args* arg) {
+static int clone_implementation_wrapper(void* arg_) {
     /* The child thread created by PAL is now running on the PAL allocated stack. We need to switch
      * to the user provided stack. */
 
     /* We acquired ownership of arg->thread from the caller, hence there is
      * no need to call get_thread. */
+    struct shim_clone_args* arg = (struct shim_clone_args*)arg_;
     struct shim_thread* my_thread = arg->thread;
     assert(my_thread);
 

--- a/LibOS/shim/src/utils/log.c
+++ b/LibOS/shim/src/utils/log.c
@@ -78,7 +78,7 @@ void log_setprefix(shim_tcb_t* tcb) {
 
 static int buf_write_all(const char* str, size_t size, void* arg) {
     __UNUSED(arg);
-    DkDebugLog((PAL_PTR)str, size);
+    DkDebugLog(str, size);
     return 0;
 }
 

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -188,14 +188,14 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo);
 int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo);
 
 /* DkProcess and DkThread calls */
-int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* param);
+int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), void* param);
 noreturn void _DkThreadExit(int* clear_child_tid);
 void _DkThreadYieldExecution(void);
 int _DkThreadResume(PAL_HANDLE thread_handle);
 int _DkProcessCreate(PAL_HANDLE* handle, const char** args);
 noreturn void _DkProcessExit(int exit_code);
-int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask);
-int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask);
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask);
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask);
 
 /* DkEvent calls */
 int _DkEventCreate(PAL_HANDLE* handle_ptr, bool init_signaled, bool auto_clear);
@@ -225,15 +225,15 @@ int _DkSystemTimeQuery(uint64_t* out_usec);
  * 0 on success, negative on failure.
  */
 int _DkRandomBitsRead(void* buffer, size_t size);
-int _DkSegmentBaseGet(enum pal_segment_reg reg, void** addr);
-int _DkSegmentBaseSet(enum pal_segment_reg reg, void* addr);
+int _DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr);
+int _DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr);
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]);
-int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
-                         PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
+int _DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
+                         void* target_info, PAL_NUM* target_info_size, void* report,
                          PAL_NUM* report_size);
-int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size, PAL_PTR quote,
+int _DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_size, void* quote,
                         PAL_NUM* quote_size);
-int _DkSetProtectedFilesKey(PAL_PTR pf_key_hex);
+int _DkSetProtectedFilesKey(const char* pf_key_hex);
 
 #define INIT_FAIL(exitcode, reason)                                                              \
     do {                                                                                         \

--- a/Pal/regression/Event.c
+++ b/Pal/regression/Event.c
@@ -1,3 +1,5 @@
+#include <stdnoreturn.h>
+
 #include "api.h"
 #include "cpu.h"
 #include "pal.h"
@@ -26,7 +28,7 @@ static void set(int* ptr, int val) {
 static int g_clear_thread_exit = 1;
 static int g_ready = 0;
 
-static void thread_func(void* arg) {
+static noreturn int thread_func(void* arg) {
     PAL_HANDLE sleep_handle = NULL;
     CHECK(DkEventCreate(&sleep_handle, /*init_signaled=*/false, /*auto_clear=*/false));
 

--- a/Pal/regression/Segment.c
+++ b/Pal/regression/Segment.c
@@ -1,7 +1,7 @@
 #include "pal.h"
 #include "pal_regression.h"
 
-void* dummy = &dummy;
+uintptr_t dummy = (uintptr_t)&dummy;
 
 int main(int argc, char** argv, char** envp) {
     if (DkSegmentBaseSet(PAL_SEGMENT_FS, dummy) < 0) {
@@ -9,7 +9,7 @@ int main(int argc, char** argv, char** envp) {
         return 1;
     }
 
-    void** ptr;
+    uintptr_t* ptr;
     __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr)::"memory");
 
     if (ptr != &dummy) {

--- a/Pal/regression/SendHandle.c
+++ b/Pal/regression/SendHandle.c
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
                     char uri[20];
 
                     size = sizeof(buffer);
-                    ret = DkStreamRead(handles[i], 0, &size, buffer, &uri, sizeof(uri));
+                    ret = DkStreamRead(handles[i], 0, &size, buffer, uri, sizeof(uri));
                     if (ret == 0 && size > 0)
                         pal_printf("Receive Socket Handle: %s\n", buffer);
 

--- a/Pal/regression/utils.c
+++ b/Pal/regression/utils.c
@@ -5,7 +5,7 @@
 // pal_printf() is required by PAL regression tests.
 static int buf_write_all(const char* str, size_t size, void* arg) {
     __UNUSED(arg);
-    DkDebugLog((PAL_PTR)str, size);
+    DkDebugLog(str, size);
     return 0;
 }
 

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -14,16 +14,16 @@ int DkSystemTimeQuery(PAL_NUM* time) {
     return _DkSystemTimeQuery(time);
 }
 
-int DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size) {
-    return _DkRandomBitsRead((void*)buffer, size);
+int DkRandomBitsRead(void* buffer, PAL_NUM size) {
+    return _DkRandomBitsRead(buffer, size);
 }
 
 #if defined(__x86_64__)
-int DkSegmentBaseGet(enum pal_segment_reg reg, PAL_PTR* addr) {
+int DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr) {
     return _DkSegmentBaseGet(reg, addr);
 }
 
-int DkSegmentBaseSet(enum pal_segment_reg reg, PAL_PTR addr) {
+int DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
     return _DkSegmentBaseSet(reg, addr);
 }
 #endif
@@ -51,18 +51,18 @@ int DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
     return 0;
 }
 
-int DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
-                        PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
+int DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
+                        void* target_info, PAL_NUM* target_info_size, void* report,
                         PAL_NUM* report_size) {
     return _DkAttestationReport(user_report_data, user_report_data_size, target_info,
                                 target_info_size, report, report_size);
 }
 
-int DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size, PAL_PTR quote,
+int DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_size, void* quote,
                        PAL_NUM* quote_size) {
     return _DkAttestationQuote(user_report_data, user_report_data_size, quote, quote_size);
 }
 
-int DkSetProtectedFilesKey(PAL_PTR pf_key_hex) {
+int DkSetProtectedFilesKey(const char* pf_key_hex) {
     return _DkSetProtectedFilesKey(pf_key_hex);
 }

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -224,13 +224,13 @@ int64_t _DkStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* 
     return ret;
 }
 
-int DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buffer, PAL_PTR source,
+int DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, void* buffer, char* source,
                  PAL_NUM size) {
     if (!handle) {
         return -PAL_ERROR_INVAL;
     }
 
-    int64_t ret = _DkStreamRead(handle, offset, *count, (void*)buffer, size ? (char*)source : NULL,
+    int64_t ret = _DkStreamRead(handle, offset, *count, buffer, size ? source : NULL,
                                 source ? size : 0);
 
     if (ret < 0) {
@@ -242,7 +242,7 @@ int DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buff
 }
 
 /* _DkStreamWrite for internal use, write to stream at absolute offset.
-   The actual behavior of stream write is defined by handler */
+ * The actual behavior of stream write is defined by handler. */
 int64_t _DkStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buf,
                        const char* addr, int addrlen) {
     const struct handle_ops* ops = HANDLE_OPS(handle);
@@ -267,14 +267,13 @@ int64_t _DkStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const
     return ret;
 }
 
-int DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buffer,
+int DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, void* buffer,
                   const char* dest) {
     if (!handle) {
         return -PAL_ERROR_INVAL;
     }
 
-    int64_t ret = _DkStreamWrite(handle, offset, *count, (void*)buffer, dest,
-                                 dest ? strlen(dest) : 0);
+    int64_t ret = _DkStreamWrite(handle, offset, *count, buffer, dest, dest ? strlen(dest) : 0);
 
     if (ret < 0) {
         return ret;
@@ -379,12 +378,12 @@ int _DkStreamGetName(PAL_HANDLE handle, char* buffer, size_t size) {
     return ret;
 }
 
-int DkStreamGetName(PAL_HANDLE handle, PAL_PTR buffer, PAL_NUM size) {
+int DkStreamGetName(PAL_HANDLE handle, char* buffer, PAL_NUM size) {
     if (!handle || !buffer || !size) {
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkStreamGetName(handle, (void*)buffer, size);
+    return _DkStreamGetName(handle, buffer, size);
 }
 
 /* _DkStreamMap for internal use. Map specific handle to certain memory,
@@ -561,6 +560,6 @@ const char* _DkStreamRealpath(PAL_HANDLE hdl) {
     return ops->getrealpath(hdl);
 }
 
-int DkDebugLog(PAL_PTR buffer, PAL_NUM size) {
+int DkDebugLog(const void* buffer, PAL_NUM size) {
     return _DkDebugLog(buffer, size);
 }

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -11,9 +11,9 @@
 #include "pal_internal.h"
 
 /* PAL call DkThreadCreate: create a thread inside the current process */
-int DkThreadCreate(PAL_PTR addr, PAL_PTR param, PAL_HANDLE* handle) {
+int DkThreadCreate(int (*callback)(void*), void* param, PAL_HANDLE* handle) {
     *handle = NULL;
-    return _DkThreadCreate(handle, (int (*)(void*))addr, (const void*)param);
+    return _DkThreadCreate(handle, callback, param);
 }
 
 /* PAL call DkThreadYieldExecution. Yield the execution of the current thread. */
@@ -22,8 +22,8 @@ void DkThreadYieldExecution(void) {
 }
 
 /* PAL call DkThreadExit: simply exit the current thread no matter what */
-noreturn void DkThreadExit(PAL_PTR clear_child_tid) {
-    _DkThreadExit((int*)clear_child_tid);
+noreturn void DkThreadExit(int* clear_child_tid) {
+    _DkThreadExit(clear_child_tid);
     /* UNREACHABLE */
 }
 
@@ -36,10 +36,10 @@ int DkThreadResume(PAL_HANDLE thread_handle) {
     return _DkThreadResume(thread_handle);
 }
 
-int DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     return _DkThreadSetCpuAffinity(thread, cpumask_size, cpu_mask);
 }
 
-int DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     return _DkThreadGetCpuAffinity(thread, cpumask_size, cpu_mask);
 }

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -205,7 +205,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
         goto fail;
     }
 
-    hdl->file.chunk_hashes = (PAL_PTR)chunk_hashes;
+    hdl->file.chunk_hashes = chunk_hashes;
     hdl->file.total = total;
     hdl->file.umem  = umem;
 
@@ -253,7 +253,7 @@ static int64_t file_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
         return pf_file_read(pf, handle, offset, count, buffer);
 
     int64_t ret;
-    sgx_chunk_hash_t* chunk_hashes = (sgx_chunk_hash_t*)handle->file.chunk_hashes;
+    sgx_chunk_hash_t* chunk_hashes = handle->file.chunk_hashes;
 
     if (!chunk_hashes) {
         if (handle->file.seekable) {
@@ -313,7 +313,7 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, co
         return pf_file_write(pf, handle, offset, count, buffer);
 
     int64_t ret;
-    sgx_chunk_hash_t* chunk_hashes = (sgx_chunk_hash_t*)handle->file.chunk_hashes;
+    sgx_chunk_hash_t* chunk_hashes = handle->file.chunk_hashes;
 
     if (!chunk_hashes) {
         if (handle->file.seekable) {
@@ -512,7 +512,7 @@ static int file_map(PAL_HANDLE handle, void** addr, pal_prot_flags_t prot, uint6
     if (pf)
         return pf_file_map(pf, handle, addr, prot, offset, size);
 
-    sgx_chunk_hash_t* chunk_hashes = (sgx_chunk_hash_t*)handle->file.chunk_hashes;
+    sgx_chunk_hash_t* chunk_hashes = handle->file.chunk_hashes;
     void* mem = *addr;
 
     /* If the file is listed in the manifest as an "allowed" file, we allow mapping the file outside
@@ -901,9 +901,9 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     char* path  = (void*)hdl + HANDLE_SIZE(dir);
     memcpy(path, uri, len + 1);
     hdl->dir.realpath    = path;
-    hdl->dir.buf         = (PAL_PTR)NULL;
-    hdl->dir.ptr         = (PAL_PTR)NULL;
-    hdl->dir.end         = (PAL_PTR)NULL;
+    hdl->dir.buf         = NULL;
+    hdl->dir.ptr         = NULL;
+    hdl->dir.end         = NULL;
     hdl->dir.endofstream = false;
     *handle              = hdl;
     return 0;
@@ -962,7 +962,7 @@ static int64_t dir_read(PAL_HANDLE handle, uint64_t offset, size_t count, void* 
         }
 
         if (!handle->dir.buf) {
-            handle->dir.buf = (PAL_PTR)malloc(DIRBUF_SIZE);
+            handle->dir.buf = malloc(DIRBUF_SIZE);
             if (!handle->dir.buf) {
                 return -PAL_ERROR_NOMEM;
             }
@@ -1000,8 +1000,8 @@ static int dir_close(PAL_HANDLE handle) {
     ocall_close(fd);
 
     if (handle->dir.buf) {
-        free((void*)handle->dir.buf);
-        handle->dir.buf = handle->dir.ptr = handle->dir.end = (PAL_PTR)NULL;
+        free(handle->dir.buf);
+        handle->dir.buf = handle->dir.ptr = handle->dir.end = NULL;
     }
 
     /* initial realpath is part of handle object and will be freed with it */

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -462,8 +462,8 @@ fail:
     _DkProcessExit(1);
 }
 
-int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
-                         PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
+int _DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
+                         void* target_info, PAL_NUM* target_info_size, void* report,
                          PAL_NUM* report_size) {
     __sgx_mem_aligned sgx_report_data_t stack_report_data = {0};
     __sgx_mem_aligned sgx_target_info_t stack_target_info = {0};
@@ -519,8 +519,8 @@ out:
     return 0;
 }
 
-int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data_size,
-                        PAL_PTR quote, PAL_NUM* quote_size) {
+int _DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_size,
+                        void* quote, PAL_NUM* quote_size) {
     if (user_report_data_size != sizeof(sgx_report_data_t))
         return -PAL_ERROR_INVAL;
 
@@ -607,7 +607,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
     return 0;
 }
 
-int _DkSetProtectedFilesKey(const PAL_PTR pf_key_hex) {
+int _DkSetProtectedFilesKey(const char* pf_key_hex) {
     return set_protected_files_key(pf_key_hex);
 }
 
@@ -853,10 +853,10 @@ int _DkRandomBitsRead(void* buffer, size_t size) {
     return 0;
 }
 
-int _DkSegmentBaseGet(enum pal_segment_reg reg, void** addr) {
+int _DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr) {
     switch (reg) {
         case PAL_SEGMENT_FS:
-            *addr = (void*)GET_ENCLAVE_TLS(fsbase);
+            *addr = GET_ENCLAVE_TLS(fsbase);
             return 0;
         case PAL_SEGMENT_GS:
             /* GS is internally used, deny any access to it */
@@ -866,7 +866,7 @@ int _DkSegmentBaseGet(enum pal_segment_reg reg, void** addr) {
     }
 }
 
-int _DkSegmentBaseSet(enum pal_segment_reg reg, void* addr) {
+int _DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
     switch (reg) {
         case PAL_SEGMENT_FS:
             SET_ENCLAVE_TLS(fsbase, addr);

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -188,7 +188,7 @@ static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size,
     switch (PAL_GET_TYPE(hdl)) {
         case PAL_TYPE_FILE:
             hdl->file.realpath = hdl->file.realpath ? (const char*)hdl + hdlsz : NULL;
-            hdl->file.chunk_hashes = (PAL_PTR)NULL;
+            hdl->file.chunk_hashes = NULL;
             break;
         case PAL_TYPE_PIPE:
         case PAL_TYPE_PIPECLI:
@@ -214,12 +214,12 @@ static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size,
         case PAL_TYPE_TCPSRV:
         case PAL_TYPE_UDP:
         case PAL_TYPE_UDPSRV: {
-            size_t s1 = hdl->sock.bind ? addr_size((PAL_PTR)hdl + hdlsz) : 0;
-            size_t s2 = hdl->sock.conn ? addr_size((PAL_PTR)hdl + hdlsz + s1) : 0;
+            size_t s1 = hdl->sock.bind ? addr_size((struct sockaddr*)((uint8_t*)hdl + hdlsz)) : 0;
+            size_t s2 = hdl->sock.conn ? addr_size((struct sockaddr*)((uint8_t*)hdl + hdlsz + s1)) : 0;
             if (s1)
-                hdl->sock.bind = (PAL_PTR)hdl + hdlsz;
+                hdl->sock.bind = (struct sockaddr*)((uint8_t*)hdl + hdlsz);
             if (s2)
-                hdl->sock.conn = (PAL_PTR)hdl + hdlsz + s2;
+                hdl->sock.conn = (struct sockaddr*)((uint8_t*)hdl + hdlsz + s2);
             break;
         }
         case PAL_TYPE_PROCESS:

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -29,7 +29,7 @@ static LISTP_TYPE(pal_handle_thread) g_thread_list = LISTP_INIT;
 
 struct thread_param {
     int (*callback)(void*);
-    const void* param;
+    void* param;
 };
 
 extern void* g_enclave_base;
@@ -93,7 +93,7 @@ void pal_start_thread(void) {
     /* UNREACHABLE */
 }
 
-int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* param) {
+int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), void* param) {
     int ret;
     PAL_HANDLE new_thread = malloc(HANDLE_SIZE(thread));
     if (!new_thread)
@@ -172,12 +172,12 @@ int _DkThreadResume(PAL_HANDLE thread_handle) {
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
-int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     int ret = ocall_sched_setaffinity(thread->thread.tcs, cpumask_size, cpu_mask);
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
-int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     int ret = ocall_sched_getaffinity(thread->thread.tcs, cpumask_size, cpu_mask);
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }

--- a/Pal/src/host/Linux-SGX/enclave_tf.h
+++ b/Pal/src/host/Linux-SGX/enclave_tf.h
@@ -12,10 +12,6 @@
  * each chunk (of size TRUSTED_CHUNK_SIZE) in the file. The per-chunk hashes are used for partial
  * verification in future reads, to avoid re-verifying the whole file again or the need of caching
  * file contents.
- *
- * Perhaps confusingly, `struct trusted_file` describes not only "sgx.trusted_files" but also
- * "sgx.allowed_files". For allowed files, `allowed = true`, `chunk_hashes = NULL`, and `uri` can be
- * not only a file but also a directory. TODO: Perhaps split "allowed_files" into a separate struct?
  */
 
 /* TODO: Move trusted/allowed files implementation into a separate file (`enclave_tf.c`?) */
@@ -29,35 +25,12 @@
 #include <sys/types.h>
 
 #include "api.h"
+#include "enclave_tf_structs.h"
 #include "pal.h"
-
-enum {
-    FILE_CHECK_POLICY_STRICT = 0,
-    FILE_CHECK_POLICY_ALLOW_ALL_BUT_LOG,
-};
 
 int init_file_check_policy(void);
 
 int get_file_check_policy(void);
-
-typedef struct {
-    uint8_t bytes[32];
-} sgx_file_hash_t;
-
-typedef struct {
-    uint8_t bytes[16];
-} sgx_chunk_hash_t;
-
-DEFINE_LIST(trusted_file);
-struct trusted_file {
-    LIST_TYPE(trusted_file) list;
-    uint64_t size;
-    bool allowed;
-    sgx_file_hash_t file_hash;      /* hash over the whole file, retrieved from the manifest */
-    sgx_chunk_hash_t* chunk_hashes; /* array of hashes over separate file chunks */
-    size_t uri_len;
-    char uri[]; /* must be NULL-terminated */
-};
 
 /*!
  * \brief Get trusted/allowed file struct, if corresponding path entry exists in the manifest

--- a/Pal/src/host/Linux-SGX/enclave_tf_structs.h
+++ b/Pal/src/host/Linux-SGX/enclave_tf_structs.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
+#ifndef ENCLAVE_TF_STRUCTS_H_
+#define ENCLAVE_TF_STRUCTS_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "list.h"
+
+enum {
+    FILE_CHECK_POLICY_STRICT = 0,
+    FILE_CHECK_POLICY_ALLOW_ALL_BUT_LOG,
+};
+
+typedef struct {
+    uint8_t bytes[32];
+} sgx_file_hash_t;
+
+typedef struct {
+    uint8_t bytes[16];
+} sgx_chunk_hash_t;
+
+/*
+ * Perhaps confusingly, `struct trusted_file` describes not only "sgx.trusted_files" but also
+ * "sgx.allowed_files". For allowed files, `allowed = true`, `chunk_hashes = NULL`, and `uri` can be
+ * not only a file but also a directory. TODO: Perhaps split "allowed_files" into a separate struct?
+ */
+DEFINE_LIST(trusted_file);
+struct trusted_file {
+    LIST_TYPE(trusted_file) list;
+    uint64_t size;
+    bool allowed;
+    sgx_file_hash_t file_hash;      /* hash over the whole file, retrieved from the manifest */
+    sgx_chunk_hash_t* chunk_hashes; /* array of hashes over separate file chunks */
+    size_t uri_len;
+    char uri[]; /* must be NULL-terminated */
+};
+
+#endif /* ENCLAVE_TF_STRUCTS_H_ */

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 
 #include "atomic.h"
+#include "enclave_tf_structs.h"
 #include "list.h"
 #include "spinlock.h"
 
@@ -27,7 +28,7 @@ DEFINE_LIST(pal_handle_thread);
 struct pal_handle_thread {
     PAL_HDR reserved;
     PAL_IDX tid;
-    PAL_PTR tcs;
+    void* tcs;
     LIST_TYPE(pal_handle_thread) list;
     void* param;
 };
@@ -56,9 +57,9 @@ typedef struct pal_handle {
             const char* realpath;
             PAL_NUM total;
             /* below fields are used only for trusted files */
-            PAL_PTR chunk_hashes; /* array of hashes of file chunks */
-            PAL_PTR umem;         /* valid only when chunk_hashes != NULL */
-            bool seekable;        /* regular files are seekable, FIFO pipes are not */
+            sgx_chunk_hash_t* chunk_hashes; /* array of hashes of file chunks */
+            void* umem;                     /* valid only when chunk_hashes != NULL */
+            bool seekable;                  /* regular files are seekable, FIFO pipes are not */
         } file;
 
         struct {
@@ -90,16 +91,16 @@ typedef struct pal_handle {
         struct {
             PAL_IDX fd;
             const char* realpath;
-            PAL_PTR buf;
-            PAL_PTR ptr;
-            PAL_PTR end;
+            void* buf;
+            void* ptr;
+            void* end;
             bool endofstream;
         } dir;
 
         struct {
             PAL_IDX fd;
-            PAL_PTR bind;
-            PAL_PTR conn;
+            struct sockaddr* bind;
+            struct sockaddr* conn;
             bool nonblocking;
             PAL_NUM linger;
             PAL_NUM receivebuf;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -26,28 +26,28 @@ struct enclave_tls {
     PAL_TCB common;
 
     /* private to Linux-SGX PAL */
-    uint64_t enclave_size;
-    uint64_t tcs_offset;
-    uint64_t initial_stack_addr;
-    uint64_t tmp_rip;
-    uint64_t sig_stack_low;
-    uint64_t sig_stack_high;
-    void*    ecall_return_addr;
-    void*    ssa;
+    uint64_t  enclave_size;
+    uint64_t  tcs_offset;
+    uint64_t  initial_stack_addr;
+    uint64_t  tmp_rip;
+    uint64_t  sig_stack_low;
+    uint64_t  sig_stack_high;
+    void*     ecall_return_addr;
+    void*     ssa;
     sgx_pal_gpr_t* gpr;
-    void*    exit_target;
-    void*    fsbase;
-    void*    pre_ocall_stack;
-    void*    ustack_top;
-    void*    ustack;
+    void*     exit_target;
+    uintptr_t fsbase;
+    void*     pre_ocall_stack;
+    void*     ustack_top;
+    void*     ustack;
     struct pal_handle_thread* thread;
-    uint64_t ocall_exit_called;
-    uint64_t thread_started;
-    uint64_t ready_for_exceptions;
-    uint64_t manifest_size;
-    void*    heap_min;
-    void*    heap_max;
-    int*     clear_child_tid;
+    uint64_t  ocall_exit_called;
+    uint64_t  thread_started;
+    uint64_t  ready_for_exceptions;
+    uint64_t  manifest_size;
+    void*     heap_min;
+    void*     heap_max;
+    int*      clear_child_tid;
     struct untrusted_area untrusted_area_cache;
 };
 

--- a/Pal/src/host/Linux/arch/x86_64/db_arch_misc.c
+++ b/Pal/src/host/Linux/arch/x86_64/db_arch_misc.c
@@ -227,10 +227,10 @@ out_vendor_id:
     return rv;
 }
 
-int _DkSegmentBaseGet(enum pal_segment_reg reg, void** addr) {
+int _DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr) {
     switch (reg) {
         case PAL_SEGMENT_FS:
-            return unix_to_pal_error(DO_SYSCALL(arch_prctl, ARCH_GET_FS, addr));
+            return unix_to_pal_error(DO_SYSCALL(arch_prctl, ARCH_GET_FS, (unsigned long*)addr));
         case PAL_SEGMENT_GS:
             // The GS segment is used for the internal TCB of PAL
             return -PAL_ERROR_DENIED;
@@ -239,10 +239,10 @@ int _DkSegmentBaseGet(enum pal_segment_reg reg, void** addr) {
     }
 }
 
-int _DkSegmentBaseSet(enum pal_segment_reg reg, void* addr) {
+int _DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
     switch (reg) {
         case PAL_SEGMENT_FS:
-            return unix_to_pal_error(DO_SYSCALL(arch_prctl, ARCH_SET_FS, addr));
+            return unix_to_pal_error(DO_SYSCALL(arch_prctl, ARCH_SET_FS, (unsigned long)addr));
         case PAL_SEGMENT_GS:
             // The GS segment is used for the internal TCB of PAL
             return -PAL_ERROR_DENIED;

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -349,9 +349,9 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     char* path = (void*)hdl + HANDLE_SIZE(dir);
     memcpy(path, uri, len + 1);
     hdl->dir.realpath    = path;
-    hdl->dir.buf         = (PAL_PTR)NULL;
-    hdl->dir.ptr         = (PAL_PTR)NULL;
-    hdl->dir.end         = (PAL_PTR)NULL;
+    hdl->dir.buf         = NULL;
+    hdl->dir.ptr         = NULL;
+    hdl->dir.end         = NULL;
     hdl->dir.endofstream = false;
     *handle = hdl;
     return 0;
@@ -409,7 +409,7 @@ static int64_t dir_read(PAL_HANDLE handle, uint64_t offset, size_t count, void* 
         }
 
         if (!handle->dir.buf) {
-            handle->dir.buf = (PAL_PTR)malloc(DIRBUF_SIZE);
+            handle->dir.buf = malloc(DIRBUF_SIZE);
             if (!handle->dir.buf) {
                 return -PAL_ERROR_NOMEM;
             }
@@ -445,8 +445,8 @@ static int dir_close(PAL_HANDLE handle) {
     int ret = DO_SYSCALL(close, fd);
 
     if (handle->dir.buf) {
-        free((void*)handle->dir.buf);
-        handle->dir.buf = handle->dir.ptr = handle->dir.end = (PAL_PTR)NULL;
+        free(handle->dir.buf);
+        handle->dir.buf = handle->dir.ptr = handle->dir.end = NULL;
     }
 
     /* initial realpath is part of handle object and will be freed with it */

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -53,8 +53,8 @@ int _DkRandomBitsRead(void* buffer, size_t size) {
     return 0;
 }
 
-int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
-                         PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
+int _DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
+                         void* target_info, PAL_NUM* target_info_size, void* report,
                          PAL_NUM* report_size) {
     __UNUSED(user_report_data);
     __UNUSED(user_report_data_size);
@@ -65,7 +65,7 @@ int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_siz
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size, PAL_PTR quote,
+int _DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_size, void* quote,
                         PAL_NUM* quote_size) {
     __UNUSED(user_report_data);
     __UNUSED(user_report_data_size);
@@ -74,7 +74,7 @@ int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkSetProtectedFilesKey(PAL_PTR pf_key_hex) {
+int _DkSetProtectedFilesKey(const char* pf_key_hex) {
     __UNUSED(pf_key_hex);
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -231,20 +231,20 @@ static inline PAL_HANDLE socket_create_handle(int type, int fd, pal_stream_optio
     init_handle_hdr(HANDLE_HDR(hdl), type);
     HANDLE_HDR(hdl)->flags |= RFD(0) | (type != PAL_TYPE_TCPSRV ? WFD(0) : 0);
     hdl->sock.fd = fd;
-    void* addr   = (void*)hdl + HANDLE_SIZE(sock);
+    uint8_t* addr = (uint8_t*)hdl + HANDLE_SIZE(sock);
     if (bind_addr) {
-        hdl->sock.bind = (PAL_PTR)addr;
+        hdl->sock.bind = (struct sockaddr*)addr;
         memcpy(addr, bind_addr, bind_addrlen);
         addr += bind_addrlen;
     } else {
-        hdl->sock.bind = (PAL_PTR)NULL;
+        hdl->sock.bind = NULL;
     }
     if (dest_addr) {
-        hdl->sock.conn = (PAL_PTR)addr;
+        hdl->sock.conn = (struct sockaddr*)addr;
         memcpy(addr, dest_addr, dest_addrlen);
         addr += dest_addrlen;
     } else {
-        hdl->sock.conn = (PAL_PTR)NULL;
+        hdl->sock.conn = NULL;
     }
 
     hdl->sock.nonblocking = !!(options & PAL_OPTION_NONBLOCK);
@@ -358,7 +358,7 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    struct sockaddr* bind_addr = (struct sockaddr*)handle->sock.bind;
+    struct sockaddr* bind_addr = handle->sock.bind;
     size_t bind_addrlen        = addr_size(bind_addr);
     struct sockaddr_storage buffer;
     int addrlen = sizeof(buffer);
@@ -908,10 +908,10 @@ static int socket_close(PAL_HANDLE handle) {
     }
 
     if (handle->sock.bind)
-        handle->sock.bind = (PAL_PTR)NULL;
+        handle->sock.bind = NULL;
 
     if (handle->sock.conn)
-        handle->sock.conn = (PAL_PTR)NULL;
+        handle->sock.conn = NULL;
 
     return 0;
 }
@@ -1076,24 +1076,24 @@ static int socket_getname(PAL_HANDLE handle, char* buffer, size_t count) {
         case PAL_TYPE_TCPSRV:
             prefix_len = static_strlen(URI_PREFIX_TCP_SRV);
             prefix = URI_PREFIX_TCP_SRV;
-            bind_addr = (struct sockaddr*)handle->sock.bind;
+            bind_addr = handle->sock.bind;
             break;
         case PAL_TYPE_TCP:
             prefix_len = static_strlen(URI_PREFIX_TCP);
             prefix = URI_PREFIX_TCP;
-            bind_addr = (struct sockaddr*)handle->sock.bind;
-            dest_addr = (struct sockaddr*)handle->sock.conn;
+            bind_addr = handle->sock.bind;
+            dest_addr = handle->sock.conn;
             break;
         case PAL_TYPE_UDPSRV:
             prefix_len = static_strlen(URI_PREFIX_UDP_SRV);
             prefix = URI_PREFIX_UDP_SRV;
-            bind_addr = (struct sockaddr*)handle->sock.bind;
+            bind_addr = handle->sock.bind;
             break;
         case PAL_TYPE_UDP:
             prefix_len = static_strlen(URI_PREFIX_UDP);
             prefix = URI_PREFIX_UDP;
-            bind_addr = (struct sockaddr*)handle->sock.bind;
-            dest_addr = (struct sockaddr*)handle->sock.conn;
+            bind_addr = handle->sock.bind;
+            dest_addr = handle->sock.conn;
             break;
         default:
             return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -164,7 +164,7 @@ int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size) {
     /* update handle fields to point to correct contents (located right after handle itself) */
     switch (PAL_GET_TYPE(hdl)) {
         case PAL_TYPE_FILE:
-            hdl->file.realpath = hdl->file.realpath ? (const char*)hdl + hdlsz : NULL;
+            hdl->file.realpath = (hdl->file.realpath ? (const char*)hdl + hdlsz : NULL);
             break;
         case PAL_TYPE_PIPE:
         case PAL_TYPE_PIPESRV:
@@ -174,18 +174,18 @@ int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size) {
         case PAL_TYPE_DEV:
             break;
         case PAL_TYPE_DIR:
-            hdl->dir.realpath = hdl->dir.realpath ? (const char*)hdl + hdlsz : NULL;
+            hdl->dir.realpath = (hdl->dir.realpath ? (const char*)hdl + hdlsz : NULL);
             break;
         case PAL_TYPE_TCP:
         case PAL_TYPE_TCPSRV:
         case PAL_TYPE_UDP:
         case PAL_TYPE_UDPSRV: {
-            size_t s1 = hdl->sock.bind ? addr_size((PAL_PTR)hdl + hdlsz) : 0;
-            size_t s2 = hdl->sock.conn ? addr_size((PAL_PTR)hdl + hdlsz + s1) : 0;
+            size_t s1 = hdl->sock.bind ? addr_size((struct sockaddr*)((uint8_t*)hdl + hdlsz)) : 0;
+            size_t s2 = hdl->sock.conn ? addr_size((struct sockaddr*)((uint8_t*)hdl + hdlsz + s1)) : 0;
             if (s1)
-                hdl->sock.bind = (PAL_PTR)hdl + hdlsz;
+                hdl->sock.bind = (struct sockaddr*)((uint8_t*)hdl + hdlsz);
             if (s2)
-                hdl->sock.conn = (PAL_PTR)hdl + hdlsz + s2;
+                hdl->sock.conn = (struct sockaddr*)((uint8_t*)hdl + hdlsz + s2);
             break;
         }
         case PAL_TYPE_PROCESS:

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -123,7 +123,7 @@ static noreturn void pal_thread_exit_wrapper(int ret_val) {
     _DkThreadExit(/*clear_child_tid=*/NULL);
 }
 
-int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* param) {
+int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), void* param) {
     int ret = 0;
     PAL_HANDLE hdl = NULL;
     void* stack = get_thread_stack();
@@ -160,7 +160,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX* tcb = child_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);
-    pal_tcb_linux_init(tcb, hdl, child_stack, callback, (void*)param);
+    pal_tcb_linux_init(tcb, hdl, child_stack, callback, param);
 
     /* align child_stack to 16 */
     child_stack = ALIGN_DOWN_PTR(child_stack, 16);
@@ -253,13 +253,13 @@ int _DkThreadResume(PAL_HANDLE thread_handle) {
     return 0;
 }
 
-int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     int ret = DO_SYSCALL(sched_setaffinity, thread->thread.tid, cpumask_size, cpu_mask);
 
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
-int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     int ret = DO_SYSCALL(sched_getaffinity, thread->thread.tid, cpumask_size, cpu_mask);
 
     return ret < 0 ? unix_to_pal_error(ret) : ret;

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -75,16 +75,16 @@ typedef struct pal_handle {
         struct {
             PAL_IDX fd;
             const char* realpath;
-            PAL_PTR buf;
-            PAL_PTR ptr;
-            PAL_PTR end;
+            void* buf;
+            void* ptr;
+            void* end;
             bool endofstream;
         } dir;
 
         struct {
             PAL_IDX fd;
-            PAL_PTR bind;
-            PAL_PTR conn;
+            struct sockaddr* bind;
+            struct sockaddr* conn;
             bool nonblocking;
             bool reuseaddr;
             PAL_NUM linger;

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -19,11 +19,11 @@ int _DkRandomBitsRead(void* buffer, size_t size) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkSegmentBaseGet(enum pal_segment_reg reg, void** addr) {
+int _DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkSegmentBaseSet(enum pal_segment_reg reg, void* addr) {
+int _DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
@@ -31,8 +31,8 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
-                         PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
+int _DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
+                         void* target_info, PAL_NUM* target_info_size, void* report,
                          PAL_NUM* report_size) {
     __UNUSED(user_report_data);
     __UNUSED(user_report_data_size);
@@ -43,7 +43,7 @@ int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_siz
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size, PAL_PTR quote,
+int _DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_size, void* quote,
                         PAL_NUM* quote_size) {
     __UNUSED(user_report_data);
     __UNUSED(user_report_data_size);
@@ -52,7 +52,7 @@ int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkSetProtectedFilesKey(PAL_PTR pf_key_hex) {
+int _DkSetProtectedFilesKey(const char* pf_key_hex) {
     __UNUSED(pf_key_hex);
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -13,7 +13,7 @@
 /* _DkThreadCreate for internal use. Create an internal thread
    inside the current process. The arguments callback and param
    specify the starting function and parameters */
-int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* param) {
+int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), void* param) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
@@ -33,11 +33,11 @@ int _DkThreadResume(PAL_HANDLE thread_handle) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, unsigned long* cpu_mask) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/common/include/assert.h
+++ b/common/include/assert.h
@@ -8,8 +8,6 @@
 #ifndef ASSERT_H
 #define ASSERT_H
 
-#include <stdnoreturn.h>
-
 #include "callbacks.h"
 #include "log.h"
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Only less controversial places for now, where the replacement type is quite obvious. Next will come `PAL_NUM`, and `PAL_PTR` occurrences in memory management (not sure yet whether to use `void*` or `uintptr_t` there).

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/258)
<!-- Reviewable:end -->
