### PR TITLE
[LibOS] Add interrupt handling around `DkStreamWaitForClient`

### DIFF
--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -117,8 +117,10 @@ static int ipc_connect(IDTYPE dest, struct shim_ipc_connection** conn_ptr) {
             log_error("buffer for IPC pipe URI too small");
             BUG();
         }
-        ret = DkStreamOpen(uri, PAL_ACCESS_RDONLY, /*share_flags=*/0, PAL_CREATE_IGNORED,
-                           /*options=*/0, &conn->handle);
+        do {
+            ret = DkStreamOpen(uri, PAL_ACCESS_RDONLY, /*share_flags=*/0, PAL_CREATE_IGNORED,
+                               /*options=*/0, &conn->handle);
+        } while (ret == -PAL_ERROR_INTERRUPTED);
         if (ret < 0) {
             ret = pal_to_unix_errno(ret);
             goto out;

--- a/LibOS/shim/src/ipc/shim_ipc_worker.c
+++ b/LibOS/shim/src/ipc/shim_ipc_worker.c
@@ -307,7 +307,11 @@ static noreturn void ipc_worker_main(void) {
                 goto out_die;
             }
             PAL_HANDLE new_handle = NULL;
-            ret = DkStreamWaitForClient(g_self_ipc_handle, &new_handle, /*options=*/0);
+            do {
+                /* Although IPC worker thread does not handle any signals (hence it should never be
+                 * interrupted), lets handle it for uniformity with the rest of the code. */
+                ret = DkStreamWaitForClient(g_self_ipc_handle, &new_handle, /*options=*/0);
+            } while (ret == -PAL_ERROR_INTERRUPTED);
             if (ret < 0) {
                 ret = pal_to_unix_errno(ret);
                 log_error(LOG_PREFIX "DkStreamWaitForClient failed: %d", ret);

--- a/LibOS/shim/src/shim_pollable_event.c
+++ b/LibOS/shim/src/shim_pollable_event.c
@@ -21,8 +21,10 @@ int create_pollable_event(struct shim_pollable_event* event) {
     }
 
     PAL_HANDLE write_handle;
-    ret = DkStreamOpen(uri, PAL_ACCESS_RDWR, /*share_flags=*/0, PAL_CREATE_IGNORED,
-                       PAL_OPTION_CLOEXEC, &write_handle);
+    do {
+        ret = DkStreamOpen(uri, PAL_ACCESS_RDWR, /*share_flags=*/0, PAL_CREATE_IGNORED,
+                           PAL_OPTION_CLOEXEC, &write_handle);
+    } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         log_error("%s: DkStreamOpen failed: %d", __func__, ret);
         ret = pal_to_unix_errno(ret);

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -43,7 +43,9 @@ static int create_pipes(struct shim_handle* srv, struct shim_handle* cli, int fl
         goto out;
     }
 
-    ret = DkStreamWaitForClient(hdl0, &hdl1, /*options=*/0);
+    do {
+        ret = DkStreamWaitForClient(hdl0, &hdl1, /*options=*/0);
+    } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
         log_error("pipe acceptance failure");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It also missed PAL to UNIX errno translations.

Fixes #376

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/381)
<!-- Reviewable:end -->
