### PR TITLE
[LibOS] Replace DENTRY_SYNTHETIC with a separate filesystem

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -37,6 +37,7 @@ enum shim_handle_type {
                       * functions */
     TYPE_PSEUDO,     /* pseudo nodes (currently directories), handled by `pseudo_*` functions */
     TYPE_TMPFS,      /* string-based files (with data inside dentry), used by `tmpfs` filesystem */
+    TYPE_SYNTHETIC,  /* synthetic files, used by `synthetic` filesystem */
 
     /* Pipes and sockets: */
     TYPE_PIPE,       /* pipes, used by `pipe` filesystem */
@@ -211,6 +212,7 @@ struct shim_handle {
         struct shim_str_handle str;             /* TYPE_STR */
         /* (no data) */                         /* TYPE_PSEUDO */
         /* (no data) */                         /* TYPE_TMPFS */
+        /* (no data) */                         /* TYPE_SYNTHETIC */
 
         struct shim_pipe_handle pipe;           /* TYPE_PIPE */
         struct shim_sock_handle sock;           /* TYPE_SOCK */

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -265,13 +265,9 @@ out:
 
 static int chroot_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
     assert(locked(&g_dcache_lock));
+    assert(dent->inode);
 
-    int ret;
-
-    if (!dent->inode)
-        return -ENOENT;
-
-    ret = chroot_do_open(hdl, dent, dent->type, flags, /*perm=*/0);
+    int ret = chroot_do_open(hdl, dent, dent->type, flags, /*perm=*/0);
     if (ret < 0)
         return ret;
 
@@ -282,6 +278,7 @@ static int chroot_open(struct shim_handle* hdl, struct shim_dentry* dent, int fl
 
 static int chroot_creat(struct shim_handle* hdl, struct shim_dentry* dent, int flags, mode_t perm) {
     assert(locked(&g_dcache_lock));
+    assert(!dent->inode);
 
     int ret;
 
@@ -302,6 +299,7 @@ static int chroot_creat(struct shim_handle* hdl, struct shim_dentry* dent, int f
 
 static int chroot_mkdir(struct shim_dentry* dent, mode_t perm) {
     assert(locked(&g_dcache_lock));
+    assert(!dent->inode);
 
     int ret;
 
@@ -493,6 +491,7 @@ out:
 
 static int chroot_unlink(struct shim_dentry* dent) {
     assert(locked(&g_dcache_lock));
+    assert(dent->inode);
 
     int ret;
 
@@ -514,6 +513,7 @@ static int chroot_unlink(struct shim_dentry* dent) {
 
 static int chroot_rename(struct shim_dentry* old, struct shim_dentry* new) {
     assert(locked(&g_dcache_lock));
+    assert(old->inode);
 
     int ret;
     char* new_uri = NULL;
@@ -556,6 +556,7 @@ out:
 
 static int chroot_chmod(struct shim_dentry* dent, mode_t perm) {
     assert(locked(&g_dcache_lock));
+    assert(dent->inode);
 
     int ret;
 

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -438,11 +438,10 @@ static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
 
     struct print_buf buf = INIT_PRINT_BUF(dump_dentry_write_all);
 
-    buf_printf(&buf, "[%6.6s ", dent->mount ? dent->mount->fs->name : "");
+    buf_printf(&buf, "[%6.6s ", dent->fs ? dent->fs->name : "");
 
     DUMP_FLAG(DENTRY_VALID, "V", ".");
     DUMP_FLAG(DENTRY_LISTED, "L", ".");
-    DUMP_FLAG(DENTRY_SYNTHETIC, "S", ".");
     buf_printf(&buf, "%3d] ", (int)REF_GET(dent->ref_count));
 
     dump_dentry_mode(&buf, dent->type, dent->perm);
@@ -465,7 +464,11 @@ static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
         case S_IFLNK: buf_puts(&buf, " -> "); break;
         default: break;
     }
+    if (!dent->parent && dent->mount) {
+        buf_printf(&buf, " (%s \"%s\")", dent->mount->fs->name, dent->mount->uri);
+    }
     buf_flush(&buf);
+
 
     if (dent->attached_mount) {
         struct shim_dentry* root = dent->attached_mount->root;

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -30,6 +30,7 @@ struct shim_fs* builtin_fs[] = {
     &epoll_builtin_fs,
     &eventfd_builtin_fs,
     &pseudo_builtin_fs,
+    &synthetic_builtin_fs,
 };
 
 static struct shim_lock mount_mgr_lock;

--- a/LibOS/shim/src/fs/shim_fs_synthetic.c
+++ b/LibOS/shim/src/fs/shim_fs_synthetic.c
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * This file contains implementation of the "synthetic" filesystem. This filesystem handles
+ * in-memory files (currently, only directories) created in the process of mounting a filesystem.
+ *
+ * For example, if the manifest specifies a mount at "/usr/bin", and "usr" does not exist, Gramine
+ * will create synthetic directories for "/usr" and "/usr/bin". While "/usr/bin" will be immediately
+ * shadowed by the mounted directory, "/usr" will remain visible for the user.
+ *
+ * Operations on synthetic files are handled by `synthetic_builtin_fs` defined below. It should be
+ * possible to retrieve information about them (`stat`, `getdents` etc.), but not modify them in any
+ * way.
+ */
+
+#include "shim_fs.h"
+
+int synthetic_setup_dentry(struct shim_dentry* dent, mode_t type, mode_t perm) {
+    assert(locked(&g_dcache_lock));
+    assert(!dent->inode);
+
+    dent->type = type;
+    dent->perm = perm;
+
+    struct shim_inode* inode = get_new_inode(dent->mount, type, perm);
+    if (!inode)
+        return -ENOMEM;
+    dent->inode = inode;
+
+    dent->fs = &synthetic_builtin_fs;
+    inode->fs = &synthetic_builtin_fs;
+
+    return 0;
+}
+
+static int synthetic_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
+    assert(locked(&g_dcache_lock));
+    assert(dent->inode);
+    __UNUSED(flags);
+
+    hdl->type = TYPE_SYNTHETIC;
+    hdl->inode = dent->inode;
+    get_inode(dent->inode);
+    return 0;
+}
+
+static struct shim_fs_ops synthetic_fs_ops = {
+    .hstat = &generic_inode_hstat,
+};
+
+static struct shim_d_ops synthetic_d_ops = {
+    .open = &synthetic_open,
+    .readdir = &generic_readdir,
+    .stat = &generic_inode_stat,
+};
+
+struct shim_fs synthetic_builtin_fs = {
+    .name = "synth",
+    .fs_ops = &synthetic_fs_ops,
+    .d_ops = &synthetic_d_ops,
+};

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -255,12 +255,11 @@ static int lookup_enter_dentry(struct lookup* lookup) {
          */
         if (lookup->flags & LOOKUP_MAKE_SYNTHETIC) {
             lookup->dent->state &= ~DENTRY_NEGATIVE;
-            lookup->dent->state |= DENTRY_VALID | DENTRY_SYNTHETIC;
-            if (!is_final || has_slash) {
-                lookup->dent->type = S_IFDIR;
-            } else {
-                lookup->dent->type = S_IFREG;
-            }
+            ret = synthetic_setup_dentry(lookup->dent, S_IFDIR, PERM_r_xr_xr_x);
+            if (ret < 0)
+                return ret;
+
+            lookup->dent->state |= DENTRY_VALID;
         } else if (is_final && (lookup->flags & LOOKUP_CREATE)) {
             /* proceed with a negative dentry */
         } else {

--- a/LibOS/shim/src/meson.build
+++ b/LibOS/shim/src/meson.build
@@ -30,6 +30,7 @@ libos_sources = files(
     'fs/shim_fs_lock.c',
     'fs/shim_fs_mem.c',
     'fs/shim_fs_pseudo.c',
+    'fs/shim_fs_synthetic.c',
     'fs/shim_fs_util.c',
     'fs/shim_namei.c',
     'fs/socket/fs.c',

--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -136,10 +136,14 @@ long shim_do_rmdir(const char* pathname) {
         goto out;
     }
 
-    if (dent->fs && dent->fs->d_ops && dent->fs->d_ops->unlink) {
-        if ((ret = dent->fs->d_ops->unlink(dent)) < 0)
-            goto out;
+    if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->unlink) {
+        ret = -EACCES;
+        goto out;
     }
+
+    ret = dent->fs->d_ops->unlink(dent);
+    if (ret < 0)
+        goto out;
 
     dent->state |= DENTRY_NEGATIVE;
 out:

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -113,6 +113,7 @@ tests = {
         ),
     },
     'stat_invalid_args': {},
+    'synthetic': {},
     'syscall': {},
     'syscall_restart': {},
     'sysfs_common': {},

--- a/LibOS/shim/test/regression/synthetic.c
+++ b/LibOS/shim/test/regression/synthetic.c
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Test for synthetic directories created by Gramine in the process of mounting. In the test
+ * configuration (`manifest.template`), "/mnt" is such a directory, because we mount a filesystem at
+ * "/mnt/tmpfs".
+ */
+
+#define _GNU_SOURCE /* O_DIRECTORY */
+#include <dirent.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* Check if it's possible to list `path` and whether it contains `subpath` */
+static void test_list(const char* path, const char* subpath) {
+    struct dirent** namelist;
+    int n = scandir(path, &namelist, /*filter=*/NULL, alphasort);
+    if (n == -1)
+        err(1, "scandir");
+
+    bool subpath_found = false;
+    for (int i = 0; i < n; i++) {
+        const char* name = namelist[i]->d_name;
+        printf("dirent: %s\n", name);
+        if (strcmp(name, subpath) == 0)
+            subpath_found = true;
+        free(namelist[i]);
+    }
+    free(namelist);
+    if (!subpath_found)
+        errx(1, "%s not found in directory entries of %s", subpath, path);
+}
+
+int main(void) {
+    const char* path = "/mnt";
+    const char* subpath = "tmpfs";
+    struct stat statbuf;
+
+    test_list(path, subpath);
+
+    if (rmdir(path) != -1 || errno != EACCES)
+        err(1, "rmdir should return EACCES");
+
+    if (stat(path, &statbuf) == -1)
+        err(1, "stat");
+
+    int fd = open(path, O_DIRECTORY);
+    if (fd == -1)
+        err(1, "open");
+
+    if (fstat(fd, &statbuf) == -1)
+        err(1, "fstat");
+
+    if (close(fd) == -1)
+        err(1, "close");
+
+    printf("TEST OK\n");
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -94,6 +94,7 @@ manifests = [
   "sigprocmask_pending",
   "spinlock",
   "stat_invalid_args",
+  "synthetic",
   "syscall",
   "syscall_restart",
   "sysfs_common",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -96,6 +96,7 @@ manifests = [
   "sigprocmask_pending",
   "spinlock",
   "stat_invalid_args",
+  "synthetic",
   "syscall",
   "syscall_restart",
   "sysfs_common",


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, synthetic files were created as special dentries with DENTRY_SYNTHETIC flag set. These dentries were marked as belonging to a filesystem (typically "chroot") but weren't really initialized by it. As a result, they could break assumptions made by that filesystem (e.g. about `dent->inode` existing).

This change treats synthetic files same as other special files (named pipes and sockets). We set `dent->fs` to mark them as belonging to a separate filesystem, and all operations for the file are forwarded to that filesystem.

In addition, for simplicity we only create synthetic directories. If the user mounts something else than a directory, the synthetic mountpoint can still be a directory: it will be shadowed by the mounted file anyway.

## How to test this PR? <!-- (if applicable) -->

There's a new regression test, `synthetic`, which tries if the `/mnt` directory in Gramine behaves correctly.

You can also dump the dentry tree to see details. Add `dump_dcache(NULL);` to `shim_exit.c:libos_clean_and_exit()`:

```
$ gramine-test run synthetic
ninja direct-synthetic
[1/1] manifest: synthetic.manifest
gramine-direct synthetic
dirent: .
dirent: tmpfs
TEST OK
[P1:T1:synthetic] [       V.  3] 040700 drwx M /
[P1:T1:synthetic] [chroot V. 12] 040775 drwx *   / (chroot "file:")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M     proc/
[P1:T1:synthetic] [pseudo V.  1] 040555 dr-x *       proc/ (pseudo "proc")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M     dev/
[P1:T1:synthetic] [pseudo V.  2] 040555 dr-x *       dev/ (pseudo "dev")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M         tty/
[P1:T1:synthetic] [chroot V.  3] 020666 crw- *           tty (chroot "dev:tty")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M     lib/
[P1:T1:synthetic] [chroot V.  5] 040755 drwx *       lib/ (chroot "file:/home/user/.local/lib/x86_64-linux-gnu/gramine/runtime/glibc")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M         x86_64-linux-gnu/
[P1:T1:synthetic] [chroot V.  1] 040755 drwx *           x86_64-linux-gnu/ (chroot "file:/lib/x86_64-linux-gnu")
[P1:T1:synthetic] [chroot V.  2] 100755 -rwx           ld-linux-x86-64.so.2
[P1:T1:synthetic] [chroot V.  2] 100755 -rwx           libpthread.so.0
[P1:T1:synthetic] [chroot V.  2] 100755 -rwx           libc.so.6
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M     bin/
[P1:T1:synthetic] [chroot V.  1] 040755 drwx *       bin/ (chroot "file:/bin")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M     synthetic/
[P1:T1:synthetic] [chroot V.  2] 100755 -rwx *       synthetic (chroot "file:/home/user/.local/lib/x86_64-linux-gnu/gramine/tests/libos/regression/synthetic")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x       mnt/
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M       tmpfs/
[P1:T1:synthetic] [ tmpfs V.  1] 040700 drwx *         tmpfs/ (tmpfs "file:dummy-unused-by-tmpfs-uri")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M     exec_victim/
[P1:T1:synthetic] [chroot V.  1] 100755 -rwx *       exec_victim (chroot "file:/home/user/.local/lib/x86_64-linux-gnu/gramine/tests/libos/regression/exec_victim")
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x       usr/
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x         lib/
[P1:T1:synthetic] [ synth V.  2] 040555 dr-x M         x86_64-linux-gnu/
[P1:T1:synthetic] [chroot V.  1] 040755 drwx *           x86_64-linux-gnu/ (chroot "file:/usr//lib/x86_64-linux-gnu")
[P1:T1:synthetic] [chroot V.  1] 000000 ?---  -    etc
```

Note the entries marked as `synth`; it means that `dent->fs == &synthetic_builtin_fs`. Most of these (e.g. `/proc`) are mountpoints, so they're shadowed by a mounted filesystem. But there are files such as `/usr`, `/usr/lib` or `/mnt` that are visible to the application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/383)
<!-- Reviewable:end -->
