### PR TITLE
[Pal/Linux-SGX] Warn about raw syscall usage

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -166,6 +166,11 @@ static bool handle_ud(sgx_cpu_context_t* uc) {
         return false;
     } else if (instr[0] == 0x0f && instr[1] == 0x05) {
         /* syscall: LibOS may know how to handle this */
+        static int log_once = 1;
+        if (__atomic_exchange_n(&log_once, 0, __ATOMIC_RELAXED)) {
+            log_always("Emulating a raw syscall instruction. This degrades performance, consider"
+                       " patching your application to use Gramine syscall API.");
+        }
         return false;
     }
     log_error("Unknown or illegal instruction executed");


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
Using raw syscall instructions is very slow on SGX PAL, so warn users about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/434)
<!-- Reviewable:end -->
