### PR TITLE
[LibOS] fs_lock: Use a separate lock for all operations

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -161,12 +161,11 @@ struct shim_dentry {
      * filesystem (see `shim_inode` below). Protected by `lock`. */
     struct shim_inode* inode;
 
-    /* File lock information, stored only in the main process. Protected by `lock`. See
-     * `shim_fs_lock.c`. */
+    /* File lock information, stored only in the main process. Managed by `shim_fs_lock.c`. */
     struct fs_lock* fs_lock;
 
     /* True if the file might have locks placed by current process. Used in processes other than
-     * main process, to prevent unnecessary IPC calls on handle close. Protected by `lock`. See
+     * main process, to prevent unnecessary IPC calls on handle close. Managed by
      * `shim_fs_lock.c`. */
     bool maybe_has_fs_locks;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Instead of using `shim_dentry.lock` for data stores in individual dentries, we use a global local (`g_fs_lock_lock`) for all fs_lock
related operations. This is in preparation for removing `shim_dentry.lock`.

Context: #279.

I realize that using a lock for guarding a field on another object (`shim_dentry`) doesn't look nice. However, I tried the alternative (taking the global lock for dentries, `g_dcache_lock`) and it breaks because of the spaghetti in filesystem code[1]. While I could probably work around this specific issue, I think it's better to keep this module separate (i.e. using its own lock) so that it's easier to reason about.

[1] If you want to know the gory details, it was `shim_pipe`: because it uses extra file descriptor, the callback for `open` actually "closes" one of these artificial file descriptors, triggering fs_lock while we're already holding `g_dcache_lock`. Because we don't expect to be holding `g_dcache_lock` at this stage, we try to lock it for the second time. IMO `shim_pipe` breaks some implicit assumptions here, but there might be more places like this.

## How to test this PR? <!-- (if applicable) -->

CI should be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/283)
<!-- Reviewable:end -->
