### PR TITLE
[Pal/Linux-SGX] Better warning message when loading trusted file fails

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -199,11 +199,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
     uint64_t total;
     void* umem;
     ret = load_trusted_or_allowed_file(tf, hdl, do_create, &chunk_hashes, &total, &umem);
-    if (ret < 0) {
-        log_warning("load_trusted_or_allowed_file(%s, %d) failed", hdl->file.realpath,
-                    hdl->file.fd);
+    if (ret < 0)
         goto fail;
-    }
 
     hdl->file.chunk_hashes = chunk_hashes;
     hdl->file.total = total;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -336,8 +336,10 @@ int load_trusted_or_allowed_file(struct trusted_file* tf, PAL_HANDLE file, bool 
     }
 
     /* trusted files: need integrity, so calculate chunk hashes and compare with hash in manifest */
-    if (!file->file.seekable)
+    if (!file->file.seekable) {
+        log_warning("Trusted file '%s' is not seekable, cannot load it", file->file.realpath);
         return -PAL_ERROR_DENIED;
+    }
 
     sgx_chunk_hash_t* chunk_hashes = NULL;
     uint8_t* tmp_chunk = NULL; /* scratch buf to calculate whole-file and chunk-of-file hashes */
@@ -421,6 +423,8 @@ int load_trusted_or_allowed_file(struct trusted_file* tf, PAL_HANDLE file, bool 
 
     /* check the generated hash-over-whole-file against the reference hash in the manifest */
     if (memcmp(&file_hash, &tf->file_hash, sizeof(file_hash))) {
+        log_warning("Hash of trusted file '%s' does not match with the reference hash in manifest",
+                    file->file.realpath);
         ret = -PAL_ERROR_DENIED;
         goto fail;
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See #302 for details.

Fixes #302.

## How to test this PR? <!-- (if applicable) -->

All tests must succeed. Try manually to create `trusted_testfile` with some random text and run the LibOS regression test:
```
gramine/LibOS/shim/test/regression$ gramine-sgx file_check_policy_strict read trusted_testfile

warning: Hash of trusted file 'trusted_testfile' does not match with the reference hash in manifest
fopen failed: Permission denied
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/304)
<!-- Reviewable:end -->
