### PR TITLE
Convert `fifo` and `socket` filesystems to use inodes 

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -149,9 +149,6 @@ struct shim_dentry {
     /* file permissions: PERM_rwxrwxrwx, etc. */
     mode_t perm;
 
-    /* Filesystem-specific data. Protected by `lock`. */
-    void* data;
-
     /* Inode associated with this dentry. Currently optional, and only for the use of underlying
      * filesystem (see `shim_inode` below). Protected by `g_dcache_lock`. */
     struct shim_inode* inode;
@@ -164,7 +161,6 @@ struct shim_dentry {
      * `shim_fs_lock.c`. */
     bool maybe_has_fs_locks;
 
-    struct shim_lock lock;
     REFTYPE ref_count;
 };
 
@@ -688,9 +684,9 @@ void put_dentry(struct shim_dentry* dent);
  *
  * \param  dent  the dentry (should be either invalid or negative)
  *
- * Resets the following dentry fields: `state`, `fs`, `type`, `perm`, `data`, `inode`. Ensures that
- * there is no leftover state from a file previously associated with the dentry, and the dentry can
- * be used for a new file.
+ * Resets the following dentry fields: `state`, `fs`, `type`, `perm`, `inode`. Ensures that there is
+ * no leftover state from a file previously associated with the dentry, and the dentry can be used
+ * for a new file.
  *
  * The caller should hold `g_dcache_lock`.
  *

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -903,4 +903,8 @@ int generic_inode_poll(struct shim_handle* hdl, int poll_type);
 
 int synthetic_setup_dentry(struct shim_dentry* dent, mode_t type, mode_t perm);
 
+int fifo_setup_dentry(struct shim_dentry* dent, mode_t perm, int fd_read, int fd_write);
+
+int unix_socket_setup_dentry(struct shim_dentry* dent, mode_t perm);
+
 #endif /* _SHIM_FS_H_ */

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -242,7 +242,7 @@ struct shim_d_ops {
      * \brief Create and open a new regular file
      *
      * \param hdl a newly created handle
-     * \param dent dentry, valid and negative (file to be created)
+     * \param dent dentry, not valid (file to be created)
      * \param flags open flags, including access mode (O_RDONLY / O_WRONLY / O_RDWR)
      * \param perm permissions of the new file
      *
@@ -257,7 +257,7 @@ struct shim_d_ops {
     /*
      * \brief Create a directory
      *
-     * \param dent dentry, valid and negative (directory to be created)
+     * \param dent dentry, not valid (directory to be created)
      * \param perm permissions of the new directory
      *
      * Creates a new directory at path described by `dent`. On success, prepares the dentry for use
@@ -682,6 +682,25 @@ void clear_directory_handle(struct shim_handle* hdl);
 void get_dentry(struct shim_dentry* dent);
 /* Decrement the reference count on dent */
 void put_dentry(struct shim_dentry* dent);
+
+/*!
+ * \brief Reset dentry state related to a file
+ *
+ * \param  dent  the dentry (should be either invalid or negative)
+ *
+ * Resets the following dentry fields: `state`, `fs`, `type`, `perm`, `data`, `inode`. Ensures that
+ * there is no leftover state from a file previously associated with the dentry, and the dentry can
+ * be used for a new file.
+ *
+ * The caller should hold `g_dcache_lock`.
+ *
+ * Should be called before initializing the dentry for a new file (e.g. `lookup`, `create`,
+ * `mkdir`).
+ *
+ * TODO: This function should not be necessary after the inode migration, as most of the fields
+ * listed above will be removed.
+ */
+void reset_dentry(struct shim_dentry* dent);
 
 /*!
  * \brief Get the dentry one level up

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -149,8 +149,6 @@ static int chroot_lookup(struct shim_dentry* dent) {
 
     int ret;
 
-    lock(&dent->lock);
-
     /*
      * We don't know the file type yet, so we can't construct a PAL URI with the right prefix. Use
      * the file type from mount URI.
@@ -200,7 +198,6 @@ static int chroot_lookup(struct shim_dentry* dent) {
 
     ret = chroot_setup_dentry(dent, type, perm, size);
 out:
-    unlock(&dent->lock);
     free(uri);
     return ret;
 }

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -529,17 +529,14 @@ static int chroot_rename(struct shim_dentry* old, struct shim_dentry* new) {
         goto out;
     }
 
-    struct shim_inode* inode = new->inode;
-    if (inode) {
-        new->inode = NULL;
-        put_inode(inode);
-    }
+    reset_dentry(new);
 
     /* No need to adjust refcount of `old->inode`: we add a reference from `new` and remove the one
      * from `old`. */
     new->inode = old->inode;
     new->type = old->type;
     new->perm = old->perm;
+    new->state |= DENTRY_VALID;
 
     old->inode = NULL;
     ret = 0;

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -171,6 +171,23 @@ void dentry_gc(struct shim_dentry* dent) {
     put_dentry(dent);
 }
 
+void reset_dentry(struct shim_dentry* dent) {
+    assert(locked(&g_dcache_lock));
+
+    dent->state = 0;
+    dent->fs = dent->mount ? dent->mount->fs : NULL;
+    dent->type = 0;
+    dent->perm = 0;
+
+    /* XXX: This leaks `data` (same as `free_dentry`), but we're in the process of removing it. */
+    dent->data = NULL;
+
+    if (dent->inode) {
+        put_inode(dent->inode);
+        dent->inode = NULL;
+    }
+}
+
 struct shim_dentry* get_new_dentry(struct shim_mount* mount, struct shim_dentry* parent,
                                    const char* name, size_t name_len) {
     assert(locked(&g_dcache_lock));

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -564,10 +564,7 @@ BEGIN_CP_FUNC(dentry) {
         /* we don't checkpoint children dentries, so need to list directory again */
         new_dent->state &= ~DENTRY_LISTED;
 
-        if (new_dent->type != S_IFIFO) {
-            /* not FIFO, no need to keep data (FIFOs stash internal FDs into data field) */
-            new_dent->data = NULL;
-        }
+        new_dent->data = NULL;
 
         /* `fs_lock` is used only by process leader. */
         new_dent->fs_lock = NULL;

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -2,7 +2,7 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * This file contains code for implementation of 'socket' filesystem.
+ * This file contains code for implementation of the `socket` filesystem.
  */
 
 #include <asm/fcntl.h>
@@ -15,6 +15,23 @@
 #include "shim_process.h"
 #include "shim_signal.h"
 #include "stat.h"
+
+int unix_socket_setup_dentry(struct shim_dentry* dent, mode_t perm) {
+    assert(locked(&g_dcache_lock));
+    assert(!dent->inode);
+
+    struct shim_inode* inode = get_new_inode(dent->mount, S_IFSOCK, perm);
+    if (!inode)
+        return -ENOMEM;
+
+    dent->fs = &socket_builtin_fs;
+    inode->fs = &socket_builtin_fs;
+
+    dent->type = S_IFSOCK;
+    dent->perm = perm;
+    dent->inode = inode;
+    return 0;
+}
 
 static int socket_close(struct shim_handle* hdl) {
     /* XXX: Shouldn't this do something? */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR converts the remaining filesystems to inodes. I finally got rid of the ugly stash-FDs-in-pointer hack. In fact, we're already able to remove `data` and `lock` fields from dentry.

The next step will be to drastically simplify the dentry object, and replace most uses with inode.

## How to test this PR? <!-- (if applicable) -->

Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/414)
<!-- Reviewable:end -->
