### PR TITLE
[Pal/Linux-SGX] Allow different masks for SGX sealing key derivation

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -532,6 +532,27 @@ ISV Product ID and SVN
 This syntax specifies the ISV Product ID and SVN to be added to the enclave
 signature.
 
+Attribute masks for SGX sealing key derivation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.seal_key.flags_mask = "[8-byte hex value]"  (default: "0xffffffffffffffff")
+    sgx.seal_key.xfrm_mask  = "[8-byte hex value]"  (default: "0xfffffffffff9ff1b")
+    sgx.seal_key.misc_mask  = "[4-byte hex value]"  (default: "0xffffffff")
+
+This syntax specifies masks used to generate the SGX sealing key. These masks
+correspond to the following SGX ``KEYREQUEST`` struct fields:
+
+- ``flags_mask``: ``KEYREQUEST.ATTRIBUTESMASK.FLAGS``
+- ``xfrm_mask``: ``KEYREQUEST.ATTRIBUTESMASK.XFRM``
+- ``misc_mask``: ``KEYREQUEST.MISCMASK``
+
+Most users do *not* need to set these masks. Only advanced users with knowledge
+of SGX sealing should use these masks. In particular, these masks allow to
+specify a subset of enclave/machine attributes to be used in sealing key
+derivation. Moreover, these masks themselves are used in sealing key derivation.
+
 Allowed files
 ^^^^^^^^^^^^^
 

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -21,6 +21,11 @@ sgx.nonpie_binary = true
 sgx.debug = true
 sgx.remote_attestation = true
 
+# below three entries are irrelevant, only for test purposes
+sgx.seal_key.flags_mask = "0xffffffffffffffff"
+sgx.seal_key.xfrm_mask  = "0xfffffffffff9ff1b"
+sgx.seal_key.misc_mask  = "0xffffffff"
+
 sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
 sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -858,6 +858,12 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     }
     g_pal_internal_mem_size = extra_mem_size + PAL_INITIAL_MEM_SIZE;
 
+    /* seal-key material initialization must come before protected-files initialization */
+    if ((ret = init_seal_key_material()) < 0) {
+        log_error("Failed to initialize SGX sealing key material: %d", ret);
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+
     if ((ret = init_file_check_policy()) < 0) {
         log_error("Failed to load the file check policy: %d", ret);
         ocall_exit(1, /*is_exitgroup=*/true);

--- a/Pal/src/host/Linux-SGX/enclave_tf.h
+++ b/Pal/src/host/Linux-SGX/enclave_tf.h
@@ -28,8 +28,9 @@
 #include "enclave_tf_structs.h"
 #include "pal.h"
 
-int init_file_check_policy(void);
+int init_seal_key_material(void);
 
+int init_file_check_policy(void);
 int get_file_check_policy(void);
 
 /*!


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR adds three new manifest options:

- `sgx.seal_key.flags_mask` for KEYREQUEST.ATTRIBUTESMASK.FLAGS
- `sgx.seal_key.xfrm_mask` for KEYREQUEST.ATTRIBUTESMASK.XFRM
- `sgx.seal_key.misc_mask` for KEYREQUEST.MISCMASK

These new manifest options allow the user to control how the SGX sealing key is generated. This flexibility is especially important for cases where files are sealed with one version of Gramine and unsealed with another version of Gramine (differing in default attribute masks).

For a very detailed explanation of this subtle issue, please check https://github.com/gramineproject/gramine/issues/274.

Fixes #274.

## How to test this PR? <!-- (if applicable) -->

See #274. But here is a snippet that proves this PR works:
```
$ echo 'sgx.seal_key.xfrm_mask = "ffffffffffffff1b"' >> manifest.template
$ SGX=1 gramine-test build

$ gramine-sgx sealed_file sealed_file_mrsigner.dat
READING OK
```

I'm not sure how to test this in CI. I could create a couple new tests with manifest files containing compatible/incompatible `sgx.seal_key.xfrm_mask`, `sgx.seal_key.flags_mask`, `sgx.seal_key.misc_mask`, but I don't know if it is worth it.

UPDATE: The person who initially reported this issue tested this PR, and it works on their workload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/275)
<!-- Reviewable:end -->
