### PR TITLE
[LibOS] Add dummy entries in `/proc/stat` and `/proc/meminfo`

### DIFF
--- a/LibOS/shim/include/shim_fs_pseudo.h
+++ b/LibOS/shim/include/shim_fs_pseudo.h
@@ -175,6 +175,7 @@ extern struct shim_fs pseudo_builtin_fs;
 int init_procfs(void);
 int proc_meminfo_load(struct shim_dentry* dent, char** out_data, size_t* out_size);
 int proc_cpuinfo_load(struct shim_dentry* dent, char** out_data, size_t* out_size);
+int proc_stat_load(struct shim_dentry* dent, char** out_data, size_t* out_size);
 int proc_self_follow_link(struct shim_dentry* dent, char** out_target);
 bool proc_thread_pid_name_exists(struct shim_dentry* parent, const char* name);
 int proc_thread_pid_list_names(struct shim_dentry* parent, readdir_callback_t callback, void* arg);

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -48,6 +48,7 @@ int init_procfs(void) {
 
     pseudo_add_str(root, "meminfo", &proc_meminfo_load);
     pseudo_add_str(root, "cpuinfo", &proc_cpuinfo_load);
+    pseudo_add_str(root, "stat", &proc_stat_load);
 
     pseudo_add_link(root, "self", &proc_self_follow_link);
 

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -17,18 +17,42 @@ int proc_meminfo_load(struct shim_dentry* dent, char** out_data, size_t* out_siz
     size_t size, max = 128;
     char* str = NULL;
 
+    assert(g_pal_public_state->mem_total >= DkMemoryAvailableQuota());
+
+    /*
+     * Enumerate minimal set of meminfo stats; as reference workloads that use these stats, we use:
+     *
+     *   - Python's psutil library
+     *     https://github.com/giampaolo/psutil/blob/f716afc8/psutil/_pslinux.py#L339-L568
+     *
+     *   - Rust's procfs crate
+     *     https://github.com/eminence/procfs/blob/fc91e469/src/meminfo.rs#L321-L383
+    */
+
     struct {
         const char* fmt;
         unsigned long val;
     } meminfo[] = {
-        {
-            "MemTotal:      %8lu kB\n",
-            g_pal_public_state->mem_total / 1024,
-        },
-        {
-            "MemFree:       %8lu kB\n",
-            DkMemoryAvailableQuota() / 1024,
-        },
+        { "MemTotal:      %8lu kB\n", g_pal_public_state->mem_total / 1024 },
+        { "MemFree:       %8lu kB\n", DkMemoryAvailableQuota() / 1024 },
+        { "MemAvailable:  %8lu kB\n", DkMemoryAvailableQuota() / 1024 },
+        { "Buffers:       %8lu kB\n", /*dummy value=*/0 },
+        { "Cached:        %8lu kB\n", /*dummy value=*/0 },
+        { "SwapCached:    %8lu kB\n", /*dummy value=*/0 },
+        { "Active:        %8lu kB\n", /*dummy value=*/0 },
+        { "Inactive:      %8lu kB\n", /*dummy value=*/0 },
+        { "SwapTotal:     %8lu kB\n", /*dummy value=*/0 },
+        { "SwapFree:      %8lu kB\n", /*dummy value=*/0 },
+        { "Dirty:         %8lu kB\n", /*dummy value=*/0 },
+        { "Writeback:     %8lu kB\n", /*dummy value=*/0 },
+        { "Mapped:        %8lu kB\n", /*dummy value=*/0 },
+        { "Shmem:         %8lu kB\n", /*dummy value=*/0 },
+        { "Slab:          %8lu kB\n", /*dummy value=*/0 },
+        { "Committed_AS:  %8lu kB\n", (g_pal_public_state->mem_total - DkMemoryAvailableQuota())
+                                          / 1024 },
+        { "VmallocTotal:  %8lu kB\n", g_pal_public_state->mem_total / 1024 },
+        { "VmallocUsed:   %8lu kB\n", /*dummy value=*/0 },
+        { "VmallocChunk:  %8lu kB\n", /*dummy value=*/0 },
     };
 
 retry:
@@ -41,8 +65,12 @@ retry:
 
     for (size_t i = 0; i < ARRAY_SIZE(meminfo); i++) {
         int ret = snprintf(str + size, max - size, meminfo[i].fmt, meminfo[i].val);
+        if (ret < 0) {
+            free(str);
+            return ret;
+        }
 
-        if (size + ret == max)
+        if (size + ret >= max)
             goto retry;
 
         size += ret;
@@ -93,16 +121,6 @@ retry:
     return ret;
 }
 
-int proc_cpuinfo_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
-    __UNUSED(dent);
-
-    size_t size = 0;
-    size_t max = 128;
-    char* str = malloc(max);
-    if (!str) {
-        return -ENOMEM;
-    }
-
 #define ADD_INFO(fmt, ...)                                            \
     do {                                                              \
         int ret = print_to_str(&str, size, &max, fmt, ##__VA_ARGS__); \
@@ -112,6 +130,15 @@ int proc_cpuinfo_load(struct shim_dentry* dent, char** out_data, size_t* out_siz
         }                                                             \
         size += ret;                                                  \
     } while (0)
+
+int proc_cpuinfo_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
+    __UNUSED(dent);
+
+    size_t size = 0;
+    size_t max = 128;
+    char* str = malloc(max);
+    if (!str)
+        return -ENOMEM;
 
     const struct pal_topo_info* ti = &g_pal_public_state->topo_info;
     const struct pal_cpu_info* ci = &g_pal_public_state->cpu_info;
@@ -133,9 +160,52 @@ int proc_cpuinfo_load(struct shim_dentry* dent, char** out_data, size_t* out_siz
                  (unsigned long)(bogomips * 100.0 + 0.5) % 100);
         ADD_INFO("\n");
     }
-#undef ADD_INFO
 
     *out_data = str;
     *out_size = size;
     return 0;
 }
+
+int proc_stat_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
+    __UNUSED(dent);
+
+    size_t size = 0;
+    size_t max = 128;
+    char* str = malloc(max);
+    if (!str)
+        return -ENOMEM;
+
+    /* 10 dummy time stats: currently all zeros */
+    uint64_t user       = 0;
+    uint64_t nice       = 0;
+    uint64_t system     = 0;
+    uint64_t idle       = 0;
+    uint64_t iowait     = 0;
+    uint64_t irq        = 0;
+    uint64_t softirq    = 0;
+    uint64_t steal      = 0;
+    uint64_t guest      = 0;
+    uint64_t guest_nice = 0;
+
+    /* below strings must match exactly the strings retrieved from /proc/stat
+     * (see Linux's fs/proc/stat.c) */
+    ADD_INFO("cpu  %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", user, nice, system, idle, iowait,
+             irq, softirq, steal, guest, guest_nice);
+    for (size_t n = 0; n < g_pal_public_state->topo_info.online_logical_cores_cnt; n++) {
+        ADD_INFO("cpu%lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", n, user, nice, system, idle,
+                 iowait, irq, softirq, steal, guest, guest_nice);
+    }
+
+    /* no "intr" and "softirq" lines: no known workloads use them, and they are hard to emulate */
+    ADD_INFO("ctxt %llu\n", 0);
+    ADD_INFO("btime %llu\n", 0);
+    ADD_INFO("processes %lu\n", 1);    /* at least this process was created */
+    ADD_INFO("procs_running %u\n", 1); /* at least this process was created */
+    ADD_INFO("procs_blocked %u\n", 0);
+
+    *out_data = str;
+    *out_size = size;
+    return 0;
+}
+
+#undef ADD_INFO

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -75,6 +75,7 @@ tests = {
     'proc_common': {},
     'proc_cpuinfo': {},
     'proc_path': {},
+    'proc_stat': {},
     'pselect': {},
     'pthread_set_get_affinity': {},
     'readdir': {},

--- a/LibOS/shim/test/regression/proc_stat.c
+++ b/LibOS/shim/test/regression/proc_stat.c
@@ -1,0 +1,195 @@
+#include <err.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define STAT_FILE "/proc/stat"
+#define BUFFSIZE  2048
+#define KEYSIZE   32
+
+/* see `man proc`, "/proc/stat" section */
+struct procstat {
+    uint64_t user;
+    uint64_t nice;
+    uint64_t system;
+    uint64_t idle;
+    uint64_t iowait;
+    uint64_t irq;
+    uint64_t softirq;
+    uint64_t steal;
+    uint64_t guest;
+    uint64_t guest_nice;
+};
+
+static bool seen_ctxt          = false;
+static bool seen_btime         = false;
+static bool seen_processes     = false;
+static bool seen_procs_running = false;
+static bool seen_procs_blocked = false;
+
+static void init_procstat(struct procstat* ps) {
+    ps->user       = UINT64_MAX;
+    ps->nice       = UINT64_MAX;
+    ps->system     = UINT64_MAX;
+    ps->idle       = UINT64_MAX;
+    ps->iowait     = UINT64_MAX;
+    ps->irq        = UINT64_MAX;
+    ps->softirq    = UINT64_MAX;
+    ps->steal      = UINT64_MAX;
+    ps->guest      = UINT64_MAX;
+    ps->guest_nice = UINT64_MAX;
+}
+
+static int check_procstat(struct procstat* ps) {
+    if (ps->user == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'user' time\n");
+        return -1;
+    }
+    if (ps->nice == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'nice' time\n");
+        return -1;
+    }
+    if (ps->system == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'system' time\n");
+        return -1;
+    }
+    if (ps->idle == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'idle' time\n");
+        return -1;
+    }
+    if (ps->iowait == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'iowait' time\n");
+        return -1;
+    }
+    if (ps->irq == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'irq' time\n");
+        return -1;
+    }
+    if (ps->softirq == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'softirq' time\n");
+        return -1;
+    }
+    if (ps->steal == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'steal' time\n");
+        return -1;
+    }
+    if (ps->guest == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'guest' time\n");
+        return -1;
+    }
+    if (ps->guest_nice == UINT64_MAX) {
+        fprintf(stderr, "Could not get 'guest_nice' time\n");
+        return -1;
+    }
+    return 0;
+}
+
+static int parse_and_check_noncpu_line(char* line) {
+    int ret;
+
+#define CHECK_LINE(seen_var, fmt)                                          \
+    do {                                                                   \
+        uint64_t val = UINT64_MAX;                                         \
+        ret = sscanf(line, fmt, &val);                                     \
+        if (ret < 0) {                                                     \
+            fprintf(stderr, "cannot parse '%s'\n", line);                  \
+            return -1;                                                     \
+        }                                                                  \
+        if (ret == 1) {                                                    \
+            if (seen_var) {                                                \
+                fprintf(stderr, "saw line '%s' more than once\n", line);   \
+                return -1;                                                 \
+            }                                                              \
+            if (val == UINT64_MAX) {                                       \
+                fprintf(stderr, "found wrong value in line '%s'\n", line); \
+                return -1;                                                 \
+            }                                                              \
+            seen_var = true;                                               \
+            return 0;                                                      \
+        }                                                                  \
+    } while (0)
+
+    CHECK_LINE(seen_ctxt,          "ctxt %lu\n");
+    CHECK_LINE(seen_btime,         "btime %lu\n");
+    CHECK_LINE(seen_processes,     "processes %lu\n");
+    CHECK_LINE(seen_procs_running, "procs_running %lu\n");
+    CHECK_LINE(seen_procs_blocked, "procs_blocked %lu\n");
+#undef CHECK_LINE
+
+    fprintf(stderr, "found unrecognized line '%s'\n", line);
+    return -1;
+}
+
+int main(int argc, char* argv[]) {
+    FILE* fp = NULL;
+    char line[BUFFSIZE];
+    char cpu[KEYSIZE];
+    struct procstat ps;
+    int cpu_idx, cpu_cnt = 0, rv = 0;
+
+    long actual_cpu_cnt = sysconf(_SC_NPROCESSORS_ONLN);
+    if (actual_cpu_cnt < 0)
+        errx(1, "cannot retrieve number of CPUs");
+
+    if ((fp = fopen(STAT_FILE, "r")) == NULL)
+        err(1, "fopen");
+
+    /* first line is "cpu" (system-wide stats on times) */
+    init_procstat(&ps);
+
+    if (fgets(line, sizeof(line), fp) == NULL)
+        errx(1, "cannot read 'cpu' line");
+
+    rv = sscanf(line, "%s %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", cpu, &ps.user, &ps.nice,
+                &ps.system, &ps.idle, &ps.iowait, &ps.irq, &ps.softirq, &ps.steal, &ps.guest,
+                &ps.guest_nice);
+    if (rv != 11)
+        errx(1, "cannot parse 'cpu' line");
+
+    if (strcmp(cpu, "cpu"))
+        errx(1, "did not find 'cpu' line");
+
+    if ((rv = check_procstat(&ps)) != 0)
+        errx(1, "unexpected values in 'cpu' line");
+
+    /* next lines are "cpuX" (per-CPU stats on times) */
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (memcmp(line, "cpu", sizeof("cpu") - 1))
+            break;
+
+        init_procstat(&ps);
+        rv = sscanf(line, "cpu%d %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", &cpu_idx, &ps.user,
+                    &ps.nice, &ps.system, &ps.idle, &ps.iowait, &ps.irq, &ps.softirq, &ps.steal,
+                    &ps.guest, &ps.guest_nice);
+        if (rv != 11)
+            errx(1, "cannot parse 'cpu%d' line", cpu_cnt);
+
+        if (cpu_idx != cpu_cnt)
+            errx(1, "unexpected 'cpu%d' line (expected 'cpu%d')", cpu_idx, cpu_cnt);
+
+        if ((rv = check_procstat(&ps)) != 0)
+            errx(1, "unexpected values in 'cpu%d' line", cpu_cnt);
+        cpu_cnt++;
+    }
+
+    if (cpu_cnt != actual_cpu_cnt)
+        errx(1, "expected to find %ld CPUs but found only %d CPUs", actual_cpu_cnt, cpu_cnt);
+
+    /* next lines are 'ctxt', 'btime', 'processes', 'procs_running', 'procs_blocked' */
+    do {
+        if (line[0] == '\n')
+            break;
+        if ((rv = parse_and_check_noncpu_line(line)) != 0)
+            errx(1, "checking non-cpu line failed");
+    } while (fgets(line, sizeof(line), fp) != NULL);
+
+    if (!seen_ctxt || !seen_btime || !seen_processes || !seen_procs_running || !seen_procs_blocked)
+        errx(1, "did not find ctxt/btime/processes/procs_running/procs_blocked line(s)");
+
+    fclose(fp);
+
+    printf("/proc/stat test passed\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -817,6 +817,7 @@ class TC_40_FileSystem(RegressionTestCase):
 
         self.assertIn('/proc/meminfo: file', lines)
         self.assertIn('/proc/cpuinfo: file', lines)
+        self.assertIn('/proc/stat: file', lines)
 
         # /proc/self, /proc/[pid]
         self.assertIn('/proc/self: link: 2', lines)
@@ -870,10 +871,16 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('proc path test success', stdout)
 
     def test_020_cpuinfo(self):
-        stdout, _ = self.run_binary(['proc_cpuinfo'], timeout=50)
+        stdout, _ = self.run_binary(['proc_cpuinfo'])
 
         # proc/cpuinfo Linux-based formatting
         self.assertIn('cpuinfo test passed', stdout)
+
+    def test_021_procstat(self):
+        stdout, _ = self.run_binary(['proc_stat'])
+
+        # proc/stat Linux-based formatting
+        self.assertIn('/proc/stat test passed', stdout)
 
     def test_030_fdleak(self):
         stdout, _ = self.run_binary(['fdleak'], timeout=10)

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -73,6 +73,7 @@ manifests = [
   "proc_common",
   "proc_cpuinfo",
   "proc_path",
+  "proc_stat",
   "pselect",
   "pthread_set_get_affinity",
   "readdir",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -75,6 +75,7 @@ manifests = [
   "proc_common",
   "proc_cpuinfo",
   "proc_path",
+  "proc_stat",
   "pselect",
   "pthread_set_get_affinity",
   "readdir",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We implement a minimal set of dummy values in these two procfs pseudo-files to satisfy workloads like Python's psutil library.

~~This PR is based on #328 (because I was testing the `qiskit` package in Python).~~ UPDATE: I rebased to remove that commit.

Fixes #329.

## How to test this PR? <!-- (if applicable) -->

A new LibOS regression test is added to test `/proc/stat`.

Also see #328 description of Python `qiskit` package for manual testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/330)
<!-- Reviewable:end -->
