### PR TITLE
[LibOS] Make sure ASan tests work in optimized builds

### DIFF
--- a/LibOS/shim/src/shim_call.c
+++ b/LibOS/shim/src/shim_call.c
@@ -28,33 +28,34 @@ static int run_test_ubsan_int_overflow(void) {
 #endif
 
 #ifdef ASAN
-/* Test: allocate a buffer on heap, write past the end of buffer (ASan only) */
+
+/*
+ * ASan tests: write past a heap/stack/global buffer. We use a volatile pointer in order to bypass
+ * compiler optimizations and warnings.
+ */
+
 __attribute__((no_sanitize("undefined")))
 static int run_test_asan_heap(void) {
-    uint8_t* buf = malloc(30);
-    buf[30] = 1;
+    char* buf = malloc(30);
+    char* volatile c = buf + 30;
+    *c = 1;
     free(buf);
     return 0;
 }
 
-/* Test: write past the end of a stack buffer (ASan only) */
 __attribute__((no_sanitize("undefined")))
 static int run_test_asan_stack(void) {
     char buf[30];
-    /* Take a pointer: direct assignment such as `buf[30] = 1;` triggers a compiler warning */
-    char* c = buf + 30;
+    char* volatile c = buf + 30;
     *c = 1;
-
     return 0;
 }
 
-/* Test: write past the end of a global (static local) buffer (ASan only) */
 __attribute__((no_sanitize("undefined")))
 static int run_test_asan_global(void) {
     static char buf[30];
-    char* c = buf + 30;
+    char* volatile c = buf + 30;
     *c = 1;
-
     return 0;
 }
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, `clang -O3` optimized the `asan_stack` and `asan_global` tests to a no-op.

This is reported in #208 (hopefully the last failure from that issue).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Compile Gramine with `--buildtype=debugoptimized` or `--buildtype=release` and ASan enabled.

The following tests do not trigger ASan on master, and should do so now:

```
regression $ gramine-test run run_test asan_stack
regression $ gramine-test run run_test asan_global
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/410)
<!-- Reviewable:end -->
