### PR TITLE
[Python] Change Python scripts' shebang to `/usr/bin/python3`

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -159,7 +159,16 @@ Conventions and high-level style
 Python
 ------
 
-.. todo:: TBD
+#. Executable Python scripts must use the shebang with the hardcoded path to
+   system Python (e.g., ``#!/usr/bin/python3``). This is required because custom
+   Python installations ("custom" meaning not provided by distro) lead to a
+   problem where packages installed via e.g. ``apt install`` are not available
+   to this custom Python. If Python scripts would use the ``#!/usr/bin/env
+   python3`` shebang, Gramine would not be able to locate system-wide-installed
+   Python packages.
+
+   Since Gramine currently supports only Debian/Ubuntu and CentOS/RHEL/Fedora
+   distros, the shebang must always be ``#!/usr/bin/python3``.
 
 Meson
 -----

--- a/LibOS/shim/test/fs/test_fs.py
+++ b/LibOS/shim/test/fs/test_fs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import filecmp
 import os
 import shutil

--- a/LibOS/shim/test/fs/test_pf.py
+++ b/LibOS/shim/test/fs/test_pf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import filecmp
 import os
 import shutil

--- a/LibOS/shim/test/fs/test_tmpfs.py
+++ b/LibOS/shim/test/fs/test_tmpfs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import unittest
 

--- a/LibOS/shim/test/ltp/test_ltp.py
+++ b/LibOS/shim/test/ltp/test_ltp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2019 Wojtek Porczyk <woju@invisiblethingslab.com>
 # Copyright (C) 2021 Intel Corporation

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import re
 import shutil

--- a/Pal/gdb_integration/debug_map_gdb.py
+++ b/Pal/gdb_integration/debug_map_gdb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2020 Intel Corporation
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import ast
 import collections
 import mmap

--- a/Pal/src/host/Linux/gdb_integration/gramine_linux_gdb.py
+++ b/Pal/src/host/Linux/gdb_integration/gramine_linux_gdb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2020 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>

--- a/python/gramine-gen-depend
+++ b/python/gramine-gen-depend
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-manifest
+++ b/python/gramine-manifest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-sgx-gen-private-key
+++ b/python/gramine-sgx-gen-private-key
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (c) 2021 Intel Corporation
 #                    Wojtek Porczyk <woju@invisiblethingslab.com>

--- a/python/gramine-sgx-get-token
+++ b/python/gramine-sgx-get-token
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-sgx-sign
+++ b/python/gramine-sgx-sign
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-test
+++ b/python/gramine-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>

--- a/python/graminelibos/sgx_get_token.py
+++ b/python/graminelibos/sgx_get_token.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2014 Stony Brook University
 # Copyright (C) 2022 Intel Corporation

--- a/python/graminelibos/sigstruct.py
+++ b/python/graminelibos/sigstruct.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/graminelibos/util_tests.py
+++ b/python/graminelibos/util_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine Python utilities should use the system-wide Python interpreter instead of the local version of Python (which may not have system-wide-installed Python packages). This was detected in GSC when running the default Python Ubuntu Docker image.

Corresponding GSC PR: https://github.com/gramineproject/gsc/pull/49

## How to test this PR? <!-- (if applicable) -->

Test GSC with our Python example: https://gramine.readthedocs.io/projects/gsc/en/latest/#example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/429)
<!-- Reviewable:end -->
