### PR TITLE
[Pal/{Linux,Linux-SGX}] Fix IPv6 address serialization

### DIFF
--- a/Pal/regression/Socket.c
+++ b/Pal/regression/Socket.c
@@ -2,6 +2,41 @@
 #include "pal.h"
 #include "pal_regression.h"
 
+/* Checks if stream matches `pattern`, and aborts otherwise. `*` in the pattern is interpreted as
+ * one or more digits, and we use it to match the port number assigned by system. */
+static void expect_name(PAL_HANDLE handle, const char* pattern) {
+    char name[128];
+    int ret = DkStreamGetName(handle, name, sizeof(name));
+    if (ret < 0) {
+        pal_printf("DkStreamGetName failed: %d\n", ret);
+        DkProcessExit(1);
+    }
+
+    const char* pn = name;
+    const char* pp = pattern;
+    while (*pn && *pp) {
+        if (*pp == '*') {
+            /* consume one or more digits */
+            if (!isdigit(*pn))
+                break;
+            while (isdigit(*pn))
+                pn++;
+            pp++;
+        } else if (*pn == *pp) {
+            /* identical characters in name and pattern */
+            pn++;
+            pp++;
+        } else {
+            /* mismatch */
+            break;
+        }
+    }
+    if (*pn || *pp) {
+        pal_printf("Wrong stream name: %s, expected: %s\n", name, pattern);
+        DkProcessExit(1);
+    }
+}
+
 int main(int argc, char** argv, char** envp) {
     char buffer1[20] = "Hello World 1", buffer2[20] = "Hello World 2";
     char buffer3[20], buffer4[20];
@@ -17,17 +52,22 @@ int main(int argc, char** argv, char** envp) {
 
     if (ret >= 0 && tcp1) {
         pal_printf("TCP Creation 1 OK\n");
+        expect_name(tcp1, "tcp.srv:127.0.0.1:3000");
 
         PAL_HANDLE tcp2 = NULL;
         ret = DkStreamOpen("tcp:127.0.0.1:3000", PAL_ACCESS_RDWR, /*share_flags=*/0,
                            PAL_CREATE_IGNORED, /*options=*/0, &tcp2);
 
         if (ret >= 0 && tcp2) {
+            /* TODO: Linux-SGX reports just "127.0.0.1:3000" here (i.e. omits the source address) */
+            // expect_name(tcp2, "tcp:127.0.0.1:*:127.0.0.1:3000");
+
             PAL_HANDLE tcp3 = NULL;
             ret = DkStreamWaitForClient(tcp1, &tcp3, /*options=*/0);
 
             if (ret >= 0 && tcp3) {
                 pal_printf("TCP Connection 1 OK\n");
+                expect_name(tcp3, "tcp:127.0.0.1:3000:127.0.0.1:*");
 
                 size = sizeof(buffer1);
                 ret = DkStreamWrite(tcp3, 0, &size, buffer1, NULL);
@@ -63,18 +103,60 @@ int main(int argc, char** argv, char** envp) {
         DkObjectClose(tcp1);
     }
 
+    /* Test IPv6 (actually, IPv4 connection to an IPv6 socket; a true IPv6 connection will not work
+     * inside a Docker host without extra configuration) */
+
+    PAL_HANDLE tcp1_ipv6 = NULL;
+    ret = DkStreamOpen("tcp.srv:[::]:3000", PAL_ACCESS_RDWR, /*share_flags=*/0,
+                       PAL_CREATE_IGNORED, PAL_OPTION_DUALSTACK, &tcp1_ipv6);
+    if (ret >= 0 && tcp1_ipv6) {
+        pal_printf("TCP (IPv6) Creation 1 OK\n");
+        expect_name(tcp1_ipv6, "tcp.srv:[0000:0000:0000:0000:0000:0000:0000:0000]:3000");
+
+        PAL_HANDLE tcp2_ipv6 = NULL;
+        ret = DkStreamOpen("tcp:127.0.0.1:3000", PAL_ACCESS_RDWR, /*share_flags=*/0,
+                           PAL_CREATE_IGNORED, /*options=*/0, &tcp2_ipv6);
+        if (ret >= 0 && tcp2_ipv6) {
+            /* TODO: Linux-SGX reports just "127.0.0.1:3000" here (i.e. omits the source address) */
+            // expect_name(tcp2_ipv6, "tcp:127.0.0.1:*:127.0.0.1:3000");
+
+            PAL_HANDLE tcp3_ipv6 = NULL;
+            ret = DkStreamWaitForClient(tcp1_ipv6, &tcp3_ipv6, /*options=*/0);
+
+            if (ret >= 0 && tcp3_ipv6) {
+                pal_printf("TCP (IPv6) Connection 1 OK\n");
+                expect_name(tcp3_ipv6,
+                            "tcp:[0000:0000:0000:0000:0000:0000:0000:0000]:3000:"
+                            "[0000:0000:0000:0000:0000:ffff:7f00:0001]:*");
+
+                DkObjectClose(tcp3_ipv6);
+            }
+
+            DkObjectClose(tcp2_ipv6);
+        }
+
+        ret = DkStreamDelete(tcp1_ipv6, PAL_DELETE_ALL);
+        if (ret < 0) {
+            pal_printf("DkStreamDelete failed\n");
+            return 1;
+        }
+        DkObjectClose(tcp1_ipv6);
+    }
+
     PAL_HANDLE udp1 = NULL;
     ret = DkStreamOpen("udp.srv:127.0.0.1:3000", PAL_ACCESS_RDWR, /*share_flags=*/0,
                        PAL_CREATE_IGNORED, /*options=*/0, &udp1);
 
     if (ret >= 0 && udp1) {
         pal_printf("UDP Creation 1 OK\n");
+        expect_name(udp1, "udp.srv:127.0.0.1:3000");
 
         PAL_HANDLE udp2 = NULL;
         ret = DkStreamOpen("udp:127.0.0.1:3000", PAL_ACCESS_RDWR, /*share_flags=*/0,
                            PAL_CREATE_IGNORED, /*options=*/0, &udp2);
 
         if (ret >= 0 && udp2) {
+            expect_name(udp2, "udp:127.0.0.1:3000");
             pal_printf("UDP Connection 1 OK\n");
 
             memset(buffer3, 0, 20);
@@ -110,6 +192,7 @@ int main(int argc, char** argv, char** envp) {
                            PAL_CREATE_IGNORED, /*options=*/0, &udp3);
 
         if (ret >= 0 && udp3) {
+            expect_name(udp3, "udp:127.0.0.1:3001:127.0.0.1:3000");
             pal_printf("UDP Connection 2 OK\n");
 
             memset(buffer3, 0, 20);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -436,6 +436,10 @@ class TC_20_SingleProcess(RegressionTestCase):
         self.assertIn('TCP Write 2 OK', stderr)
         self.assertIn('TCP Read 2: Hello World 2', stderr)
 
+        # TCP (IPv6)
+        self.assertIn('TCP (IPv6) Creation 1 OK', stderr)
+        self.assertIn('TCP (IPv6) Connection 1 OK', stderr)
+
         # UDP Socket Creation
         self.assertIn('UDP Creation 1 OK', stderr)
 

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -156,8 +156,9 @@ static int inet_create_uri(char* buf, size_t buf_size, struct sockaddr* addr, si
 
         /* for IPv6, the address will be in the form of
            "[xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx]:port". */
-        len = snprintf(buf, buf_size, "[%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x]:%u", addr[0],
-                       addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],
+        len = snprintf(buf, buf_size, "[%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x]:%u",
+                       __ntohs(addr[0]), __ntohs(addr[1]), __ntohs(addr[2]), __ntohs(addr[3]),
+                       __ntohs(addr[4]), __ntohs(addr[5]), __ntohs(addr[6]), __ntohs(addr[7]),
                        __ntohs(addr_in6->sin6_port));
     } else {
         return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -158,8 +158,9 @@ static int inet_create_uri(char* buf, size_t buf_size, struct sockaddr* addr, si
 
         /* for IPv6, the address will be in the form of
            "[xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx]:port". */
-        len = snprintf(buf, buf_size, "[%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x]:%u", addr[0],
-                       addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],
+        len = snprintf(buf, buf_size, "[%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x]:%u",
+                       __ntohs(addr[0]), __ntohs(addr[1]), __ntohs(addr[2]), __ntohs(addr[3]),
+                       __ntohs(addr[4]), __ntohs(addr[5]), __ntohs(addr[6]), __ntohs(addr[7]),
                        __ntohs(addr_in6->sin6_port));
     } else {
         return -PAL_ERROR_INVAL;


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

PAL's DkStreamGetName operation incorrectly serialized IPv6 addresses, flipping the bytes on little-endian architectures. This caused MySQL to reject incoming connections (because e.g. a connection from 127.0.0.1 was reported by Gramine as coming from 0.127.1.0).

Fixes #246.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

* MySQL 5.7 should work, as described in #246. Unfortunately we don't have an example project for MySQL, and MySQL version 8 (available in Ubuntu repositories) does not work yet (it crashes on an assertion, I haven't investigated deeply).
* I modified the `Socket` PAL regression test to reproduce the scenario happening in MySQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/299)
<!-- Reviewable:end -->
