### PR TITLE
[Pal] Move PAL_HANDLE::flags to host specific part

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -117,6 +117,8 @@ nitpick_ignore = [
     ('c:type', 'union'),
     ('c:type', 'enum'), # parsing of these seems to be broken:
                         #     WARNING: c:type reference target not found: enum
+    # `PAL_HANDLE` has a non complete definition outside of PAL
+    ('c:type', 'PAL_HANDLE'),
 ]
 
 manpages_url = 'https://manpages.debian.org/{path}'

--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -41,24 +41,21 @@ Data types
 PAL handles
 """""""""""
 
-The PAL handles are identifiers that are returned by PAL when opening or
-creating resources. The basic data structure of a PAL handle is defined as
-follows::
+``PAL_HANDLE`` is the type of identifiers that are returned by PAL when opening
+or creating resources. It is an opaque type, that should not be accessed outside
+of PAL and its details depend on the actual PAL version (host).
+There is a common header (present on all PAL hosts) accessible from PAL code,
+which allows for checking the handle type::
 
-   typedef union pal_handle {
+   typedef struct {
        struct {
            PAL_IDX type;
        } hdr;
-       /* other resource-specific definitions */
+       /* other host-specific definitions */
    }* PAL_HANDLE;
 
-.. doxygenunion:: pal_handle
-   :project: pal
-.. doxygentypedef:: PAL_HANDLE
-   :project: pal
-
-As shown above, a PAL handle is usually defined as a `union` data type that
-contains different subtypes that represent each resource such as files,
+Rest of the fields are private to specific PAL hosts, but they usually define
+different handle subtypes that represent different resources such as files,
 directories, pipes or sockets. The actual memory allocated for the PAL handles
 may be variable-sized.
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -733,7 +733,7 @@ BEGIN_CP_FUNC(handle) {
 
         if (new_hdl->pal_handle) {
             struct shim_palhdl_entry* entry;
-            DO_CP(palhdl, hdl->pal_handle, &entry);
+            DO_CP(palhdl_ptr, &hdl->pal_handle, &entry);
             entry->phandle = &new_hdl->pal_handle;
         }
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -142,12 +142,14 @@ BEGIN_CP_FUNC(memory) {
 }
 END_CP_FUNC_NO_RS(memory)
 
-BEGIN_CP_FUNC(palhdl) {
+/* Checkpointing mess takes `sizeof(*obj)`, but `PAL_HANDLE` is just opaque pointer, which we do not
+ * know the size of, hence we pass a pointer to it and just dereference it here. */
+BEGIN_CP_FUNC(palhdl_ptr) {
     __UNUSED(size);
     size_t off = ADD_CP_OFFSET(sizeof(struct shim_palhdl_entry));
     struct shim_palhdl_entry* entry = (void*)(base + off);
 
-    entry->handle  = (PAL_HANDLE)obj;
+    entry->handle  = *(PAL_HANDLE*)obj;
     entry->phandle = NULL;
     entry->prev    = store->last_palhdl_entry;
 
@@ -158,7 +160,7 @@ BEGIN_CP_FUNC(palhdl) {
     if (objp)
         *objp = entry;
 }
-END_CP_FUNC_NO_RS(palhdl)
+END_CP_FUNC_NO_RS(palhdl_ptr)
 
 BEGIN_CP_FUNC(migratable) {
     __UNUSED(obj);

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -35,38 +35,26 @@ typedef uint32_t    PAL_IDX; /*!< an index */
 #define URI_MAX 4096
 
 #ifdef IN_PAL
-#include "atomic.h"
-typedef struct atomic_int PAL_REF;
 
 typedef struct {
     PAL_IDX type;
-    uint32_t flags;
 } PAL_HDR;
 
 #include "pal_host.h"
 
-#ifndef HANDLE_HDR
 #define HANDLE_HDR(handle) (&((handle)->hdr))
-#endif
+#define PAL_GET_TYPE(h) (HANDLE_HDR(h)->type)
+#define UNKNOWN_HANDLE(handle) (PAL_GET_TYPE(handle) >= PAL_HANDLE_TYPE_BOUND)
 
-static inline void init_handle_hdr(PAL_HDR* hdr, int pal_type) {
-    hdr->type  = pal_type;
-    hdr->flags = 0;
+static inline void init_handle_hdr(PAL_HANDLE handle, int pal_type) {
+    HANDLE_HDR(handle)->type = pal_type;
 }
 
-#else
-typedef union pal_handle {
-    struct {
-        PAL_IDX type;
-        /* the PAL-level reference counting is deprecated */
-    } hdr;
-}* PAL_HANDLE;
+#else /* IN_PAL */
 
-#ifndef HANDLE_HDR
-#define HANDLE_HDR(handle) (&((handle)->hdr))
-#endif
+typedef struct _pal_handle_undefined_type* PAL_HANDLE;
 
-#endif /* !IN_PAL */
+#endif /* IN_PAL */
 
 #include "pal-arch.h"
 
@@ -90,8 +78,6 @@ enum {
 };
 
 #define PAL_IDX_POISON         ((PAL_IDX)-1) /* PAL identifier poison value */
-#define PAL_GET_TYPE(h)        (HANDLE_HDR(h)->type)
-#define UNKNOWN_HANDLE(handle) (PAL_GET_TYPE(handle) >= PAL_HANDLE_TYPE_BOUND)
 
 typedef struct PAL_PTR_RANGE_ {
     PAL_PTR start, end;

--- a/Pal/regression/SendHandle.c
+++ b/Pal/regression/SendHandle.c
@@ -21,8 +21,8 @@ int main(int argc, char** argv) {
 
             memset(buffer, 0, 20);
 
-            switch (PAL_GET_TYPE(handles[i])) {
-                case PAL_TYPE_PIPESRV: {
+            switch (i) {
+                case 0:; /* pipe.srv */
                     PAL_HANDLE pipe = NULL;
                     ret = DkStreamWaitForClient(handles[i], &pipe, /*options=*/0);
 
@@ -36,9 +36,8 @@ int main(int argc, char** argv) {
                     }
 
                     break;
-                }
 
-                case PAL_TYPE_UDPSRV: {
+                case 1:; /* udp.srv */
                     char uri[20];
 
                     size = sizeof(buffer);
@@ -47,9 +46,8 @@ int main(int argc, char** argv) {
                         pal_printf("Receive Socket Handle: %s\n", buffer);
 
                     break;
-                }
 
-                case PAL_TYPE_FILE:
+                case 2: /* file */
                     size = sizeof(buffer);
                     ret = DkStreamRead(handles[i], 0, &size, buffer, NULL, 0);
                     if (ret == 0 && size > 0)

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -31,21 +31,21 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     assert(WITHIN_MASK(share,   PAL_SHARE_MASK));
     assert(WITHIN_MASK(options, PAL_OPTION_MASK));
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(dev));
     if (!hdl)
         return -PAL_ERROR_NOMEM;
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_DEV);
+    init_handle_hdr(hdl, PAL_TYPE_DEV);
 
     if (!strcmp(uri, "tty")) {
         /* special case of "dev:tty" device which is the standard input + standard output */
         hdl->dev.nonblocking = false;
 
         if (access == PAL_ACCESS_RDONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+            hdl->flags |= PAL_HANDLE_FD_READABLE;
             hdl->dev.fd = 0; /* host stdin */
         } else if (access == PAL_ACCESS_WRONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_WRITABLE;
+            hdl->flags |= PAL_HANDLE_FD_WRITABLE;
             hdl->dev.fd = 1; /* host stdout */
         } else {
             assert(access == PAL_ACCESS_RDWR);
@@ -67,12 +67,12 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         hdl->dev.fd = ret;
 
         if (access == PAL_ACCESS_RDONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+            hdl->flags |= PAL_HANDLE_FD_READABLE;
         } else if (access == PAL_ACCESS_WRONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_WRITABLE;
+            hdl->flags |= PAL_HANDLE_FD_WRITABLE;
         } else {
             assert(access == PAL_ACCESS_RDWR);
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+            hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
         }
     }
 
@@ -87,7 +87,7 @@ static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void*
     if (offset || HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    if (!(HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_READABLE))
+    if (!(handle->flags & PAL_HANDLE_FD_READABLE))
         return -PAL_ERROR_DENIED;
 
     if (handle->dev.fd == PAL_IDX_POISON)
@@ -101,7 +101,7 @@ static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, cons
     if (offset || HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    if (!(HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_WRITABLE))
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
     if (handle->dev.fd == PAL_IDX_POISON)
@@ -182,8 +182,8 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     if (handle->dev.fd == 0 || handle->dev.fd == 1) {
         /* special case of "dev:tty" device which is the standard input + standard output */
-        attr->readable     = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_READABLE;
-        attr->writable     = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_WRITABLE;
+        attr->readable     = handle->flags & PAL_HANDLE_FD_READABLE;
+        attr->writable     = handle->flags & PAL_HANDLE_FD_WRITABLE;
         attr->runnable     = false;
         attr->share_flags  = 0;
         attr->pending_size = 0;

--- a/Pal/src/host/Linux-SGX/db_eventfd.c
+++ b/Pal/src/host/Linux-SGX/db_eventfd.c
@@ -52,15 +52,15 @@ static int eventfd_pal_open(PAL_HANDLE* handle, const char* type, const char* ur
     if (fd < 0)
         return unix_to_pal_error(fd);
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(eventfd));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(eventfd));
     if (!hdl) {
         ocall_close(fd);
         return -PAL_ERROR_NOMEM;
     }
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_EVENTFD);
+    init_handle_hdr(hdl, PAL_TYPE_EVENTFD);
 
     /* Note: using index 0, given that there is only 1 eventfd FD per pal-handle. */
-    HANDLE_HDR(hdl)->flags = PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    hdl->flags = PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
 
     hdl->eventfd.fd          = fd;
     hdl->eventfd.nonblocking = !!(options & PAL_OPTION_NONBLOCK);
@@ -116,7 +116,7 @@ static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) 
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->eventfd.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = ocall_fionread(handle->eventfd.fd);

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -17,12 +17,12 @@
 #include "spinlock.h"
 
 int _DkEventCreate(PAL_HANDLE* handle_ptr, bool init_signaled, bool auto_clear) {
-    PAL_HANDLE handle = malloc(HANDLE_SIZE(event));
+    PAL_HANDLE handle = calloc(1, HANDLE_SIZE(event));
     if (!handle) {
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(handle), PAL_TYPE_EVENT);
+    init_handle_hdr(handle, PAL_TYPE_EVENT);
     handle->event.signaled_untrusted = malloc_untrusted(sizeof(*handle->event.signaled_untrusted));
     if (!handle->event.signaled_untrusted) {
         free(handle);

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -68,8 +68,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_FILE);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(hdl, PAL_TYPE_FILE);
+    hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
 
     memcpy((char*)hdl + HANDLE_SIZE(file), normpath, normpath_size);
     hdl->file.realpath = (const char*)hdl + HANDLE_SIZE(file);
@@ -887,13 +887,13 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         return unix_to_pal_error(fd);
 
     size_t len = strlen(uri);
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dir) + len + 1);
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(dir) + len + 1);
     if (!hdl) {
         ocall_close(fd);
         return -PAL_ERROR_NOMEM;
     }
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_DIR);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+    init_handle_hdr(hdl, PAL_TYPE_DIR);
+    hdl->flags |= PAL_HANDLE_FD_READABLE;
     hdl->dir.fd = fd;
     char* path  = (void*)hdl + HANDLE_SIZE(dir);
     memcpy(path, uri, len + 1);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -891,12 +891,13 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     }
 
     /* set up thread handle */
-    PAL_HANDLE first_thread = malloc(HANDLE_SIZE(thread));
+    PAL_HANDLE first_thread = calloc(1, HANDLE_SIZE(thread));
     if (!first_thread) {
         log_error("Out of memory");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
-    init_handle_hdr(HANDLE_HDR(first_thread), PAL_TYPE_THREAD);
+
+    init_handle_hdr(first_thread, PAL_TYPE_THREAD);
     first_thread->thread.tcs = g_enclave_base + GET_ENCLAVE_TLS(tcs_offset);
     /* child threads are assigned TIDs 2,3,...; see pal_start_thread() */
     first_thread->thread.tid = 1;

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -50,7 +50,7 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_
 
         /* collect internal-handle FD (only if it is readable/writable)
          * hdl might be a event/non-pollable object, simply ignore it */
-        uint32_t flags = HANDLE_HDR(hdl)->flags;
+        uint32_t flags = hdl->flags;
         if ((flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))
                 && hdl->generic.fd != PAL_IDX_POISON) {
             // TODO: why does these check for flags?
@@ -106,12 +106,13 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_
             ret_events[j] |= PAL_WAIT_ERROR;
 
         /* update handle's internal fields (flags) */
+        /* FIXME: something is wrong here, it reads and writes to flags without any locks... */
         PAL_HANDLE hdl = handle_array[j];
         assert(hdl);
-        if (HANDLE_HDR(hdl)->flags & PAL_HANDLE_FD_ERROR)
+        if (hdl->flags & PAL_HANDLE_FD_ERROR)
             ret_events[j] |= PAL_WAIT_ERROR;
         if (fds[i].revents & (POLLHUP | POLLERR | POLLNVAL))
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_ERROR;
+            hdl->flags |= PAL_HANDLE_FD_ERROR;
     }
 
     ret = 0;

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -78,14 +78,14 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, pal_stream_options_
     if (ret < 0)
         return unix_to_pal_error(ret);
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(pipe));
     if (!hdl) {
         ocall_close(ret);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_PIPESRV);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE; /* cannot write to a listening socket */
+    init_handle_hdr(hdl, PAL_TYPE_PIPESRV);
+    hdl->flags |= PAL_HANDLE_FD_READABLE; /* cannot write to a listening socket */
     hdl->pipe.fd          = ret;
     hdl->pipe.nonblocking = !!(options & PAL_OPTION_NONBLOCK);
 
@@ -130,14 +130,14 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     if (ret < 0)
         return unix_to_pal_error(ret);
 
-    PAL_HANDLE clnt = malloc(HANDLE_SIZE(pipe));
+    PAL_HANDLE clnt = calloc(1, HANDLE_SIZE(pipe));
     if (!clnt) {
         ocall_close(ret);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(clnt), PAL_TYPE_PIPECLI);
-    HANDLE_HDR(clnt)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(clnt, PAL_TYPE_PIPECLI);
+    clnt->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     clnt->pipe.fd          = ret;
     clnt->pipe.name        = handle->pipe.name;
     clnt->pipe.nonblocking = !!(flags & SOCK_NONBLOCK);
@@ -197,14 +197,14 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
     if (ret < 0)
         return unix_to_pal_error(ret);
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(pipe));
     if (!hdl) {
         ocall_close(ret);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_PIPE);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(hdl, PAL_TYPE_PIPE);
+    hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     hdl->pipe.fd            = ret;
     hdl->pipe.nonblocking   = !!(options & PAL_OPTION_NONBLOCK);
 
@@ -415,7 +415,7 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->pipe.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading (doesn't make sense for "listening" pipes) */
     attr->pending_size = 0;

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -147,12 +147,12 @@ int _DkProcessCreate(PAL_HANDLE* handle, const char** args) {
     if (ret < 0)
         return unix_to_pal_error(ret);
 
-    PAL_HANDLE child = malloc(HANDLE_SIZE(process));
+    PAL_HANDLE child = calloc(1, HANDLE_SIZE(process));
     if (!child)
         return -PAL_ERROR_NOMEM;
 
-    init_handle_hdr(HANDLE_HDR(child), PAL_TYPE_PROCESS);
-    HANDLE_HDR(child)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(child, PAL_TYPE_PROCESS);
+    child->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     child->process.stream      = stream_fd;
     child->process.nonblocking = false;
     child->process.is_server   = true;
@@ -219,12 +219,12 @@ int init_child_process(int parent_stream_fd, PAL_HANDLE* out_parent_handle,
     if (g_pal_linuxsgx_state.enclave_initialized)
         return -PAL_ERROR_DENIED;
 
-    PAL_HANDLE parent = malloc(HANDLE_SIZE(process));
+    PAL_HANDLE parent = calloc(1, HANDLE_SIZE(process));
     if (!parent)
         return -PAL_ERROR_NOMEM;
 
-    init_handle_hdr(HANDLE_HDR(parent), PAL_TYPE_PROCESS);
-    HANDLE_HDR(parent)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(parent, PAL_TYPE_PROCESS);
+    parent->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
 
     parent->process.stream      = parent_stream_fd;
     parent->process.nonblocking = false;
@@ -372,7 +372,7 @@ static int proc_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->process.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = ocall_fionread(handle->process.stream);

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -222,17 +222,15 @@ static inline PAL_HANDLE socket_create_handle(int type, int fd, pal_stream_optio
                                               struct sockaddr* bind_addr, size_t bind_addrlen,
                                               struct sockaddr* dest_addr, size_t dest_addrlen,
                                               struct sockopt* sock_options) {
-    PAL_HANDLE hdl =
-        malloc(HANDLE_SIZE(sock) + (bind_addr ? bind_addrlen : 0) + (dest_addr ? dest_addrlen : 0));
-
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(sock) + (bind_addr ? bind_addrlen : 0)
+                               + (dest_addr ? dest_addrlen : 0));
     if (!hdl)
         return NULL;
 
-    memset(hdl, 0, sizeof(struct pal_handle));
-    init_handle_hdr(HANDLE_HDR(hdl), type);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+    init_handle_hdr(hdl, type);
+    hdl->flags |= PAL_HANDLE_FD_READABLE;
     if (type != PAL_TYPE_TCPSRV) {
-        HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_WRITABLE;
+        hdl->flags |= PAL_HANDLE_FD_WRITABLE;
     }
     hdl->sock.fd = fd;
     uint8_t* addr = (uint8_t*)hdl + HANDLE_SIZE(sock);
@@ -691,7 +689,7 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type           = HANDLE_HDR(handle)->type;
     attr->nonblocking           = handle->sock.nonblocking;
-    attr->disconnected          = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected          = handle->flags & PAL_HANDLE_FD_ERROR;
 
     attr->socket.linger         = handle->sock.linger;
     attr->socket.receivebuf     = handle->sock.receivebuf;

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -263,7 +263,7 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
 
     ssize_t ret;
     struct hdl_header hdl_hdr = {
-        .has_fd = HANDLE_HDR(cargo)->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE),
+        .has_fd = cargo->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE),
         .data_size = hdl_data_size
     };
     int fd = hdl->process.stream;
@@ -382,7 +382,7 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
     if (hdl_hdr.has_fd) {
         handle->generic.fd = host_fd;
     } else {
-        HANDLE_HDR(handle)->flags &= ~(PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE);
+        handle->flags &= ~(PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE);
     }
 
     *cargo = handle;

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -95,10 +95,12 @@ void pal_start_thread(void) {
 
 int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), void* param) {
     int ret;
-    PAL_HANDLE new_thread = malloc(HANDLE_SIZE(thread));
+    PAL_HANDLE new_thread = calloc(1, HANDLE_SIZE(thread));
     if (!new_thread)
         return -PAL_ERROR_NOMEM;
-    init_handle_hdr(HANDLE_HDR(new_thread), PAL_TYPE_THREAD);
+
+    init_handle_hdr(new_thread, PAL_TYPE_THREAD);
+
     /*
      * tid will be filled later by pal_start_thread()
      * tid is cleared to avoid random value here.

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -40,14 +40,18 @@ typedef struct {
 /* RPC streams are encrypted with 256-bit AES keys */
 typedef uint8_t PAL_SESSION_KEY[32];
 
-typedef struct pal_handle {
+typedef struct {
     /*
      * Here we define the internal structure of PAL_HANDLE.
      * user has no access to the content inside these handles.
      */
 
     PAL_HDR hdr;
+    /* Bitmask of `PAL_HANDLE_FD_*` flags. */
+    uint32_t flags;
+
     union {
+        /* Common field for accessing underlying host fd. See also `PAL_HANDLE_FD_READABLE`. */
         struct {
             PAL_IDX fd;
         } generic;
@@ -138,8 +142,11 @@ typedef struct pal_handle {
 
 #define HANDLE_TYPE(handle) ((handle)->hdr.type)
 
+/* These two flags indicate whether the underlying host fd of `PAL_HANDLE` is readable and/or
+ * writable respectively. If none of these is set, then the handle has no host-level fd. */
 #define PAL_HANDLE_FD_READABLE  1
 #define PAL_HANDLE_FD_WRITABLE  2
+/* Set if an error was seen on this handle. Currently only set by `_DkStreamsWaitEvents`. */
 #define PAL_HANDLE_FD_ERROR     4
 
 #endif /* PAL_HOST_H */

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -29,21 +29,21 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     assert(WITHIN_MASK(share,   PAL_SHARE_MASK));
     assert(WITHIN_MASK(options, PAL_OPTION_MASK));
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(dev));
     if (!hdl)
         return -PAL_ERROR_NOMEM;
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_DEV);
+    init_handle_hdr(hdl, PAL_TYPE_DEV);
 
     if (!strcmp(uri, "tty")) {
         /* special case of "dev:tty" device which is the standard input + standard output */
         hdl->dev.nonblocking = false;
 
         if (access == PAL_ACCESS_RDONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+            hdl->flags |= PAL_HANDLE_FD_READABLE;
             hdl->dev.fd = 0; /* host stdin */
         } else if (access == PAL_ACCESS_WRONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_WRITABLE;
+            hdl->flags |= PAL_HANDLE_FD_WRITABLE;
             hdl->dev.fd = 1; /* host stdout */
         } else {
             assert(access == PAL_ACCESS_RDWR);
@@ -65,12 +65,12 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         hdl->dev.fd = ret;
 
         if (access == PAL_ACCESS_RDONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+            hdl->flags |= PAL_HANDLE_FD_READABLE;
         } else if (access == PAL_ACCESS_WRONLY) {
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_WRITABLE;
+            hdl->flags |= PAL_HANDLE_FD_WRITABLE;
         } else {
             assert(access == PAL_ACCESS_RDWR);
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+            hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
         }
     }
 
@@ -85,7 +85,7 @@ static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void*
     if (offset || HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    if (!(HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_READABLE))
+    if (!(handle->flags & PAL_HANDLE_FD_READABLE))
         return -PAL_ERROR_DENIED;
 
     if (handle->dev.fd == PAL_IDX_POISON)
@@ -99,7 +99,7 @@ static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, cons
     if (offset || HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    if (!(HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_WRITABLE))
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
     if (handle->dev.fd == PAL_IDX_POISON)
@@ -172,8 +172,8 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     if (handle->dev.fd == 0 || handle->dev.fd == 1) {
         /* special case of "dev:tty" device which is the standard input + standard output */
-        attr->readable     = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_READABLE;
-        attr->writable     = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_WRITABLE;
+        attr->readable     = handle->flags & PAL_HANDLE_FD_READABLE;
+        attr->writable     = handle->flags & PAL_HANDLE_FD_WRITABLE;
         attr->runnable     = false;
         attr->share_flags  = 0;
         attr->pending_size = 0;

--- a/Pal/src/host/Linux/db_eventfd.c
+++ b/Pal/src/host/Linux/db_eventfd.c
@@ -54,15 +54,15 @@ static int eventfd_pal_open(PAL_HANDLE* handle, const char* type, const char* ur
     if (fd < 0)
         return unix_to_pal_error(fd);
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(eventfd));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(eventfd));
     if (!hdl) {
         DO_SYSCALL(close, fd);
         return -PAL_ERROR_NOMEM;
     }
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_EVENTFD);
+    init_handle_hdr(hdl, PAL_TYPE_EVENTFD);
 
     /* Note: using index 0, given that there is only 1 eventfd FD per pal-handle. */
-    HANDLE_HDR(hdl)->flags = PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    hdl->flags = PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
 
     hdl->eventfd.fd          = fd;
     hdl->eventfd.nonblocking = !!(options & PAL_OPTION_NONBLOCK);
@@ -116,7 +116,7 @@ static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) 
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->eventfd.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = DO_SYSCALL(ioctl, handle->eventfd.fd, FIONREAD, &val);

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -18,12 +18,12 @@
 #include "pal_linux_error.h"
 
 int _DkEventCreate(PAL_HANDLE* handle_ptr, bool init_signaled, bool auto_clear) {
-    PAL_HANDLE handle = malloc(HANDLE_SIZE(event));
+    PAL_HANDLE handle = calloc(1, HANDLE_SIZE(event));
     if (!handle) {
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(handle), PAL_TYPE_EVENT);
+    init_handle_hdr(handle, PAL_TYPE_EVENT);
     spinlock_init(&handle->event.lock);
     handle->event.auto_clear = auto_clear;
     handle->event.waiters_cnt = 0;

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -42,14 +42,14 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
 
     /* if try_create_path succeeded, prepare for the file handle */
     size_t uri_size = strlen(uri) + 1;
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(file) + uri_size);
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(file) + uri_size);
     if (!hdl) {
         DO_SYSCALL(close, ret);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_FILE);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(hdl, PAL_TYPE_FILE);
+    hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     hdl->file.fd = ret;
     hdl->file.map_start = NULL;
     char* path = (void*)hdl + HANDLE_SIZE(file);
@@ -339,21 +339,26 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         return unix_to_pal_error(fd);
 
     size_t len = strlen(uri);
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dir) + len + 1);
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(dir) + len + 1);
     if (!hdl) {
         DO_SYSCALL(close, fd);
         return -PAL_ERROR_NOMEM;
     }
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_DIR);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+
+    init_handle_hdr(hdl, PAL_TYPE_DIR);
+
+    hdl->flags |= PAL_HANDLE_FD_READABLE;
     hdl->dir.fd = fd;
+
     char* path = (void*)hdl + HANDLE_SIZE(dir);
     memcpy(path, uri, len + 1);
+
     hdl->dir.realpath    = path;
     hdl->dir.buf         = NULL;
     hdl->dir.ptr         = NULL;
     hdl->dir.end         = NULL;
     hdl->dir.endofstream = false;
+
     *handle = hdl;
     return 0;
 }

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -274,10 +274,11 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
         INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
     }
 
-    PAL_HANDLE first_thread = malloc(HANDLE_SIZE(thread));
+    PAL_HANDLE first_thread = calloc(1, HANDLE_SIZE(thread));
     if (!first_thread)
         INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
-    init_handle_hdr(HANDLE_HDR(first_thread), PAL_TYPE_THREAD);
+
+    init_handle_hdr(first_thread, PAL_TYPE_THREAD);
     first_thread->thread.tid = DO_SYSCALL(gettid);
 
     void* alt_stack = calloc(1, ALT_STACK_SIZE);

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -48,7 +48,7 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_
 
         /* collect internal-handle FD (only if it is readable/writable)
          * hdl might be a event/non-pollable object, simply ignore it */
-        uint32_t flags = HANDLE_HDR(hdl)->flags;
+        uint32_t flags = hdl->flags;
         if ((flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))
                 && hdl->generic.fd != PAL_IDX_POISON) {
             int fdevents = 0;
@@ -116,10 +116,10 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_
         /* update handle's internal fields (flags) */
         PAL_HANDLE hdl = handle_array[j];
         assert(hdl);
-        if (HANDLE_HDR(hdl)->flags & PAL_HANDLE_FD_ERROR)
+        if (hdl->flags & PAL_HANDLE_FD_ERROR)
             ret_events[j] |= PAL_WAIT_ERROR;
         if (fds[i].revents & (POLLHUP | POLLERR | POLLNVAL))
-            HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_ERROR;
+            hdl->flags |= PAL_HANDLE_FD_ERROR;
     }
 
     ret = 0;

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -63,14 +63,14 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, pal_stream_options_
         return unix_to_pal_error(ret);
     }
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(pipe));
     if (!hdl) {
         DO_SYSCALL(close, fd);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_PIPESRV);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;  /* cannot write to a listening socket */
+    init_handle_hdr(hdl, PAL_TYPE_PIPESRV);
+    hdl->flags |= PAL_HANDLE_FD_READABLE;  /* cannot write to a listening socket */
     hdl->pipe.fd            = fd;
     hdl->pipe.nonblocking   = !!(options & PAL_OPTION_NONBLOCK);
 
@@ -109,14 +109,14 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     if (newfd < 0)
         return unix_to_pal_error(newfd);
 
-    PAL_HANDLE clnt = malloc(HANDLE_SIZE(pipe));
+    PAL_HANDLE clnt = calloc(1, HANDLE_SIZE(pipe));
     if (!clnt) {
         DO_SYSCALL(close, newfd);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(clnt), PAL_TYPE_PIPECLI);
-    HANDLE_HDR(clnt)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(clnt, PAL_TYPE_PIPECLI);
+    clnt->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     clnt->pipe.fd            = newfd;
     clnt->pipe.name          = handle->pipe.name;
     clnt->pipe.nonblocking   = !!(flags & SOCK_NONBLOCK);
@@ -158,14 +158,14 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
         return unix_to_pal_error(ret);
     }
 
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(pipe));
     if (!hdl) {
         DO_SYSCALL(close, fd);
         return -PAL_ERROR_NOMEM;
     }
 
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_PIPE);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(hdl, PAL_TYPE_PIPE);
+    hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     hdl->pipe.fd            = fd;
     hdl->pipe.nonblocking   = !!(options & PAL_OPTION_NONBLOCK);
 
@@ -325,7 +325,7 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->pipe.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading (doesn't make sense for "listening" pipes) */
     attr->pending_size = 0;

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -49,25 +49,25 @@ static inline int create_process_handle(PAL_HANDLE* parent, PAL_HANDLE* child) {
         goto out;
     }
 
-    phdl = malloc(HANDLE_SIZE(process));
+    phdl = calloc(1, HANDLE_SIZE(process));
     if (!phdl) {
         ret = -PAL_ERROR_NOMEM;
         goto out;
     }
 
-    init_handle_hdr(HANDLE_HDR(phdl), PAL_TYPE_PROCESS);
-    HANDLE_HDR(phdl)->flags  |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(phdl, PAL_TYPE_PROCESS);
+    phdl->flags  |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     phdl->process.stream      = fds[0];
     phdl->process.nonblocking = false;
 
-    chdl = malloc(HANDLE_SIZE(process));
+    chdl = calloc(1, HANDLE_SIZE(process));
     if (!chdl) {
         ret = -PAL_ERROR_NOMEM;
         goto out;
     }
 
-    init_handle_hdr(HANDLE_HDR(chdl), PAL_TYPE_PROCESS);
-    HANDLE_HDR(chdl)->flags  |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
+    init_handle_hdr(chdl, PAL_TYPE_PROCESS);
+    chdl->flags  |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     chdl->process.stream      = fds[1];
     chdl->process.nonblocking = false;
 
@@ -354,7 +354,7 @@ static int proc_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->process.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = DO_SYSCALL(ioctl, handle->process.stream, FIONREAD, &val);

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -223,17 +223,15 @@ static int socket_parse_uri(char* uri, struct sockaddr** bind_addr, size_t* bind
 static inline PAL_HANDLE socket_create_handle(int type, int fd, pal_stream_options_t options,
                                               struct sockaddr* bind_addr, size_t bind_addrlen,
                                               struct sockaddr* dest_addr, size_t dest_addrlen) {
-    PAL_HANDLE hdl =
-        malloc(HANDLE_SIZE(sock) + (bind_addr ? bind_addrlen : 0) + (dest_addr ? dest_addrlen : 0));
-
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(sock) + (bind_addr ? bind_addrlen : 0)
+                               + (dest_addr ? dest_addrlen : 0));
     if (!hdl)
         return NULL;
 
-    memset(hdl, 0, sizeof(struct pal_handle));
-    init_handle_hdr(HANDLE_HDR(hdl), type);
-    HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_READABLE;
+    init_handle_hdr(hdl, type);
+    hdl->flags |= PAL_HANDLE_FD_READABLE;
     if (type != PAL_TYPE_TCPSRV) {
-        HANDLE_HDR(hdl)->flags |= PAL_HANDLE_FD_WRITABLE;
+        hdl->flags |= PAL_HANDLE_FD_WRITABLE;
     }
     hdl->sock.fd = fd;
     uint8_t* addr = (uint8_t*)hdl + HANDLE_SIZE(sock);
@@ -931,7 +929,7 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->sock.nonblocking;
-    attr->disconnected = HANDLE_HDR(handle)->flags & PAL_HANDLE_FD_ERROR;
+    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     attr->socket.linger         = handle->sock.linger;
     attr->socket.receivebuf     = handle->sock.receivebuf;

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -66,7 +66,7 @@ out:
 }
 
 int handle_set_cloexec(PAL_HANDLE handle, bool enable) {
-    if (HANDLE_HDR(handle)->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE)) {
+    if (handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE)) {
         long flags = enable ? FD_CLOEXEC : 0;
         int ret = DO_SYSCALL(fcntl, handle->generic.fd, F_SETFD, flags);
         if (ret < 0 && ret != -EBADF)
@@ -216,7 +216,7 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
 
     ssize_t ret;
     struct hdl_header hdl_hdr = {
-        .has_fd = HANDLE_HDR(cargo)->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE),
+        .has_fd = cargo->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE),
         .data_size = hdl_data_size
     };
     int fd = hdl->process.stream;
@@ -337,7 +337,7 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
         assert(control_hdr->cmsg_len == CMSG_LEN(sizeof(int)));
         handle->generic.fd = *(int*)CMSG_DATA(control_hdr);
     } else {
-        HANDLE_HDR(handle)->flags &= ~(PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE);
+        handle->flags &= ~(PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE);
     }
 
     *cargo = handle;

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -151,12 +151,12 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), void* param) {
 
     void* child_stack = stack + THREAD_STACK_SIZE;
 
-    hdl = malloc(HANDLE_SIZE(thread));
+    hdl = calloc(1, HANDLE_SIZE(thread));
     if (!hdl) {
         ret = -PAL_ERROR_NOMEM;
         goto err;
     }
-    init_handle_hdr(HANDLE_HDR(hdl), PAL_TYPE_THREAD);
+    init_handle_hdr(hdl, PAL_TYPE_THREAD);
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX* tcb = child_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -21,15 +21,18 @@ typedef struct {
     char str[PIPE_NAME_MAX];
 } PAL_PIPE_NAME;
 
-typedef struct pal_handle {
+typedef struct {
     /* TSAI: Here we define the internal types of PAL_HANDLE
      * in PAL design, user has not to access the content inside the
      * handle, also there is no need to allocate the internal
      * handles, so we hide the type name of these handles on purpose.
      */
     PAL_HDR hdr;
+    /* Bitmask of `PAL_HANDLE_FD_*` flags. */
+    uint32_t flags;
 
     union {
+        /* Common field for accessing underlying host fd. See also `PAL_HANDLE_FD_READABLE`. */
         struct {
             PAL_IDX fd;
         } generic;
@@ -109,8 +112,11 @@ typedef struct pal_handle {
 
 #define HANDLE_TYPE(handle) ((handle)->hdr.type)
 
+/* These two flags indicate whether the underlying host fd of `PAL_HANDLE` is readable and/or
+ * writable respectively. If none of these is set, then the handle has no host-level fd. */
 #define PAL_HANDLE_FD_READABLE  1
 #define PAL_HANDLE_FD_WRITABLE  2
+/* Set if an error was seen on this handle. Currently only set by `_DkStreamsWaitEvents`. */
 #define PAL_HANDLE_FD_ERROR     4
 
 int arch_do_rt_sigprocmask(int sig, int how);

--- a/Pal/src/host/Skeleton/pal_host.h
+++ b/Pal/src/host/Skeleton/pal_host.h
@@ -12,57 +12,29 @@
 #error "cannot be included outside PAL"
 #endif
 
-typedef struct pal_handle {
+typedef struct {
     /* TSAI: Here we define the internal types of PAL_HANDLE in PAL design, user has not to access
      * the content inside the handle, also there is no need to allocate the internal handles, so we
      * hide the type name of these handles on purpose.
      */
     PAL_HDR hdr;
+    uint32_t flags;
 
-    union {
-        struct {
-            PAL_IDX fd;
-        } generic;
-
-        /* DP: Here we just define a placeholder fd; place your details here. Not every type
-         * requires an fd either - this is up to your host-specific code.
-         */
-        struct {
-            PAL_IDX fd;
-        } file;
-
-        struct {
-            PAL_IDX fd;
-        } pipe;
-
-        struct {
-            PAL_IDX unused;
-        } eventfd;
-
-        struct {
-            PAL_IDX fd;
-        } dev;
-
-        struct {
-            PAL_IDX fd;
-        } dir;
-
-        struct {
-            PAL_IDX fd;
-        } sock;
-
-        struct {
-            PAL_IDX unused;
-        } process;
-
-        struct {
-            PAL_IDX unused;
-        } thread;
-
-        struct {
-            int unused;
-        } event;
-    };
+    /*
+     * PAL has different kinds of handles, so you probably want to add an union with data specific
+     * for following types:
+     * - file,
+     * - pipe,
+     * - eventfd,
+     * - dev,
+     * - dir,
+     * - sock,
+     * - process,
+     * - thread,
+     * - event.
+     * Note that this is just a hint, not a requirement. You can check the Linux PAL for a sample
+     * implementation.
+     */
 }* PAL_HANDLE;
 
 #endif /* PAL_HOST_H */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

These flags were host specific, yet defined in common `PAL_HDR`. This commit also makes `PAL_HANDLE` an opaque type that cannot be accessed from non PAL code (e.g. LibOS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/301)
<!-- Reviewable:end -->
