### PR TITLE
[LibOS] Do not re-map private VMA contents in checkpoint restore

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -245,24 +245,9 @@ skip = yes
 [eventfd2_*]
 skip = yes
 
-# BROK: Test haven't reported results
-[execl01]
-must-pass =
-    1
-
 # error while loading libc.so.6
 [execle01]
 skip = yes
-
-# BROK: Test haven't reported results
-[execlp01]
-must-pass =
-    1
-
-# BROK: Test haven't reported results
-[execv01]
-must-pass =
-    1
 
 # error while loading libc.so.6
 [execve01]
@@ -291,11 +276,6 @@ skip = yes
 # copy child
 [execveat03]
 skip = yes
-
-# BROK: Test haven't reported results
-[execvp01]
-must-pass =
-    1
 
 [faccessat01]
 timeout = 80
@@ -1226,12 +1206,6 @@ skip = yes
 [nanosleep01]
 skip = yes
 
-# reports TBROK due to lack of reported results (no shared memory in Gramine)
-[nanosleep02]
-must-pass =
-    1
-    2
-
 [nftw01]
 skip = yes
 
@@ -2075,10 +2049,6 @@ must-pass =
 
 [setrlimit04]
 skip = yes
-
-[setrlimit05]
-must-pass =
-    1
 
 [setrlimit06]
 skip = yes

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -56,6 +56,7 @@ tests = {
     'madvise': {},
     'mkfifo': {},
     'mmap_file': {},
+    'mmap_file_backed': {},
     'mprotect_file_fork': {},
     'mprotect_prot_growsdown': {},
     'multi_pthread': {},

--- a/LibOS/shim/test/regression/mmap_file_backed.c
+++ b/LibOS/shim/test/regression/mmap_file_backed.c
@@ -1,6 +1,5 @@
 #define _GNU_SOURCE
 #include <err.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
@@ -14,8 +13,8 @@ int main(int argc, char** argv) {
     if (page_size < 0)
         err(1, "sysconf");
 
-    /* open the file (this executable's manifest) for read, find its size, mmap (with read-write
-     * protections) at least one page more than the file size and mprotect the last page */
+    /* open the file (this executable) for read, find its size, mmap (with read-write protections)
+     * at least one page more than the file size and mprotect the last page */
     FILE* fp = fopen(argv[0], "r");
     if (!fp)
         err(1, "fopen");

--- a/LibOS/shim/test/regression/mmap_file_backed.c
+++ b/LibOS/shim/test/regression/mmap_file_backed.c
@@ -1,0 +1,76 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int ret;
+
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0)
+        err(1, "sysconf");
+
+    /* open the file (this executable's manifest) for read, find its size, mmap (with read-write
+     * protections) at least one page more than the file size and mprotect the last page */
+    FILE* fp = fopen(argv[0], "r");
+    if (!fp)
+        err(1, "fopen");
+
+    ret = fseek(fp, 0, SEEK_END);
+    if (ret < 0)
+        err(1, "fseek");
+
+    long fsize = ftell(fp);
+    if (fsize < 0)
+        err(1, "ftell");
+
+    rewind(fp); /* for sanity */
+
+    size_t mmap_size = fsize + page_size * 2; /* file size plus at least one full aligned page */
+    mmap_size &= ~(page_size - 1);            /* align down */
+
+    void* addr = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fileno(fp), 0);
+    if (addr == MAP_FAILED)
+        err(1, "mmap");
+
+    ret = mprotect(addr + mmap_size - page_size, page_size, PROT_NONE);
+    if (ret < 0)
+        err(1, "mprotect");
+
+    /* Below fork triggers checkpoint-and-restore logic in Gramine LibOS, which will send all VMAs
+     * info and all corresponding memory contents to the child. These VMAs contain two VMAs that
+     * were split from the file-backed mmap above: the first VMA with the lower part (backed by file
+     * contents) and the second VMA with a single page (not backed by file contents).
+     *
+     * There was a bug in Gramine that forced LibOS to re-map the memory-region content of the
+     * second VMA via mmap(..., <file-fd>, <offset-past-file-end>). This is incorrect because
+     * private writable mappings must inherit memory content from the parent. It led to specific
+     * checks for trusted/protected files on Linux-SGX to fail. So the below fork checks that this
+     * bug was fixed (otherwise Gramine crashes). */
+    int pid = fork();
+    if (pid == -1)
+        err(1, "fork");
+
+    if (pid != 0) {
+        /* parent */
+        int st = 0;
+        ret = wait(&st);
+        if (ret < 0)
+            err(1, "wait");
+
+        if (!WIFEXITED(st) || WEXITSTATUS(st) != 0)
+            errx(1, "abnormal child termination: %d\n", st);
+
+        puts("Parent process done");
+    } else {
+        /* child does nothing interesting */
+        puts("Child process done");
+    }
+
+    fclose(fp);
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -649,7 +649,12 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('mmap test 5 passed', stdout)
         self.assertIn('mmap test 8 passed', stdout)
 
-    def test_052_large_mmap(self):
+    def test_052_mmap_file_backed(self):
+        stdout, _ = self.run_binary(['mmap_file_backed'], timeout=60)
+        self.assertIn('Child process done', stdout)
+        self.assertIn('Parent process done', stdout)
+
+    def test_053_large_mmap(self):
         try:
             stdout, _ = self.run_binary(['large_mmap'], timeout=480)
 
@@ -663,17 +668,17 @@ class TC_30_Syscall(RegressionTestCase):
             # This test generates a 4 GB file, don't leave it in FS.
             os.remove('testfile')
 
-    def test_053_mprotect_file_fork(self):
+    def test_054_mprotect_file_fork(self):
         stdout, _ = self.run_binary(['mprotect_file_fork'])
 
         self.assertIn('Test successful!', stdout)
 
-    def test_054_mprotect_prot_growsdown(self):
+    def test_055_mprotect_prot_growsdown(self):
         stdout, _ = self.run_binary(['mprotect_prot_growsdown'])
 
         self.assertIn('TEST OK', stdout)
 
-    def test_055_madvise(self):
+    def test_056_madvise(self):
         stdout, _ = self.run_binary(['madvise'])
         self.assertIn('TEST OK', stdout)
 

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -57,6 +57,7 @@ manifests = [
   "madvise",
   "mkfifo",
   "mmap_file",
+  "mmap_file_backed",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -59,6 +59,7 @@ manifests = [
   "madvise",
   "mkfifo",
   "mmap_file",
+  "mmap_file_backed",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There was a bug in Gramine: tainted file-backed memory regions marked as `MAP_PRIVATE` were not sent to the child process sometimes -- instead these memory regions were re-mapped in the child from the corresponding file.

This PR forces Gramine LibOS to always send such memory regions in the checkpoint and disallows them to be re-mapped by child. This is in line with POSIX: "MAP_PRIVATE <...> It is unspecified whether changes made to the file after the mmap() call are visible in the mapped region." Gramine implementation chooses to *not* propagate file changes.

For some details and previous wrong attempts at fixing it see #328 and #336.

## How to test this PR? <!-- (if applicable) -->

This bug was found on Python's qiskit package (it led to a segfault on SGX PAL). This commit adds new LibOS regression test to catch this bug.

Also see descriptions in #328.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/338)
<!-- Reviewable:end -->
