### PR TITLE
[Pal] Add missing syscall to close fds

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -52,11 +52,6 @@ struct pal_enclave {
     bool remote_attestation_enabled;
     bool use_epid_attestation; /* Valid only if `remote_attestation_enabled` is true, selects
                                 * EPID/DCAP attestation scheme. */
-
-    /* files */
-    int sigfile;
-    int token;
-
     char* libpal_uri; /* Path to the PAL binary */
 
 #ifdef DEBUG


### PR DESCRIPTION
Signed-off-by: Zhang Lili <lili.z.zhang@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Seems the two file descriptors (enclave->token and enclave->sigfile) will not be used after the call initialize_enclave().   Close the fds for resource recycling.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/479)
<!-- Reviewable:end -->
