### PR TITLE
[Docs] Describe all `/dev/attestation/` pseudo-files

### DIFF
--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -86,11 +86,11 @@ static int user_report_data_save(struct shim_dentry* dent, const char* data, siz
 }
 
 /*!
- * \brief Modify target info used in `report` and `quote` pseudo-files.
+ * \brief Modify target info used in `report` pseudo-file.
  *
  * This file `/dev/attestation/target_info` can be opened for read and write. Typically, it is
- * opened and written into before opening and reading from `/dev/attestation/report` or
- * `/dev/attestation/quote` files, so they can use the provided target info.
+ * opened and written into before opening and reading from `/dev/attestation/report` file, so the
+ * latter can use the provided target info.
  *
  * In case of SGX, target info is an opaque blob of size 512B.
  */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, our documentation on attestation only mentioned two attestation-related pseudo-files: `user_report_data` and `quote` (these are the only files needed to implement SGX remote attestation).

This PR adds descriptions of the rest files: `target_info`, `my_target_info` and `report` (these files are used in SGX local attestation). Also, some incorrect statements are fixed.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/333)
<!-- Reviewable:end -->
