### PR TITLE
[Pal,LibOS] Add arch_prctl XSTATE component permission options for AMX

### DIFF
--- a/LibOS/shim/src/arch/x86_64/shim_arch_prctl.c
+++ b/LibOS/shim/src/arch/x86_64/shim_arch_prctl.c
@@ -12,6 +12,20 @@
 #include "shim_table.h"
 #include "shim_tcb.h"
 
+/* To support AMX in linux kernel v5.16, prctl add XSTATE components permission
+ * control APIs, refer:
+ * https://elixir.bootlin.com/linux/v5.16/source/arch/x86/include/uapi/asm/prctl.h
+ */
+#if !defined(ARCH_GET_XCOMP_SUPP)
+#define ARCH_GET_XCOMP_SUPP	0x1021
+#endif
+#if !defined(ARCH_GET_XCOMP_PERM)
+#define ARCH_GET_XCOMP_PERM	0x1022
+#endif
+#if !defined(ARCH_REQ_XCOMP_PERM)
+#define ARCH_REQ_XCOMP_PERM	0x1023
+#endif
+
 long shim_do_arch_prctl(int code, unsigned long addr) {
     switch (code) {
         case ARCH_SET_FS:
@@ -20,6 +34,12 @@ long shim_do_arch_prctl(int code, unsigned long addr) {
 
         case ARCH_GET_FS:
             return pal_to_unix_errno(DkSegmentBaseGet(PAL_SEGMENT_FS, (unsigned long*)addr));
+
+        case ARCH_GET_XCOMP_SUPP:
+        case ARCH_GET_XCOMP_PERM:
+            return pal_to_unix_errno(DkXCompPerm(code, (unsigned long*)addr));
+        case ARCH_REQ_XCOMP_PERM:
+            return pal_to_unix_errno(DkXCompPerm(code, &addr));
 
         default:
             log_warning("Not supported flag (0x%x) passed to arch_prctl", code);

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -695,6 +695,17 @@ int DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr);
 int DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr);
 
 /*!
+ * \brief Get/Request XSTATE components permission
+ *
+ * \param[in] code the option of get/requst permission
+ * \param[in,out] addr the bit number in XFD as input 
+ *                     or a filled value with the permssion as output
+ *
+ * \return 0 on success, negative error value on failure
+ */
+int DkXCompPerm(int code, unsigned long* addr);
+
+/*!
  * \brief Return the amount of currently available memory for LibOS/application
  * usage.
  */

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -226,6 +226,7 @@ int _DkRandomBitsRead(void* buffer, size_t size);
 double _DkGetBogomips(void);
 int _DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr);
 int _DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr);
+int _DkXCompPerm(int code, unsigned long* addr);
 int _DkCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[4]);
 int _DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
                          void* target_info, PAL_NUM* target_info_size, void* report,

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -24,6 +24,10 @@ int DkSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr) {
 int DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
     return _DkSegmentBaseSet(reg, addr);
 }
+
+int DkXCompPerm(int code, unsigned long* addr) {
+    return _DkXCompPerm(code, addr);
+}
 #endif
 
 PAL_NUM DkMemoryAvailableQuota(void) {

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -719,3 +719,9 @@ int _DkSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
             return -PAL_ERROR_INVAL;
     }
 }
+
+int _DkXCompPerm(int code, unsigned long* addr) {
+    int ret = ocall_xcomp_perm(code, addr);
+
+    return ret;
+}

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -112,3 +112,5 @@ int ocall_eventfd(int flags);
  */
 int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
                     const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len);
+
+int ocall_xcomp_perm(int code, unsigned long* addr);

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -66,6 +66,7 @@ enum {
     OCALL_DEBUG_DESCRIBE_LOCATION,
     OCALL_EVENTFD,
     OCALL_GET_QUOTE,
+    OCALL_XCOMP_PERM,
     OCALL_NR,
 };
 
@@ -300,6 +301,11 @@ typedef struct {
     char*             ms_quote;
     size_t            ms_quote_len;
 } ms_ocall_get_quote_t;
+
+typedef struct {
+    int code;
+    unsigned long addr;
+} ms_ocall_xcomp_perm_t;
 
 #pragma pack(pop)
 

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -46,6 +46,12 @@ extern struct pal_linuxsgx_state {
     PAL_PTR heap_min, heap_max;
 } g_pal_linuxsgx_state;
 
