### PR TITLE
[common] Fix mbedtls configuration mismatch

### DIFF
--- a/subprojects/packagefiles/mbedtls/compile-gramine.sh
+++ b/subprojects/packagefiles/mbedtls/compile-gramine.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+CFLAGS='-O2 -DMBEDTLS_CONFIG_FILE=\"mbedtls/config-gramine.h\"'
+
+export CFLAGS
+exec "$(dirname "$0")"/compile.sh "$@"

--- a/subprojects/packagefiles/mbedtls/gramine.patch
+++ b/subprojects/packagefiles/mbedtls/gramine.patch
@@ -92,19 +92,6 @@ index e367fbd9cdd42c81b108a92037b1b16d562a6f55..e9524f66ba4203e7654b1023656c1830
      /* mbedtls_ssl_reset() leaves the handshake sub-structure allocated,
       * which we don't want - otherwise we'd end up freeing the wrong transform
       * by calling mbedtls_ssl_handshake_wrapup_free_hs_transform()
-diff --git i/include/mbedtls/config.h w/include/mbedtls/config.h
-index d370dbff5e8f6d231719aba4453304545c6332bc..b0b3f02ef5a7bda27e06de7f5afe8d9da7fc755e 100644
---- i/include/mbedtls/config.h
-+++ w/include/mbedtls/config.h
-@@ -2620,7 +2620,7 @@
-  * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C
-  *
-  */
--//#define MBEDTLS_CMAC_C
-+#define MBEDTLS_CMAC_C
- 
- /**
-  * \def MBEDTLS_CTR_DRBG_C
 diff --git i/library/Makefile w/library/Makefile
 index 6bb9c1781db543d9bb9ef8478fa4431fbe3af5b8..f80d0ab18126472b15acbc661cb13337ee154d7d 100644
 --- i/library/Makefile

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-gramine.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-gramine.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * This is the configuration for Gramine's userspace build of mbedtls. It overrides the default
+ * `mbedtls/config.h`.
+ */
+
+#ifndef MBEDTLS_CONFIG_GRAMINE_H_
+#define MBEDTLS_CONFIG_GRAMINE_H_
+
+#include "mbedtls/config.h"
+
+#define MBEDTLS_CMAC_C
+
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_GRAMINE_H_ */

--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -15,7 +15,7 @@ mbedtls_libs_output = [
 # PR for patch support in wraps: https://github.com/mesonbuild/meson/pull/4570
 mbedtls_libs = custom_target('mbedtls',
     command: [
-        find_program('compile.sh'),
+        find_program('compile-gramine.sh'),
         '@CURRENT_SOURCE_DIR@',
         meson.current_build_dir(),
         '@PRIVATE_DIR@',
@@ -82,6 +82,7 @@ mbedtls_inc = include_directories('include')
 mbedtls_dep = declare_dependency(
     link_with: [mbedtls_libs[1], mbedtls_libs[3], mbedtls_libs[5]],
     include_directories: mbedtls_inc,
+    compile_args: '-DMBEDTLS_CONFIG_FILE="mbedtls/config-gramine.h"',
 )
 mbedtls_pal_dep = declare_dependency(
     # HACK: Apparently Meson considers the `mbedtls_pal_libs` to be "not linkable", because it has


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This ensures that userspace programs using the mbedtls library (e.g. `gramine-sgx-pf-crypt`) use the same configuration flags as the the mbedtls library itself.

The problem was that the Meson build applied a patch to a copy of `mbedtls/config.h`, but the programs included the unpatched version. As a result, the both sides disagreed about size of some data structures, causing `gramine-sgx-pf-crypt` to crash (when compiled with Clang in release mode).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

This is one of the issues reported in #208 (https://github.com/gramineproject/gramine/issues/208#issuecomment-1032270427). If you compile Gramine with Clang in release or debugoptimized mode, the FS tests will fail:

```
$ SGX=1 gramine-test pytest test_pf.py
...
E   subprocess.CalledProcessError: Command '['gramine-sgx-pf-crypt', 'decrypt', '-w', 'tmp/wrap-key', '-i', 'tmp/pf_output/0', '-o', 'tmp/pf_output/0.dec']' died with <Signals.SIGSEGV: 11>.
...
```

The crash should be fixed with this PR (remember to `rm subprojects/mbedtls-mbedtls-2.26.0 -rf` before rebuilding!)

## Details

Here's the problematic code (in `pf_util.c`):

```c
pf_status_t mbedtls_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv, const void* aad,
                                    size_t aad_size, const void* input, size_t input_size,
                                    void* output, const pf_mac_t* mac) {
    pf_status_t status = PF_STATUS_CALLBACK_FAILED;

    mbedtls_gcm_context gcm;
    mbedtls_gcm_init(&gcm);
```

If you disassemble this code (in `libsgx_util.so`), you'll notice that `gcm` has size of `0x1a0`. GDB also confirms this. However, `mbedtls_gcm_init` zeroes out `0x1a8` bytes. When compiled with Clang in release mode, this happens to wipe the saved value of RBX register.

This is because the following structure (part of `mbedtls_gcm_context`) has a conditionally defined field:
```c
typedef struct mbedtls_cipher_context_t
{
...
#if defined(MBEDTLS_CMAC_C)
    /** CMAC-specific context. */
    mbedtls_cmac_context_t *cmac_ctx;
#endif
```

Our patch enabled `MBEDTLS_CMAC_C` in an include file (`mbedtls/config.h`), but the patch was applied in the Meson build directory. The rest of Gramine was compiled with the unpatched version of the include file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/389)
<!-- Reviewable:end -->
