### PR TITLE
Drop support for `loader.preload` and URIs in `libos.entrypoint` in manifests

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -1,8 +1,6 @@
 # This is a general manifest template for running Bash and core utility programs,
 # including ls, cat, cp, date, and rm.
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/bash"
 

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -1,7 +1,5 @@
 # Blender manifest example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/blender/blender"
 

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -1,7 +1,5 @@
 # Busybox manifest file example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "busybox"
 

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -1,7 +1,5 @@
 # Hello World manifest file example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "helloworld"
 loader.log_level = "{{ log_level }}"

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -1,7 +1,5 @@
 # lighttpd manifest example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/sbin/lighttpd"
 

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -1,7 +1,5 @@
 # Memcached manifest file example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "memcached"
 

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -1,7 +1,5 @@
 # Nginx manifest example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/sbin/nginx"
 

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -1,7 +1,5 @@
 # Python3 manifest example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -1,7 +1,5 @@
 # Client manifest file (both for EPID and DCAP)
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "client"
 

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -1,7 +1,5 @@
 # RA-TLS manifest file example
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "server"
 

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -1,7 +1,5 @@
 # Secret Provisioning manifest file example (client)
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "secret_prov_client"
 

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -1,7 +1,5 @@
 # Secret Provisioning manifest file example (minimal client)
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "secret_prov_min_client"
 

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -1,7 +1,5 @@
 # Secret Provisioning manifest file example (Protected Files client)
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "secret_prov_pf_client"
 

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -2,10 +2,6 @@
 
 ################################## GRAMINE ####################################
 
-# Deprecated option, only for compatibility with Gramine v1.0. For newer
-# versions of Gramine, use `loader.entrypoint` instead.
-loader.preload = "file:{{ gramine.libos }}"
-
 # PAL entrypoint (points to the LibOS layer library of Gramine). There is
 # currently only one implementation, so it is always set to libsysdb.so.
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -1,7 +1,5 @@
 # This is a general manifest template for running SQLite.
 
-loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/sqlite3"
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -105,11 +105,6 @@ at that path. For example::
      # { path = "/usr/bin/python3.8", uri = "file:python3.8" },
    ]
 
-.. note ::
-   Earlier, ``libos.entrypoint`` was a PAL URI. If you used it with a relative
-   path, it's probably enough to remove ``file:`` prefix (convert
-   ``"file:hello"`` to ``"hello"``).
-
 Command-line arguments
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -858,19 +858,6 @@ Linux scheduler: the effective maximum is 250 samples per second.
 Deprecated options
 ------------------
 
-Preloaded library (deprecated option)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-   loader.preload = "[URI]"
-
-This syntax specifies the library to be preloaded before loading the executable.
-This usually points to the LibOS library ``libsysdb.so``.
-
-Note that previously this syntax allowed to specify the list of URIs (separated
-by commas). This ability was never used and therefore was removed completely.
-
 FS mount points (deprecated syntax)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -104,10 +104,11 @@ static int init_exec_handle(void) {
     exec_path = entrypoint;
 
     if (strstartswith(exec_path, URI_PREFIX_FILE)) {
-        /* TODO: change to error after some deprecation period */
-        log_error("'libos.entrypoint' is now a Gramine path, not URI. "
-                  "Ignoring the 'file:' prefix.");
-        exec_path += strlen(URI_PREFIX_FILE);
+        /* Technically we could skip this check, but it's something easy to confuse with
+         * loader.entrypoint, so better to have this handled nicely for the users. */
+        log_error("'libos.entrypoint' should be an in-Gramine path, not URI.");
+        ret = -EINVAL;
+        goto out;
     }
 
     hdl = get_new_handle();

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -509,15 +509,6 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     if (ret < 0)
         INIT_FAIL_MANIFEST(PAL_ERROR_INVAL, "Cannot parse 'loader.entrypoint'");
 
-    if (!entrypoint_name) {
-        ret = toml_string_in(g_pal_public_state.manifest_root, "loader.preload", &entrypoint_name);
-        if (ret < 0)
-            INIT_FAIL_MANIFEST(PAL_ERROR_INVAL, "Cannot parse 'loader.preload'");
-
-        if (entrypoint_name)
-            log_warning("'loader.preload' is deprecated; please switch to 'loader.entrypoint'");
-    }
-
     if (!entrypoint_name)
         INIT_FAIL(PAL_ERROR_INVAL, "No 'loader.entrypoint' is specified in the manifest");
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Both were long deprecated, time to get rid of them for the next release.

Corresponding examples PR: https://github.com/gramineproject/examples/pull/16.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/404)
<!-- Reviewable:end -->