+enum cpu_extension {
+    X87, SSE, AVX, MPX_BNDREGS, MPX_BNDCSR, AVX512_OPMASK, AVX512_ZMM256, AVX512_ZMM512,
+    PKRU = 9,
+    AMX_TILECFG = 17, AMX_TILEDATA,
+    LAST_CPU_EXTENSION,
+};
 
 #define ACCESS_R 4
 #define ACCESS_W 2
@@ -76,13 +82,6 @@ extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_END   ((void*)(&__text_end))
 #define DATA_START ((void*)(&__data_start))
 #define DATA_END   ((void*)(&__data_end))
-
-enum cpu_extension {
-    X87, SSE, AVX, MPX_BNDREGS, MPX_BNDCSR, AVX512_OPMASK, AVX512_ZMM256, AVX512_ZMM512,
-    PKRU = 9,
-    AMX_TILECFG = 17, AMX_TILEDATA,
-    LAST_CPU_EXTENSION,
-};
 
 extern const uint32_t g_cpu_extension_sizes[];
 extern const uint32_t g_cpu_extension_offsets[];

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -30,6 +30,10 @@
     do {                 \
     } while (0)
 
+#if !defined(ARCH_REQ_XCOMP_PERM)
+#define ARCH_REQ_XCOMP_PERM	0x1023
+#endif
+
 static long sgx_ocall_exit(void* pms) {
     ms_ocall_exit_t* ms = (ms_ocall_exit_t*)pms;
     ODEBUG(OCALL_EXIT, NULL);
@@ -675,6 +679,19 @@ static long sgx_ocall_get_quote(void* pms) {
                           &ms->ms_nonce, &ms->ms_quote, &ms->ms_quote_len);
 }
 
+static long sgx_ocall_xcomp_perm(void* pms) {
+    ms_ocall_xcomp_perm_t* ms = (ms_ocall_xcomp_perm_t*)pms;
+    long ret;
+    ODEBUG(OCALL_XCOMP_PERM, ms);
+
+    if (ms->code == ARCH_REQ_XCOMP_PERM)
+        ret = DO_SYSCALL(arch_prctl, ms->code, ms->addr);
+    else
+        ret = DO_SYSCALL(arch_prctl, ms->code, &ms->addr);
+
+    return ret;
+}
+
 sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_EXIT]                     = sgx_ocall_exit,
     [OCALL_MMAP_UNTRUSTED]           = sgx_ocall_mmap_untrusted,
@@ -717,6 +734,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_DEBUG_DESCRIBE_LOCATION]  = sgx_ocall_debug_describe_location,
     [OCALL_EVENTFD]                  = sgx_ocall_eventfd,
     [OCALL_GET_QUOTE]                = sgx_ocall_get_quote,
+    [OCALL_XCOMP_PERM]               = sgx_ocall_xcomp_perm,
 };
 
 #define EDEBUG(code, ms) \

--- a/Pal/src/host/Linux/arch/x86_64/db_arch_misc.c
+++ b/Pal/src/host/Linux/arch/x86_64/db_arch_misc.c
@@ -38,3 +38,11 @@ int _DkCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) {
     cpuid(leaf, subleaf, values);
     return 0;
 }
+
+int _DkXCompPerm(int code, unsigned long* addr) {
+    int ret = DO_SYSCALL(arch_prctl, code, addr);
+    if (ret < 0)
+        return unix_to_pal_error(ret);
+
+    return ret;
+}

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -46,3 +46,4 @@ DkAttestationQuote
 DkSetProtectedFilesKey
 DkDebugLog
 DkGetPalPublicState
+DkXCompPerm


### PR DESCRIPTION
From linux kernel v5.16, Advanced Matrix Extensions (AMX) is in upstream with XFD handled permission control, expose the APIs and add the permission for XFD handling the #NM exception, refer 3.2.6 in
https://software.intel.com/content/dam/develop/external/us/en/documents-tps/architecture-instruction-set-extensions-programming-reference.pdf

Signed-off-by: Dong, Xiaocheng <xiaocheng.dong@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Expose more arch_prctl XSTATE component permission APIs for AMX
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Running AMX enabled workloads in a AMX enabled system

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/418)
<!-- Reviewable:end -->
