### PR TITLE
[LibOS] Fix FUTEX_WAKE_OP's implementation of `ANDN` operation

### DIFF
--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -531,7 +531,7 @@ static int futex_wake_op(uint32_t* uaddr1, uint32_t* uaddr2, int to_wake1, int t
             oldval = __atomic_fetch_or(uaddr2, oparg, __ATOMIC_RELAXED);
             break;
         case FUTEX_OP_ANDN:
-            oldval = __atomic_fetch_nand(uaddr2, oparg, __ATOMIC_RELAXED);
+            oldval = __atomic_fetch_and(uaddr2, ~oparg, __ATOMIC_RELAXED);
             break;
         case FUTEX_OP_XOR:
             oldval = __atomic_fetch_xor(uaddr2, oparg, __ATOMIC_RELAXED);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Current code implements `ANDN` op as NAND operation but this op according to man pages should do a complement of `oparg` and then `bitwise and` with the value of `uaddr2`. This commit fixes the issue.

This commit also updates the `futex_wake_op` regression test for `FUTEX_OP_ANDN` and other operations as well.

## How to test this PR?
Please run `futex_wake_op` LibOS regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/265)
<!-- Reviewable:end -->
