### PR TITLE
[LibOS] Add warnings for unsupported `CLOCK_{PROCESS,THREAD}_CPUTIME_ID`

### DIFF
--- a/LibOS/shim/src/sys/shim_time.c
+++ b/LibOS/shim/src/sys/shim_time.c
@@ -64,6 +64,14 @@ long shim_do_clock_gettime(clockid_t which_clock, struct timespec* tp) {
     if (!is_user_memory_writable(tp, sizeof(*tp)))
         return -EFAULT;
 
+    if (which_clock == CLOCK_PROCESS_CPUTIME_ID || which_clock == CLOCK_THREAD_CPUTIME_ID) {
+        static unsigned int warned = 0;
+        if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
+            log_warning("Per-process and per-thread CPU-time clocks are not supported in "
+                        "clock_gettime(); they are replaced with system-wide real-time clock.");
+        }
+    }
+
     uint64_t time = 0;
     int ret = DkSystemTimeQuery(&time);
     if (ret < 0) {
@@ -79,6 +87,14 @@ long shim_do_clock_getres(clockid_t which_clock, struct timespec* tp) {
     /* all clocks are the same */
     if (!(0 <= which_clock && which_clock < MAX_CLOCKS))
         return -EINVAL;
+
+    if (which_clock == CLOCK_PROCESS_CPUTIME_ID || which_clock == CLOCK_THREAD_CPUTIME_ID) {
+        static unsigned int warned = 0;
+        if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
+            log_warning("Per-process and per-thread CPU-time clocks are not supported in "
+                        "clock_getres(); they are replaced with system-wide real-time clock.");
+        }
+    }
 
     if (tp) {
         if (!is_user_memory_writable(tp, sizeof(*tp)))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See #327 for details.

Fixes #327.

## How to test this PR? <!-- (if applicable) -->

This doesn't merit its own test, but one can locally test like I did. Change `CI-Examples/helloworld` like this:
```diff
diff --git a/CI-Examples/helloworld/helloworld.c b/CI-Examples/helloworld/helloworld.c
@@ -1,6 +1,15 @@
 #include <stdio.h>
+#include <time.h>

 int main(void) {
+    struct timespec tp;
+    fprintf(stderr, "1\n");
+    clock_gettime(CLOCK_REALTIME, &tp);
+    fprintf(stderr, "2\n");
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
+    fprintf(stderr, "3\n");
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tp);
+    fprintf(stderr, "4\n");
     printf("Hello, world\n");
     return 0;
 }
```

Then build with `make DEBUG=1` and run with `gramine-direct helloworld`:
```
1
2
[P1:T1:helloworld] warning: Per-process and per-thread CPU-time clocks are not supported in clock_gettime(); they are replaced with system-wide real-time clock.
3
4
Hello, world
```

As is expected, the warning is printed on first PROCESS/THREAD clock (in-between 2 and 3).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/331)
<!-- Reviewable:end -->
