### PR TITLE
[Meson] Build without werror by default

### DIFF
--- a/.ci/lib/config.jenkinsfile
+++ b/.ci/lib/config.jenkinsfile
@@ -1,4 +1,3 @@
-env.WERROR = '1'
 env.MAKEOPTS = '-j8'
 
 python_platlib = sh(returnStdout: true, script: 'python3 Scripts/get-python-platlib.py "$PREFIX"')

--- a/.ci/lib/stage-build-nosgx.jenkinsfile
+++ b/.ci/lib/stage-build-nosgx.jenkinsfile
@@ -13,6 +13,7 @@ stage('build') {
     try {
         sh '''
             meson setup build/ \
+                --werror \
                 --prefix="$PREFIX" \
                 --buildtype="$BUILDTYPE" \
                 -Dskeleton=enabled \

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -32,6 +32,7 @@ stage('build') {
     try {
         sh '''
             meson setup build-dcap/ \
+                --werror \
                 --prefix="$PREFIX" \
                 --buildtype="$BUILDTYPE" \
                 -Ddirect=disabled \
@@ -49,6 +50,7 @@ stage('build') {
     try {
         sh '''
             meson setup build/ \
+                --werror \
                 --prefix="$PREFIX" \
                 --buildtype="$BUILDTYPE" \
                 -Ddirect=disabled \

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -182,7 +182,7 @@ also built by Meson, must be installed as well. To do that, configure your build
 directory with ``-Dtests=enabled`` and install Gramine::
 
    # add -Dsgx=enabled and SGX options if necessary
-   meson setup build/ -Dtests=enabled -Ddirect=enabled
+   meson setup build/ --werror -Dtests=enabled -Ddirect=enabled
 
    ninja -C build/
    sudo ninja -C build/ install

--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -158,6 +158,11 @@ means non-SGX version)::
 
 .. note::
 
+   If you plan to contribute changes to Gramine, then you should always build it
+   with ``--werror`` added to the invocation above.
+
+.. note::
+
    If you invoked ``meson setup`` once, the next invocation of this command will
    *not* have any effect. Instead, to change the build configuration, use
    ``meson configure``. For example, if you built with ``meson setup build/

--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -14,7 +14,7 @@ debugging process easier.
 To build Gramine with debug symbols, the source code needs to be compiled with
 ``--buildtype=debug``::
 
-    meson setup build-debug/ --buildtype=debug -Ddirect=enabled
+    meson setup build-debug/ --werror --buildtype=debug -Ddirect=enabled
     ninja -C build-debug/
     sudo ninja -C build-debug/ install
 
@@ -37,7 +37,7 @@ execution *outside* the enclave).
 To build Gramine with debug symbols, the source code needs to be compiled with
 ``--buildtype=debug``::
 
-    meson setup build-debug/ --buildtype=debug -Dsgx=enabled
+    meson setup build-debug/ --werror --buildtype=debug -Dsgx=enabled
     ninja -C build-debug/
     sudo ninja -C build-debug/ install
 

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,6 @@ project(
     default_options: [
         'c_std=c11',
         'cpp_std=c++14',
-        'werror=true',
     ],
 )
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Compiler warnings are not stable and sometimes based on heuristics, so we shouldn't fail the build on warnings by default (this can easily cause Gramine to be unbuildable on new compilers/distros due to trivial or non-issues, see e.g. https://github.com/gramineproject/gramine/pull/220).

## How to test this PR? <!-- (if applicable) -->

Build with and without passing `--werror` to `meson setup`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/409)
<!-- Reviewable:end -->
