### PR TITLE
[LibOS] Add support for temporary changing of signal mask by syscalls

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -125,11 +125,8 @@ bool maybe_emulate_syscall(PAL_CONTEXT* context);
  * \brief Handle a signal
  *
  * \param context CPU context
- * \param old_mask_ptr pointer to the old signal mask
  *
  * If there is a signal to be handled, this function arranges its delivery using `prepare_sigframe`.
- * If \p old_mask_ptr is not `NULL`, it is stored into the signal frame, otherwise the current
- * signal mask is used.
  * Returns `true` if a not-ignored signal was handled (hence \p context was changed), `false`
  * otherwise.
  *
@@ -141,7 +138,7 @@ bool maybe_emulate_syscall(PAL_CONTEXT* context);
  * 2) The signal arrived in the middle of or after `handle_signal`. In such case delivery of this
  *    signal is delayed until the next syscall is issued or another signal arrives.
  */
-bool handle_signal(PAL_CONTEXT* context, __sigset_t* old_mask_ptr);
+bool handle_signal(PAL_CONTEXT* context);
 
 /*!
  * \brief Translate PAL error code into UNIX error code.

--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -153,6 +153,19 @@ void pop_unblocked_signal(__sigset_t* mask, struct shim_signal* signal);
 void get_sig_mask(struct shim_thread* thread, __sigset_t* mask);
 void set_sig_mask(struct shim_thread* thread, const __sigset_t* new_set);
 
+/*!
+ * \brief Set signal mask requested by user
+ *
+ * \param mask_ptr Pointer to the user signal mask (may be NULL)
+ * \param setsize Size of `__sigset_t`
+ *
+ * \return `0` on success, negative error code on failure.
+ *
+ * This function saves the current signal mask (in `struct shim_thread`) and sets it to \p mask_ptr.
+ * If \p mask_ptr is NULL, this does nothing.
+ */
+int set_user_sigmask(const __sigset_t* mask_ptr, size_t setsize);
+
 int kill_current_proc(siginfo_t* info);
 int do_kill_thread(IDTYPE sender, IDTYPE tgid, IDTYPE tid, int sig);
 int do_kill_proc(IDTYPE sender, IDTYPE pid, int sig);

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -28,7 +28,7 @@ long shim_do_fstat(int fd, struct stat* statbuf);
 long shim_do_lstat(const char* file, struct stat* stat);
 long shim_do_statfs(const char* path, struct statfs* buf);
 long shim_do_fstatfs(int fd, struct statfs* buf);
-long shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout);
+long shim_do_poll(struct pollfd* fds, unsigned int nfds, int timeout);
 long shim_do_lseek(int fd, off_t offset, int origin);
 void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, unsigned long offset);
 long shim_do_mprotect(void* addr, size_t len, int prot);
@@ -177,9 +177,9 @@ long shim_do_fchmodat(int dfd, const char* filename, mode_t mode);
 long shim_do_fchownat(int dfd, const char* filename, uid_t user, gid_t group, int flags);
 long shim_do_faccessat(int dfd, const char* filename, mode_t mode);
 long shim_do_pselect6(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds,
-                      const struct __kernel_timespec* tsp, const __sigset_t* sigmask);
-long shim_do_ppoll(struct pollfd* fds, int nfds, struct timespec* tsp, const __sigset_t* sigmask,
-                   size_t sigsetsize);
+                      const struct __kernel_timespec* tsp, void* sigmask_argpack);
+long shim_do_ppoll(struct pollfd* fds, unsigned int nfds, struct timespec* tsp,
+                   const __sigset_t* sigmask_ptr, size_t sigsetsize);
 long shim_do_set_robust_list(struct robust_list_head* head, size_t len);
 long shim_do_get_robust_list(pid_t pid, struct robust_list_head** head, size_t* len);
 long shim_do_epoll_pwait(int epfd, struct __kernel_epoll_event* events, int maxevents,

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -86,8 +86,13 @@ struct shim_thread {
     int* clear_child_tid;    /* LibOS zeroes it to notify parent that thread exited */
     int clear_child_tid_pal; /* PAL zeroes it to notify LibOS that thread exited */
 
-    /* signal handling */
+    /* Thread signal mask. Should be accessed with `this_thread->lock` held. Must not be modified
+     * by threads other than the current thread. */
     __sigset_t signal_mask;
+    /* Old, saved signal mask. Accessible only by the current thread. */
+    __sigset_t saved_sigmask;
+    /* True if the above mask was set and needs to be restored. */
+    bool has_saved_sigmask;
     /* If you need both locks, take `thread->signal_dispositions->lock` before `thread->lock`. */
     struct shim_signal_dispositions* signal_dispositions;
     struct shim_signal_queue signal_queue;

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -287,6 +287,7 @@ struct shim_thread* get_new_thread(void) {
     lock(&thread->lock);
     set_sig_mask(thread, &cur_thread->signal_mask);
     unlock(&thread->lock);
+    thread->has_saved_sigmask = false;
 
     struct shim_handle_map* map = get_thread_handle_map(cur_thread);
     assert(map);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This is used by e.g. `sigsuspend`, `pselect` and `ppoll`. Note that `epoll_pwait` is not changed, since it will be reworked in a follow up PR.

Fixes https://github.com/gramineproject/graphene/issues/789

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/354)
<!-- Reviewable:end -->
