### PR TITLE
[CI-Examples] Extend nginx example to use secure cmdline args

### DIFF
--- a/CI-Examples/nginx/.gitignore
+++ b/CI-Examples/nginx/.gitignore
@@ -1,6 +1,7 @@
 *.tar.gz
 /install/*
 /nginx-*/*
+/nginx_args
 /OUTPUT
 /result-*
 /ssl/ca.*

--- a/CI-Examples/nginx/Makefile
+++ b/CI-Examples/nginx/Makefile
@@ -21,7 +21,7 @@ GRAMINE_LOG_LEVEL = error
 endif
 
 .PHONY: all
-all: $(INSTALL_DIR)/sbin/nginx nginx.manifest config testdata ssldata
+all: $(INSTALL_DIR)/sbin/nginx nginx.manifest config testdata ssldata nginx_args
 ifeq ($(SGX),1)
 all: nginx.manifest.sgx nginx.sig nginx.token
 endif
@@ -109,6 +109,9 @@ $(INSTALL_DIR)/conf/server.crt: ssl/ca_config.conf $(INSTALL_DIR)/sbin/nginx
 .PHONY: ssldata
 ssldata: $(INSTALL_DIR)/conf/server.crt
 
+nginx_args:
+	gramine-argv-serializer "nginx" "-c" "conf/nginx-gramine.conf" > $@
+
 .PHONY: start-native-server
 start-native-server: all
 	$(INSTALL_DIR)/sbin/nginx -c conf/nginx-gramine.conf
@@ -121,11 +124,11 @@ endif
 
 .PHONY: start-gramine-server
 start-gramine-server: all
-	$(GRAMINE) ./nginx -c conf/nginx-gramine.conf
+	$(GRAMINE) ./nginx
 
 .PHONY: clean
 clean:
-	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT result-* tmp
+	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT result-* tmp nginx_args
 
 .PHONY: distclean
 distclean: clean

--- a/CI-Examples/nginx/README.md
+++ b/CI-Examples/nginx/README.md
@@ -26,14 +26,18 @@ make SGX=1
 ../common_tools/benchmark-http.sh https://127.0.0.1:8444
 kill -SIGINT %%
 
-# run Nginx in non-SGX Gramine against HTTP and HTTPS benchmarks
-gramine-direct ./nginx -c conf/nginx-gramine.conf &
+# Run Nginx in non-SGX Gramine against HTTP and HTTPS benchmarks.
+# Note: The command-line arguments are passed using `loader.argv_src_file`
+# manifest option.
+gramine-direct ./nginx &
 ../common_tools/benchmark-http.sh 127.0.0.1:8002
 ../common_tools/benchmark-http.sh https://127.0.0.1:8444
 kill -SIGINT %%
 
-# run Nginx in Gramine-SGX against HTTP and HTTPS benchmarks
-gramine-sgx ./nginx -c conf/nginx-gramine.conf &
+# Run Nginx in Gramine-SGX against HTTP and HTTPS benchmarks.
+# Note: The command-line arguments are securely passed using
+# `loader.argv_src_file` manifest option.
+gramine-sgx ./nginx &
 ../common_tools/benchmark-http.sh 127.0.0.1:8002
 ../common_tools/benchmark-http.sh https://127.0.0.1:8444
 kill -SIGINT %%

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -7,8 +7,7 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/local/lib:/usr/lib:/usr/{{ arch_libdir }}"
 
-loader.insecure__use_cmdline_argv = true
-
+loader.argv_src_file = "file:nginx_args"
 sys.enable_sigterm_injection = true
 
 fs.mounts = [
@@ -36,6 +35,7 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
+  "file:nginx_args",
 ]
 
 sgx.allowed_files = [

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -184,6 +184,7 @@ html_static_path = ['_static']
 man_pages = [
     ('manpages/gramine', 'gramine-direct', 'Gramine', [author], 1),
     ('manpages/gramine', 'gramine-sgx', 'Gramine', [author], 1),
+    ('manpages/gramine-argv-serializer', 'gramine-argv-serializer', 'Serialize command line arguments', [author], 1),
     ('manpages/gramine-manifest', 'gramine-manifest', 'Gramine manifest preprocessor', [author], 1),
     ('manpages/gramine-sgx-gen-private-key', 'gramine-sgx-gen-private-key', 'Gramine SGX key generator', [author], 1),
     ('manpages/gramine-sgx-get-token', 'gramine-sgx-get-token', 'Gramine SGX Token generator', [author], 1),

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -83,7 +83,6 @@ Table of Contents
    manpages/*
 
 .. TODO manpages:
-   gramine-argv-serializer
    gramine-direct
    gramine-sgx
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -132,7 +132,7 @@ or
 If you want your application to use commandline arguments you need to either set
 ``loader.insecure__use_cmdline_argv`` (insecure in almost all cases) or point
 ``loader.argv_src_file`` to a file containing output of
-:program:`gramine-argv-serializer`.
+:ref:`gramine-argv-serializer<gramine-argv-serializer>`.
 
 ``loader.argv_src_file`` is intended to point to either a trusted file or a
 protected file. The former allows to securely hardcode arguments (current
@@ -178,9 +178,10 @@ environment variable from the host, specify a TOML table with the key-value pair
 value or be a passthrough.
 
 ``loader.env_src_file`` allows to specify a URI to a file containing serialized
-environment, which can be generated using :program:`gramine-argv-serializer`.
-This option is intended to point to either a trusted file or a protected file.
-The former allows to securely hardcode environments (in a more flexible way than
+environment, which can be generated using
+:ref:`gramine-argv-serializer<gramine-argv-serializer>`. This option is intended
+to point to either a trusted file or a protected file. The former allows to
+securely hardcode environments (in a more flexible way than
 ``loader.env.[ENVIRON]`` option), the latter allows the environments to be
 provided at runtime from an external (trusted) source.
 

--- a/Documentation/manpages/gramine-argv-serializer.rst
+++ b/Documentation/manpages/gramine-argv-serializer.rst
@@ -1,0 +1,32 @@
+.. _gramine-argv-serializer:
+
+.. program:: gramine-argv-serializer
+
+======================================================================
+:program:`gramine-argv-serializer` -- Serialize command line arguments
+======================================================================
+
+Synopsis
+========
+
+:command:`gramine-argv-serializer` [*ARGS*]
+
+Description
+===========
+
+`gramine-argv-serializer` serializes the command line arguments and prints it
+to stdout. The result is intended to be redirected to a file that can
+be used as a trusted or a protected file and ``loader.argv_src_file`` manifest
+option pointed to it.
+For more information on the usage, please refer to :doc:`../manifest-syntax`.
+
+For an example on how to use this utility from Python, please refer to
+:file:`LibOS/shim/test/regression/test_libos.py`.
+
+Example
+=======
+
+.. code-block:: sh
+
+   gramine-argv-serializer "binary_name" "arg1" "arg2" > gramine_args.txt
+


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR extends `nginx` CI-Example to showcase the usage of passing command-line arguments securely to the application running inside the enclave. It also adds documentation on the usage of `gramine-argv-serializer` tool.

## How to test this PR? <!-- (if applicable) -->
Please run the `nginx` example as part of `CI-Examples`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/460)
<!-- Reviewable:end -->
