### PR TITLE
[LibOS/regression] Disable mounting host "/etc" in `host_root_fs` test

### DIFF
--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -12,6 +12,11 @@ fs.mount.gramine_lib.type = "chroot"
 fs.mount.gramine_lib.path = "/lib"
 fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
 
+# overwrite host "/etc" - we don't want host-level configuration files, e.g. dynamic loader caches
+fs.mount.disable_etc.type = "tmpfs"
+fs.mount.disable_etc.path = "/etc"
+fs.mount.disable_etc.uri = "file:unused"
+
 sgx.nonpie_binary = true
 sgx.debug = true
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
`host_root_fs` regression test mounts whole host root directory inside Gramine. Dynamic loaders ("ld.so") tend to cache locations of dynamic libraries and hold such caches in "/etc" directory, which could brake this test.

Fixes #271 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/271)
<!-- Reviewable:end -->
