### PR TITLE
[LibOS] Fix segfault during async-signal upcalls

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -500,7 +500,9 @@ static void quit_upcall(bool is_in_pal, PAL_NUM addr, PAL_CONTEXT* context) {
         return;
     }
 
-    if (is_internal(get_cur_thread()) || context_is_libos(context) || is_in_pal) {
+    /* "quit" signal may occur during LibOS thread initialization (at which point `cur == NULL`) */
+    struct shim_thread* cur = get_cur_thread();
+    if (!cur || is_internal(cur) || context_is_libos(context) || is_in_pal) {
         return;
     }
     handle_signal(context, /*old_mask_ptr=*/NULL);
@@ -509,7 +511,10 @@ static void quit_upcall(bool is_in_pal, PAL_NUM addr, PAL_CONTEXT* context) {
 static void interrupted_upcall(bool is_in_pal, PAL_NUM addr, PAL_CONTEXT* context) {
     __UNUSED(addr);
 
-    if (is_internal(get_cur_thread()) || context_is_libos(context) || is_in_pal) {
+    /* "interrupted" signal may occur during LibOS thread initialization (at which point
+     * `cur == NULL`) */
+    struct shim_thread* cur = get_cur_thread();
+    if (!cur || is_internal(cur) || context_is_libos(context) || is_in_pal) {
         return;
     }
     handle_signal(context, /*old_mask_ptr=*/NULL);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It is possible that an async signal occurs during LibOS thread initialization and is forwarded by PAL to `quit_upcall()` / `interrupted_upcall()`. At this point, `get_cur_thread() == NULL` and `is_internal()` helper function segfaults on `thread->tid`. This commit fixes this bug.

Note that we don't implement a similar change for *synchronous signals* because it is assumed that sync signals can never happen during LibOS code.

## How to test this PR? <!-- (if applicable) -->

This bug was found while I was experimenting with something different on Gramine. That workload increased the frequency of async signals; some of these signals got delivered while in LibOS thread initialization. This manifested itself as a MEMFAULT in Gramine PAL terminology, and led to an infinite loop of such MEMFAULTs.

On my extreme workload, this bug happened about 1 in 10 runs. I believe it's hard to catch this bug in normal workloads of Gramine, so no (simple) way to test this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/311)
<!-- Reviewable:end -->
