### PR TITLE
[LibOS] Re-map tainted shared file-backed memory regions on fork

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -245,24 +245,9 @@ skip = yes
 [eventfd2_*]
 skip = yes
 
-# BROK: Test haven't reported results
-[execl01]
-must-pass =
-    1
-
 # error while loading libc.so.6
 [execle01]
 skip = yes
-
-# BROK: Test haven't reported results
-[execlp01]
-must-pass =
-    1
-
-# BROK: Test haven't reported results
-[execv01]
-must-pass =
-    1
 
 # error while loading libc.so.6
 [execve01]
@@ -291,11 +276,6 @@ skip = yes
 # copy child
 [execveat03]
 skip = yes
-
-# BROK: Test haven't reported results
-[execvp01]
-must-pass =
-    1
 
 [faccessat01]
 timeout = 80
@@ -1226,12 +1206,6 @@ skip = yes
 [nanosleep01]
 skip = yes
 
-# reports TBROK due to lack of reported results (no shared memory in Gramine)
-[nanosleep02]
-must-pass =
-    1
-    2
-
 [nftw01]
 skip = yes
 
@@ -2075,10 +2049,6 @@ must-pass =
 
 [setrlimit04]
 skip = yes
-
-[setrlimit05]
-must-pass =
-    1
 
 [setrlimit06]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine sent the contents a tainted shared file-backed memory region in a checkpoint blob (in a `shim_mem_entry` object). This resulted in this memory region being allocated as anonymous via `DkVirtualMemoryAlloc()` in the child process, so the updates on this memory region were not reflected in parent/child.

## How to test this PR? <!-- (if applicable) -->

Fixing this bug allows to remove the workaround for BROK LTP tests. This is because LTP reports results of the child via the file `/dev/shm` mapped as `MAP_SHARED`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/349)
<!-- Reviewable:end -->
