### PR TITLE
[LibOS] Improve GDB treatment of vDSO

### DIFF
--- a/LibOS/shim/src/vdso/arch/x86_64/meson.build
+++ b/LibOS/shim/src/vdso/arch/x86_64/meson.build
@@ -24,6 +24,10 @@ vdso_so_dbg = shared_library('vdso',
     link_depends: ['vdso.lds'],
 )
 
+# Strip symbols and debug info.
+#
+# TODO: It would be nice to keep debug info if we're in a debug build, but this seems to prevent GDB
+# from displaying a proper backtrace.
 vdso_not_checked_so = custom_target('vdso_not_checked.so',
     command: [objcopy, '-S', '@INPUT@', '@OUTPUT@'],
     input: vdso_so_dbg,


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This change stops GDB from trying to load vDSO as regular files, and instead loads them from process memory. As a result, GDB backtrace is fixed for stacks involving vDSO (e.g. `shim_do_gettimeofday`).
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

The GDB warnings (`file not found: .../[vdso_libos]`) should be gone.

There should be a proper backtrace for `shim_do_gettimeofday`:

```
LibOS/shim/test/regression $ GDB=1 gramine-direct gettimeofday
(gdb) break shim_do_gettimeofday
(gdb) run
...
(gdb) bt
#0  shim_do_gettimeofday (tv=0x7ffff3f692b8 <read_exact>, tz=0x0) at ../LibOS/shim/src/sys/shim_time.c:17
#1  0x00007ffff3f691b8 in shim_emulate_syscall (context=0x7ffff3efef38) at ../LibOS/shim/src/shim_syscalls.c:41
#2  0x00007ffff3f8a3ff in syscalldb () at ../LibOS/shim/src/arch/x86_64/syscallas.S:173
#3  0x00007ffff3f8a402 in __morestack () at ../LibOS/shim/src/arch/x86_64/syscallas.S:204
#4  0x000078863ce785c6 in ?? ()
#5  0x000078863ce78624 in gettimeofday ()
#6  0x0000000000401303 in main (argc=1, argv=0x78863d0eaee8) at ../LibOS/shim/test/regression/gettimeofday.c:35
#7  0x000078863c8ab147 in __libc_start_call_main (main=main@entry=0x4012d2 <main>, argc=argc@entry=1, 
    argv=argv@entry=0x78863d0eaee8) at ../sysdeps/nptl/libc_start_call_main.h:58
#8  0x000078863c8ab20c in __libc_start_main_impl (main=0x4012d2 <main>, argc=1, argv=0x78863d0eaee8, init=<optimized out>, 
    fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x78863d0eaed8) at ../csu/libc-start.c:409
#9  0x000000000040115e in _start ()
```

On `master`, the backtrace breaks on entry to Gramine (`__morestack`).

Note that there is `??` in here. It corresponds to `vdso_arch_syscall` which is a `static` function inside vDSO. It's gone because we strip symbols from the vDSO binary. However, the backtrace goes on.

(I tried to keep debug info, but GDB failed to load it or even display a traceback. I think this is useful enough, there's really not much code in there).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/294)
<!-- Reviewable:end -->
