### PR TITLE
[python] gramine-sgx-sign: fix incompatibility with old Ninja

### DIFF
--- a/python/gramine-sgx-sign
+++ b/python/gramine-sgx-sign
@@ -47,20 +47,22 @@ def main(output, libpal, key, manifest_file, sigfile, depfile, verbose):
         f.write(sigstruct.to_bytes())
 
     if depfile:
-        # `.manifest.sgx` depends on all files we just expanded
-        depfile.write(f'{output}:')
-        for filename in expanded:
-            depfile.write(f'  \\\n\t{filename}')
-        depfile.write('\n')
-        depfile.write('\n')
+        # Dependencies:
+        #
+        # - `.manifest.sgx` depends on all files we just expanded
+        # - `.sig` additionally depends on libpal and key
+        #
+        # TODO (Ninja 1.10): We print all these as dependencies for `.manifest.sgx`. This will still
+        # cause `.sig` to be rebuilt when necessary: we build both these files together, so it's not
+        # possible to rebuild one without the other.
+        #
+        # This is a workaround for the fact that Ninja prior to version 1.10 does not
+        # support depfiles with multiple outputs (and parses such depfiles incorrectly).
+        deps = [*expanded, libpal, key]
 
-        # `.sig` additionally depends on libpal and key
-        depfile.write(f'{sigfile}:')
-        depfile.write(f' \\\n\t{libpal}')
-        depfile.write(f' \\\n\t{key}')
-        for filename in expanded:
+        depfile.write(f'{output}:')
+        for filename in deps:
             depfile.write(f' \\\n\t{filename}')
-        depfile.write('\n')
         depfile.write('\n')
 
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes the "dependency cycle" error that appears when building test manifests on Ubuntu 18.04 (Ninja 1.8.2).

Fixes #257.

## How to test this PR? <!-- (if applicable) -->

See #257 for how to reproduce the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/260)
<!-- Reviewable:end -->
