### PR TITLE
[CI-Examples] Update examples to also use `loader.preload`

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -1,6 +1,8 @@
 # This is a general manifest template for running Bash and core utility programs,
 # including ls, cat, cp, date, and rm.
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/bash"
 

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -1,5 +1,7 @@
 # Blender manifest example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/blender/blender"
 

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -1,5 +1,7 @@
 # Busybox manifest file example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "busybox"
 

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -1,5 +1,7 @@
 # Hello World manifest file example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "helloworld"
 loader.log_level = "{{ log_level }}"

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -1,5 +1,7 @@
 # lighttpd manifest example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/sbin/lighttpd"
 

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -1,5 +1,7 @@
 # Memcached manifest file example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "memcached"
 

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -1,5 +1,7 @@
 # Nginx manifest example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/sbin/nginx"
 

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -1,5 +1,7 @@
 # Python3 manifest example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -1,5 +1,7 @@
 # Client manifest file (both for EPID and DCAP)
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "client"
 

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -1,5 +1,7 @@
 # RA-TLS manifest file example
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "server"
 

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -1,5 +1,7 @@
 # Secret Provisioning manifest file example (client)
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "secret_prov_client"
 

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -1,5 +1,7 @@
 # Secret Provisioning manifest file example (minimal client)
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "secret_prov_min_client"
 

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -1,5 +1,7 @@
 # Secret Provisioning manifest file example (Protected Files client)
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "secret_prov_pf_client"
 

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -2,8 +2,12 @@
 
 ################################## GRAMINE ####################################
 
-# PAL entrypoint (points to the LibOS layer library of Gramine). There is currently only one
-# implementation, so it is always set to libsysdb.so.
+# Deprecated option, only for compatibility with Gramine v1.0. For newer
+# versions of Gramine, use `loader.entrypoint` instead.
+loader.preload = "file:{{ gramine.libos }}"
+
+# PAL entrypoint (points to the LibOS layer library of Gramine). There is
+# currently only one implementation, so it is always set to libsysdb.so.
 loader.entrypoint = "file:{{ gramine.libos }}"
 
 # Entrypoint binary which Gramine invokes.

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -1,5 +1,7 @@
 # This is a general manifest template for running SQLite.
 
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/sqlite3"
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is for backwards compatibility with Gramine v1.0. We currently have Gramine v1.0 installation package, and our QuickStart doc installs this version but runs the latest `CI-Examples/helloworld` sample app.

Commit "Update examples to use `loader.entrypoint` instead of `loader.preload`" removed the `loader.preload` manifest option from all examples' manifests. However, Gramine v1.0 doesn't recognize the new `loader.entrypoint` option and thus fails. This commit fixes that.

See #237 for context.

## How to test this PR? <!-- (if applicable) -->

CI must succeed. No functional change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/287)
<!-- Reviewable:end -->
