### PR TITLE
[LibOS] Make `fsync()` and `fdatasync()` a no-op on dirs

### DIFF
--- a/LibOS/shim/test/ltp/ltp-sgx.cfg
+++ b/LibOS/shim/test/ltp/ltp-sgx.cfg
@@ -53,8 +53,6 @@ skip = yes
 
 [fsync03]
 timeout = 60
-must-pass =
-    1
 
 [ftruncate01]
 skip = yes

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -545,14 +545,8 @@ skip = yes
 [fsync02]
 timeout = 120
 
-# 1. fsync() on a pipe returns EROFS, not EINVAL
-# 2. fsync() on a socket returns EROFS, not EINVAL
-# 5. fsync() on a fifo returns EROFS, not EINVAL
 [fsync03]
 timeout = 40
-must-pass =
-    3
-    4
 
 # tries to mount a filesystem
 [fsync04]

--- a/LibOS/shim/test/regression/synthetic.c
+++ b/LibOS/shim/test/regression/synthetic.c
@@ -62,6 +62,10 @@ int main(void) {
     if (fstat(fd, &statbuf) == -1)
         err(1, "fstat");
 
+    /* fsync on the directory is only for testing that it doesn't fail (and is a no-op) */
+    if (fsync(fd) == -1)
+        err(1, "fsync");
+
     if (close(fd) == -1)
         err(1, "close");
 

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -993,6 +993,10 @@ class TC_40_FileSystem(RegressionTestCase):
             self.assertNotIn('READING FROM MODIFIED ENCLAVE OK', stdout)
             self.assertIn('Permission denied', stdout)
 
+    def test_060_synthetic(self):
+        stdout, _ = self.run_binary(['synthetic'])
+        self.assertIn("TEST OK", stdout)
+
 
 class TC_50_GDB(RegressionTestCase):
     def setUp(self):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR also changes these syscalls to return `EINVAL` error code on special files (same as what Linux returns), as well as enables the LTP test `fsync03` that expects this error code.

This PR also adds previously "forgotten" `synthetic` LibOS regression test to Pytest, and augments this test with `fsync()` check.

## How to test this PR? <!-- (if applicable) -->

LTP and LibOS regression tests are added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/464)
<!-- Reviewable:end -->
