### PR TITLE
Convert manifests to new mount format

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -13,21 +13,12 @@ loader.env.PATH = "{{ execdir }}"
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib64.type = "chroot"
-fs.mount.lib64.path = "{{ arch_libdir }}"
-fs.mount.lib64.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr_lib.type = "chroot"
-fs.mount.usr_lib.path = "/usr/lib"
-fs.mount.usr_lib.uri = "file:/usr/lib"
-
-fs.mount.bin.type = "chroot"
-fs.mount.bin.path = "{{ execdir }}"
-fs.mount.bin.uri = "file:{{ execdir }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/lib", uri = "file:/usr/lib" },
+  { path = "{{ execdir }}", uri = "file:{{ execdir }}" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -13,29 +13,14 @@ loader.env.PWD = ""
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/gramine_lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.blender_lib.type = "chroot"
-fs.mount.blender_lib.path = "/blender_lib"
-fs.mount.blender_lib.uri = "file:{{ blender_dir }}/lib"
-
-fs.mount.usr_lib.type = "chroot"
-fs.mount.usr_lib.path = "/usr/{{ arch_libdir }}"
-fs.mount.usr_lib.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "{{ arch_libdir }}"
-fs.mount.lib.uri = "file:{{ arch_libdir }}"
-
-fs.mount.scenes.type = "chroot"
-fs.mount.scenes.path = "/data"
-fs.mount.scenes.uri = "file:{{ data_dir }}"
-
-fs.mount.blender.type = "chroot"
-fs.mount.blender.path = "/blender"
-fs.mount.blender.uri = "file:{{ blender_dir }}"
+fs.mounts = [
+  { path = "/gramine_lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/blender_lib", uri = "file:{{ blender_dir }}/lib" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/data", uri = "file:{{ data_dir }}" },
+  { path = "/blender", uri = "file:{{ blender_dir }}" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -16,17 +16,11 @@ loader.env.HOSTNAME = "test"
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib1.type = "chroot"
-fs.mount.lib1.path = "/lib"
-fs.mount.lib1.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -9,9 +9,9 @@ loader.argv0_override = "helloworld"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -13,25 +13,14 @@ loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr", uri = "file:/usr" },
+  { path = "{{ install_dir_abspath }}", uri = "file:{{ install_dir }}" },
 
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.cwd.type = "chroot"
-fs.mount.cwd.path = "{{ install_dir_abspath }}"
-fs.mount.cwd.uri = "file:{{ install_dir }}"
-
-fs.mount.var_tmp.type = "tmpfs"
-fs.mount.var_tmp.path = "/var/tmp"
-fs.mount.var_tmp.uri = "file:dummy-unused-by-tmpfs-uri"
+  { type = "tmpfs", path = "/var/tmp" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -13,21 +13,12 @@ loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr/{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -13,29 +13,14 @@ loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
-
-fs.mount.lib4.type = "chroot"
-fs.mount.lib4.path = "/usr/local/lib"
-fs.mount.lib4.uri = "file:/usr/local/lib"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
-
-fs.mount.cwd.type = "chroot"
-fs.mount.cwd.path = "{{ install_dir_abspath }}"
-fs.mount.cwd.uri = "file:{{ install_dir }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "/usr/local/lib", uri = "file:/usr/local/lib" },
+  { path = "/etc", uri = "file:/etc" },
+  { path = "{{ install_dir_abspath }}", uri = "file:{{ install_dir }}" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -13,33 +13,15 @@ loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.pyhome.type = "chroot"
-fs.mount.pyhome.path = "{{ python.stdlib }}"
-fs.mount.pyhome.uri = "file:{{ python.stdlib }}"
-
-fs.mount.pydisthome.type = "chroot"
-fs.mount.pydisthome.path = "{{ python.distlib }}"
-fs.mount.pydisthome.uri = "file:{{ python.distlib }}"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr", uri = "file:/usr" },
+  { path = "{{ python.stdlib }}", uri = "file:{{ python.stdlib }}" },
+  { path = "{{ python.distlib }}", uri = "file:{{ python.distlib }}" },
+  { path = "/tmp", uri = "file:/tmp" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.nonpie_binary = true

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -19,8 +19,9 @@ fs.mounts = [
   { path = "/usr", uri = "file:/usr" },
   { path = "{{ python.stdlib }}", uri = "file:{{ python.stdlib }}" },
   { path = "{{ python.distlib }}", uri = "file:{{ python.distlib }}" },
-  { path = "/tmp", uri = "file:/tmp" },
   { path = "/etc", uri = "file:/etc" },
+
+  { type = "tmpfs", path = "/tmp" },
 ]
 
 sgx.debug = true
@@ -51,5 +52,4 @@ sgx.allowed_files = [
   "file:/etc/gai.conf",
   "file:/etc/host.conf",
   "file:/etc/resolv.conf",
-  "file:/tmp",
 ]

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -14,21 +14,12 @@ loader.env.LC_ALL = "C"
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.remote_attestation = true

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -13,21 +13,12 @@ loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.remote_attestation = true

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -11,21 +11,12 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.remote_attestation = true

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -15,21 +15,12 @@ loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdumm
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.remote_attestation = true

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -16,21 +16,12 @@ loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdumm
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "/etc", uri = "file:/etc" },
+]
 
 sgx.debug = true
 sgx.remote_attestation = true

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -28,7 +28,7 @@ loader.insecure__use_cmdline_argv = true
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Gramine visible paths, not host-OS paths (i.e.,
-# paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).
+# paths must be taken from fs.mounts[...].path, not fs.mounts[...].uri).
 #
 # In case of Redis:
 # - /lib is searched for Glibc libraries (ld, libc, libpthread)
@@ -49,27 +49,21 @@ sys.enable_sigterm_injection = true
 # - In-Gramine visible path names may be arbitrary but we reuse host-OS URIs
 #   for simplicity (except for the first 'lib' case).
 
-# Mount host-OS directory to Gramine glibc/runtime libraries (in 'uri') into
-# in-Gramine visible directory /lib (in 'path').
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+fs.mounts = [
+  # Mount host-OS directory to Gramine glibc/runtime libraries (in 'uri') into
+  # in-Gramine visible directory /lib (in 'path').
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
 
-# Mount host-OS directory to Name Service Switch (NSS) libraries (in 'uri')
-# into in-Gramine visible directory /lib/x86_64-linux-gnu (in 'path').
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+  # Mount host-OS directory to Name Service Switch (NSS) libraries (in 'uri')
+  # into in-Gramine visible directory /lib/x86_64-linux-gnu (in 'path').
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
 
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr/{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
 
-# Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
-# into in-Gramine visible directory /etc (in 'path').
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
+  # Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
+  # into in-Gramine visible directory /etc (in 'path').
+  { path = "/etc", uri = "file:/etc" },
+]
 
 ############################### SGX: GENERAL ##################################
 

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -14,17 +14,11 @@ loader.env.PATH = "{{ execdir }}"
 # Set HOME to suppress "warning: cannot find home directory; cannot read ~/.sqliterc"
 loader.env.HOME = "/"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib64.type = "chroot"
-fs.mount.lib64.path = "{{ arch_libdir }}"
-fs.mount.lib64.uri = "file:{{ arch_libdir }}"
-
-fs.mount.sqlite3.type = "chroot"
-fs.mount.sqlite3.path = "{{ execdir }}/sqlite3"
-fs.mount.sqlite3.uri = "file:{{ execdir }}/sqlite3"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "{{ execdir }}/sqlite3", uri = "file:{{ execdir }}/sqlite3" },
+]
 
 sgx.debug = true
 sgx.enclave_size = "256M"

--- a/Documentation/devel/onboarding.rst
+++ b/Documentation/devel/onboarding.rst
@@ -269,11 +269,11 @@ fine on native Linux but fails under Gramine::
      ``loader.insecure__disable_aslr = true``. But don't use the last two
      options in production; use them only for debugging and analysis!
 
-   - Analyze FS mount points (``fs.mount`` fields) in the manifest file
-     carefully. Check for duplicate mount points -- remember that a duplicate
-     mount point's path *shadows* the previous mount point's path (i.e., if you
-     have ``fs.mount.libs.path = "/lib"`` and then ``fs.mount.more_libs.path =
-     "/lib"``, then files from the former path will disappear inside Gramine).
+   - Analyze FS mount points (``fs.mounts``) in the manifest file carefully.
+     Check for duplicate mount points -- remember that a duplicate mount point's
+     path *shadows* the previous mount point's path (i.e., if you have two
+     mounts with ``path = "/lib"``, then files from the former mount will
+     disappear inside Gramine).
 
    - Collect the strace (system call trace) log on the original (native)
      application, e.g.::

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -99,7 +99,7 @@ at that path. For example::
 
    libos.entrypoint = "/usr/bin/python3.8"
 
-   fs.mount = [
+   fs.mounts = [
      { path = "/usr/bin/python3.8", uri = "file:/usr/bin/python3.8" },
      # Or, if using a binary from your local directory:
      # { path = "/usr/bin/python3.8", uri = "file:python3.8" },
@@ -339,7 +339,7 @@ FS mount points
 
 ::
 
-    fs.mount = [
+    fs.mounts = [
       { type = "[chroot|...]", path = "[PATH]", uri = "[URI]" },
       { type = "[chroot|...]", path = "[PATH]", uri = "[URI]" },
     ]
@@ -348,12 +348,12 @@ Or, as separate sections:
 
 ::
 
-    [[fs.mount]]
+    [[fs.mounts]]
     type = "[chroot|...]"
     path = "[PATH]"
     uri  = "[URI]"
 
-    [[fs.mount]]
+    [[fs.mounts]]
     type = "[chroot|...]"
     path = "[PATH]"
     uri  = "[URI]"
@@ -881,4 +881,4 @@ FS mount points (deprecated syntax)
    fs.mount.[identifier].uri  = "[URI]"
 
 This syntax used a TOML table schema with keys for each mount. It has been
-replaced with a TOML array.
+replaced with the ``fs.mounts`` TOML array.

--- a/Documentation/manpages/gramine-manifest.rst
+++ b/Documentation/manpages/gramine-manifest.rst
@@ -91,10 +91,9 @@ Example
    libos.entrypoint = "{{ entrypoint }}"
    loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
-   [fs.mount.runtime]
-   type = "chroot"
-   path = "/lib"
-   uri = "file:{{ gramine.runtimedir() }}"
+   fs.mounts = [
+     { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+   ]
 
    sgx.trusted_files = [
      "file:{{ entrypoint }}",

--- a/Documentation/tutorials/pytorch/index.rst
+++ b/Documentation/tutorials/pytorch/index.rst
@@ -203,9 +203,10 @@ We mount the entire glibc host-level directory to the ``/lib`` directory seen
 inside Gramine. This trick allows to transparently replace standard C libraries
 with Gramine-patched libraries::
 
-   fs.mount.lib.type = "chroot"
-   fs.mount.lib.path = "/lib"
-   fs.mount.lib.uri  = "file:{{ gramine.runtime() }}/"
+   fs.mounts = [
+     { path = "/lib", uri = "file:{{ gramine.runtime() }}/" },
+     ...
+   ]
 
 We also mount other directories such as ``/usr``,  ``/etc``, and ``/tmp``
 required by Python and PyTorch (they search for libraries and utility files in
@@ -213,9 +214,10 @@ these system directories).
 
 Finally, we mount the path containing the Python packages installed via pip::
 
-   fs.mount.pip.type = "chroot"
-   fs.mount.pip.path = "{{ env.HOME }}/.local/lib"
-   fs.mount.pip.uri  = "file:{{ env.HOME }}/.local/lib"
+   fs.mounts = [
+     ...
+     { path = "{{ env.HOME }}/.local/lib", uri = "file:{{ env.HOME }}/.local/lib" },
+   ]
 
 Now we can run ``make`` to build/copy all required Gramine files::
 

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -4,29 +4,15 @@ libos.entrypoint = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir() }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/mounted", uri = "file:tmp" },
 
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
-
-fs.mount.host_lib.type = "chroot"
-fs.mount.host_lib.path = "{{ arch_libdir }}"
-fs.mount.host_lib.uri = "file:{{ arch_libdir }}"
-
-fs.mount.host_usr_lib.type = "chroot"
-fs.mount.host_usr_lib.path = "/usr/{{ arch_libdir }}"
-fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.output.type = "chroot"
-fs.mount.output.path = "/mounted"
-fs.mount.output.uri = "file:tmp"
-
-fs.mount.tmpfs.type = "tmpfs"
-fs.mount.tmpfs.path = "/mnt-tmpfs"
-fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
+  { type = "tmpfs", path = "/mnt-tmpfs" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -11,7 +11,6 @@ fs.root.uri = "file:{{ binary_dir }}"
 
 fs.mounts = [
   { path = "/etc", uri = "file:/etc" },
-  { path = "/dev/shm", uri = "file:/tmp" },
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr", uri = "file:/usr" },

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -7,32 +7,16 @@ loader.env.LD_PRELOAD = "{{ coreutils_libdir }}/libstdbuf.so"
 loader.env._STDBUF_O = "L"
 loader.insecure__use_cmdline_argv = true
 
-fs.root.type = "chroot"
 fs.root.uri = "file:{{ binary_dir }}"
 
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "etc"
-fs.mount.etc.uri = "file:/etc"
-
-fs.mount.shm.type = "chroot"
-fs.mount.shm.path = "/dev/shm"
-fs.mount.shm.uri = "file:/tmp"
-
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib64.type = "chroot"
-fs.mount.lib64.path = "{{ arch_libdir }}"
-fs.mount.lib64.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
+fs.mounts = [
+  { path = "/etc", uri = "file:/etc" },
+  { path = "/dev/shm", uri = "file:/tmp" },
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr", uri = "file:/usr" },
+  { path = "/tmp", uri = "file:/tmp" },
+]
 
 fs.experimental__enable_sysfs_topology = true
 sys.brk.max_size = "32M"

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -7,13 +7,10 @@ loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.argv_src_file = "file:argv_test_input"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -5,6 +5,9 @@ loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 
+# Keep the deprecated `fs.mount` syntax for test purposes
+# TODO: this syntax is deprecated in v1.2 and will be removed two versions after it.
+
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"

--- a/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
+++ b/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
@@ -7,21 +7,12 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 # Preload libunwind so that it has precedence over libstdc++ when resolving stack-unwinding routines
 loader.env.LD_PRELOAD = "libunwind.so.8"
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
-
-fs.mount.host_lib.type = "chroot"
-fs.mount.host_lib.path = "{{ arch_libdir }}"
-fs.mount.host_lib.uri = "file:{{ arch_libdir }}"
-
-fs.mount.host_usr_lib.type = "chroot"
-fs.mount.host_usr_lib.path = "/usr/{{ arch_libdir }}"
-fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+]
 
 sgx.thread_num = 8
 sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/debug_log_file.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_file.manifest.template
@@ -9,13 +9,10 @@ loader.env.LD_LIBRARY_PATH = "/lib"
 loader.log_level = "debug"
 loader.log_file = "tmp/debug_log_file.log"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/debug_log_inline.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest.template
@@ -8,13 +8,10 @@ loader.env.LD_LIBRARY_PATH = "/lib"
 
 loader.log_level = "debug"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/device_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/device_passthrough.manifest.template
@@ -8,17 +8,11 @@ loader.env.LD_LIBRARY_PATH = "/lib"
 # feature has any test coverage
 libos.check_invalid_pointers = false
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
-
-fs.mount.dev.type = "chroot"
-fs.mount.dev.path = "/dev/host-zero"
-fs.mount.dev.uri = "dev:/dev/zero"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "/dev/host-zero", uri = "dev:/dev/zero" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -7,13 +7,10 @@ loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.env_src_file = "file:env_test_input"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -7,13 +7,10 @@ loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_host_env = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/env_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/env_passthrough.manifest.template
@@ -12,13 +12,10 @@ loader.env.B = { value = "OVERWRITTEN_VALUE" }
 # loader.env.C = { passthrough = false }  # not allowed for security reasons
 # loader.env.E = { passthrough = true, value = "THIS_IS_INCORRECT_SYNTAX" }
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -9,13 +9,10 @@ loader.insecure__use_cmdline_argv = true
 
 loader.log_level = "warning"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -9,13 +9,10 @@ loader.insecure__use_cmdline_argv = true
 
 loader.log_level = "warning"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -4,18 +4,13 @@ libos.entrypoint = "{{ binary_dir }}/{{ entrypoint }}"
 loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.root.type = "chroot"
-fs.root.path = "/"
 fs.root.uri = "file:/"
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-# overwrite host "/etc" - we don't want host-level configuration files, e.g. dynamic loader caches
-fs.mount.disable_etc.type = "tmpfs"
-fs.mount.disable_etc.path = "/etc"
-fs.mount.disable_etc.uri = "file:unused"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  # overwrite host "/etc" - we don't want host-level configuration files, e.g. dynamic loader caches
+  { type = "tmpfs", path = "/etc" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -4,18 +4,12 @@ libos.entrypoint = "{{ entrypoint }}"
 loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
-
-# purposefully force mount failure to cause early shim abort
-fs.mount.test.type = "chroot"
-fs.mount.test.path = "/test"
-fs.mount.test.uri = "file:I_DONT_EXIST"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  # purposefully force mount failure to cause early shim abort
+  { path = "/test", uri = "file:I_DONT_EXIST" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -6,13 +6,10 @@ libos.entrypoint = "{{ entrypoint }}"
 loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -8,13 +8,10 @@ loader.env.LD_LIBRARY_PATH = "/lib"
 # in an SGX enclave restricted to 8GB of virtual space if ASLR is enabled
 loader.insecure__disable_aslr = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.enclave_size = "8G"
 sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -8,7 +8,7 @@ loader.insecure__use_cmdline_argv = true
 # for eventfd test
 sys.insecure__allow_eventfd = true
 
-fs.mount = [
+fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
   { path = "/exec_victim", uri = "file:{{ binary_dir }}/exec_victim" },

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -4,13 +4,10 @@ libos.entrypoint = "{{ entrypoint }}"
 loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 # app runs with 4 parallel threads + Gramine has couple internal threads
 sgx.thread_num = 8

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -4,13 +4,10 @@ libos.entrypoint = "multi_pthread"
 loader.argv0_override = "multi_pthread"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "multi_pthread"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/multi_pthread"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/multi_pthread", uri = "file:{{ binary_dir }}/multi_pthread" },
+]
 
 # app runs with 4 parallel threads + Gramine has couple internal threads
 sgx.thread_num = 8

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -17,17 +17,11 @@ sgx.preheat_enclave = true
 # (by calling `sched_setaffinity` with NULL and expecting it to return either -EFAULT or -ENOSYS)
 # libos.check_invalid_pointers = false
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
-
-fs.mount.host_usr_lib.type = "chroot"
-fs.mount.host_usr_lib.path = "/usr/{{ arch_libdir }}"
-fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+]
 
 sgx.thread_num = 32
 sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/sysfs_common.manifest.template
+++ b/LibOS/shim/test/regression/sysfs_common.manifest.template
@@ -4,13 +4,10 @@ libos.entrypoint = "{{ entrypoint }}"
 loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
-fs.mount.gramine_lib.type = "chroot"
-fs.mount.gramine_lib.path = "/lib"
-fs.mount.gramine_lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 fs.experimental__enable_sysfs_topology = true
 

--- a/LibOS/shim/test/regression/uid_gid.manifest.template
+++ b/LibOS/shim/test/regression/uid_gid.manifest.template
@@ -7,13 +7,10 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.uid = 1338
 loader.gid = 1337
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
-
-fs.mount.entrypoint.type = "chroot"
-fs.mount.entrypoint.path = "{{ entrypoint }}"
-fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/Pal/regression/Bootstrap6.manifest.template
+++ b/Pal/regression/Bootstrap6.manifest.template
@@ -4,8 +4,6 @@ loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
 loader.argv0_override = "{{ entrypoint }}"
 
-fs.mount.root.uri = "file:"
-
 sgx.enclave_size = "8192M"
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -2,8 +2,6 @@ loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.argv0_override = "{{ entrypoint }}"
 loader.log_level = "debug"
 
-fs.mount.root.uri = "file:"
-
 sgx.nonpie_binary = true
 sgx.debug = true
 

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -8,8 +8,6 @@ sgx.debug = true
 # part of the Gramine memory
 loader.pal_internal_mem_size = "64M"
 
-fs.mount.root.uri = "file:"
-
 sgx.nonpie_binary = true # all tests are currently non-PIE unless overridden
 
 sgx.allowed_files = [

--- a/common/include/toml_utils.h
+++ b/common/include/toml_utils.h
@@ -46,7 +46,7 @@ int toml_int_in(const toml_table_t* root, const char* key, int64_t defaultval, i
  * \brief Find a string key-value in TOML manifest.
  *
  * \param root      Root table of the TOML manifest.
- * \param key       Dotted key (e.g. "fs.mount.lib1.type").
+ * \param key       Dotted key (e.g. "fs.root.uri").
  * \param retval    Pointer to output string.
  *
  * Returns 0 if there were no errors (but value may have not been found in manifest and was set to

--- a/common/src/string/toml_utils.c
+++ b/common/src/string/toml_utils.c
@@ -19,8 +19,8 @@ static char* find_next_char(char* s, char ch) {
     return s;
 }
 
-/* Searches for a dotted-key (e.g. "fs.mount.lib1.type") from `root`; returns NULL if value for
- * such key is not found. Double quotes are respected, same as in TOML. */
+/* Searches for a dotted-key (e.g. "fs.root.uri") from `root`; returns NULL if value for such key is
+ * not found. Double quotes are respected, same as in TOML. */
 static toml_raw_t toml_raw_in_dottedkey(const toml_table_t* root, const char* _key) {
     char* key = strdup(_key);
     if (!key)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Follow-up to #411. Converts remaining manifests and documentation.

For the manifests, I used editor automation (regexp replace + a macro), but some manual adjustments were also necessary.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Read it carefully.

Here are some checks I did to find what to convert:
* `git grep 'fs\.mount\.'` - old table syntax
* `git grep 'path = "[^/]'` - non-absolute paths (but also shows paths with variables like `"{{ arch_libdir }}/..."`)
* `git grep 'type = "chroot"'` - should not be necessary anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/417)
<!-- Reviewable:end -->
