### PR TITLE
[LibOS] Pass file offset to `read` and `write` callbacks

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -33,11 +33,39 @@ struct shim_fs_ops {
     /* close: clean up the file state inside the handle */
     int (*close)(struct shim_handle* hdl);
 
-    /* read: the content from the file opened as handle */
-    ssize_t (*read)(struct shim_handle* hdl, void* buf, size_t count);
+    /*
+     * \brief Read from file.
+     *
+     * \param         hdl    File handle.
+     * \param         buf    Buffer to read into.
+     * \param         count  Size of `buffer`.
+     * \param[in,out] pos    Position at which to start reading. Might be updated on success.
+     *
+     * \returns Number of bytes read on success, negative error code on failure.
+     *
+     * This callback updates `*pos` if the file is seekable (e.g. not a pipe or socket).
+     *
+     * TODO: Callers should make sure that `count` doesn't overflow `ssize_t`, and `*pos + count`
+     * doesn't overflow `file_off_t`.
+     */
+    ssize_t (*read)(struct shim_handle* hdl, void* buf, size_t count, file_off_t* pos);
 
-    /* write: the content from the file opened as handle */
-    ssize_t (*write)(struct shim_handle* hdl, const void* buf, size_t count);
+    /*
+     * \brief Write to file.
+     *
+     * \param         hdl    File handle.
+     * \param         buf    Buffer to write from.
+     * \param         count  Size of `buffer`.
+     * \param[in,out] pos    Position at which to start writing. Might be updated on success.
+     *
+     * \returns Number of bytes written on success, negative error code on failure.
+     *
+     * This callback updates `*pos` if the file is seekable (e.g. not a pipe or socket).
+     *
+     * TODO: Callers should make sure that `count` doesn't overflow `ssize_t`, and `*pos + count`
+     * doesn't overflow `file_off_t`.
+     */
+    ssize_t (*write)(struct shim_handle* hdl, const void* buf, size_t count, file_off_t* pos);
 
     /* mmap: mmap handle to address */
     int (*mmap)(struct shim_handle* hdl, void** addr, size_t size, int prot, int flags,

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -186,7 +186,7 @@ struct shim_handle {
      */
     struct shim_inode* inode;
 
-    /* Offset in file */
+    /* Offset in file. Protected by `pos_lock`. */
     file_off_t pos;
 
     /* This list contains `shim_epoll_item` objects this handle is part of. All accesses should be
@@ -229,6 +229,11 @@ struct shim_handle {
     int flags; /* Linux' O_* flags */
     int acc_mode;
     struct shim_lock lock;
+
+    /* Lock for handle position (`pos`). Intended for operations that change the position (e.g.
+     * `read`, `seek` but not `pread`). This lock should be taken *before* `shim_handle.lock` and
+     * `shim_inode.lock`. */
+    struct shim_lock pos_lock;
 };
 
 /* allocating / manage handle */

--- a/LibOS/shim/src/fs/eventfd/fs.c
+++ b/LibOS/shim/src/fs/eventfd/fs.c
@@ -13,7 +13,9 @@
 #include "shim_internal.h"
 #include "shim_lock.h"
 
-static ssize_t eventfd_read(struct shim_handle* hdl, void* buf, size_t count) {
+static ssize_t eventfd_read(struct shim_handle* hdl, void* buf, size_t count, file_off_t* pos) {
+    __UNUSED(pos);
+
     if (count < sizeof(uint64_t))
         return -EINVAL;
 
@@ -28,7 +30,10 @@ static ssize_t eventfd_read(struct shim_handle* hdl, void* buf, size_t count) {
     return (ssize_t)count;
 }
 
-static ssize_t eventfd_write(struct shim_handle* hdl, const void* buf, size_t count) {
+static ssize_t eventfd_write(struct shim_handle* hdl, const void* buf, size_t count,
+                             file_off_t* pos) {
+    __UNUSED(pos);
+
     if (count < sizeof(uint64_t))
         return -EINVAL;
 

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -84,8 +84,10 @@ int fifo_setup_dentry(struct shim_dentry* dent, mode_t perm, int fd_read, int fd
     return 0;
 }
 
-static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
+static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count, file_off_t* pos) {
     assert(hdl->type == TYPE_PIPE);
+    __UNUSED(pos);
+
     if (!hdl->info.pipe.ready_for_ops)
         return -EACCES;
 
@@ -100,8 +102,10 @@ static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
     return (ssize_t)count;
 }
 
-static ssize_t pipe_write(struct shim_handle* hdl, const void* buf, size_t count) {
+static ssize_t pipe_write(struct shim_handle* hdl, const void* buf, size_t count, file_off_t* pos) {
     assert(hdl->type == TYPE_PIPE);
+    __UNUSED(pos);
+
     if (!hdl->info.pipe.ready_for_ops)
         return -EACCES;
 

--- a/LibOS/shim/src/fs/shim_fs_util.c
+++ b/LibOS/shim/src/fs/shim_fs_util.c
@@ -92,8 +92,8 @@ int generic_inode_hstat(struct shim_handle* hdl, struct stat* buf) {
 file_off_t generic_inode_seek(struct shim_handle* hdl, file_off_t offset, int origin) {
     file_off_t ret;
 
+    lock(&hdl->pos_lock);
     lock(&hdl->inode->lock);
-    lock(&hdl->lock);
     file_off_t pos = hdl->pos;
     file_off_t size = hdl->inode->size;
 
@@ -102,16 +102,16 @@ file_off_t generic_inode_seek(struct shim_handle* hdl, file_off_t offset, int or
         hdl->pos = pos;
         ret = pos;
     }
-    unlock(&hdl->lock);
     unlock(&hdl->inode->lock);
+    unlock(&hdl->pos_lock);
     return ret;
 }
 
 int generic_inode_poll(struct shim_handle* hdl, int poll_type) {
     int ret;
 
+    lock(&hdl->pos_lock);
     lock(&hdl->inode->lock);
-    lock(&hdl->lock);
 
     if (hdl->inode->type == S_IFREG) {
         ret = 0;
@@ -126,7 +126,7 @@ int generic_inode_poll(struct shim_handle* hdl, int poll_type) {
         ret = -EAGAIN;
     }
 
-    unlock(&hdl->lock);
     unlock(&hdl->inode->lock);
+    unlock(&hdl->pos_lock);
     return ret;
 }

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -36,8 +36,10 @@ static int socket_close(struct shim_handle* hdl) {
     return 0;
 }
 
-static ssize_t socket_read(struct shim_handle* hdl, void* buf, size_t count) {
+static ssize_t socket_read(struct shim_handle* hdl, void* buf, size_t count, file_off_t* pos) {
     assert(hdl->type == TYPE_SOCK);
+    __UNUSED(pos);
+
     struct shim_sock_handle* sock = &hdl->info.sock;
 
     lock(&hdl->lock);
@@ -72,8 +74,11 @@ static ssize_t socket_read(struct shim_handle* hdl, void* buf, size_t count) {
     return (ssize_t)count;
 }
 
-static ssize_t socket_write(struct shim_handle* hdl, const void* buf, size_t count) {
+static ssize_t socket_write(struct shim_handle* hdl, const void* buf, size_t count,
+                            file_off_t* pos) {
     assert(hdl->type == TYPE_SOCK);
+    __UNUSED(pos);
+
     struct shim_sock_handle* sock = &hdl->info.sock;
 
     lock(&hdl->lock);

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -547,20 +547,11 @@ static int read_file_fragment(struct shim_handle* file, void* buf, size_t size, 
     if (!file)
         return -EINVAL;
 
-    if (!file->fs || !file->fs->fs_ops)
+    if (!file->fs || !file->fs->fs_ops || !file->fs->fs_ops->read)
         return -EACCES;
 
-    ssize_t (*read)(struct shim_handle*, void*, size_t)      = file->fs->fs_ops->read;
-    file_off_t (*seek)(struct shim_handle*, file_off_t, int) = file->fs->fs_ops->seek;
-
-    if (!read || !seek)
-        return -EACCES;
-
-    file_off_t seek_ret = seek(file, offset, SEEK_SET);
-    if (seek_ret < 0)
-        return seek_ret;
-
-    ssize_t read_ret = read(file, buf, size);
+    ssize_t pos = offset;
+    ssize_t read_ret = file->fs->fs_ops->read(file, buf, size, &pos);
     if (read_ret < 0)
         return read_ret;
 

--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -467,8 +467,7 @@ long shim_do_sendfile(int out_fd, int in_fd, off_t* offset, size_t count) {
         unlock(&in_hdl->pos_lock);
     }
 
-    int mode = out_hdl->flags & O_ACCMODE;
-    if (!(mode == O_WRONLY || mode == O_RDWR)) {
+    if (!(out_hdl->acc_mode & MAY_WRITE)) {
         /* Linux errors out if output fd isn't writable */
         ret = -EBADF;
         goto out;

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1840,20 +1840,6 @@ must-pass =
 [send02]
 skip = yes
 
-# some bug in UDP server/client creation, not related to sendfile() itself
-[sendfile02]
-skip = yes
-
-[sendfile02_64]
-skip = yes
-
-# some bug in UDP server/client creation, not related to sendfile() itself
-[sendfile06]
-skip = yes
-
-[sendfile06_64]
-skip = yes
-
 # some bug in socketpair creation, not related to sendfile() itself
 [sendfile07]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Instead of using the handle position, `read` and `write` receive file position as a parameter (and might choose to update it). This is a similar design to Linux internals.

As a result, there's no need to emulate operations like `pread` using `seek`, and filesystem callbacks can be simpler.

This is in preparation for adding another filesystem (for protected files).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/449)
<!-- Reviewable:end -->
