### PR TITLE
Drop support for using 0/1 for bools in manifests

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -32,7 +32,7 @@ fs.mount.etc.uri = "file:/etc"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ ra_client_linkable }}
+sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -30,7 +30,7 @@ fs.mount.etc.uri = "file:/etc"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ ra_client_linkable }}
+sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -34,7 +34,7 @@ fs.mount.etc.uri = "file:/etc"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ ra_client_linkable }}
+sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -35,7 +35,7 @@ fs.mount.etc.uri = "file:/etc"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ ra_client_linkable }}
+sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/common/src/string/toml_utils.c
+++ b/common/src/string/toml_utils.c
@@ -75,25 +75,14 @@ int toml_bool_in(const toml_table_t* root, const char* key, bool defaultval, boo
         *retval = defaultval;
         return 0;
     }
+
     int intval;
     int ret = toml_rtob(raw, &intval);
-    if (ret == 0) {
-        *retval = (bool)intval;
-    } else {
-        // Maybe someone used the old syntax?
-        // TODO: remove this fallback after some time.
-        int64_t int64_val;
-        ret = toml_int_in(root, key, (int)defaultval, &int64_val);
-        if (ret == 0 && (int64_val == 0 || int64_val == 1)) {
-            log_warning("Manifest contains a deprecated syntax for '%s' key. Please use true/false "
-                        "instead of 1/0", key);
-            *retval = (bool)int64_val;
-        } else {
-            ret = -1;
-        }
-    }
+    if (ret != 0)
+        return -1;
 
-    return ret;
+    *retval = (bool)intval;
+    return 0;
 }
 
 int toml_int_in(const toml_table_t* root, const char* key, int64_t defaultval, int64_t* retval) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It was already long-deprecated, time to remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/375)
<!-- Reviewable:end -->
