### PR TITLE
Ubuntu 21.10 fixes

### DIFF
--- a/LibOS/shim/src/arch/x86_64/shim.lds
+++ b/LibOS/shim/src/arch/x86_64/shim.lds
@@ -44,6 +44,12 @@ SECTIONS
   {
     /* the rest of text segments */
     *(.text .stub .text.*);
+  }
+  .fini          : { *(.fini) }
+  .rodata :
+  {
+    /* the rest of rodata */
+    *(.rodata .rodata.*)
     . = ALIGN(8);
     __cp_name = .;
     *(SORT(.cp_name.*));
@@ -51,12 +57,6 @@ SECTIONS
     *(SORT(.cp_func.*));
     __rs_func = .;
     *(SORT(.rs_func.*));
-  }
-  .fini          : { *(.fini) }
-  .rodata :
-  {
-    /* the rest of rodata */
-    *(.rodata .rodata.*)
   }
   .eh_frame_hdr  : { *(.eh_frame_hdr) }
   .eh_frame      : ONLY_IF_RO { *(.eh_frame) }

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -171,6 +171,11 @@ if enable_glibc
     }
 endif
 if enable_musl
+    if meson.get_compiler('c').get_id() != 'gcc'
+        error('Compiling tests is currently unsupported with Musl and compilers other than GCC. ' +
+              'You need to either disable Musl (-Dmusl=disabled) or use GCC (CC=gcc).')
+    endif
+
     musl_specs_path_cmd = run_command('sh', '-c',
         'grep -Po -e \'-specs "\K([^"]*)\' `which musl-gcc`')
     musl_specs_path = musl_specs_path_cmd.stdout().strip()

--- a/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.c
+++ b/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.c
@@ -324,6 +324,7 @@ static int peek_user(int memdev, pid_t tid, struct enclave_dbginfo* ei, struct u
     if (ret < 0)
         return ret;
 
+    memset(ud, 0, sizeof(*ud));
     fill_regs(&ud->regs, &gpr);
     return 0;
 }

--- a/common/include/asan.h
+++ b/common/include/asan.h
@@ -58,7 +58,7 @@
  *       -fsanitize=address
  *       -fno-sanitize-link-runtime
  *       -mllvm -asan-mapping-offset=0x18000000000
- *       -mllvm -asan-use-after-return=0
+ *       -mllvm -asan-use-after-return=0  (`never` in LLVM 13 or higher)
  *       -mllvm -asan-stack=0
  *       -DASAN
  *

--- a/meson.build
+++ b/meson.build
@@ -211,9 +211,14 @@ if asan
         '-fsanitize=address',
         '-fno-sanitize-link-runtime',
         '-mllvm', '-asan-mapping-offset=' + asan_shadow_start,
-        '-mllvm', '-asan-use-after-return=0',
         '-DASAN',
     ]
+
+    if meson.get_compiler('c').version().version_compare('>=13')
+        cflags_sanitizers += ['-mllvm', '-asan-use-after-return=never']
+    else
+        cflags_sanitizers += ['-mllvm', '-asan-use-after-return=0']
+    endif
 endif
 
 #


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes compilation and linker warnings for GCC, and incompatibility with newest Clang/LLVM. See the commits.

## How to test this PR? <!-- (if applicable) -->

* Compile with GCC 11 / ld 2.37
* Compile with Clang 13 and `-Dasan=enabled` (note that for Clang you also need `-Dmusl=disabled`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/284)
<!-- Reviewable:end -->
