### PR TITLE
[LibOS] Add missing unlock on error return path in `shim_do_rmdir`

### DIFF
--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -122,8 +122,9 @@ long shim_do_rmdir(const char* pathname) {
 
     lock(&g_dcache_lock);
     ret = path_lookupat(/*start=*/NULL, pathname, LOOKUP_NO_FOLLOW | LOOKUP_DIRECTORY, &dent);
-    if (ret < 0)
-        return ret;
+    if (ret < 0) {
+        goto out;
+    }
 
     if (!dent->parent) {
         ret = -EACCES;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Fixes a bug introduced in #282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/307)
<!-- Reviewable:end -->
