### PR TITLE
Convert `tmpfs` to use inodes

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -158,7 +158,7 @@ struct shim_dentry {
     void* data;
 
     /* Inode associated with this dentry. Currently optional, and only for the use of underlying
-     * filesystem (see `shim_inode` below). Protected by `lock`. */
+     * filesystem (see `shim_inode` below). Protected by `g_dcache_lock`. */
     struct shim_inode* inode;
 
     /* File lock information, stored only in the main process. Managed by `shim_fs_lock.c`. */

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -179,6 +179,9 @@ struct shim_handle {
      * filesystem (see `shim_inode` in `shim_fs.h`). Eventually, should replace `dentry` fields.
      *
      * This field does not change, so reading it does not require holding `lock`.
+     *
+     * When taking locks for both handle and inode (`hdl->lock` and `hdl->inode->lock`), you should
+     * lock the *inode* first.
      */
     struct shim_inode* inode;
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -732,10 +732,6 @@ BEGIN_CP_FUNC(handle) {
             DO_CP_MEMBER(dentry, hdl, new_hdl, dentry);
         }
 
-        if (hdl->inode) {
-            DO_CP_MEMBER(inode, hdl, new_hdl, inode);
-        }
-
         if (new_hdl->pal_handle) {
             struct shim_palhdl_entry* entry;
             DO_CP(palhdl_ptr, &hdl->pal_handle, &entry);
@@ -767,6 +763,12 @@ BEGIN_CP_FUNC(handle) {
         }
 
         unlock(&hdl->lock);
+        if (hdl->inode) {
+            /* NOTE: Checkpointing `inode` will take `inode->lock`, so we need to do it after
+             * `hdl->lock` is released. */
+            DO_CP_MEMBER(inode, hdl, new_hdl, inode);
+        }
+
         ADD_CP_FUNC_ENTRY(off);
     } else {
         new_hdl = (struct shim_handle*)(base + off);

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -536,6 +536,9 @@ BEGIN_CP_FUNC(dentry) {
     __UNUSED(size);
     assert(size == sizeof(struct shim_dentry));
 
+    /* We should be holding `g_dcache_lock` for the whole checkpointing process. */
+    assert(locked(&g_dcache_lock));
+
     struct shim_dentry* dent     = (struct shim_dentry*)obj;
     struct shim_dentry* new_dent = NULL;
 

--- a/LibOS/shim/src/fs/shim_fs_util.c
+++ b/LibOS/shim/src/fs/shim_fs_util.c
@@ -6,6 +6,8 @@
 #include <stdint.h>
 
 #include "shim_fs.h"
+#include "shim_lock.h"
+#include "stat.h"
 
 int generic_seek(file_off_t pos, file_off_t size, file_off_t offset, int origin,
                  file_off_t* out_pos) {
@@ -36,4 +38,90 @@ int generic_seek(file_off_t pos, file_off_t size, file_off_t offset, int origin,
 
     *out_pos = pos;
     return 0;
+}
+
+static int generic_istat(struct shim_inode* inode, struct stat* buf) {
+    memset(buf, 0, sizeof(*buf));
+
+    lock(&inode->lock);
+    buf->st_mode = inode->type | inode->perm;
+    buf->st_size = inode->size;
+    /*
+     * Pretend `nlink` is 2 for directories (to account for "." and ".."), 1 for other files.
+     *
+     * Applications are unlikely to depend on exact value of `nlink`, and for us, it's inconvenient
+     * to keep track of the exact value (we would have to list the directory, and also take into
+     * account synthetic files created by Graphene, such as named pipes and sockets).
+     */
+    buf->st_nlink = (inode->type == S_IFDIR ? 2 : 1);
+
+    if (inode->mount->uri)
+        buf->st_dev = hash_str(inode->mount->uri);
+
+    unlock(&inode->lock);
+    return 0;
+}
+
+int generic_inode_stat(struct shim_dentry* dent, struct stat* buf) {
+    assert(locked(&g_dcache_lock));
+    if (!dent->inode) {
+        /*
+         * TODO: This can happen for synthetic dentries (DENTRY_SYNTHETIC) created as intermediate
+         * directories to a mountpoint. These should be treated specially, same as other
+         * Gramine-internal files (pipes, sockets). For now, we fail `stat()` with -ENOENT.
+         */
+        assert(dent->state & DENTRY_SYNTHETIC);
+        log_debug("%s: disregarding synthetic dentry: %s", __func__, dent->name);
+        return -ENOENT;
+    }
+
+    return generic_istat(dent->inode, buf);
+}
+
+int generic_inode_hstat(struct shim_handle* hdl, struct stat* buf) {
+    assert(hdl->inode);
+
+    return generic_istat(hdl->inode, buf);
+}
+
+file_off_t generic_inode_seek(struct shim_handle* hdl, file_off_t offset, int origin) {
+    file_off_t ret;
+
+    lock(&hdl->inode->lock);
+    lock(&hdl->lock);
+    file_off_t pos = hdl->pos;
+    file_off_t size = hdl->inode->size;
+
+    ret = generic_seek(pos, size, offset, origin, &pos);
+    if (ret == 0) {
+        hdl->pos = pos;
+        ret = pos;
+    }
+    unlock(&hdl->lock);
+    unlock(&hdl->inode->lock);
+    return ret;
+}
+
+int generic_inode_poll(struct shim_handle* hdl, int poll_type) {
+    int ret;
+
+    lock(&hdl->inode->lock);
+    lock(&hdl->lock);
+
+    if (hdl->inode->type == S_IFREG) {
+        ret = 0;
+        if (poll_type & FS_POLL_WR)
+            ret |= FS_POLL_WR;
+        /* TODO: The `hdl->pos < hdl->inode->size` condition is wrong, the `poll` syscall treats
+         * end-of-file as readable. Check if removing this condition doesn't break anything
+         * in our `poll` implementation. */
+        if ((poll_type & FS_POLL_RD) && hdl->pos < hdl->inode->size)
+            ret |= FS_POLL_RD;
+    } else {
+        ret = -EAGAIN;
+    }
+
+    unlock(&hdl->lock);
+    unlock(&hdl->inode->lock);
+    return ret;
 }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Next step in inodes conversion (#279). Based on open PR #282.

- Use `g_dcache_lock` for the dentry inode field
- Take `g_dcache_lock` for the whole checkpointing process
- Convert `tmpfs` to use inodes (fixes unlinking, renaming, and corner cases when migrating handles)
- Support `inode->data` (with deallocation and migration)
- Factor out some generic callbacks (seek, stat, hstat, poll)

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI should be enough. Some tests are now enabled for tmpfs (`send_handle`, `rename_unlink`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/297)
<!-- Reviewable:end -->
