### PR TITLE
[LibOS] Convert `fs.mount` to an array

### DIFF
--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -8,33 +8,16 @@ loader.insecure__use_cmdline_argv = true
 # for eventfd test
 sys.insecure__allow_eventfd = true
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
+fs.mount = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "/exec_victim", uri = "file:{{ binary_dir }}/exec_victim" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/bin", uri = "file:/bin" },
 
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
-
-fs.mount.exec_victim.type = "chroot"
-fs.mount.exec_victim.path = "exec_victim"
-fs.mount.exec_victim.uri = "file:{{ binary_dir }}/exec_victim"
-
-fs.mount.host_lib.type = "chroot"
-fs.mount.host_lib.path = "{{ arch_libdir }}"
-fs.mount.host_lib.uri = "file:{{ arch_libdir }}"
-
-fs.mount.host_usr_lib.type = "chroot"
-fs.mount.host_usr_lib.path = "/usr/{{ arch_libdir }}"
-fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.bin.type = "chroot"
-fs.mount.bin.path = "/bin"
-fs.mount.bin.uri = "file:/bin"
-
-fs.mount.tmpfs.type = "tmpfs"
-fs.mount.tmpfs.path = "/mnt/tmpfs"
-fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
+  { type = "tmpfs", path = "/mnt/tmpfs" },
+]
 
 sgx.thread_num = 16
 sgx.nonpie_binary = true


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This converts the `fs.mount` manifest key to an array instead of table. Similar to `sgx.{trusted,allowed,protected}_files`, an array can be parsed more efficiently. It's also more natural, because order matters when specifying mount points.

The old (table) syntax is still accepted, but triggers a deprecation warning.

This commit converts the main manifest for regression tests. Other manifests will be converted later.

In addition, Gramine now allows omitting the `type` key (with "chroot" as default) and the `uri` key (so that it's easier to use the `tmpfs` filesystem).

Issue: #23 (although we might want to close it after the deprecated syntax is gone).

Prerequisite for #371: new syntax for trusted/protected files.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

The `manifest.template` in LibOS regression tests should exercise the new code. You can modify it to check how things fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/411)
<!-- Reviewable:end -->
