### PR TITLE
[Pal/Linux-SGX] Update tools to use IAS API v4

### DIFF
--- a/Documentation/manpages/gramine-sgx-ias-request.rst
+++ b/Documentation/manpages/gramine-sgx-ias-request.rst
@@ -85,10 +85,6 @@ Commands
 
       Path to save IAS certificate to (optional).
 
-   .. option:: -a, --advisory-path
-
-      Path to save IAS security advisories to (optional).
-
    .. option:: -R, --report-url
 
       URL for the IAS attestation report endpoint (optional).
@@ -107,7 +103,7 @@ Examples
 
 .. code-block:: sh
 
-    $ gramine-sgx-ias-request report -k $IAS_API_KEY -q gr.quote -r ias.report -s ias.sig -c ias.cert -a ias.adv -v
+    $ gramine-sgx-ias-request report -k $IAS_API_KEY -q gr.quote -r ias.report -s ias.sig -c ias.cert -v
     Verbose output enabled
     IAS request:
     {"isvEnclaveQuote":"AgABAO8..."}
@@ -116,7 +112,6 @@ Examples
     IAS report saved to: ias.report
     IAS report signature saved to: ias.sig
     IAS certificate saved to: ias.cert
-    IAS advisory saved to: ias.adv
     IAS submission successful
 
     $ cat ias.report

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.c
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.c
@@ -243,6 +243,22 @@ int verify_ias_report_extract_quote(const uint8_t* ias_report, size_t ias_report
             )) {
         ret = 0;
         INFO("IAS report: allowing quote status %s\n", node->valuestring);
+
+        cJSON* url_node = cJSON_GetObjectItem(json, "advisoryURL");
+        if (url_node && url_node->type == cJSON_String)
+            INFO("            [ advisory URL: %s ]\n", url_node->valuestring);
+
+        cJSON* ids_node = cJSON_GetObjectItem(json, "advisoryIDs");
+        if (ids_node && ids_node->type == cJSON_Array) {
+            char* ids_str = cJSON_Print(ids_node);
+            if (!ids_str) {
+                ERROR("IAS report: out-of-memory during reading advisoryIDs\n");
+                ret = -1;
+                goto out;
+            }
+            INFO("            [ advisory IDs: %s ]\n", ids_str);
+            free(ids_str);
+        }
     }
 
     if (ret != 0) {

--- a/Pal/src/host/Linux-SGX/tools/common/ias.h
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.h
@@ -54,7 +54,6 @@ int ias_get_sigrl(struct ias_context_t* context, uint8_t gid[4], size_t* sigrl_s
  * \param[in] report_path   (Optional) File to save IAS report to.
  * \param[in] sig_path      (Optional) File to save IAS report's signature to.
  * \param[in] cert_path     (Optional) File to save IAS certificate to.
- * \param[in] advisory_path (Optional) File to save IAS security advisories to.
  * \return 0 on success, -1 otherwise.
  *
  *  This version of the function is convenient for command-line utilities. To get raw IAS contents,
@@ -64,7 +63,7 @@ int ias_get_sigrl(struct ias_context_t* context, uint8_t gid[4], size_t* sigrl_s
  */
 int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t quote_size,
                      const char* nonce, const char* report_path, const char* sig_path,
-                     const char* cert_path, const char* advisory_path);
+                     const char* cert_path);
 
 /*!
  * \brief Send quote to IAS for verification (same as ias_verify_quote() but not saving to files).
@@ -79,13 +78,11 @@ int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t qu
  * \param[out] sig_data_size      (Optional) Size of allocated IAS report's signature.
  * \param[out] cert_data_ptr      (Optional) Pointer to allocated IAS certificate.
  * \param[out] cert_data_size     (Optional) Size of allocated IAS certificate.
- * \param[out] advisory_data_ptr  (Optional) Pointer to allocated IAS security advisories.
- * \param[out] advisory_data_size (Optional) Size of allocated IAS security advisories.
  * \return 0 on success, -1 otherwise.
  *
  *  This version of the function is convenient for library usage. This function allocates buffers
- *  for IAS contents and passes them to caller via \a report_data_ptr, \a sig_data_ptr,
- *  \a cert_data_ptr and \a advisory_data_ptr. The caller is responsible for freeing them.
+ *  for IAS contents and passes them to caller via \a report_data_ptr, \a sig_data_ptr and
+ *  \a cert_data_ptr. The caller is responsible for freeing them.
  *  To save IAS contents to files, use ias_verify_quote().
  *
  * \details Sends quote to the "Verify Attestation Evidence" IAS endpoint.
@@ -93,6 +90,5 @@ int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t qu
 int ias_verify_quote_raw(struct ias_context_t* context, const void* quote, size_t quote_size,
                          const char* nonce, char** report_data_ptr, size_t* report_data_size,
                          char** sig_data_ptr, size_t* sig_data_size, char** cert_data_ptr,
-                         size_t* cert_data_size, char** advisory_data_ptr,
-                         size_t* advisory_data_size);
+                         size_t* cert_data_size);
 #endif /* _IAS_H */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine tools (including RA-TLS) used IAS API v3. This version is deprecated and will be EOLed on 16. August 2022. This commit updates Gramine to IAS API v4; the only difference is that Advisory URL & IDs are returned in HTTP response body (in v3, they are returned in HTTP response headers).

Closes https://github.com/gramineproject/graphene/pull/2268.

## How to test this PR? <!-- (if applicable) -->

I tested manually on my machine.

1. Test with `ra-tls-mbedtls`:
```
~/gramineproject/gramine/CI-Examples/ra-tls-mbedtls$ RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
        RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 RA_TLS_EPID_API_KEY=<my-key> ./client epid
  . Seeding the random number generator... ok
  . Connecting to tcp/localhost/4433... ok
  . Setting up the SSL/TLS structure... ok
  . Loading the CA root certificate ... ok
  . Installing RA-TLS callback ... ok
  . Performing the SSL/TLS handshake...
IAS report: signature verified correctly
IAS report: allowing quote status GROUP_OUT_OF_DATE
            [ advisory URL: https://security-center.intel.com ]
            [ advisory IDs: ["INTEL-SA-00477", "INTEL-SA-00381", "INTEL-SA-00389", "INTEL-SA-00320", "INTEL-SA-00329", "INTEL$
SA-00220", "INTEL-SA-00270", "INTEL-SA-00293", "INTEL-SA-00233", "INTEL-SA-00203", "INTEL-SA-00106", "INTEL-SA-00115", "INTEL$
SA-00135"] ]
 ok
  . Verifying peer X.509 certificate... ok
```

2. Test with a pre-generated EPID quote of some SGX enclave on my machine and Gramine tools.

- You first need to generate the EPID quote. For this I used the following trick in the `attestation` LibOS regression test:
```
$ git diff
diff --git a/LibOS/shim/test/regression/attestation.c b/LibOS/shim/test/regression/attestation.c
@@ -225,6 +225,8 @@ static int test_quote_interface(void) {
         return FAILURE;
     }

+    file_write_f("quote-epid.dat", (char*)&g_quote, bytes);
+
     /* 3. verify report data read from `quote` */
     if ((size_t)bytes < sizeof(sgx_quote_body_t)) {
         fprintf(stderr, "obtained SGX quote is too small: %ldB (must be at least %ldB)\n", bytes,
diff --git a/LibOS/shim/test/regression/attestation.manifest.template 
@@ -37,3 +37,5 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
+
+sgx.allowed_files = [ "file:quote-epid.dat" ]
```

- Then rebuild and run the `attestation` test:
```
$ ninja -C build-debug/ install
$ cd LibOS/shim/test/regression/
$ RA_CLIENT_SPID=<my-spid> SGX=1 gramine-test build
$ touch quote-epid.dat
$ gramine-sgx attestation
```

- Then run Gramine tools on the resulting `quote-epid.dat`:
```
$ gramine-sgx-ias-request report --api-key <my-key> --quote-path quote-epid.dat \
        --report-path report.dat --sig-path sig.dat  --cert-path cert.dat
IAS submission successful

$ gramine-sgx-ias-verify-report --report-path report.dat --sig-path sig.dat --allow-outdated-tcb
IAS report: signature verified correctly
IAS report: allowing quote status GROUP_OUT_OF_DATE
            [ advisory URL: https://security-center.intel.com ]
            [ advisory IDs: ["INTEL-SA-00477", "INTEL-SA-00381", "INTEL-SA-00389", "INTEL-SA-00320", "INTEL-SA-00329", "INTEL-SA-00220", "INTEL-SA-00270", "INTEL-SA-00293", "INTEL-SA-00233", "INTEL-SA-00203", "INTEL-SA-00106", "INTEL-SA-00115", "INTEL-SA-00135"] ]
verify_quote_body_enclave_attributes: Quote: DEBUG bit in enclave attributes is set
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/453)
<!-- Reviewable:end -->
