### PR TITLE
[Docs] Fix an error in "Prepare a signing key section" in Quick Start Guide

### DIFF
--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -44,6 +44,7 @@ Prepare a signing key
 
 Only for SGX, and if you haven't already::
 
+   mkdir -p "$HOME"/.config/gramine/
    openssl genrsa -3 -out "$HOME"/.config/gramine/enclave-key.pem 3072
 
 Clone the repository and run sample application


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Command for Prepare signing key in Quick Start Guide assumes we already have a gramine directory inside `"$HOME"/.config/` without which it throws a `No such file or directory` error. This commit adds the command to create that `gramine` dir.

Link to Quick Start Guide: https://gramine.readthedocs.io/en/latest/quickstart.html#prepare-a-signing-key

Fixes: #377 
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/378)
<!-- Reviewable:end -->
