### PR TITLE
[Pal/Linux-SGX] Init memory region on mmap past trusted-file end

### DIFF
--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -56,6 +56,7 @@ tests = {
     'madvise': {},
     'mkfifo': {},
     'mmap_file': {},
+    'mmap_file_backed': {},
     'mprotect_file_fork': {},
     'mprotect_prot_growsdown': {},
     'multi_pthread': {},

--- a/LibOS/shim/test/regression/mmap_file_backed.c
+++ b/LibOS/shim/test/regression/mmap_file_backed.c
@@ -1,0 +1,79 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int ret;
+
+    if (argc != 2)
+        errx(1, "Usage: %s file_to_mmap", argv[0]);
+
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0)
+        err(1, "sysconf");
+
+    /* open the file for read, find its size, mmap at least one page more than the file size and
+     * mprotect the last page */
+    FILE* fp = fopen(argv[1], "r");
+    if (!fp)
+        err(1, "fopen");
+
+    ret = fseek(fp, 0, SEEK_END);
+    if (ret < 0)
+        err(1, "fseek");
+
+    long fsize = ftell(fp);
+    if (fsize < 0)
+        err(1, "ftell");
+
+    rewind(fp); /* for sanity */
+
+    size_t mmap_size = fsize + page_size * 2; /* file size plus at least one full aligned page */
+    mmap_size &= ~(page_size - 1);            /* align down */
+
+    /* mmap with write-only protections: we want to taint the mmapped region; we cannot use
+     * read-write permissions because this is disallowed for SGX protected files */
+    void* addr = mmap(NULL, mmap_size, PROT_WRITE, MAP_PRIVATE, fileno(fp), 0);
+    if (addr == MAP_FAILED)
+        err(1, "mmap");
+
+    ret = mprotect(addr + mmap_size - page_size, page_size, PROT_NONE);
+    if (ret < 0)
+        err(1, "mprotect");
+
+    /* Below fork triggers checkpoint-and-restore logic in Gramine LibOS, which will send all VMAs
+     * info and all corresponding memory contents to the child. These VMAs contain two VMAs that
+     * were split from the file-backed mmap above: the first VMA with the lower part (backed by file
+     * contents, except one or two last pages that may be not backed completely) and the second VMA
+     * with a single page (not backed by file contents).
+     *
+     * There was a bug in Gramine-SGX: mmap(..., <file-fd>, <offset-past-file-end>) during
+     * checkpoint restore in the child crashed on trusted files. So the below fork checks that this
+     * bug was fixed. */
+    int pid = fork();
+    if (pid == -1)
+        err(1, "fork");
+
+    if (pid != 0) {
+        /* parent */
+        int st = 0;
+        ret = wait(&st);
+        if (ret < 0)
+            err(1, "wait");
+
+        if (!WIFEXITED(st) || WEXITSTATUS(st) != 0)
+            errx(1, "abnormal child termination: %d", st);
+
+        puts("Parent process done");
+    } else {
+        /* child does nothing interesting */
+        puts("Child process done");
+    }
+
+    fclose(fp);
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -649,7 +649,31 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('mmap test 5 passed', stdout)
         self.assertIn('mmap test 8 passed', stdout)
 
-    def test_052_large_mmap(self):
+    @unittest.skipUnless(HAS_SGX,
+        'Trusted files are only available with SGX')
+    def test_052_mmap_file_backed_trusted(self):
+        stdout, _ = self.run_binary(['mmap_file_backed', 'mmap_file_backed'], timeout=60)
+        self.assertIn('Child process done', stdout)
+        self.assertIn('Parent process done', stdout)
+
+    @unittest.skipUnless(HAS_SGX,
+        'Protected files are only available with SGX')
+    def test_053_mmap_file_backed_protected(self):
+        # create the protected file
+        pf_path = 'sealed_file_mrsigner.dat'
+        if os.path.exists(pf_path):
+            os.remove(pf_path)
+        stdout, _ = self.run_binary(['sealed_file', pf_path])
+        self.assertIn('CREATION OK', stdout)
+
+        try:
+            stdout, _ = self.run_binary(['mmap_file_backed', pf_path], timeout=60)
+            self.assertIn('Child process done', stdout)
+            self.assertIn('Parent process done', stdout)
+        finally:
+            os.remove(pf_path)
+
+    def test_054_large_mmap(self):
         try:
             stdout, _ = self.run_binary(['large_mmap'], timeout=480)
 
@@ -663,17 +687,17 @@ class TC_30_Syscall(RegressionTestCase):
             # This test generates a 4 GB file, don't leave it in FS.
             os.remove('testfile')
 
-    def test_053_mprotect_file_fork(self):
+    def test_055_mprotect_file_fork(self):
         stdout, _ = self.run_binary(['mprotect_file_fork'])
 
         self.assertIn('Test successful!', stdout)
 
-    def test_054_mprotect_prot_growsdown(self):
+    def test_056_mprotect_prot_growsdown(self):
         stdout, _ = self.run_binary(['mprotect_prot_growsdown'])
 
         self.assertIn('TEST OK', stdout)
 
-    def test_055_madvise(self):
+    def test_057_madvise(self):
         stdout, _ = self.run_binary(['madvise'])
         self.assertIn('TEST OK', stdout)
 

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -57,6 +57,7 @@ manifests = [
   "madvise",
   "mkfifo",
   "mmap_file",
+  "mmap_file_backed",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -59,6 +59,7 @@ manifests = [
   "madvise",
   "mkfifo",
   "mmap_file",
+  "mmap_file_backed",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There was a bug in Gramine-SGX implementation of trusted files: invocation of `mmap(..., <trusted-file-fd>, <offset-past-file-end>)` crashed Gramine process. Such an invocation can happen during checkpoint restore in the child process. This PR fixes this bug by initializing (zeroing) the memory region on such mmap and simply returning success.

For my previous failed attempt to fix this bug, see #328 and #336 and #338.

## How to test this PR? <!-- (if applicable) -->

This bug was found on Python's qiskit package (it led to a segfault on SGX PAL).

This PR adds new LibOS regression test to catch this bug. The test also checks protected-files logic: it was not affected by this bug but we still add such check for future-proofing.

Also see descriptions in #328.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/346)
<!-- Reviewable:end -->
