### PR TITLE
[Pal] Remove superfluous PAL_MEM_INFO struct

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -103,12 +103,6 @@ PAL public state - topology information
    :project: pal
    :members:
 
-.. doxygentypedef:: PAL_MEM_INFO
-   :project: pal
-.. doxygenstruct:: PAL_MEM_INFO_
-   :project: pal
-   :members:
-
 PAL APIs
 --------
 

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -23,7 +23,7 @@ int proc_meminfo_load(struct shim_dentry* dent, char** out_data, size_t* out_siz
     } meminfo[] = {
         {
             "MemTotal:      %8lu kB\n",
-            g_pal_public_state->mem_info.mem_total / 1024,
+            g_pal_public_state->mem_total / 1024,
         },
         {
             "MemFree:       %8lu kB\n",

--- a/LibOS/shim/src/sys/shim_getrlimit.c
+++ b/LibOS/shim/src/sys/shim_getrlimit.c
@@ -168,8 +168,8 @@ long shim_do_sysinfo(struct sysinfo* info) {
         return -EFAULT;
 
     memset(info, 0, sizeof(*info));
-    info->totalram  = g_pal_public_state->mem_info.mem_total;
-    info->totalhigh = g_pal_public_state->mem_info.mem_total;
+    info->totalram  = g_pal_public_state->mem_total;
+    info->totalhigh = g_pal_public_state->mem_total;
     info->freeram   = DkMemoryAvailableQuota();
     info->freehigh  = DkMemoryAvailableQuota();
     info->mem_unit  = 1;

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -83,10 +83,6 @@ typedef struct PAL_PTR_RANGE_ {
     PAL_PTR start, end;
 } PAL_PTR_RANGE;
 
-typedef struct PAL_MEM_INFO_ {
-    PAL_NUM mem_total;
-} PAL_MEM_INFO;
-
 /********** PAL APIs **********/
 
 /* Part of PAL state which is shared between all PALs and accessible (read-only) by the binary
@@ -129,8 +125,9 @@ struct pal_public_state {
      */
     PAL_NUM alloc_align;
 
+    size_t mem_total;
+
     PAL_CPU_INFO cpu_info; /*!< CPU information (only required ones) */
-    PAL_MEM_INFO mem_info; /*!< memory information (only required ones) */
     PAL_TOPO_INFO topo_info; /*!< Topology information (only required ones) */
     bool enable_sysfs_topology;
 };

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -84,11 +84,11 @@ int main(int argc, char** argv, char** envp) {
         pal_printf("Memory Allocation with Address OK\n");
 
     /* Testing total memory */
-    pal_printf("Total Memory: %lu\n", DkGetPalPublicState()->mem_info.mem_total);
+    pal_printf("Total Memory: %lu\n", DkGetPalPublicState()->mem_total);
 
     /* Testing available memory (must be within valid range) */
     PAL_NUM avail = DkMemoryAvailableQuota();
-    if (avail > 0 && avail < DkGetPalPublicState()->mem_info.mem_total)
+    if (avail > 0 && avail < DkGetPalPublicState()->mem_total)
         pal_printf("Get Memory Available Quota OK\n");
 
     return 0;

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -536,7 +536,7 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     if (_DkGetCPUInfo(&g_pal_public_state.cpu_info) < 0) {
         goto out_fail;
     }
-    g_pal_public_state.mem_info.mem_total = _DkMemoryQuota();
+    g_pal_public_state.mem_total = _DkMemoryQuota();
 
     /* TODO: temporary measure, remove it once sysfs topology is thoroughly validated */
     bool enable_sysfs_topology;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Split out from #314 (removing superfluous `PAL_MEM_INFO` struct).

## How to test this PR? <!-- (if applicable) -->

CI, no functional changes intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/318)
<!-- Reviewable:end -->
