### PR TITLE
[Pal/Linux-SGX] Fix AESM warning 'Malformed request received'

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -209,9 +209,7 @@ failed:
 
 int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
                    const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len) {
-    int ret = connect_aesm_service();
-    if (ret < 0)
-        return ret;
+    int ret;
 
     Request req   = REQUEST__INIT;
     Response* res = NULL;


### PR DESCRIPTION
## Description of the changes 

When generating quotes in Gramine, a warning message "Malformed request received" will appear in AESM log.

This is because in retrieve_quote(), a new connection to AESM service is created but never used or closed. Removing this connection prevents AESM from printing the warning message.

Subsequent request_aesm_service() uses its own connection, therefore remains untouched.

Fixes gramineproject/graphene#2448

## How to test this PR? 

After applying this patch, generating quotes in Gramine will no longer generate warning messages in AESM log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/280)
<!-- Reviewable:end -->
