### PR TITLE
[LibOS] Support renaming encrypted files

### DIFF
--- a/LibOS/shim/include/shim_fs_encrypted.h
+++ b/LibOS/shim/include/shim_fs_encrypted.h
@@ -137,6 +137,7 @@ int encrypted_file_read(struct shim_encrypted_file* enc, void* buf, size_t buf_s
                         file_off_t offset, size_t* out_count);
 int encrypted_file_write(struct shim_encrypted_file* enc, const void* buf, size_t buf_size,
                          file_off_t offset, size_t* out_count);
+int encrypted_file_rename(struct shim_encrypted_file* enc, const char* new_uri);
 
 int encrypted_file_get_size(struct shim_encrypted_file* enc, file_off_t* out_size);
 int encrypted_file_set_size(struct shim_encrypted_file* enc, file_off_t size);

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -603,7 +603,7 @@ class TC_30_Syscall(RegressionTestCase):
                     os.unlink(path)
         self.assertIn('TEST OK', stdout)
 
-    @unittest.skip('Protected files do not support renaming yet')
+    @unittest.skip('Protected files (as implemented in Linux-SGX PAL) do not support renaming yet')
     @unittest.skipUnless(HAS_SGX,
         'Protected files are only available with SGX')
     def test_034_rename_unlink_pf(self):
@@ -618,7 +618,23 @@ class TC_30_Syscall(RegressionTestCase):
                     os.unlink(path)
         self.assertIn('TEST OK', stdout)
 
-    def test_035_rename_unlink_tmpfs(self):
+    def test_035_rename_unlink_enc(self):
+        os.makedirs('tmp/enc', exist_ok=True)
+        file1 = 'tmp/enc/file1'
+        file2 = 'tmp/enc/file2'
+        # Delete the files: the test overwrites them anyway, but it may fail if they are malformed.
+        for path in [file1, file2]:
+            if os.path.exists(path):
+                os.unlink(path)
+        try:
+            stdout, _ = self.run_binary(['rename_unlink', file1, file2])
+        finally:
+            for path in [file1, file2]:
+                if os.path.exists(path):
+                    os.unlink(path)
+        self.assertIn('TEST OK', stdout)
+
+    def test_036_rename_unlink_tmpfs(self):
         file1 = '/mnt/tmpfs/file1'
         file2 = '/mnt/tmpfs/file2'
         stdout, _ = self.run_binary(['rename_unlink', file1, file2])

--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -1254,6 +1254,26 @@ pf_status_t pf_set_size(pf_context_t* pf, uint64_t size) {
     return PF_STATUS_NOT_IMPLEMENTED;
 }
 
+pf_status_t pf_rename(pf_context_t* pf, const char* new_path) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (!(pf->mode & PF_FILE_MODE_WRITE))
+        return PF_STATUS_INVALID_MODE;
+
+    size_t new_path_size = strlen(new_path) + 1;
+    if (new_path_size > PATH_MAX_SIZE)
+        return PF_STATUS_PATH_TOO_LONG;
+
+    memset(pf->encrypted_part_plain.path, 0, sizeof(pf->encrypted_part_plain.path));
+    memcpy(pf->encrypted_part_plain.path, new_path, new_path_size);
+    pf->need_writing = true;
+    if (!ipf_internal_flush(pf))
+        return pf->last_error;
+
+    return PF_STATUS_SUCCESS;
+}
+
 pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output,
                     size_t* bytes_read) {
     if (!g_initialized)

--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -261,6 +261,17 @@ pf_status_t pf_get_size(pf_context_t* pf, uint64_t* size);
 pf_status_t pf_set_size(pf_context_t* pf, uint64_t size);
 
 /*!
+ * \brief Rename a PF.
+ *
+ * \param pf        PF context.
+ * \param new_path  New file path.
+ *
+ * Updates the path inside protected file header, and flushes all changes. The caller is responsible
+ * for renaming the underlying file.
+ */
+pf_status_t pf_rename(pf_context_t* pf, const char* new_path);
+
+/*!
  * \brief Get underlying handle of a PF
  *
  * \param [in] pf PF context


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This adds rename support for encrypted files. The lowest layer is much like the old implementation in #31, but thanks to encrypted files being in LibOS, the issues mentioned there do not appear:

* it's possible to rename a file that is currently open
* it's not possible to rename a file "into" or "out of" encrypted files (since rename works only within a mounted filesystem)
* this shouldn't introduce problems with reference counting

Part of protected files redesign (#371).

Note that this does *not* affect `sgx.protected_files`, which still uses the old subsystem (we'll switch once the new one has all the same features).

## How to test this PR? <!-- (if applicable) -->

The `rename_unlink` test is enabled for encrypted files. It tests various scenarios for deleting and renaming a file, possibly overwriting another file, keeping an open handle to the now-unlinked file, etc.

I also performed a manual test using the Python example:

```toml
fs.mounts = [
  { type = "encrypted", path = "/enc", uri = "file:enc" },
]
fs.insecure__keys.default = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
```

```py
from pathlib import Path
import os

Path('enc/a').write_text('Hello world')
os.rename('enc/a', 'enc/b')
print(Path('enc/b').read_text())
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/497)
<!-- Reviewable:end -->
