### PR TITLE
[common] Fix potential null ptr dereference in "alloc_concat3"

### DIFF
--- a/common/src/string/utils.c
+++ b/common/src/string/utils.c
@@ -30,11 +30,11 @@ char* alloc_concat3(const char* a, size_t a_len, const char* b, size_t b_len,
     if (!buf)
         return NULL;
 
-    if (a_len)
+    if (a != NULL && a_len)
         memcpy(buf, a, a_len);
-    if (b_len)
+    if (b != NULL && b_len)
         memcpy(buf + a_len, b, b_len);
-    if (c_len)
+    if (c != NULL && c_len)
         memcpy(buf + a_len + b_len, c, c_len);
 
     buf[a_len + b_len + c_len] = '\0';


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The input pointers of `alloc_concat3` could be null. Passing a null
pointer to `memcpy()` would produce possible null pointer dereference or
undefined behaviors.

This patch ensures that null ptr inputs are not passed into `memcpy()`.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/437)
<!-- Reviewable:end -->
