### PR TITLE
[LibOS] Move fully to inodes

### DIFF
--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -76,12 +76,9 @@ int fifo_setup_dentry(struct shim_dentry* dent, mode_t perm, int fd_read, int fd
     fifo_data->fd_read = fd_read;
     fifo_data->fd_write = fd_write;
 
-    dent->fs = &fifo_builtin_fs;
     inode->fs = &fifo_builtin_fs;
     inode->data = fifo_data;
 
-    dent->type = S_IFIFO;
-    dent->perm = perm;
     dent->inode = inode;
 
     return 0;

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -139,8 +139,6 @@ static int pseudo_open(struct shim_handle* hdl, struct shim_dentry* dent, int fl
             break;
         }
     }
-    hdl->inode = dent->inode;
-    get_inode(dent->inode);
 
     return 0;
 }
@@ -177,8 +175,6 @@ static int pseudo_lookup(struct shim_dentry* dent) {
 
     inode->data = node;
 
-    dent->type = type;
-    dent->perm = node->perm;
     dent->inode = inode;
     return 0;
 }

--- a/LibOS/shim/src/fs/shim_fs_synthetic.c
+++ b/LibOS/shim/src/fs/shim_fs_synthetic.c
@@ -22,15 +22,11 @@ int synthetic_setup_dentry(struct shim_dentry* dent, mode_t type, mode_t perm) {
     assert(locked(&g_dcache_lock));
     assert(!dent->inode);
 
-    dent->type = type;
-    dent->perm = perm;
-
     struct shim_inode* inode = get_new_inode(dent->mount, type, perm);
     if (!inode)
         return -ENOMEM;
     dent->inode = inode;
 
-    dent->fs = &synthetic_builtin_fs;
     inode->fs = &synthetic_builtin_fs;
 
     return 0;
@@ -39,11 +35,10 @@ int synthetic_setup_dentry(struct shim_dentry* dent, mode_t type, mode_t perm) {
 static int synthetic_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
     assert(locked(&g_dcache_lock));
     assert(dent->inode);
+    __UNUSED(dent);
     __UNUSED(flags);
 
     hdl->type = TYPE_SYNTHETIC;
-    hdl->inode = dent->inode;
-    get_inode(dent->inode);
     return 0;
 }
 

--- a/LibOS/shim/src/fs/shim_fs_util.c
+++ b/LibOS/shim/src/fs/shim_fs_util.c
@@ -40,11 +40,12 @@ int generic_seek(file_off_t pos, file_off_t size, file_off_t offset, int origin,
 
 int generic_readdir(struct shim_dentry* dent, readdir_callback_t callback, void* arg) {
     assert(locked(&g_dcache_lock));
-    assert(dent->type == S_IFDIR);
+    assert(dent->inode);
+    assert(dent->inode->type == S_IFDIR);
 
     struct shim_dentry* child;
     LISTP_FOR_EACH_ENTRY(child, &dent->children, siblings) {
-        if ((child->state & DENTRY_VALID) && !(child->state & DENTRY_NEGATIVE)) {
+        if (child->inode) {
             int ret = callback(child->name, arg);
             if (ret < 0)
                 return ret;

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -24,11 +24,8 @@ int unix_socket_setup_dentry(struct shim_dentry* dent, mode_t perm) {
     if (!inode)
         return -ENOMEM;
 
-    dent->fs = &socket_builtin_fs;
     inode->fs = &socket_builtin_fs;
 
-    dent->type = S_IFSOCK;
-    dent->perm = perm;
     dent->inode = inode;
     return 0;
 }

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -88,7 +88,7 @@ long shim_do_fchdir(int fd) {
 
     struct shim_dentry* dent = hdl->dentry;
 
-    if (dent->type != S_IFDIR) {
+    if (!dent->inode || dent->inode->type != S_IFDIR) {
         char* path = NULL;
         dentry_abs_path(dent, &path, /*size=*/NULL);
         log_debug("%s is not a directory", path);

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -369,7 +369,7 @@ static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getden
         goto out_no_unlock;
     }
 
-    if (hdl->dentry->state & DENTRY_NEGATIVE) {
+    if (!hdl->dentry->inode) {
         ret = -ENOENT;
         goto out_no_unlock;
     }
@@ -385,6 +385,8 @@ static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getden
     assert(hdl->pos >= 0);
     while ((size_t)hdl->pos < dirhdl->count) {
         struct shim_dentry* dent = dirhdl->dents[hdl->pos];
+        assert(dent->inode);
+
         const char* name;
         size_t name_len;
 
@@ -400,7 +402,7 @@ static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getden
         }
 
         uint64_t d_ino = dentry_ino(dent);
-        char d_type = get_dirent_type(dent->type);
+        char d_type = get_dirent_type(dent->inode->type);
 
         size_t ent_size;
 

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -306,7 +306,7 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
         goto out;
     }
 
-    if (!(dent->state & DENTRY_NEGATIVE)) {
+    if (dent->inode) {
         ret = -EEXIST;
         goto out;
     }
@@ -365,11 +365,9 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
     }
 
     /* set up the dentry for FIFO */
-    reset_dentry(dent);
     ret = fifo_setup_dentry(dent, mode & ~S_IFMT, vfd1, vfd2);
     if (ret < 0)
         goto out;
-    dent->state |= DENTRY_VALID;
 
     ret = 0;
 out:

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -456,11 +456,9 @@ static int get_unix_socket_dentry(const char* path, bool is_bind, struct shim_de
     if (ret < 0)
         goto out;
 
-    if (dent->state & DENTRY_NEGATIVE) {
+    if (!dent->inode) {
         /* No file exists, create one. */
-        reset_dentry(dent);
         ret = unix_socket_setup_dentry(dent, PERM_rw_______);
-        dent->state |= DENTRY_VALID;
     } else if (is_bind) {
         /* The file exists and we're inside `bind()`. We should fail. */
         ret = -EADDRINUSE;
@@ -468,7 +466,7 @@ static int get_unix_socket_dentry(const char* path, bool is_bind, struct shim_de
     } else {
         /* The file exists and we're inside `connect()`. We should fail if the file is not a
          * socket. */
-        if (dent->type != S_IFSOCK) {
+        if (dent->inode->type != S_IFSOCK) {
             ret = -ECONNREFUSED;
             goto out;
         }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This change removes the `state` dentry field, and uses the `inode` field directly: a dentry is either positive (with inode) or negative (without inode). Dentry fields describing the file (`type`, `perm`) are also gone.

As a consequence, negative lookups are no longer cached: a negative dentry only means that a file is not known to exist.

## How to test this PR? <!-- (if applicable) -->

Jenkins should be enough.

## What's next

Cleanup: using inode as a parameter should simplify the implementation of individual filesystems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/428)
<!-- Reviewable:end -->
