### PR TITLE
[Pal] Always map LibOS binary inside enclave memory

### DIFF
--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -22,10 +22,9 @@ sgx.debug = true
 
 sgx.file_check_policy = "allow_all_but_log"
 
-sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
-  "file:{{ gramine.runtimedir(libc) }}/",
-]
+# there are no "file:{{ gramine.libos }}" and "file:{{ gramine.runtimedir() }}/"
+# entries in `sgx.trusted_files` -- this is on purpose; we want to test that
+# `allow_all_but_log` also applies to Gramine-runtime files (e.g., LibOS binary)
 
 # below entry in sgx.trusted_files is to test TOML-table syntax without `sha256`
 [[sgx.trusted_files]]

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -377,10 +377,12 @@ static int create_and_relocate_entrypoint(PAL_HANDLE handle, const char* elf_fil
          * first segment's p_vaddr. This is to ensure that l_base_diff will not be less than 0.
          *
          * FIXME: We (ab)use _DkStreamMap() because _DkVirtualMemoryAlloc() cannot be used to
-         *        allocate memory at PAL-chosen address (it expects `map_addr` to be fixed).
+         *        allocate memory at PAL-chosen address (it expects `map_addr` to be fixed). Note
+         *        that `PAL_PROT_WRITECOPY` is specified to prevent allocating memory in untrusted
+         *        memory in case of Linux-SGX PAL (see Linux-SGX/db_files.c:file_map).
          */
         void* map_addr = NULL;
-        ret = _DkStreamMap(handle, &map_addr, /*prot=*/0, /*offset=*/0,
+        ret = _DkStreamMap(handle, &map_addr, /*prot=*/PAL_PROT_WRITECOPY, /*offset=*/0,
                            loadcmds[loadcmds_cnt - 1].alloc_end);
         if (ret < 0) {
             log_error("Failed to allocate memory for all LOAD segments of DYN ELF file");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

In the [recent RTLD refactoring](https://github.com/gramineproject/gramine/pull/152), the LibOS binary was initially mapped into memory via `_DkStreamMap(..., /*prot=*/0, ...)`. This led to a corner case in the Linux-SGX PAL: if `sgx.file_check_policy = "allow_all_but_log"` was set in the manifest (or the LibOS binary was marked in `sgx.allowed_files`), the LibOS binary was considered an allowed file. And because protections were `0` (aka MAP_SHARED), Linux-SGX's `file_map()` callback decided to map the file in untrusted memory, which was incorrect and led to failures later.

This commit fixes this bug by specifying `PAL_PROT_WRITECOPY` -- this guarantees that the file will be mapped inside enclave memory.

Kudos to @aneessahib who reported this issue.

## How to test this PR? <!-- (if applicable) -->

I modified one of the LibOS regression tests to catch this in the future.

A simple way to test it is to remove all `sgx.trusted_files`/`sgx.allowed_files` in some example and replace with `sgx.file_check_policy = "allow_all_but_log"`. For example, doing this in the Bash example:
```
diff --git a/CI-Examples/bash/manifest.template b/CI-Examples/bash/manifest.template
@@ -32,14 +32,4 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4

-sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
-  "file:{{ execdir }}/",
-  "file:{{ gramine.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-]
-
-sgx.allowed_files = [
-  "file:scripts/",
-]
+sgx.file_check_policy = "allow_all_but_log"
```

- Without this PR, fails like this:
```
warning: Allowing access to unknown file '/home/dimakuv/gramineproject/gramine/built-debug/lib/x86_64-linux-gnu/gramine/libsysdb.so' due to file_check_policy settings.
error: Failed to map segment from ELF file
error: Could not map the ELF file into memory and then relocate it
error: PAL failed at ../Pal/src/db_main.c:pal_main:558 (exitcode = 4, reason=Unable to load loader.entrypoint)
debug: DkProcessExit: Returning exit code 4
```

- With this PR, succeeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/281)
<!-- Reviewable:end -->
