### PR TITLE
[LibOS] Uniformly calculate `st_dev` in chroot stat functions

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -343,6 +343,7 @@ static int chroot_istat(struct shim_inode* inode, struct stat* buf) {
     lock(&inode->lock);
     buf->st_mode = inode->type | inode->perm;
     buf->st_size = inode->size;
+    buf->st_dev = hash_str(inode->mount->uri);
     /*
      * Pretend `nlink` is 2 for directories (to account for "." and ".."), 1 for other files.
      *
@@ -367,11 +368,7 @@ static int chroot_stat(struct shim_dentry* dent, struct stat* buf) {
     }
 
     ret = chroot_istat(dent->inode, buf);
-    if (ret < 0)
-        goto out;
 
-    buf->st_dev = hash_str(dent->mount->uri);
-    ret = 0;
 out:
     unlock(&dent->lock);
     return ret;

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -158,6 +158,8 @@ static int tmpfs_stat(struct shim_dentry* dent, struct stat* buf) {
     buf->st_ctime = data->ctime;
     buf->st_mtime = data->mtime;
     buf->st_atime = data->atime;
+    /* TODO: change to `hash_str(dent->inode->mount->uri)` once tmpfs supports inodes. */
+    buf->st_dev = 2;
     ret = 0;
 
 out:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
`st_dev` was calculated differently in `stat` (path stat) and `fstat` (fd stat).

Fixes #246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/273)
<!-- Reviewable:end -->
