### PR TITLE
[LibOS] Add support to run non ELF executables

### DIFF
--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -7,6 +7,7 @@
 #define ERESTARTSYS     512 /* Usual case - restart if SA_RESTART is set. */
 #define ERESTARTNOINTR  513 /* Always restart. */
 #define ERESTARTNOHAND  514 /* Restart if no signal handler. */
+#define BINPRM_BUF_SIZE 256 /* Default shebang size */
 
 /* Internal LibOS stack size: 7 pages + one guard page normally, 15 pages + one guard page when ASan
  * is enabled (stack sanitization causes functions to take up more space). */

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -37,6 +37,7 @@ int init_elf_objects(void);
 int check_elf_object(struct shim_handle* file);
 int load_elf_object(struct shim_handle* file, struct link_map** out_map);
 int load_elf_interp(struct link_map* exec_map);
+int check_and_load_shebang(struct shim_handle* file, char* interpreter);
 noreturn void execute_elf_object(struct link_map* exec_map, void* argp, elf_auxv_t* auxp);
 void remove_loaded_elf_objects(void);
 int init_brk_from_executable(struct link_map* exec_map);

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -569,7 +569,38 @@ static int read_file_fragment(struct shim_handle* file, void* buf, size_t size, 
     return 0;
 }
 
-static int load_elf_header(struct shim_handle* file, elf_ehdr_t* ehdr) {
+int check_and_load_shebang(struct shim_handle* file, char* interpreter) {
+    const char* errstring = NULL;
+    char shebang[BINPRM_BUF_SIZE];
+    int ret = read_file_fragment(file, shebang, sizeof(shebang), /*offset=*/0);
+    
+    if ((shebang[0] != '#') || (shebang[1] != '!')) {
+        errstring = "Failed to read shebang line from %s";
+        ret = -ENOEXEC;
+        goto err;
+    }
+    else {
+         for (size_t i=2; shebang[i] != '\n'; i++) {
+            interpreter[i-2] = shebang[i];
+            interpreter[i-1] = '\0';
+        }
+        log_debug("Interpreter to be used %s", interpreter);
+    }
+
+    return 0;
+
+err:;
+    char* path = NULL;
+    if (file->dentry) {
+        // This may fail, but we are already inside a more serious error handler.
+        dentry_abs_path(file->dentry, &path, /*size=*/NULL);
+    }
+    log_error(errstring, path ? path : "(unknown)");
+    free(path);
+    return ret;
+}
+
+static int load_elf_header(struct shim_handle* file, ElfW(Ehdr)* ehdr) {
     const char* errstring = NULL;
     int ret = read_file_fragment(file, ehdr, sizeof(*ehdr), /*offset=*/0);
     if (ret < 0) {


### PR DESCRIPTION
Signed-off-by: aneessahib <anees.a.sahib@intel.com>

Added support to read shebang line from scripts to determine the interpreter during `execve` syscall flow.

