### PR TITLE
[Pal,LibOS] Move to C11 atomics from GCC built-ins

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -15,10 +15,10 @@
 #include <linux/shm.h>
 #include <linux/un.h>
 #include <stdalign.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "atomic.h"  // TODO: migrate to stdatomic.h
 #include "list.h"
 #include "pal.h"
 #include "shim_defs.h"
@@ -176,7 +176,7 @@ struct shim_epoll_item {
 };
 
 struct shim_epoll_handle {
-    size_t waiter_cnt;
+    _Atomic size_t waiter_cnt;
 
     /* Number of items on fds list. */
     size_t fds_count;
@@ -214,9 +214,9 @@ struct shim_handle {
     /* Only meaningful if the handle is registered in some epoll instance with `EPOLLET` semantics.
      * `false` if it already triggered an `EPOLLIN` event for the current portion of data otherwise
      * `true` and the next `epoll_wait` will consider this handle and report events for it. */
-    bool needs_et_poll_in;
+    atomic_bool needs_et_poll_in;
     /* Same as above but for `EPOLLOUT` events. */
-    bool needs_et_poll_out;
+    atomic_bool needs_et_poll_out;
 
     struct shim_qstr uri; /* URI representing this handle, it is not
                            * necessary to be set. */

--- a/LibOS/shim/include/shim_process.h
+++ b/LibOS/shim/include/shim_process.h
@@ -37,7 +37,7 @@ struct shim_process {
     IDTYPE ppid;
 
     /* This field should be accessed atomically, so no lock needed. */
-    IDTYPE pgid;
+    _Atomic IDTYPE pgid;
 
     /* Currently all threads share filesystem information. For more info check `CLONE_FS` flag in
      * `clone.c`. Protected by `fs_lock`. */

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -3,7 +3,6 @@
 
 #include "api.h"
 #include "assert.h"
-#include "atomic.h"
 #include "gramine_entry_api.h"
 #include "pal.h"
 #include "shim_entry.h"

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -336,7 +336,7 @@ typedef uint64_t HASHTYPE;
 #define FILE_OFF_MAX INT64_MAX
 typedef int64_t file_off_t;
 
-typedef struct atomic_int REFTYPE;
+typedef _Atomic int64_t REFTYPE;
 
 struct shim_lock {
     PAL_HANDLE lock;

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -755,7 +755,7 @@ BEGIN_CP_FUNC(handle) {
             case TYPE_EPOLL:
                 /* `new_hdl->info.epoll.fds_count` stays the same - copied above. */
                 DO_CP(epoll_item, &hdl->info.epoll.fds, &new_hdl->info.epoll.fds);
-                __atomic_store_n(&new_hdl->info.epoll.waiter_cnt, 0, __ATOMIC_RELAXED);
+                atomic_store_explicit(&new_hdl->info.epoll.waiter_cnt, 0, memory_order_relaxed);
                 memset(&new_hdl->info.epoll.event, '\0', sizeof(new_hdl->info.epoll.event));
                 break;
             case TYPE_SOCK:

--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -168,7 +168,7 @@ static bool mark_child_exited(child_cmp_t child_cmp, unsigned long arg, IDTYPE c
     while (wait_queue) {
         struct shim_thread_queue* next = wait_queue->next;
         struct shim_thread* thread = wait_queue->thread;
-        __atomic_store_n(&wait_queue->in_use, false, __ATOMIC_RELEASE);
+        atomic_store_explicit(&wait_queue->in_use, false, memory_order_release);
         /* In theory the atomic release store above does not prevent hoisting of code to before it.
          * Here we rely on the order: first store to `in_use`, then wake the thread. Let's add
          * a compiler barrier to prevent compiler from messing with this (e.g. if `thread_wakeup`

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -150,7 +150,7 @@ static int init_main_thread(void) {
         return -ESRCH;
     }
     g_process.pid = cur_thread->tid;
-    __atomic_store_n(&g_process.pgid, g_process.pid, __ATOMIC_RELEASE);
+    atomic_store_explicit(&g_process.pgid, g_process.pid, memory_order_release);
 
     int64_t uid_int64;
     ret = toml_int_in(g_manifest_root, "loader.uid", /*defaultval=*/0, &uid_int64);
@@ -450,7 +450,7 @@ void cleanup_thread(IDTYPE caller, void* arg) {
     assert(thread);
 
     /* wait on clear_child_tid_pal; this signals that PAL layer exited child thread */
-    while (__atomic_load_n(&thread->clear_child_tid_pal, __ATOMIC_RELAXED) != 0)
+    while (atomic_load_explicit(&thread->clear_child_tid_pal, memory_order_relaxed) != 0)
         CPU_RELAX();
 
     if (thread->robust_list) {

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -254,8 +254,8 @@ static int wait_for_response(struct ipc_msg_waiter* waiter) {
 }
 
 int ipc_send_msg_and_get_response(IDTYPE dest, struct shim_ipc_msg* msg, void** resp) {
-    static uint64_t ipc_seq_counter = 1;
-    uint64_t seq = __atomic_fetch_add(&ipc_seq_counter, 1, __ATOMIC_RELAXED);
+    static _Atomic uint64_t ipc_seq_counter = 1;
+    uint64_t seq = atomic_fetch_add_explicit(&ipc_seq_counter, 1, memory_order_relaxed);
     SET_UNALIGNED(msg->header.seq, seq);
 
     struct ipc_msg_waiter waiter = {

--- a/LibOS/shim/src/ipc/shim_ipc_vmid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_vmid.c
@@ -9,10 +9,11 @@
 #include "shim_types.h"
 #include "shim_utils.h"
 
-static IDTYPE g_last_vmid = STARTING_VMID;
+static _Atomic IDTYPE g_last_vmid = STARTING_VMID;
 
 static IDTYPE get_next_vmid(void) {
-    return __atomic_add_fetch(&g_last_vmid, 1, __ATOMIC_RELAXED);
+    atomic_fetch_add_explicit(&g_last_vmid, 1, memory_order_relaxed);
+    return g_last_vmid;
 }
 
 int ipc_get_new_vmid(IDTYPE* vmid) {

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -171,7 +171,7 @@ static long do_clone_new_vm(IDTYPE child_vmid, unsigned long flags, struct shim_
     struct shim_process process_description = {
         .pid = thread->tid,
         .ppid = g_process.pid,
-        .pgid = __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE),
+        .pgid = atomic_load_explicit(&g_process.pgid, memory_order_acquire),
         .root = g_process.root,
         .cwd = g_process.cwd,
         .umask = g_process.umask,
@@ -357,7 +357,7 @@ long shim_do_clone(unsigned long flags, unsigned long user_stack_addr, int* pare
 
         /* We should not have saved any references to this thread anywhere and `put_thread` below
          * should free it. */
-        assert(__atomic_load_n(&thread->ref_count.counter, __ATOMIC_RELAXED) == 1);
+        assert(atomic_load_explicit(&thread->ref_count, memory_order_relaxed) == 1);
 
         /* We do not own `thread->tid` aka `tid` anymore, clean it so that `put_thread` does not
          * try to release it. */

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -118,7 +118,7 @@ static int mark_thread_to_die(struct shim_thread* thread, void* arg) {
         return 0;
     }
 
-    bool need_wakeup = !__atomic_exchange_n(&thread->time_to_die, true, __ATOMIC_ACQ_REL);
+    bool need_wakeup = !atomic_exchange_explicit(&thread->time_to_die, true, memory_order_acq_rel);
 
     /* Now let's kick `thread`, so that it notices (in `handle_signal`) the flag `time_to_die`
      * set above (but only if we really set that flag). */
@@ -156,8 +156,8 @@ noreturn void process_exit(int error_code, int term_signal) {
 
     /* If process_exit is invoked multiple times, only a single invocation proceeds past this
      * point. */
-    static int first = 0;
-    if (__atomic_exchange_n(&first, 1, __ATOMIC_RELAXED) != 0) {
+    static atomic_int first = 0;
+    if (atomic_exchange_explicit(&first, 1, memory_order_relaxed) != 0) {
         /* Just exit current thread. */
         thread_exit(error_code, term_signal);
     }

--- a/LibOS/shim/src/sys/shim_getpid.c
+++ b/LibOS/shim/src/sys/shim_getpid.c
@@ -37,7 +37,7 @@ long shim_do_setpgid(pid_t pid, pid_t pgid) {
     }
 
     if (!pid || g_process.pid == (IDTYPE)pid) {
-        __atomic_store_n(&g_process.pgid, (IDTYPE)pgid ?: g_process.pid, __ATOMIC_RELEASE);
+        atomic_store_explicit(&g_process.pgid, (IDTYPE)pgid ?: g_process.pid, memory_order_release);
         /* TODO: inform parent about pgid change. */
         return 0;
     }
@@ -48,7 +48,7 @@ long shim_do_setpgid(pid_t pid, pid_t pgid) {
 
 long shim_do_getpgid(pid_t pid) {
     if (!pid || g_process.pid == (IDTYPE)pid) {
-        return __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE);
+        return atomic_load_explicit(&g_process.pgid, memory_order_acquire);
     }
 
     /* TODO: Currently we do not support getting pgid of other processes.

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -46,7 +46,7 @@ long shim_do_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
                 ret = -EFAULT;
                 break;
             }
-            *(int*)arg = __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE);
+            *(int*)arg = atomic_load_explicit(&g_process.pgid, memory_order_acquire);
             ret = 0;
             break;
         case FIONBIO:

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -403,7 +403,7 @@ int do_kill_proc(IDTYPE sender, IDTYPE pid, int sig) {
 }
 
 int do_kill_pgroup(IDTYPE sender, IDTYPE pgid, int sig) {
-    IDTYPE current_pgid = __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE);
+    IDTYPE current_pgid = atomic_load_explicit(&g_process.pgid, memory_order_acquire);
     if (!pgid) {
         pgid = current_pgid;
     }

--- a/LibOS/shim/test/regression/double_fork.c
+++ b/LibOS/shim/test/regression/double_fork.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <linux/futex.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/syscall.h>
@@ -38,9 +39,9 @@ static void do_grandchild(int fd) {
     _exit(42);
 }
 
-static uint32_t last_sig = 0;
+static _Atomic uint32_t last_sig = 0;
 static void handler(int sig) {
-    __atomic_store_n(&last_sig, sig, __ATOMIC_RELAXED);
+    atomic_store_explicit(&last_sig, sig, memory_order_relaxed);
 }
 
 int main(void) {

--- a/LibOS/shim/test/regression/futex_requeue.c
+++ b/LibOS/shim/test/regression/futex_requeue.c
@@ -3,6 +3,7 @@
 #include <limits.h>
 #include <linux/futex.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -40,10 +41,10 @@ static void check(int x) {
 }
 
 static void store(int* ptr, int val) {
-    __atomic_store_n(ptr, val, __ATOMIC_SEQ_CST);
+    atomic_store_explicit(ptr, val, memory_order_seq_cst);
 }
 static int load(int* ptr) {
-    return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+    return atomic_load_explicit(ptr, memory_order_seq_cst);
 }
 
 static int futex1 = 0;

--- a/LibOS/shim/test/regression/futex_wake_op.c
+++ b/LibOS/shim/test/regression/futex_wake_op.c
@@ -3,6 +3,7 @@
 #include <limits.h>
 #include <linux/futex.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,10 +40,10 @@ static void check(int x) {
 }
 
 static void store(int* ptr, int val) {
-    __atomic_store_n(ptr, val, __ATOMIC_SEQ_CST);
+    atomic_store_explicit(ptr, val, memory_order_seq_cst);
 }
 static int load(int* ptr) {
-    return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+    return atomic_load_explicit(ptr, memory_order_seq_cst);
 }
 
 static int wakeop_arg_extend(int x) {

--- a/LibOS/shim/test/regression/sighandler_reset.c
+++ b/LibOS/shim/test/regression/sighandler_reset.c
@@ -2,6 +2,7 @@
 #include <err.h>
 #include <errno.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/signal.h>
@@ -9,10 +10,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-static unsigned count = 0;
+static atomic_uint count = 0;
 
 static void handler(int signum) {
-    __atomic_add_fetch(&count, 1, __ATOMIC_RELEASE);
+    atomic_fetch_add_explicit(&count, 1, memory_order_release);
     printf("Got signal %d\n", signum);
 }
 
@@ -60,7 +61,7 @@ int main(void) {
         errx(1, "unexpected exit status: %d", status);
     }
 
-    unsigned tmp_count = __atomic_load_n(&count, __ATOMIC_ACQUIRE);
+    unsigned tmp_count = atomic_load_explicit(&count, memory_order_acquire);
     printf("Handler was invoked %u time(s).\n", tmp_count);
 
     if (tmp_count != 1)

--- a/Pal/include/host/Linux-common/syscall.h
+++ b/Pal/include/host/Linux-common/syscall.h
@@ -12,7 +12,7 @@ long vfork(void) __attribute__((returns_twice));
 void gramine_raw_syscalls_code_begin(void);
 void gramine_raw_syscalls_code_end(void);
 
-noreturn void _DkThreadExit_asm_stub(uint32_t* thread_stack_spinlock, int* clear_child_tid);
+noreturn void _DkThreadExit_asm_stub(_Atomic uint32_t* thread_stack_spinlock, int* clear_child_tid);
 
 #define _extend(x) ((unsigned long)(x))
 

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -40,8 +40,7 @@ typedef uint32_t    PAL_IDX; /*!< an index */
 #define URI_MAX 4096
 
 #ifdef IN_PAL
-#include "atomic.h"
-typedef struct atomic_int PAL_REF;
+typedef _Atomic int64_t PAL_REF;
 
 typedef struct {
     PAL_IDX type;

--- a/Pal/regression/Event.c
+++ b/Pal/regression/Event.c
@@ -1,3 +1,5 @@
+#include <stdatomic.h>
+
 #include "api.h"
 #include "cpu.h"
 #include "pal.h"
@@ -13,18 +15,18 @@
     _x;                                                                 \
 })
 
-static void wait_for(int* ptr, int val) {
+static void wait_for(atomic_int* ptr, int val) {
     while (__atomic_load_n(ptr, __ATOMIC_ACQUIRE) != val) {
         CPU_RELAX();
     }
 }
 
-static void set(int* ptr, int val) {
+static void set(atomic_int* ptr, int val) {
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
 }
 
-static int g_clear_thread_exit = 1;
-static int g_ready = 0;
+static atomic_int g_clear_thread_exit = 1;
+static atomic_int g_ready = 0;
 
 static void thread_func(void* arg) {
     PAL_HANDLE sleep_handle = NULL;

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -17,13 +17,13 @@
 static pal_event_handler_t g_handlers[PAL_EVENT_NUM_BOUND] = {0};
 
 pal_event_handler_t _DkGetExceptionHandler(enum pal_event event) {
-    return __atomic_load_n(&g_handlers[event], __ATOMIC_ACQUIRE);
+    return atomic_load_explicit(&g_handlers[event], memory_order_acquire);
 }
 
 void DkSetExceptionHandler(pal_event_handler_t handler, enum pal_event event) {
     assert(handler && event != PAL_EVENT_NO_EVENT && event < ARRAY_SIZE(g_handlers));
 
-    __atomic_store_n(&g_handlers[event], handler, __ATOMIC_RELEASE);
+    atomic_store_explicit(&g_handlers[event], handler, memory_order_release);
 }
 
 /* The below function is used by stack protector's __stack_chk_fail(), _FORTIFY_SOURCE's *_chk()

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -6,7 +6,6 @@
  */
 
 #include "api.h"
-#include "atomic.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "pal_internal.h"

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -108,8 +108,8 @@ static void save_pal_context(PAL_CONTEXT* ctx, sgx_cpu_context_t* uc,
 }
 
 static void emulate_rdtsc_and_print_warning(sgx_cpu_context_t* uc) {
-    static int first = 0;
-    if (__atomic_exchange_n(&first, 1, __ATOMIC_RELAXED) == 0) {
+    static _Atomic int first = 0;
+    if (atomic_exchange_explicit(&first, 1, memory_order_relaxed) == 0) {
         /* if we end up emulating RDTSC/RDTSCP instruction, we cannot use invariant TSC */
         extern uint64_t g_tsc_hz;
         g_tsc_hz = 0;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -76,7 +76,7 @@ int ocall_clone_thread(void);
 
 int ocall_create_process(size_t nargs, const char** args, int* stream_fd);
 
-int ocall_futex(uint32_t* uaddr, int op, int val, uint64_t* timeout_us);
+int ocall_futex(_Atomic uint32_t* uaddr, int op, int val, uint64_t* timeout_us);
 
 int ocall_gettime(uint64_t* microsec);
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -189,7 +189,7 @@ typedef struct {
 } ms_ocall_sched_getaffinity_t;
 
 typedef struct {
-    uint32_t* ms_futex;
+    _Atomic uint32_t* ms_futex;
     int ms_op, ms_val;
     uint64_t ms_timeout_us;
 } ms_ocall_futex_t;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -16,7 +16,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "atomic.h"
 #include "list.h"
 #include "spinlock.h"
 
@@ -67,7 +66,7 @@ typedef struct pal_handle {
             bool nonblocking;
             bool is_server;
             PAL_SESSION_KEY session_key;
-            PAL_NUM handshake_done;
+            _Atomic PAL_NUM handshake_done;
             void* ssl_ctx;
         } pipe;
 
@@ -135,7 +134,7 @@ typedef struct pal_handle {
             bool auto_clear;
             /* Access to the *content* of this field should be atomic, because it's used as futex
              * word on the untrusted host. */
-            uint32_t* signaled_untrusted;
+            _Atomic uint32_t* signaled_untrusted;
         } event;
     };
 }* PAL_HANDLE;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -795,7 +795,7 @@ static int rpc_thread_loop(void* arg) {
         req->result = f(req->buffer);
 
         /* this code is based on Mutex 2 from Futexes are Tricky */
-        int old_lock_state = __atomic_fetch_sub(&req->lock.lock, 1, __ATOMIC_ACQ_REL);
+        int old_lock_state = atomic_fetch_sub_explicit(&req->lock.lock, 1, memory_order_acq_rel);
         if (old_lock_state == SPINLOCK_LOCKED_WITH_WAITERS) {
             /* must unlock and wake waiters */
             spinlock_unlock(&req->lock);

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -18,10 +18,10 @@
 
 struct thread_map {
     unsigned int    tid;
-    sgx_arch_tcs_t* tcs;
+    _Atomic sgx_arch_tcs_t* tcs;
 };
 
-static sgx_arch_tcs_t* g_enclave_tcs;
+static _Atomic sgx_arch_tcs_t* g_enclave_tcs;
 static int g_enclave_thread_num;
 static struct thread_map* g_enclave_thread_map;
 
@@ -284,7 +284,8 @@ int clone_thread(void) {
 }
 
 int get_tid_from_tcs(void* tcs) {
-    int index = (sgx_arch_tcs_t*)tcs - g_enclave_tcs;
+    _Atomic sgx_arch_tcs_t* atomic_tcs = tcs;
+    int index = atomic_tcs - g_enclave_tcs;
     struct thread_map* map = &g_enclave_thread_map[index];
     if (index >= g_enclave_thread_num)
         return -EINVAL;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -11,8 +11,8 @@
 struct untrusted_area {
     void* addr;
     size_t size;
-    uint64_t in_use; /* must be uint64_t, because SET_ENCLAVE_TLS() currently supports only 8-byte
-                      * types. TODO: fix this. */
+    _Atomic uint64_t in_use; /* must be uint64_t, because SET_ENCLAVE_TLS() currently supports only 8-byte
+                              * types. TODO: fix this. */
     bool valid;
 };
 
@@ -95,7 +95,7 @@ static inline void pal_set_tcb_stack_canary(uint64_t canary) {
 /* private to untrusted Linux PAL, unique to each untrusted thread */
 typedef struct pal_tcb_urts {
     struct pal_tcb_urts* self;
-    sgx_arch_tcs_t* tcs;           /* TCS page of SGX corresponding to thread, for EENTER */
+    _Atomic sgx_arch_tcs_t* tcs;   /* TCS page of SGX corresponding to thread, for EENTER */
     void* stack;                   /* bottom of stack, for later freeing when thread exits */
     void* alt_stack;               /* bottom of alt stack, for child thread to init alt stack */
     uint8_t is_in_aex_profiling;   /* non-zero if thread is currently doing AEX profiling */

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -88,8 +88,8 @@ static void perform_signal_handling(enum pal_event event, bool is_in_pal, PAL_NU
 static void handle_sync_signal(int signum, siginfo_t* info, struct ucontext* uc) {
     if (info->si_signo == SIGSYS && info->si_code == SYS_SECCOMP) {
         ucontext_revert_syscall(uc, info->si_arch, info->si_syscall, info->si_call_addr);
-        static int log_once = 1;
-        if (__atomic_exchange_n(&log_once, 0, __ATOMIC_RELAXED)) {
+        static _Atomic int log_once = 1;
+        if (atomic_exchange_explicit(&log_once, 0, memory_order_relaxed)) {
             log_always("Emulating a raw system/supervisor call. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -110,7 +110,7 @@ typedef struct pal_handle {
         struct {
             spinlock_t lock;
             uint32_t waiters_cnt;
-            uint32_t signaled;
+            _Atomic uint32_t signaled;
             bool auto_clear;
         } event;
     };


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commit migrates GCC built-ins to C11 atomics. It also removes custom C11 atomics defined in `atomic.h` file and uses the C11 standard way.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

Fixes #20 

## How to test this PR? <!-- (if applicable) -->
Both LibOS, as well as Pal regression, have been updated as part of this PR. Please run these test suites to validate the PR.

