### PR TITLE
[Pal/Linux-SGX] Remove redundant newlines in messages in PFs

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.c
@@ -215,7 +215,7 @@ static int pf_set_linux_callbacks(pf_debug_f debug_f) {
 
 /* Debug print callback for protected files */
 static void cb_debug(const char* msg) {
-    DBG("%s", msg);
+    DBG("%s\n", msg);
 }
 
 /* Initialize protected files for native environment */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously the debug log looked like this:
```
debug: load_protected_file: sealed_file_mrenclave.dat, fd 16, size 0, mode 2, create 1, pf 0xf402a30
debug: load_protected_file: sealed_file_mrenclave.dat, fd 16: opening new PF 0xf402a30
debug: ipf_open: handle: 16, path: 'sealed_file_mrenclave.dat', real size: 0, mode: 0x2

debug: ipf_open: OK (data size 0)

CREATION OK
```

Now the redundant newlines are removed.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/347)
<!-- Reviewable:end -->
