### PR TITLE
Update Github issues template to require Gramine commit hash

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,9 +10,9 @@ if you have questions, please use our mailing list: users@gramineproject.io
 ## Description of the problem
 
 ## Steps to reproduce
-<!-- NOTE: please specify the exact commit ID on which you reproduced the issue
+<!--
 
-### PLEASE ENSURE THAT THE ISSUE REPRODUCES ON THE CURRENT MASTER BRANCH ###
+@@@ PLEASE ENSURE THAT THE ISSUE REPRODUCES ON THE CURRENT MASTER BRANCH @@@
 
 -->
 
@@ -22,3 +22,9 @@ if you have questions, please use our mailing list: users@gramineproject.io
 
 <!-- ## Additional information -->
 <!-- if applicable, uncomment and fill this section -->
+
+## Gramine commit hash
+
+<!-- Please provide the hash of the commit you used to build Gramine.
+     If you installed Gramine from a repository or other prebuilt package,
+     please provide the exact version. -->


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Although we had a note in the comment, nobody really gave the hash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/380)
<!-- Reviewable:end -->
