### PR TITLE
[common] Make `DIV_ROUND_UP()` overflow-safe

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -363,7 +363,7 @@ int load_trusted_or_allowed_file(struct trusted_file* tf, PAL_HANDLE file, bool 
     }
     spinlock_unlock(&g_trusted_file_lock);
 
-    chunk_hashes = malloc(sizeof(sgx_chunk_hash_t) * DIV_ROUND_UP(tf->size, TRUSTED_CHUNK_SIZE));
+    chunk_hashes = malloc(sizeof(sgx_chunk_hash_t) * UDIV_ROUND_UP(tf->size, TRUSTED_CHUNK_SIZE));
     if (!chunk_hashes) {
         ret = -PAL_ERROR_NOMEM;
         goto fail;

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -77,12 +77,15 @@ typedef ptrdiff_t ssize_t;
         (((x) & ((x) - 1)) == 0); \
     })
 
-#define DIV_ROUND_UP(n,d)               (((n) + (d) - 1) / (d))
+/* Safe against overflows. May be slower than `(((n) + (d) - 1) / (d))` (which is not
+ * overflow-safe!), but hopefully the compiler will merge division and modulo into one
+ * instruction. */
+#define UDIV_ROUND_UP(n, d)             ((n) / (d) + !!((n) % (d)))
 
 #define BITS_IN_BYTE                    8
 #define BITS_IN_TYPE(type)              (sizeof(type) * BITS_IN_BYTE)
-#define BITS_TO_UINT32S(nr)             DIV_ROUND_UP(nr, BITS_IN_TYPE(uint32_t))
-#define BITS_TO_LONGS(nr)               DIV_ROUND_UP(nr, BITS_IN_TYPE(long))
+#define BITS_TO_UINT32S(nr)             UDIV_ROUND_UP(nr, BITS_IN_TYPE(uint32_t))
+#define BITS_TO_LONGS(nr)               UDIV_ROUND_UP(nr, BITS_IN_TYPE(long))
 /* Note: This macro is not intended for use when nbits == BITS_IN_TYPE(type) */
 #define SET_HIGHEST_N_BITS(type, nbits) (~(((uint64_t)1 << (BITS_IN_TYPE(type) - (nbits))) - 1))
 #define WITHIN_MASK(val, mask) (((val) | (mask)) == (mask))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There are no security bugs related to this right now, but looks like something which may end up used for untrusted size calculations someday.

## How to test this PR? <!-- (if applicable) -->

https://godbolt.org/z/e96rW16G4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/440)
<!-- Reviewable:end -->
