### PR TITLE
[Docs] Add admonition about master branch

### DIFF
--- a/Documentation/_templates/layout.html
+++ b/Documentation/_templates/layout.html
@@ -1,0 +1,15 @@
+{% extends '!layout.html' %}
+{% block document %}
+{% if READTHEDOCS and current_version == 'latest' %}
+<div class="admonition caution">
+    <p class="admonition-title">Caution</p>
+    <p>
+        This is documentation for the development version of the project, aka
+        master branch. If you installed Gramine from packages, documentation
+        for the stable version is available at
+        <a href="https://gramine.rtfd.io/en/stable/">https://gramine.rtfd.io/en/stable/</a>.
+    </p>
+</div>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -78,9 +78,28 @@ pygments_style = None
 highlight_language = 'c'
 primary_domain = 'c'
 
-rst_prolog = '''
+rst_stable_checkout = '\\'
+if 'READTHEDOCS' in os.environ:
+    rtd_current_version = os.environ['READTHEDOCS_VERSION']
+
+    if rtd_current_version.startswith('v'):
+        rst_stable_checkout = rtd_current_version
+
+    elif rtd_current_version == 'stable':
+        # we don't have a version, we may be able to check from git
+        try:
+            tags = [tag for tag in subprocess.check_output(
+                    ['git', 'tag', '--points-at']).decode().strip().split()
+                if tag.startswith('v')]
+            rst_stable_checkout = tags.pop()
+        except (subprocess.CalledProcessError, IndexError):
+            pass
+
+rst_prolog = f'''
 .. |~| unicode:: 0xa0
    :trim:
+
+.. |stable-checkout| replace:: {rst_stable_checkout}
 '''
 
 breathe_projects = {p: '_build/doxygen-{}/xml'.format(p)

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -53,9 +53,9 @@ be protected and should not be disclosed to anyone.
 Clone the repository and run sample application
 -----------------------------------------------
 
-::
+.. parsed-literal::
 
-   git clone --depth 1 https://github.com/gramineproject/gramine.git
+   git clone --depth 1 \https://github.com/gramineproject/gramine.git |stable-checkout|
    cd gramine/CI-Examples/helloworld
 
 Without SGX::


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There were a few reports from people who used `/en/latest` documentation against v1.1 packaged version and got confused, because things got changed (last one was #477).

Let's add a warning to `/en/latest`.

Also, fix build issues caused by too new jinja.

## How to test this PR? <!-- (if applicable) -->

https://gramine.readthedocs.io/en/woju-docs-warning/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/481)
<!-- Reviewable:end -->
