### PR TITLE
[LibOS/regression] Do not treat warnings as errors in some tests

### DIFF
--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -19,7 +19,9 @@ tests = {
     'eventfd': {},
     'exec': {},
     'exec_fork': {},
-    'exec_invalid_args': {},
+    'exec_invalid_args': {
+        'c_args': '-Wno-error',
+    },
     'exec_same': {},
     'exec_victim': {},
     'exit': {},
@@ -112,7 +114,9 @@ tests = {
             join_paths('../../../../common/include/arch', host_machine.cpu_family()),
         ),
     },
-    'stat_invalid_args': {},
+    'stat_invalid_args': {
+        'c_args': '-Wno-error',
+    },
     'synthetic': {},
     'syscall': {},
     'syscall_restart': {},


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some LibOS tests (`exec_invalid_args` and `stat_invalid_args`) specifically test incorrect syscall argument values.

## How to test this PR? <!-- (if applicable) -->

This was detected on a machine with Ubuntu 21.10 and 5.16.10 kernel and Glibc 2.34 (and some new GCC version). Meson was configured with `--werror`. The errors were like this:
```
../LibOS/shim/test/regression/exec_invalid_args.c:21:9: error: ‘execve’ reading 8 bytes from a region of size 0 [-Werror=stringop-overread]
   21 |     r = execve(argv[0], badptr_argv, good_envp);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../LibOS/shim/test/regression/exec_invalid_args.c:21:9: note: referencing argument 2 of type ‘char * const*’
In file included from ../LibOS/shim/test/regression/exec_invalid_args.c:4:
/usr/include/unistd.h:572:12: note: in a call to function ‘execve’
  572 | extern int execve (const char *__path, char *const __argv[],
      |            ^~~~~~
...
cc1: all warnings being treated as errors
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/442)
<!-- Reviewable:end -->
