### PR TITLE
[CI-Examples] Update benchmark-http.sh script to use wrk2 benchmark

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -77,7 +77,7 @@ stage('test-direct') {
             make -j8 all
             make start-gramine-server &
             ../../scripts/wait_for_server 5 127.0.0.1 8003
-            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
+            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8003
         '''
     }
     timeout(time: 10, unit: 'MINUTES') {
@@ -86,7 +86,7 @@ stage('test-direct') {
             make -j8 all
             make start-gramine-server &
             ../../scripts/wait_for_server 5 127.0.0.1 8002
-            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
+            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8002
         '''
     }
     timeout(time: 15, unit: 'MINUTES') {
@@ -95,7 +95,7 @@ stage('test-direct') {
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
             ../../scripts/wait_for_server 5 127.0.0.1 3000
-            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:3000
+            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:3000
         '''
     }
     timeout(time: 5, unit: 'MINUTES') {

--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -62,7 +62,7 @@ stage('test-sgx') {
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
             ../../scripts/wait_for_server 60 127.0.0.1 8003
-            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
+            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8003
         '''
     }
     timeout(time: 15, unit: 'MINUTES') {
@@ -71,7 +71,7 @@ stage('test-sgx') {
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
             ../../scripts/wait_for_server 60 127.0.0.1 8002
-            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
+            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8002
         '''
     }
     timeout(time: 15, unit: 'MINUTES') {
@@ -80,7 +80,7 @@ stage('test-sgx') {
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
             ../../scripts/wait_for_server 60 127.0.0.1 3000
-            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:3000
+            LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:3000
         '''
     }
     timeout(time: 5, unit: 'MINUTES') {

--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:18.04
 
 # Add steps here to set up dependencies
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    apache2-utils \
     autoconf \
     bison \
     build-essential \
@@ -68,6 +67,16 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     wget \
     zlib1g \
     zlib1g-dev
+
+# Install wrk2 benchmark. This benchmark is used in `benchmark-http.sh`.
+RUN git clone https://github.com/giltene/wrk2.git \
+    && cd wrk2 \
+    && git checkout 44a94c17d8e6a0bac8559b53da76848e430cb7a7 \
+    && make \
+    && cp wrk /usr/local/bin \
+    && cd .. \
+    && rm -rf wrk2
+
 
 # NOTE about meson version: we support "0.55 or newer", so in CI we pin to latest patch version of
 # the earliest supported minor version (pip implicitly installs latest version satisfying the

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:20.04
 
 # Add steps here to set up dependencies
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    apache2-utils \
     autoconf \
     bison \
     build-essential \
@@ -72,6 +71,15 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     wget \
     zlib1g \
     zlib1g-dev
+
+# Install wrk2 benchmark. This benchmark is used in `benchmark-http.sh`.
+RUN git clone https://github.com/giltene/wrk2.git \
+    && cd wrk2 \
+    && git checkout 44a94c17d8e6a0bac8559b53da76848e430cb7a7 \
+    && make \
+    && cp wrk /usr/local/bin \
+    && cd .. \
+    && rm -rf wrk2
 
 # NOTE about meson version: we support "0.55 or newer", so in CI we pin to latest patch version of
 # the earliest supported minor version (pip implicitly installs latest version satisfying the

--- a/CI-Examples/common_tools/benchmark-http.sh
+++ b/CI-Examples/common_tools/benchmark-http.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# On Ubuntu, this script requires apache2-utils for the ab binary.
+# On Ubuntu, this script requires wrk2 tool installed for the wrk binary.
 #
 # Run like: ./benchmark-http.sh host:port
 #
@@ -10,13 +10,61 @@ declare -A THROUGHPUTS
 declare -A LATENCIES
 LOOP=${LOOP:-1}
 DOWNLOAD_HOST=$1
-DOWNLOAD_FILE=random/10K.1.html
-REQUESTS=10000
+DOWNLOAD_FILE=${DOWNLOAD_FILE:-random/10K.1.html}
+CONNECTIONS=${CONNECTIONS:-300}
+REQUESTS=${REQUESTS:-10000}
+DURATION=${DURATION:-30}
 CONCURRENCY_LIST=${CONCURRENCY_LIST:-"1 2 4 8 16 32 64 128 256"}
-OPTIONS="-k"
 RESULT=result-$(date +%y%m%d-%H%M%S)
 
 touch "$RESULT"
+throughput_in_bytes() {
+    local THROUGHPUT_VAL=0
+    local THROUGHPUT_UNIT=""
+    if [[ "$1" =~ ^([0-9]*)(\.[0-9]*)?([kMG]?)$ ]]; then
+        THROUGHPUT_VAL="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+        THROUGHPUT_UNIT=${BASH_REMATCH[3]}
+    fi
+
+    if [ -z "$THROUGHPUT_UNIT" ]; then
+        THROUGHPUT=$THROUGHPUT_VAL
+    elif [ "$THROUGHPUT_UNIT" = "k" ]; then
+        THROUGHPUT=$(bc <<< "$THROUGHPUT_VAL*1000")
+    elif [ "$THROUGHPUT_UNIT" = "M" ]; then
+        THROUGHPUT=$(bc <<< "$THROUGHPUT_VAL*1000000")
+    elif [ "$THROUGHPUT_UNIT" = "G" ]; then
+        THROUGHPUT=$(bc <<< "$THROUGHPUT_VAL*1000000000")
+    else
+        THROUGHPUT=0
+    fi
+
+    echo "$THROUGHPUT"
+}
+
+latency_in_milliseconds() {
+    local LATENCY_VAL=0
+    local LATENCY_UNIT=""
+    if [[ "$1" =~ ^([0-9]*)(\.[0-9]*)?(us|ms|s|m|h)?$ ]]; then
+        LATENCY_VAL="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+        LATENCY_UNIT=${BASH_REMATCH[3]}
+    fi
+
+    if [ -z "$LATENCY_UNIT" ] || [ "$LATENCY_UNIT" = "ms" ]; then
+        LATENCY=$LATENCY_VAL
+    elif [ "$LATENCY_UNIT" = "us" ]; then
+        LATENCY=$(bc <<< "scale=3; $LATENCY_VAL/1000")
+    elif [ "$LATENCY_UNIT" = "s" ]; then
+        LATENCY=$(bc <<< "$LATENCY_VAL*1000")
+    elif [ "$LATENCY_UNIT" = "m" ]; then
+        LATENCY=$(bc <<< "$LATENCY_VAL*1000*60")
+    elif [ "$LATENCY_UNIT" = "h" ]; then
+        LATENCY=$(bc <<< "$LATENCY_VAL*1000*3600")
+    else
+        LATENCY=0
+    fi
+
+    echo "$LATENCY"
+}
 
 RUN=0
 while [ $RUN -lt "$LOOP" ]
@@ -24,26 +72,42 @@ do
     for CONCURRENCY in $CONCURRENCY_LIST
     do
         rm -f OUTPUT
-        echo "ab $OPTIONS -n $REQUESTS -c $CONCURRENCY $DOWNLOAD_HOST/$DOWNLOAD_FILE"
-        ab $OPTIONS -n $REQUESTS -c "$CONCURRENCY" "$DOWNLOAD_HOST/$DOWNLOAD_FILE" > OUTPUT || exit $?
+        echo "wrk -c $CONNECTIONS -d $DURATION -t $CONCURRENCY -R $REQUESTS $DOWNLOAD_HOST/$DOWNLOAD_FILE"
+        wrk -c "$CONNECTIONS" -d "$DURATION" -t "$CONCURRENCY" -R "$REQUESTS" "$DOWNLOAD_HOST/$DOWNLOAD_FILE" > OUTPUT || exit $?
 
         sleep 5
 
-        THROUGHPUT=$(grep -m1 "Requests per second:" OUTPUT | awk '{ print $4 }')
-        LATENCY=$(grep -m1 "Time per request:" OUTPUT | awk '{ print $4 }')
-        FAILED=$(grep -m1 "Failed requests:" OUTPUT | awk '{print $3 }')
-        THROUGHPUTS[$CONCURRENCY]="${THROUGHPUTS[$CONCURRENCY]} $THROUGHPUT"
-        LATENCIES[$CONCURRENCY]="${LATENCIES[$CONCURRENCY]} $LATENCY"
-        echo "concurrency=$CONCURRENCY, throughput=$THROUGHPUT, latency=$LATENCY, failed=$FAILED"
+        THROUGHPUT_STR=$(grep -m1 "Req/Sec" OUTPUT | awk '{ print $2 }')
+        THROUGHPUT=$(throughput_in_bytes "$THROUGHPUT_STR")
+        if [ "$THROUGHPUT" = "0" ]; then
+            echo "Throughput is zero!"; exit 1;
+        fi
+
+        LATENCY_STR=$(grep -m1 "Latency" OUTPUT | awk '{ print $2 }')
+        LATENCY=$(latency_in_milliseconds "$LATENCY_STR")
+        if [ "$LATENCY" = "0" ]; then
+            echo "Latency is zero!"; exit 1;
+        fi
+
+        if [ ${#THROUGHPUTS[$CONCURRENCY]} -eq 0 ] || [ ${#LATENCIES[$CONCURRENCY]} -eq 0 ]; then
+            THROUGHPUTS[$CONCURRENCY]="$THROUGHPUT"
+            LATENCIES[$CONCURRENCY]="$LATENCY"
+        else
+            THROUGHPUTS[$CONCURRENCY]="${THROUGHPUTS[$CONCURRENCY]} $THROUGHPUT"
+            LATENCIES[$CONCURRENCY]="${LATENCIES[$CONCURRENCY]} $LATENCY"
+        fi
+        echo "Run = $((RUN+1)) Concurrency = $CONCURRENCY Per thread Throughput (bytes) = $THROUGHPUT, Latency (ms) = $LATENCY"
+
     done
     (( RUN++ ))
 done
 
 for CONCURRENCY in $CONCURRENCY_LIST
 do
-    THROUGHPUT=$(echo "${THROUGHPUTS[$CONCURRENCY]}" | tr " " "\n" | sort -n | awk '{a[NR]=$0}END{if(NR%2==1)print a[int(NR/2)+1];else print(a[NR/2-1]+a[NR/2])/2}')
-    LATENCY=$(echo "${LATENCIES[$CONCURRENCY]}" | tr " " "\n" | sort -n | awk '{a[NR]=$0}END{if(NR%2==1)print a[int(NR/2)+1];else print(a[NR/2-1]+a[NR/2])/2}')
-    echo "$THROUGHPUT,$LATENCY" >> "$RESULT"
+    THROUGHPUT=$(echo "${THROUGHPUTS[$CONCURRENCY]}" | tr " " "\n" | sort -n | awk '{a[NR]=$0}END{if(NR%2==1)print a[(NR + 1)/2];else print (a[NR/2]+a[NR/2 + 1])/2}')
+    LATENCY=$(echo "${LATENCIES[$CONCURRENCY]}" | tr " " "\n" | sort -n | awk '{a[NR]=$0}END{if(NR%2==1)print a[(NR + 1)/2];else print (a[NR/2]+a[NR/2 + 1])/2}')
+    printf "Concurrency = %3d: Per Thread Median Througput (bytes) = %9.3f, Latency (ms) = %9.3f\n" \
+        "$CONCURRENCY" "$THROUGHPUT" "$LATENCY" | tee -a "$RESULT"
 done
 
 echo "Result file: $RESULT"

--- a/CI-Examples/lighttpd/README.md
+++ b/CI-Examples/lighttpd/README.md
@@ -9,7 +9,7 @@ For this example, we build lighttpd from source instead of using an existing
 binary. To build lighttpd on Ubuntu 18.04, please make sure that the following
 packages are installed:
 
-    sudo apt-get install -y build-essential apache2-utils
+    sudo apt-get install -y build-essential libssl-dev zlib1g-dev
 
 ## Linux
 
@@ -37,9 +37,10 @@ Once the server has started, you can test it with `wget` or `curl`
     wget http://127.0.0.1:8003/random/10K.1.html
     curl --compressed http://127.0.0.1:8003/random/10K.1.html -o 10K.1.html
 
-You may also run the benchmark script using `ab` (Apachebench)
+You may also run the benchmark script using `wrk` (wrk2). Please refer to
+https://github.com/giltene/wrk2 for more information.
 
-    ../common_tools/benchmark-http.sh 127.0.0.1:8003
+    ../common_tools/benchmark-http.sh http://127.0.0.1:8003
 
 Use Ctrl-C to terminate the server once you are finished testing lighttpd.
 

--- a/CI-Examples/nginx/README.md
+++ b/CI-Examples/nginx/README.md
@@ -6,13 +6,10 @@ recent version of Nginx web server (as of this writing, version 1.16.1).
 We build Nginx from the source code instead of using an existing installation.
 On Ubuntu 18.04, please make sure that the following packages are installed:
 ```sh
-sudo apt-get install -y build-essential apache2-utils libssl-dev
+sudo apt-get install -y build-essential libssl-dev zlib1g-dev
 ```
-
-NOTE: The "benchmark-http.sh" script uses the Apache Benchmark (ab) under the
-hood. At least the default version of ab shipped with Ubuntu 18.04 (v2.3) does
-not work correctly with Nginx and HTTPS (it fails on KeepAlive HTTPS requests).
-We recommend to use the wrk benchmarking tool.
+NOTE: The "benchmark-http.sh" script uses the wrk benchmark (wrk2) under the
+hood. Please refer to https://github.com/giltene/wrk2.
 
 # Quick Start
 
@@ -20,9 +17,9 @@ We recommend to use the wrk benchmarking tool.
 # build Nginx and the final manifest
 make SGX=1
 
-# run original Nginx against HTTP and HTTPS benchmarks (benchmark-http.sh, uses ab)
+# run original Nginx against HTTP and HTTPS benchmarks (benchmark-http.sh, uses wrk2)
 ./install/sbin/nginx -c conf/nginx-gramine.conf &
-../common_tools/benchmark-http.sh 127.0.0.1:8002
+../common_tools/benchmark-http.sh http://127.0.0.1:8002
 ../common_tools/benchmark-http.sh https://127.0.0.1:8444
 kill -SIGINT %%
 
@@ -30,7 +27,7 @@ kill -SIGINT %%
 # Note: The command-line arguments are passed using `loader.argv_src_file`
 # manifest option.
 gramine-direct ./nginx &
-../common_tools/benchmark-http.sh 127.0.0.1:8002
+../common_tools/benchmark-http.sh http://127.0.0.1:8002
 ../common_tools/benchmark-http.sh https://127.0.0.1:8444
 kill -SIGINT %%
 
@@ -38,7 +35,7 @@ kill -SIGINT %%
 # Note: The command-line arguments are securely passed using
 # `loader.argv_src_file` manifest option.
 gramine-sgx ./nginx &
-../common_tools/benchmark-http.sh 127.0.0.1:8002
+../common_tools/benchmark-http.sh http://127.0.0.1:8002
 ../common_tools/benchmark-http.sh https://127.0.0.1:8444
 kill -SIGINT %%
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `benchmark-http.sh` script uses the Apache Benchmark (ab) under the hood. At least the default version of ab shipped with Ubuntu 18.04 (v2.3) does not work correctly with Nginx and HTTPS (it fails on KeepAlive HTTPS requests). So updated the script to use `wrk2`. Secondly, the median calculation in the script is broken and this PR addresses the issue. This PR also adds APIs to parse and convert throughput and latency metrics with SI units to plain numbers.  (Note: `wrk2` shows the results with SI units.)
 
## How to test this PR? <!-- (if applicable) -->
Please run `nginx` or `ligttpd` as part of our `CI-Examples`

## Expected results
The results file should display median throughput and latency correctly.

## Actual results without this PR.
When `LOOP = 1` which is the default case, we see only zeros.
```
cat result-220321-091419                                                                                                                   
0,0
0,0
0,0
0,0
0,0
0,0
0,0
0,0
0,0
```

When `LOOP = 2`, the median of two iterations (average value) should be shown but only the smallest of the two loops are shown. Please see below:
```
Run1:
ab -k -n 10000 -c 256 127.0.0.1:8002/random/10K.1.html
Completed 1000 requests
Completed 2000 requests
Completed 3000 requests
Completed 4000 requests
Completed 5000 requests
Completed 6000 requests
Completed 7000 requests
Completed 8000 requests
Completed 9000 requests
Completed 10000 requests
Finished 10000 requests
concurrency=256, throughput=14279.47, latency=17.928, failed=0

Run2:
ab -k -n 10000 -c 256 127.0.0.1:8002/random/10K.1.html
Completed 1000 requests
Completed 2000 requests
Completed 3000 requests
Completed 4000 requests
Completed 5000 requests
Completed 6000 requests
Completed 7000 requests
Completed 8000 requests
Completed 9000 requests
Completed 10000 requests
Finished 10000 requests
concurrency=256, throughput=14233.03, latency=17.986, failed=0

cat result-220321-091548                                                                                                      
14233.03,17.928 ===================> Shows the smallest values of both runs instead of median.
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/465)
<!-- Reviewable:end -->
