### PR TITLE
[LibOS/Pal] pass timeout value with correct type `struct timeval` to `setsockopt` syscall

### DIFF
--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -416,7 +416,7 @@ typedef struct _PAL_STREAM_ATTR {
         struct {
             PAL_NUM linger;
             PAL_NUM receivebuf, sendbuf;
-            PAL_NUM receivetimeout, sendtimeout;
+            uint64_t receivetimeout_us, sendtimeout_us;
             bool tcp_cork;
             bool tcp_keepalive;
             bool tcp_nodelay;

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -121,7 +121,7 @@ struct cmsghdr {
 
 struct sockopt {
     int receivebuf, sendbuf;
-    int receivetimeout, sendtimeout;
+    uint64_t receivetimeout_us, sendtimeout_us;
     int linger;
     int reuseaddr : 1;
     int tcp_cork : 1;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -105,8 +105,8 @@ typedef struct {
             PAL_NUM linger;
             PAL_NUM receivebuf;
             PAL_NUM sendbuf;
-            PAL_NUM receivetimeout;
-            PAL_NUM sendtimeout;
+            uint64_t receivetimeout_us;
+            uint64_t sendtimeout_us;
             bool tcp_cork;
             bool tcp_keepalive;
             bool tcp_nodelay;

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -84,8 +84,8 @@ typedef struct {
             PAL_NUM linger;
             PAL_NUM receivebuf;
             PAL_NUM sendbuf;
-            PAL_NUM receivetimeout;
-            PAL_NUM sendtimeout;
+            uint64_t receivetimeout_us;
+            uint64_t sendtimeout_us;
             bool tcp_cork;
             bool tcp_keepalive;
             bool tcp_nodelay;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
`setsockopt` syscall fails with socket options `SO_RCVTIMEO` and `SO_SNDTIMEO`. Argument for socket options `SO_RCVTIMEO` and `SO_SNDTIMEO` is a `struct timeval` but `int` type was used which causes the `setsockopt` syscall failure.

Changing the argument type to `struct timeval` from `int` with these socket options fixes the issue.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Fixes #341

## How to test this PR? <!-- (if applicable) -->
Added regression test in `gramine/LibOS/shim/test/regression/tcp_ipv6_v6only.c`
execute the test `tcp_ipv6_v6only` to verify the fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/415)
<!-- Reviewable:end -->
