### PR TITLE
[Pal/Linux-SGX] Proceed with initialization even if trusted file doesn't exist

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -198,6 +198,28 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
     sgx_chunk_hash_t* chunk_hashes;
     uint64_t total;
     void* umem;
+
+    char* file_uri = malloc(URI_MAX);
+    if (!file_uri)
+        return -PAL_ERROR_NOMEM;
+
+    ret = _DkStreamGetName(hdl, file_uri, URI_MAX);
+    if (ret < 0) {
+        free(file_uri);
+        return ret;
+    }
+
+    PAL_STREAM_ATTR attr;
+    ret = _DkStreamAttributesQuery(file_uri, &attr);
+    if (ret < 0) {
+        log_error("Could not find size of file: %s\n", file_uri);
+        free(file_uri);
+        return ret;
+    }
+
+    free(file_uri);
+    tf->size = attr.pending_size;
+
     ret = load_trusted_or_allowed_file(tf, hdl, do_create, &chunk_hashes, &total, &umem);
     if (ret < 0)
         goto fail;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -542,8 +542,6 @@ failed:
 }
 
 static int register_file(const char* uri, const char* checksum_str, bool check_duplicates) {
-    int ret;
-
     if (checksum_str && strlen(checksum_str) != sizeof(sgx_file_hash_t) * 2) {
         log_error("Hash (%s) of a trusted file %s is not a SHA256 hash", checksum_str, uri);
         return -PAL_ERROR_INVAL;
@@ -582,15 +580,6 @@ static int register_file(const char* uri, const char* checksum_str, bool check_d
     memcpy(new->uri, uri, uri_len + 1);
 
     if (checksum_str) {
-        PAL_STREAM_ATTR attr;
-        ret = _DkStreamAttributesQuery(uri, &attr);
-        if (ret < 0) {
-            log_error("Could not find size of file: %s", uri);
-            free(new);
-            return ret;
-        }
-        new->size = attr.pending_size;
-
         assert(strlen(checksum_str) == sizeof(sgx_file_hash_t) * 2);
         for (size_t i = 0; i < sizeof(sgx_file_hash_t); i++) {
             int8_t byte1 = hex2dec(checksum_str[i * 2]);


### PR DESCRIPTION
Signed-off-by: Jitender Kumar <jitender.kumar@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

Signed-off-by: Jitender Kumar <jitender.kumar@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
During initialization process (enclave load) we register trusted files and initializes size of trusted files `tf->size` using `_DkStreamAttributesQuery()` which tries to access the file and fails if file doesn't exists.

code changes in this PR to defer the size initialization until actual file access need arises. Now initializing size of trusted file `tf->size` on file_open operation.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
Fixes #263 
## How to test this PR? <!-- (if applicable) -->
1. Create a dummy file, add the same to trusted-files list in `/gramine/CI-Examples/helloworld` manifest file. Remove dummy file. Should be able to run the example successfully.
2. Add below code in  file `/gramine/CI-Examples/helloworld/helloworld.c` to access it during runtime. Build the example. Should be able to run helloworld example successfully with expected error `cannot open dummyfile`.
```
int fd = open("dummyfile", O_RDONLY);
if (fd < 0) {
fprintf(stderr, "[error] cannot open dummyfile\n");
return -1;
}
```
