### PR TITLE
[LibOS] Properly return peer address for accept() and accept4()

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1010,7 +1010,7 @@ static int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr
         inet_rebase_port(true, cli_sock->domain, &cli_sock->addr.in.conn, false);
 
         if (addr)
-            *addrlen = inet_copy_addr(sock->domain, addr, *addrlen, &sock->addr.in.conn);
+            *addrlen = inet_copy_addr(cli_sock->domain, addr, *addrlen, &cli_sock->addr.in.conn);
     }
 
     ret = set_new_fd_handle(cli, flags & O_CLOEXEC ? FD_CLOEXEC : 0, NULL);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

When returning from accept() or accept4(), the address should come from the accepted socket, not the listening socket.

Fixes #344 
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

The argument addr should now be filled with the peer address on return.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/412)
<!-- Reviewable:end -->
