### PR TITLE
Drop support for dictionary syntax for files in manifest

### DIFF
--- a/CI-Examples/README.md
+++ b/CI-Examples/README.md
@@ -63,4 +63,4 @@ addition, your application sample should have the following elements:
 Please do not include any tarball of source code or binaries in the application
 samples. If an application requires downloading the source code or binaries,
 please provide instructions in the `README.md`, or download them automatically
-and verify the checksums as part of the build process.
+and verify the hashes as part of the build process.

--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -45,7 +45,7 @@ MBEDTLS_SRC ?= mbedtls-$(MBEDTLS_VERSION).tar.gz
 MBEDTLS_URI ?= \
 	https://github.com/ARMmbed/mbedtls/archive \
 	https://packages.gramineproject.io/distfiles
-MBEDTLS_CHECKSUM ?= 35d8d87509cd0d002bddbd5508b9d2b931c5e83747d087234cc7ad551d53fe05
+MBEDTLS_HASH ?= 35d8d87509cd0d002bddbd5508b9d2b931c5e83747d087234cc7ad551d53fe05
 
 ifeq ($(DEBUG),1)
 MBED_BUILD_TYPE=Debug
@@ -54,7 +54,7 @@ MBED_BUILD_TYPE=Release
 endif
 
 $(MBEDTLS_SRC):
-	../common_tools/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
+	../common_tools/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_HASH)
 
 .SECONDARY: mbedtls/.mbedtls_downloaded
 mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC)

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -828,19 +828,6 @@ Linux scheduler: the effective maximum is 250 samples per second.
 Deprecated options
 ------------------
 
-Allowed/Trusted/Protected Files (deprecated schema)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.allowed_files.[identifier] = "[URI]"
-    sgx.trusted_files.[identifier] = "[URI]"
-    sgx.protected_files.[identifier] = "[URI]"
-
-These manifest options used the TOML-table schema that had a bogus
-``[identifier]`` key. This excessive TOML-table schema was replaced with a more
-appropriate TOML-array one.
-
 Preloaded library (deprecated option)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Documentation/manpages/gramine-manifest.rst
+++ b/Documentation/manpages/gramine-manifest.rst
@@ -96,9 +96,10 @@ Example
    path = "/lib"
    uri = "file:{{ gramine.runtimedir() }}"
 
-   [sgx.trusted_files]
-   entrypoint = "file:{{ entrypoint }}"
-   runtime = "file:{{ gramine.runtimedir() }}/"
+   sgx.trusted_files = [
+     "file:{{ entrypoint }}",
+     "file:{{ gramine.runtimedir() }}/",
+   ]
 
 :file:`Makefile`:
 

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -18,8 +18,9 @@ fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 sgx.nonpie_binary = true
 sgx.debug = true
 
-# this tests the old syntax for allowed_files (TOML table)
-sgx.allowed_files.env = "file:env_test_input"
+sgx.allowed_files = [
+  "file:env_test_input",
+]
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt.c
+++ b/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt.c
@@ -46,7 +46,7 @@ static void usage(void) {
     INFO("\n");
     INFO("NOTE: Files encrypted using the 'encrypt' mode embed the output path string, exactly\n");
     INFO("      as specified in '-o PATH'. Therefore, the Gramine manifest must specify this\n");
-    INFO("      exact path in sgx.protected_files.xyz = \"PATH\".\n");
+    INFO("      exact path in sgx.protected_files list.\n");
 }
 
 int main(int argc, char* argv[]) {

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (c) 2021 Wojtek Porczyk <woju@invisiblethingslab.com>
-# Copyright (c) 2020 Intel Corporation
+# Copyright (c) 2022 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
-# Copyright (c) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>
 
 """
@@ -12,7 +11,6 @@ Gramine manifest management and rendering
 import hashlib
 import os
 import pathlib
-import sys
 
 import toml
 
@@ -105,31 +103,19 @@ class Manifest:
         loader = manifest.setdefault('loader', {})
         loader.setdefault('preload', '')
 
-        # TODO: uncomment once we drop the old syntax support completely.
-        #if not isinstance(sgx['trusted_files'], list):
-        #    raise ValueError("Unsupported trusted files syntax, more info: " +
-        #        "https://gramine.readthedocs.io/en/latest/manifest-syntax.html#trusted-files")
+        if not isinstance(sgx['trusted_files'], list):
+            raise ValueError("Unsupported trusted files syntax, more info: " +
+                  "https://gramine.readthedocs.io/en/latest/manifest-syntax.html#trusted-files")
 
         # Current toml versions (< 1.0) do not support non-homogeneous arrays
         trusted_files = []
-        if isinstance(sgx['trusted_files'], dict):
-            # Old, deprecated syntax "sgx.trusted_files.key = value".
-            print("This trusted files syntax is deprecated, please move to the new one: " +
-                  "https://gramine.readthedocs.io/en/latest/manifest-syntax.html#trusted-files",
-                  file=sys.stderr)
-            for _, tf in sgx['trusted_files'].items():
-                if isinstance(tf, str):
-                    append_tf(trusted_files, tf, None)
-                else:
-                    raise ManifestError(f'Unknown trusted file format: {tf!r}')
-        else:
-            for tf in sgx['trusted_files']:
-                if isinstance(tf, dict) and 'uri' in tf:
-                    trusted_files.append(tf)
-                elif isinstance(tf, str):
-                    append_tf(trusted_files, tf, None)
-                else:
-                    raise ManifestError(f'Unknown trusted file format: {tf!r}')
+        for tf in sgx['trusted_files']:
+            if isinstance(tf, dict) and 'uri' in tf:
+                trusted_files.append(tf)
+            elif isinstance(tf, str):
+                append_tf(trusted_files, tf, None)
+            else:
+                raise ManifestError(f'Unknown trusted file format: {tf!r}')
 
         sgx['trusted_files'] = trusted_files
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We've been printing a warning about this for half a year and two releases (1.0 and 1.1) now, time to get rid of it.

And also we can finally fix the checksum vs hash confusion in our codebase.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/374)
<!-- Reviewable:end -->
