### PR TITLE
remove launch token dependency for DCAP enclaves

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -110,13 +110,13 @@ bool is_wrfsbase_supported(void) {
     return true;
 }
 
-int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
+int create_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct) {
     assert(secs->size && IS_POWER_OF_2(secs->size));
     assert(IS_ALIGNED(secs->base, secs->size));
 
     secs->ssa_frame_size = SSA_FRAME_SIZE / g_page_size; /* SECS expects SSA frame size in pages */
-    secs->misc_select    = token->masked_misc_select_le;
-    memcpy(&secs->attributes, &token->body.attributes, sizeof(sgx_attributes_t));
+    secs->misc_select    = sigstruct->body.misc_select;
+    memcpy(&secs->attributes, &sigstruct->body.attributes, sizeof(sgx_attributes_t));
 
     /* Do not initialize secs->mr_signer and secs->mr_enclave here as they are
      * not used by ECREATE to populate the internal SECS. SECS's mr_enclave is

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -72,7 +72,8 @@ bool is_wrfsbase_supported(void);
 int read_enclave_token(int token_file, sgx_arch_token_t* token);
 int read_enclave_sigstruct(int sigfile, sgx_arch_enclave_css_t* sig);
 
-int create_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct);
+int create_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct,
+                   sgx_arch_token_t* token);
 
 enum sgx_page_type { SGX_PAGE_SECS, SGX_PAGE_TCS, SGX_PAGE_REG };
 int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, unsigned long size,

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -72,7 +72,7 @@ bool is_wrfsbase_supported(void);
 int read_enclave_token(int token_file, sgx_arch_token_t* token);
 int read_enclave_sigstruct(int sigfile, sgx_arch_enclave_css_t* sig);
 
-int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token);
+int create_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct);
 
 enum sgx_page_type { SGX_PAGE_SECS, SGX_PAGE_TCS, SGX_PAGE_REG };
 int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, unsigned long size,

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -305,7 +305,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     memset(&enclave_secs, 0, sizeof(enclave_secs));
     enclave_secs.base = enclave->baseaddr;
     enclave_secs.size = enclave->size;
-    ret = create_enclave(&enclave_secs, &enclave_sigstruct);
+    ret = create_enclave(&enclave_secs, &enclave_sigstruct, &enclave_token);
     if (ret < 0) {
         log_error("Creating enclave failed: %d", ret);
         goto out;


### PR DESCRIPTION
Looking into a C port for `gramine-sgx-get-token` to get rid of the python runtime dependency I discovered that DCAP enclaves do not need a real token and instead just depend on a dummy token. Looking further I found that the dummy token information is generated from the SIGSTRUCT, so instead of using the information from the dummy token struct I took it directly from the SIGSTRUCT.

This removes the dummy launch token of DCAP enclaves and hence the python runtime dependency of DCAP enclaves.

See also:
- https://github.com/gramineproject/gsc/issues/37
- https://github.com/gramineproject/gsc/issues/61
- https://github.com/gramineproject/gsc/issues/13

Related PR in GSC repo: https://github.com/gramineproject/gsc/pull/62

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/363)
<!-- Reviewable:end -->
