### PR TITLE
[Pal/Linux-SGX] Garbage collect helper pipe-handshake threads

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -455,7 +455,7 @@ void cleanup_thread(IDTYPE caller, void* arg) {
     assert(thread);
 
     /* wait on clear_child_tid_pal; this signals that PAL layer exited child thread */
-    while (__atomic_load_n(&thread->clear_child_tid_pal, __ATOMIC_RELAXED) != 0)
+    while (__atomic_load_n(&thread->clear_child_tid_pal, __ATOMIC_ACQUIRE) != 0)
         CPU_RELAX();
 
     if (thread->robust_list) {

--- a/LibOS/shim/src/ipc/shim_ipc_worker.c
+++ b/LibOS/shim/src/ipc/shim_ipc_worker.c
@@ -415,7 +415,7 @@ int init_ipc_worker(void) {
 void terminate_ipc_worker(void) {
     set_pollable_event(&exit_notification_event, 1);
 
-    while (__atomic_load_n(&g_clear_on_worker_exit, __ATOMIC_RELAXED)) {
+    while (__atomic_load_n(&g_clear_on_worker_exit, __ATOMIC_ACQUIRE)) {
         CPU_RELAX();
     }
 

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -74,6 +74,7 @@ typedef struct {
             PAL_SESSION_KEY session_key;
             PAL_NUM handshake_done;
             void* ssl_ctx;
+            void* handshake_helper_thread_hdl;
         } pipe;
 
         struct {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Linux-SGX PAL performs a TLS handshake when creating a PAL pipe. For this, the PAL creates a helper thread but its resources were never cleared previously. This lead to memory leaks each time a PAL pipe was created (e.g., for IPC communication and pollable events).

Fixes #365. Fixes https://github.com/gramineproject/graphene/issues/2467.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. You can manually test it by adding log messages and running e.g. `pipe` LibOS regression test (that's what I did to verify this patch).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/366)
<!-- Reviewable:end -->
