### PR TITLE
[LibOS] Verify buffer argument of the `fstat` syscall

### DIFF
--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -102,6 +102,9 @@ long shim_do_fstat(int fd, struct stat* stat) {
     if (!hdl)
         return -EBADF;
 
+    if (!is_user_memory_writable(stat, sizeof(*stat)))
+        return -EFAULT;
+
     int ret = do_hstat(hdl, stat);
     put_handle(hdl);
     return ret;

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -537,13 +537,6 @@ skip = yes
 [fstat02_64]
 skip = yes
 
-# TBROK: Test 0 haven't reported results
-[fstat03]
-skip = yes
-
-[fstat03_64]
-skip = yes
-
 # tries to mount a filesystem
 [fsync01]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

LTP fstat03 tests `shim_do_fstat` sys call and reports `internal memory fault` for the second test where `stat_buf` is NULL which should return `EFAULT` but test fails as `memset` tries to set NULL buffer. `shim_do_fstat` call does not sanitize the `stat_buf` before using it.

Code changes in this PR sanitizes the inputs to `shim_do_fstat` syscall before using them.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
Fixes #356 

## How to test this PR? <!-- (if applicable) -->
execute LTP test `fstat03` with command: `gramine-direct fstat03`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/362)
<!-- Reviewable:end -->
