### PR TITLE
[Pal/Linux-SGX] Enable SGX hotspots profiling with Intel(R) VTune Pro…

### DIFF
--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -603,10 +603,46 @@ OCALL is executed, and ``perf report`` displays percentages based on the number
 of samples.
 
 
+.. _vtune-sgx-profiling:
+
+Profiling SGX hotspots with Intel VTune Profiler
+----------------------------------------------------
+
+This section describes how to use `VTune
+<https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/introduction.html>`__
+profiler to find SGX hotspots.
+
+Installing VTune
+""""""""""""""""""""
+
+Please download and install Intel VTune Profiler from `here
+<https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html>`__.
+
+Collecting SGX hotspots and viewing the report
+""""""""""""""""""""""""""""""""""""""""""""""
+
+#. Compile Gramine with
+   ``-Dvtune=enabled -Dvtune_sdk_path=<VTune SDK install path>``.
+
+   If ``vtune_sdk_path`` is not provided, Gramine will use the default VTune
+   installation path.
+
+#. Add ``sgx.vtune_profile = true`` and ``sgx.debug = true`` to the manifest.
+
+#. Run your application under VTune.
+
+   ``vtune -collect sgx-hotspots -result-dir results -- gramine-sgx <workload>``
+
+   It will output the data collected to a directory ``results``.
+
+#. To view the report, run
+   ``vtune -report hotspots -r <vtune data collection output directory>`` or use
+   Intel VTune Profiler GUI application.
+
+
 Other useful tools for profiling
 --------------------------------
 
-* Intel VTune Profiler (TODO)
 * ``strace -c`` will display Linux system call statistics
 * Valgrind (with `Callgrind
   <https://valgrind.org/docs/manual/cl-manual.html>`__) unfortunately doesn't

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -856,6 +856,24 @@ Linux scheduler: the effective maximum is 250 samples per second.
    This option applies only to ``aex`` mode. In the ``ocall_*`` modes, currently
    all samples are taken.
 
+SGX profiling with Intel VTune Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.vtune_profile = [true|false]
+    (Default: false)
+
+This syntax specifies whether to enable SGX profiling with Intel VTune Profiler.
+Gramine must be compiled with ``DEBUG=1`` or ``DEBUGOPT=1`` for this option to
+work (the latter is advised). In addition, the application manifest must also
+contain ``sgx.debug = true``.
+
+.. note::
+   The manifest options ``sgx.vtune_profile`` and ``sgx.profile.*`` can work
+   independently.
+
+See :ref:`vtune-sgx-profiling` for more information.
 
 Deprecated options
 ------------------

--- a/Pal/src/host/Linux-SGX/meson.build
+++ b/Pal/src/host/Linux-SGX/meson.build
@@ -159,6 +159,8 @@ libpal_sgx_urts = executable('loader',
     dependencies: [
         common_dep,
         protobuf_dep,
+        vtune_dep,
+        dl_dep,
     ],
 
     install: true,

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -30,6 +30,8 @@
     do {                 \
     } while (0)
 
+extern bool g_vtune_profile_enabled;
+
 static long sgx_ocall_exit(void* pms) {
     ms_ocall_exit_t* ms = (ms_ocall_exit_t*)pms;
     ODEBUG(OCALL_EXIT, NULL);
@@ -46,6 +48,13 @@ static long sgx_ocall_exit(void* pms) {
 #ifdef DEBUG
         sgx_profile_finish();
 #endif
+
+#ifdef SGX_VTUNE_PROFILE
+        if (g_vtune_profile_enabled) {
+            extern void __itt_fini_ittlib(void);
+            __itt_fini_ittlib();
+        }
+#endif
         DO_SYSCALL(exit_group, (int)ms->ms_exitcode);
         die_or_inf_loop();
     }
@@ -61,6 +70,12 @@ static long sgx_ocall_exit(void* pms) {
         update_and_print_stats(/*process_wide=*/true);
 #ifdef DEBUG
         sgx_profile_finish();
+#endif
+#ifdef SGX_VTUNE_PROFILE
+        if (g_vtune_profile_enabled) {
+            extern void __itt_fini_ittlib(void);
+            __itt_fini_ittlib();
+        }
 #endif
         DO_SYSCALL(exit_group, (int)ms->ms_exitcode);
         die_or_inf_loop();

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ endif
 
 direct = get_option('direct') == 'enabled'
 sgx = get_option('sgx') == 'enabled'
+vtune = get_option('vtune') == 'enabled'
 skeleton = get_option('skeleton') == 'enabled'
 
 dcap = get_option('dcap') == 'enabled'
@@ -166,6 +167,11 @@ if sgx
                   sgx_driver_header, sgx_driver_include_path))
     endif
 
+  if vtune
+    add_project_arguments('-DSGX_VTUNE_PROFILE', language: 'c')
+    vtune_sdk_path = get_option('vtune_sdk_path')
+  endif
+
     conf_sgx.set('CONFIG_SGX_DRIVER_HEADER_ABSPATH', sgx_driver_header_abspath)
     conf_sgx.set_quoted('CONFIG_SGX_DRIVER_DEVICE', sgx_driver_device)
 endif
@@ -273,6 +279,21 @@ if sgx
     if dcap
         sgx_dcap_quoteverify_dep = cc.find_library('sgx_dcap_quoteverify')
     endif
+
+  vtune_dep = []
+  dl_dep = []
+
+  if vtune
+      dl_dep = cc.find_library('dl', required: true)
+      vtune_dep = declare_dependency(
+          dependencies: [
+              cc.find_library('ittnotify', dirs: join_paths(vtune_sdk_path, 'lib64'), required: true),
+              dl_dep,
+          ],
+          include_directories: include_directories(join_paths(vtune_sdk_path, 'include')),
+      )
+  endif
+
 endif
 
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,3 +33,9 @@ option('sgx_driver_device', type: 'string',
 
 option('syslibdir', type: 'string',
     description: 'Path to the system library directory')
+
+option('vtune', type: 'combo', choices: ['disabled', 'enabled'],
+    description: 'Enable profiling with VTune for Gramine with SGX')
+option('vtune_sdk_path', type: 'string',
+    value: '/opt/intel/oneapi/vtune/latest/sdk',
+    description: 'Path to the VTune SDK installation')


### PR DESCRIPTION
…filer

Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR enables SGX hotspots profiling with Intel&reg; VTune&trade; Profiler.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
- Install Intel&reg; VTune&trade; Profiler from [here ](https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html).
- Build Gramine with ``-Dvtune=enabled -Dvtune_sdk_path=<VTune SDK installation path>``.
- Add ``sgx.vtune_profiling = true`` to the manifest.
- Run your application under vtune.

   ``vtune -collect sgx-hotspots -- gramine-sgx <workload>``
      
   It will output the data collected to a directory of the format ``r000sgxhs``.

- To view the report, run ``vtune -report hotspots -r <vtune data collection output directory>``

- Alternatively, the report can be viewed in Install Intel&reg; VTune&trade; Profiler also.

![image](https://user-images.githubusercontent.com/29835993/162860821-dac9772e-27b3-478a-a7db-63c192bafc55.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/478)
<!-- Reviewable:end -->
