### PR TITLE
[Pal] Consolidate db_*.c for Pal/Linux and Pal/Linux-SGX

### DIFF
--- a/Pal/include/host/Linux-common/hostcall.h
+++ b/Pal/include/host/Linux-common/hostcall.h
@@ -1,0 +1,14 @@
+#ifndef HOSTCALL_H_
+#define HOSTCALL_H_
+
+#if defined(DB_LINUX)
+#include "syscall.h"
+
+#define HOSTCALL(name, args...) DO_SYSCALL(name, args)
+#elif defined(DB_LINUX_SGX)
+#include "enclave_ocalls.h"
+
+#define HOSTCALL(name, args...) ocall_##name(args)
+#endif
+
+#endif // HOSTCALL_H_

--- a/Pal/src/host/Linux-SGX/meson.build
+++ b/Pal/src/host/Linux-SGX/meson.build
@@ -17,6 +17,7 @@ sgx_inc = [
 cflags_pal_sgx = [
     cflags_pal_common,
     '-DHOST_TYPE=Linux-SGX',
+    '-DDB_LINUX_SGX',
     # Some of the code uses `alignof` on expressions, which is a GNU extension. Silence Clang - it
     # complains but does support it.
     '-Wno-gnu-alignof-expression',
@@ -53,7 +54,6 @@ pal_sgx_map = custom_target('pal.map',
 pal_sgx_lds = join_paths(meson.current_source_dir(), 'enclave.lds')
 
 libpal_sgx = shared_library('pal',
-    'db_devices.c',
     'db_eventfd.c',
     'db_events.c',
     'db_exception.c',
@@ -82,6 +82,7 @@ libpal_sgx = shared_library('pal',
     'protected-files/protected_files.c',
     pal_sgx_asm_offsets_h,
     pal_common_sources,
+    pal_linux_common_sources_db,
     pal_linux_common_sources_enclave,
     gsgx_h,
 

--- a/Pal/src/host/Linux-common/db_devices.c
+++ b/Pal/src/host/Linux-common/db_devices.c
@@ -11,11 +11,13 @@
  */
 
 #include "api.h"
+#include "hostcall.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "pal_flags_conv.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "perm.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum pal_access access,
@@ -54,10 +56,10 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         /* other devices must be opened through the host */
         hdl->dev.nonblocking = !!(options & PAL_OPTION_NONBLOCK);
 
-        ret = DO_SYSCALL(open, uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
-                                    PAL_CREATE_TO_LINUX_OPEN(create)  |
-                                    PAL_OPTION_TO_LINUX_OPEN(options),
-                         share);
+        ret = HOSTCALL(open, uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
+                PAL_CREATE_TO_LINUX_OPEN(create)  |
+                PAL_OPTION_TO_LINUX_OPEN(options),
+                share);
         if (ret < 0) {
             ret = unix_to_pal_error(ret);
             goto fail;
@@ -82,6 +84,12 @@ fail:
 }
 
 static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
+#if defined(DB_LINUX)
+    int64_t bytes;
+#elif defined(DB_LINUX_SGX)
+    ssize_t bytes;
+#endif
+
     if (offset || HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
@@ -91,11 +99,17 @@ static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void*
     if (handle->dev.fd == PAL_IDX_POISON)
         return -PAL_ERROR_DENIED;
 
-    int64_t bytes = DO_SYSCALL(read, handle->dev.fd, buffer, size);
+    bytes = HOSTCALL(read, handle->dev.fd, buffer, size);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 
 static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
+#if defined(DB_LINUX)
+    int64_t bytes;
+#elif defined(DB_LINUX_SGX)
+    ssize_t bytes;
+#endif
+
     if (offset || HANDLE_HDR(handle)->type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
@@ -105,7 +119,7 @@ static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, cons
     if (handle->dev.fd == PAL_IDX_POISON)
         return -PAL_ERROR_DENIED;
 
-    int64_t bytes = DO_SYSCALL(write, handle->dev.fd, buffer, size);
+    bytes = HOSTCALL(write, handle->dev.fd, buffer, size);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 
@@ -116,7 +130,7 @@ static int dev_close(PAL_HANDLE handle) {
     /* currently we just assign `0`/`1` FDs without duplicating, so close is a no-op for them */
     int ret = 0;
     if (handle->dev.fd != PAL_IDX_POISON && handle->dev.fd != 0 && handle->dev.fd != 1) {
-        ret = DO_SYSCALL(close, handle->dev.fd);
+        ret = HOSTCALL(close, handle->dev.fd);
     }
     handle->dev.fd = PAL_IDX_POISON;
     return ret < 0 ? unix_to_pal_error(ret) : 0;
@@ -127,7 +141,7 @@ static int dev_flush(PAL_HANDLE handle) {
         return -PAL_ERROR_INVAL;
 
     if (handle->dev.fd != PAL_IDX_POISON) {
-        int ret = DO_SYSCALL(fsync, handle->dev.fd);
+        int ret = HOSTCALL(fsync, handle->dev.fd);
         if (ret < 0)
             return unix_to_pal_error(ret);
     }
@@ -150,9 +164,23 @@ static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* att
     } else {
         /* other devices must query the host */
         struct stat stat_buf;
-        int ret = DO_SYSCALL(stat, uri, &stat_buf);
+#if defined(DB_LINUX)
+        int ret = HOSTCALL(stat, uri, &stat_buf);
         if (ret < 0)
             return unix_to_pal_error(ret);
+#elif defined(DB_LINUX_SGX)
+        int fd = ocall_open(uri, 0, 0);
+        if (fd < 0)
+            return unix_to_pal_error(fd);
+
+        int ret = HOSTCALL(fstat, fd, &stat_buf);
+        if (ret < 0) {
+            ocall_close(fd);
+            return unix_to_pal_error(ret);
+        }
+
+        ocall_close(fd);
+#endif
 
         attr->readable     = stataccess(&stat_buf, ACCESS_R);
         attr->writable     = stataccess(&stat_buf, ACCESS_W);
@@ -180,7 +208,7 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     } else {
         /* other devices must query the host */
         struct stat stat_buf;
-        int ret = DO_SYSCALL(fstat, handle->dev.fd, &stat_buf);
+        int ret = HOSTCALL(fstat, handle->dev.fd, &stat_buf);
         if (ret < 0)
             return unix_to_pal_error(ret);
 

--- a/Pal/src/host/Linux-common/meson.build
+++ b/Pal/src/host/Linux-common/meson.build
@@ -18,7 +18,12 @@ foreach src : pal_linux_common_sources_urts_arch
     pal_linux_common_sources_urts += files(join_paths('arch', host_machine.cpu_family(), src))
 endforeach
 
+pal_linux_common_sources_db = files(
+    'db_devices.c',
+)
+
 pal_linux_common_sources = [
+    pal_linux_common_sources_db,
     pal_linux_common_sources_enclave,
     pal_linux_common_sources_urts,
 ]

--- a/Pal/src/host/Linux/meson.build
+++ b/Pal/src/host/Linux/meson.build
@@ -1,5 +1,4 @@
 pal_direct_sources = files(
-    'db_devices.c',
     'db_eventfd.c',
     'db_events.c',
     'db_exception.c',
@@ -52,6 +51,7 @@ libpal_direct = shared_library('pal',
         cflags_sanitizers,
         cflags_custom_stack_protector,
         '-DHOST_TYPE=Linux',
+        '-DDB_LINUX',
     ],
 
     link_args: [


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

Note that this is just a proposal/WIP. I'd like to have some feedbacks before updating all the related files.

`db_*.c` of Pal/Linux and Pal/Linux_SGX are mostly following the same logic to implement narrow Drawbridge-like ABI interfaces where the only difference is host syscall or ocall. Maintaining them separately may lead to inconsistent behaviors when bugs are fixed in one place but not in the other and may consequently raise the maintenance cost.

This patch proposes to:
* share code of `db_*.c` in Pal/Linux and Pal/Linux_SGX
* have the common code maintained in Pal/Linux-common
* determine the hostcall type thru conditional compilation
* leverage the unified hostcall for syscall or ocall

Partially addresses https://github.com/gramineproject/gramine/issues/14

Related to https://github.com/gramineproject/graphene/issues/443

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/433)
<!-- Reviewable:end -->
