### PR TITLE
[Pal/LibOS] Fix overflow checks in calloc()

### DIFF
--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -101,11 +101,11 @@ void* malloc(size_t size) {
     return mem;
 }
 
-void* calloc(size_t nmemb, size_t size) {
-    // This overflow checking is not a UB, because the operands are unsigned.
-    size_t total = nmemb * size;
-    if (total / size != nmemb)
+void* calloc(size_t num, size_t size) {
+    size_t total;
+    if (__builtin_mul_overflow(num, size, &total))
         return NULL;
+
     void* ptr = malloc(total);
     if (ptr)
         memset(ptr, 0, total);

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -250,7 +250,7 @@ int _DkSetProtectedFilesKey(const char* pf_key_hex);
 void init_slab_mgr(char* mem_pool, size_t mem_pool_size);
 void* malloc(size_t size);
 void* malloc_copy(const void* mem, size_t size);
-void* calloc(size_t nmem, size_t size);
+void* calloc(size_t num, size_t size);
 void free(void* mem);
 
 #ifdef __GNUC__

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -164,12 +164,14 @@ void* malloc_copy(const void* mem, size_t size) {
     return nmem;
 }
 
-void* calloc(size_t nmem, size_t size) {
-    void* ptr = malloc(nmem * size);
+void* calloc(size_t num, size_t size) {
+    size_t total;
+    if (__builtin_mul_overflow(num, size, &total))
+        return NULL;
 
+    void* ptr = malloc(total);
     if (ptr)
-        memset(ptr, 0, nmem * size);
-
+        memset(ptr, 0, total);
     return ptr;
 }
 

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
@@ -48,7 +48,7 @@
 #include <limits.h>
 #include <stddef.h>
 
-void* calloc(size_t nmem, size_t size);
+void* calloc(size_t num, size_t size);
 void free(void*);
 
 #define MBEDTLS_PLATFORM_STD_CALLOC   calloc


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Two related things:
- Fixes a bug in PAL's calloc() (missing overflow check, most likely a security issue).
- Changes LibOS's calloc() to use overflow builtins for better performance (no division needed; we use GCC/clang builtins everywhere anyways).

## How to test this PR? <!-- (if applicable) -->

Read the code carefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/370)
<!-- Reviewable:end -->
