### PR TITLE
Take `g_dcache_lock` in dentry-related functions

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -47,7 +47,9 @@ int init_process(int argc, const char** argv) {
     g_process.umask = 0022;
 
     struct shim_dentry* dent = NULL;
+    lock(&g_dcache_lock);
     int ret = path_lookupat(/*start=*/NULL, "/", LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &dent);
+    unlock(&g_dcache_lock);
     if (ret < 0) {
         log_error("Could not set up dentry for \"/\", something is seriously broken.");
         return ret;

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -252,8 +252,6 @@ static int chroot_do_open(struct shim_handle* hdl, struct shim_dentry* dent, mod
 
         hdl->type = TYPE_CHROOT;
         hdl->pos = 0;
-        hdl->flags = flags;
-        hdl->acc_mode = ACC_MODE(flags & O_ACCMODE);
         hdl->pal_handle = palhdl;
     } else {
         DkObjectClose(palhdl);
@@ -287,16 +285,12 @@ out:
     return ret;
 }
 
-static int chroot_creat(struct shim_handle* hdl, struct shim_dentry* dir, struct shim_dentry* dent,
-                        int flags, mode_t mode) {
-    __UNUSED(dir);
-
+static int chroot_creat(struct shim_handle* hdl, struct shim_dentry* dent, int flags, mode_t perm) {
     assert(locked(&g_dcache_lock));
 
     int ret;
 
     mode_t type = S_IFREG;
-    mode_t perm = mode & ~S_IFMT;
 
     lock(&dent->lock);
     ret = chroot_do_open(hdl, dent, type, flags | O_CREAT | O_EXCL, perm);
@@ -316,15 +310,12 @@ out:
     return ret;
 }
 
-static int chroot_mkdir(struct shim_dentry* dir, struct shim_dentry* dent, mode_t mode) {
-    __UNUSED(dir);
-
+static int chroot_mkdir(struct shim_dentry* dent, mode_t perm) {
     assert(locked(&g_dcache_lock));
 
     int ret;
 
     mode_t type = S_IFDIR;
-    mode_t perm = mode & ~S_IFMT;
 
     lock(&dent->lock);
     ret = chroot_do_open(/*hdl=*/NULL, dent, type, O_CREAT | O_EXCL, perm);
@@ -581,9 +572,7 @@ out:
     return ret;
 }
 
-static int chroot_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
-    __UNUSED(dir);
-
+static int chroot_unlink(struct shim_dentry* dent) {
     int ret;
 
     lock(&dent->lock);

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -212,9 +212,9 @@ static int fifo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flag
     /* rewire new hdl to contents of intermediate FIFO hdl */
     assert(fifo_hdl->type == TYPE_PIPE);
     assert(fifo_hdl->uri);
+    assert(fifo_hdl->acc_mode == ACC_MODE(flags & O_ACCMODE));
 
     hdl->type       = fifo_hdl->type;
-    hdl->acc_mode   = fifo_hdl->acc_mode;
     hdl->info       = fifo_hdl->info;
     hdl->pal_handle = fifo_hdl->pal_handle;
 

--- a/LibOS/shim/src/fs/shim_fs_lock.c
+++ b/LibOS/shim/src/fs/shim_fs_lock.c
@@ -507,7 +507,9 @@ int posix_lock_set_from_ipc(const char* path, struct posix_lock* pl, bool wait, 
     struct shim_dentry* dent = NULL;
     struct posix_lock_request* req = NULL;
 
+    lock(&g_dcache_lock);
     int ret = path_lookupat(g_dentry_root, path, LOOKUP_NO_FOLLOW, &dent);
+    unlock(&g_dcache_lock);
     if (ret < 0) {
         log_warning("posix_lock_set_from_ipc: error on dentry lookup for %s: %d", path, ret);
         goto out;
@@ -586,7 +588,9 @@ int posix_lock_get_from_ipc(const char* path, struct posix_lock* pl, struct posi
     assert(!g_process_ipc_ids.leader_vmid);
 
     struct shim_dentry* dent = NULL;
+    lock(&g_dcache_lock);
     int ret = path_lookupat(g_dentry_root, path, LOOKUP_NO_FOLLOW, &dent);
+    unlock(&g_dcache_lock);
     if (ret < 0) {
         log_warning("posix_lock_get_from_ipc: error on dentry lookup for %s: %d", path, ret);
         return ret;

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -139,8 +139,6 @@ static int pseudo_open(struct shim_handle* hdl, struct shim_dentry* dent, int fl
             break;
         }
     }
-    hdl->flags = flags;
-    hdl->acc_mode = ACC_MODE(flags & O_ACCMODE);
 
     return 0;
 }

--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -37,7 +37,7 @@ long shim_do_faccessat(int dfd, const char* filename, mode_t mode) {
 
     lock(&g_dcache_lock);
 
-    ret = _path_lookupat(dir, filename, LOOKUP_FOLLOW, &dent);
+    ret = path_lookupat(dir, filename, LOOKUP_FOLLOW, &dent);
     if (ret < 0)
         goto out;
 

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -67,7 +67,10 @@ long shim_do_chdir(const char* filename) {
     if (strnlen(filename, PATH_MAX + 1) == PATH_MAX + 1)
         return -ENAMETOOLONG;
 
-    if ((ret = path_lookupat(/*start=*/NULL, filename, LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &dent)) < 0)
+    lock(&g_dcache_lock);
+    ret = path_lookupat(/*start=*/NULL, filename, LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &dent);
+    unlock(&g_dcache_lock);
+    if (ret < 0)
         return ret;
 
     if (!dent)

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -15,6 +15,7 @@
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
+#include "shim_lock.h"
 #include "shim_table.h"
 #include "shim_types.h"
 #include "shim_utils.h"
@@ -297,7 +298,9 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
     if (*pathname != '/' && (ret = get_dirfd_dentry(dirfd, &dir)) < 0)
         goto out;
 
+    lock(&g_dcache_lock);
     ret = path_lookupat(dir, pathname, LOOKUP_NO_FOLLOW | LOOKUP_CREATE, &dent);
+    unlock(&g_dcache_lock);
     if (ret < 0) {
         goto out;
     }

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -490,8 +490,10 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
         }
 
         struct shim_dentry* dent = NULL;
+        lock(&g_dcache_lock);
         ret = path_lookupat(/*start=*/NULL, saddr->sun_path, LOOKUP_NO_FOLLOW | LOOKUP_CREATE,
                             &dent);
+        unlock(&g_dcache_lock);
         if (ret < 0)
             goto out;
 
@@ -773,8 +775,10 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
         }
 
         struct shim_dentry* dent = NULL;
+        lock(&g_dcache_lock);
         ret = path_lookupat(/*start=*/NULL, saddr->sun_path, LOOKUP_FOLLOW | LOOKUP_CREATE,
                             &dent);
+        unlock(&g_dcache_lock);
         if (ret < 0)
             goto out;
 

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -17,6 +17,7 @@
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
+#include "perm.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum pal_access access,
                     pal_share_flags_t share, enum pal_create_mode create,
@@ -146,7 +147,7 @@ static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* att
         attr->readable     = true; /* we don't know if it's stdin/stdout so simply return true */
         attr->writable     = true; /* we don't know if it's stdin/stdout so simply return true */
         attr->runnable     = false;
-        attr->share_flags  = 0;
+        attr->share_flags  = PERM_rw_rw_rw_;
         attr->pending_size = 0;
     } else {
         /* other devices must query the host */

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -16,6 +16,7 @@
 #include "pal_flags_conv.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "perm.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum pal_access access,
                     pal_share_flags_t share, enum pal_create_mode create,
@@ -144,7 +145,7 @@ static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* att
         attr->readable     = true; /* we don't know if it's stdin/stdout so simply return true */
         attr->writable     = true; /* we don't know if it's stdin/stdout so simply return true */
         attr->runnable     = false;
-        attr->share_flags  = 0;
+        attr->share_flags  = PERM_rw_rw_rw_;
         attr->pending_size = 0;
     } else {
         /* other devices must query the host */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit makes holding `g_dcache_lock` mandatory when calling `path_lookupat`, `dentry_open` and dentry callbacks (`shim_d_ops`). The callbacks are now also better documented.

This is in preparation for removing the per-object dentry lock (`shim_dentry.lock`), and later, switching to inodes. It should also make the filesystem functions less prone to race conditions.

Context: #279 (inodes migration). Should also help with https://github.com/gramineproject/graphene/issues/944 (but since I touch only some of the filesystem code, I won't claim it's fixed yet).

## How to test this PR? <!-- (if applicable) -->

I spent some time making sure the callbacks are called according to documentation; I would be grateful for a double-check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/282)
<!-- Reviewable:end -->
