### PR TITLE
[Pal] Support opening TTY devices with O_TRUNC flag

### DIFF
--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -206,11 +206,26 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     return 0;
 }
 
+/* this dummy function is implemented to support opening TTY devices with O_TRUNC flag */
+static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+    if (HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
+        return -PAL_ERROR_INVAL;
+
+    if (!(handle->dev.fd == 0 || handle->dev.fd == 1))
+        return -PAL_ERROR_NOTSUPPORT;
+
+    if (length != 0)
+        return -PAL_ERROR_INVAL;
+
+    return 0;
+}
+
 struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .close          = &dev_close,
+    .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -196,11 +196,26 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     return 0;
 }
 
+/* this dummy function is implemented to support opening TTY devices with O_TRUNC flag */
+static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+    if (HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
+        return -PAL_ERROR_INVAL;
+
+    if (!(handle->dev.fd == 0 || handle->dev.fd == 1))
+        return -PAL_ERROR_NOTSUPPORT;
+
+    if (length != 0)
+        return -PAL_ERROR_INVAL;
+
+    return 0;
+}
+
 struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .close          = &dev_close,
+    .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/Pal/src/host/Skeleton/db_devices.c
+++ b/Pal/src/host/Skeleton/db_devices.c
@@ -40,11 +40,17 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
+/* this dummy function is implemented to support opening TTY devices with O_TRUNC flag */
+static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
 struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .close          = &dev_close,
+    .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Write to `/proc/self/fd/2` (which is symlink to /dev/tty) fails with `O_TRUNC` flag which translates to `DkStreamSetLength` as `setlength` function is not implemented for dev:tty devices.

This PR adds dummy function `setlength` to support O_TRUNC flag.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
Fixes #303 

## How to test this PR? <!-- (if applicable) -->

Should be able to execute below commands successfully:
```
gramine-direct busybox sh -c 'echo foo>/proc/self/fd/2'
gramine-sgx busybox sh -c 'echo foo>/proc/self/fd/2'
```
as described in link  https://github.com/gramineproject/gramine/issues/303#issuecomment-1002591818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/332)
<!-- Reviewable:end -->
