### PR TITLE
[LibOS] Skip mmapping past-file-end VMA contents in checkpoint restore

### DIFF
--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -56,6 +56,7 @@ tests = {
     'madvise': {},
     'mkfifo': {},
     'mmap_file': {},
+    'mmap_file_backed': {},
     'mprotect_file_fork': {},
     'mprotect_prot_growsdown': {},
     'multi_pthread': {},

--- a/LibOS/shim/test/regression/mmap_file_backed.c
+++ b/LibOS/shim/test/regression/mmap_file_backed.c
@@ -1,0 +1,75 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int ret;
+
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0)
+        err(1, "sysconf");
+
+    /* open the file (this executable's manifest) for read, find its size, mmap (with read-write
+     * protections) at least one page more than the file size and mprotect the last page */
+    FILE* fp = fopen(argv[0], "r");
+    if (!fp)
+        err(1, "fopen");
+
+    ret = fseek(fp, 0, SEEK_END);
+    if (ret < 0)
+        err(1, "fseek");
+
+    long fsize = ftell(fp);
+    if (fsize < 0)
+        err(1, "ftell");
+
+    rewind(fp); /* for sanity */
+
+    size_t mmap_size = fsize + page_size * 2; /* file size plus at least one full aligned page */
+    mmap_size &= ~(page_size - 1);            /* align down */
+
+    void* addr = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fileno(fp), 0);
+    if (addr == MAP_FAILED)
+        err(1, "mmap");
+
+    ret = mprotect(addr + mmap_size - page_size, page_size, PROT_NONE);
+    if (ret < 0)
+        err(1, "mprotect");
+
+    /* Below fork triggers checkpoint-and-restore logic in Gramine LibOS, which will send all VMAs
+     * info and all corresponding memory contents to the child. These VMAs contain two VMAs that
+     * were split from the file-backed mmap above: the first VMA with the lower part (backed by file
+     * contents) and the second VMA with a single page (not backed by file contents).
+     *
+     * There was a bug in Gramine that forced LibOS to mmap(..., <file-fd>, <offset-past-file-end>)
+     * for the second VMA. This is allowed but meaningless in Linux, but for trusted/protected files
+     * on Linux-SGX this leads to their specific checks failing. So the below fork checks that this
+     * bug was fixed (otherwise Gramine crashes). */
+    int pid = fork();
+    if (pid == -1)
+        err(1, "fork");
+
+    if (pid != 0) {
+        /* parent */
+        int st = 0;
+        ret = wait(&st);
+        if (ret < 0)
+            err(1, "wait");
+
+        if (!WIFEXITED(st) || WEXITSTATUS(st) != 0)
+            errx(1, "abnormal child termination: %d\n", st);
+
+        puts("Parent process done");
+    } else {
+        /* child does nothing interesting */
+        puts("Child process done");
+    }
+
+    fclose(fp);
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -649,7 +649,12 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('mmap test 5 passed', stdout)
         self.assertIn('mmap test 8 passed', stdout)
 
-    def test_052_large_mmap(self):
+    def test_052_mmap_file_backed(self):
+        stdout, _ = self.run_binary(['mmap_file_backed'], timeout=60)
+        self.assertIn('Child process done', stdout)
+        self.assertIn('Parent process done', stdout)
+
+    def test_053_large_mmap(self):
         try:
             stdout, _ = self.run_binary(['large_mmap'], timeout=480)
 
@@ -663,17 +668,17 @@ class TC_30_Syscall(RegressionTestCase):
             # This test generates a 4 GB file, don't leave it in FS.
             os.remove('testfile')
 
-    def test_053_mprotect_file_fork(self):
+    def test_054_mprotect_file_fork(self):
         stdout, _ = self.run_binary(['mprotect_file_fork'])
 
         self.assertIn('Test successful!', stdout)
 
-    def test_054_mprotect_prot_growsdown(self):
+    def test_055_mprotect_prot_growsdown(self):
         stdout, _ = self.run_binary(['mprotect_prot_growsdown'])
 
         self.assertIn('TEST OK', stdout)
 
-    def test_055_madvise(self):
+    def test_056_madvise(self):
         stdout, _ = self.run_binary(['madvise'])
         self.assertIn('TEST OK', stdout)
 

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -57,6 +57,7 @@ manifests = [
   "madvise",
   "mkfifo",
   "mmap_file",
+  "mmap_file_backed",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -59,6 +59,7 @@ manifests = [
   "madvise",
   "mkfifo",
   "mmap_file",
+  "mmap_file_backed",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There was a bug in Gramine: if a VMA was file-backed and then split into two VMAs, such that the second VMA starts past the end of the corresponding file, this VMA info was sent to the child process (but not the contents of the corresponding memory region). However, this VMA info in the sent checkpoint had the `need_mapped` field that was interpreted by the child process as "mmap from the file at given offset".

This operation is meaningless (because the given offset is past the end of file) but allowed in Linux. However, for trusted/protected files on Linux-SGX this leads to their SGX-specific checks failing, and Gramine
crashed. This PR fixes this bug.

For some details and a wrong attempt at fixing it see #328.

## How to test this PR? <!-- (if applicable) -->

This bug was found on Python's qiskit package (it led to a segfault). This PR adds a new LibOS regression test to catch this bug.

Also see descriptions in #328.