### PR TITLE
[Pal/Linux] Introduce `sys.enable_host_vdso` manifest option

### DIFF
--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -40,6 +40,15 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 # Allow for injecting SIGTERM signal from the host.
 sys.enable_sigterm_injection = true
 
+################################ PERFORMANCE ##################################
+
+# The vDSO library is provided by the Linux kernel and may be used by Gramine to
+# improve performance of frequently-used system calls such as `clock_gettime()`.
+# By default, Gramine disables host vDSO because of the bug in Linux that may
+# lead to sporadic failures of multi-process applications. Since Redis is
+# single-process, we can safely enable host vDSO to improve performance.
+sys.enable_host_vdso = true
+
 ################################# MOUNT FS  ###################################
 
 # General notes:

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -299,8 +299,8 @@ Allowing eventfd
     sys.insecure__allow_eventfd = [true|false]
     (Default: false)
 
-This specifies whether to allow system calls `eventfd()` and `eventfd2()`. Since
-eventfd emulation currently relies on the host, these system calls are
+This specifies whether to allow system calls ``eventfd()`` and ``eventfd2()``.
+Since eventfd emulation currently relies on the host, these system calls are
 disallowed by default due to security concerns.
 
 External SIGTERM injection
@@ -316,6 +316,26 @@ into Gramine. Could be useful to handle graceful shutdown.
 Be careful! In SGX environment, the untrusted host could inject that signal in
 an arbitrary moment. Examine what your application's `SIGTERM` handler does and
 whether it poses any security threat.
+
+Enabling host vDSO
+^^^^^^^^^^^^^^^^^^
+
+::
+
+    sys.enable_host_vdso = [true|false]
+    (Default: false)
+
+This specifies whether Gramine can use the host vDSO library to improve
+performance of frequently-used system calls such as ``clock_gettime()``.
+By default, Gramine does not use the host vDSO library because of the bug in
+Linux that may lead to sporadic failures of multi-process applications. You can
+safely enable this option for single-process applications.
+
+Note that currently this manifest option does *not* apply to the SGX environment
+(because it doesn't use host vDSO anyway).
+
+For technical details on this Linux bug, please see
+https://lore.kernel.org/lkml/9b82908f-eed1-b6b7-62aa-ecbba7bf048b@gmail.com/.
 
 Root FS mount point
 ^^^^^^^^^^^^^^^^^^^

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -12,6 +12,9 @@ fs.mount.entrypoint.type = "chroot"
 fs.mount.entrypoint.path = "{{ entrypoint }}"
 fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 
+# for testing only (multi_pthread is single-process so enabling host vDSO is definitely safe)
+sys.enable_host_vdso = true
+
 # app runs with 4 parallel threads + Gramine has couple internal threads
 sgx.thread_num = 8
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There is a bug in the Linux kernel: the placement of the vDSO library is randomized even when app is started with `ADDR_NO_RANDOMIZE`. This bug manifests itself on systems with 5-level paging enabled (e.g., newer Icelake Intel CPUs).

The only way to completely circumvent this bug is to not use the vDSO library. This PR changes default Gramine behavior to disable host vDSO and introduces `sys.enable_host_vdso` to re-enable it. This manifest option does not apply to the SGX environment (because it doesn't use host vDSO anyway).

For the initial attempt to fix this bug, see commit e7429e13bb3e9 "[Pal/Linux] Add a workaround for a kernel bug randomizing VDSO". Unfortunately, that bug fix does not eliminate the bug completely but only makes it less frequent.

## How to test this PR? <!-- (if applicable) -->

CI. I added `sys.enable_host_vdso = true` in a couple tests/examples, just to test it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/388)
<!-- Reviewable:end -->
