### PR TITLE
[LibOS/regression] Use `syscall()` in `exec_invalid_args` test

### DIFF
--- a/LibOS/shim/test/regression/exec_invalid_args.c
+++ b/LibOS/shim/test/regression/exec_invalid_args.c
@@ -1,6 +1,7 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdio.h>
-#include <stdlib.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 int main(int argc, const char** argv, const char** envp) {
@@ -14,23 +15,23 @@ int main(int argc, const char** argv, const char** envp) {
     char* bad_envp[]  = {badptr, NULL};
     char* good_envp[] = {(char*)"DUMMY", NULL};
 
-    r = execve(badptr, good_argv, good_envp);
+    r = syscall(SYS_execve, badptr, good_argv, good_envp);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-path) correctly returned error\n");
 
-    r = execve(argv[0], badptr_argv, good_envp);
+    r = syscall(SYS_execve, argv[0], badptr_argv, good_envp);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-argv-ptr) correctly returned error\n");
 
-    r = execve(argv[0], good_argv, badptr_argv);
+    r = syscall(SYS_execve, argv[0], good_argv, badptr_argv);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-envp-ptr) correctly returned error\n");
 
-    r = execve(argv[0], bad_argv, good_envp);
+    r = syscall(SYS_execve, argv[0], bad_argv, good_envp);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-argv) correctly returned error\n");
 
-    r = execve(argv[0], good_argv, bad_envp);
+    r = syscall(SYS_execve, argv[0], good_argv, bad_envp);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-envp) correctly returned error\n");
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, this test used the Glibc wrapper `execve()`, which led to the error "execve reading 8 bytes from a region of size 0" in newer GCC.

## How to test this PR? <!-- (if applicable) -->

This was detected on a machine with Ubuntu 21.10 and 5.16.10 kernel and Glibc 2.34 (and some new GCC version). Meson was configured with `--werror`. The errors were like this:
```
../LibOS/shim/test/regression/exec_invalid_args.c:21:9: error: ‘execve’ reading 8 bytes from a region of size 0 [-Werror=stringop-overread]
   21 |     r = execve(argv[0], badptr_argv, good_envp);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../LibOS/shim/test/regression/exec_invalid_args.c:21:9: note: referencing argument 2 of type ‘char * const*’
In file included from ../LibOS/shim/test/regression/exec_invalid_args.c:4:
/usr/include/unistd.h:572:12: note: in a call to function ‘execve’
  572 | extern int execve (const char *__path, char *const __argv[],
      |            ^~~~~~
...
cc1: all warnings being treated as errors
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/444)
<!-- Reviewable:end -->
