### PR TITLE
[Pal/Linux-SGX] Skip "TOML parsing" message in child enclaves

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -174,7 +174,7 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
 
     secs->attributes.flags |= SGX_FLAGS_INITIALIZED;
 
-    log_debug("enclave created:");
+    log_debug("Enclave created:");
     log_debug("    base:           0x%016lx", secs->base);
     log_debug("    size:           0x%016lx", secs->size);
     log_debug("    misc_select:    0x%08x",   secs->misc_select);
@@ -265,9 +265,9 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
     }
 
     if (size == g_page_size)
-        log_debug("adding page  to enclave: %p [%s:%s] (%s)%s", addr, t, p, comment, m);
+        log_debug("Adding page  to enclave: %p [%s:%s] (%s)%s", addr, t, p, comment, m);
     else
-        log_debug("adding pages to enclave: %p-%p [%s:%s] (%s)%s", addr, addr + size, t, p,
+        log_debug("Adding pages to enclave: %p-%p [%s:%s] (%s)%s", addr, addr + size, t, p,
                   comment, m);
 
 #ifdef SGX_DCAP
@@ -383,7 +383,7 @@ int init_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct,
 #endif
     unsigned long enclave_valid_addr = secs->base + secs->size - g_page_size;
 
-    log_debug("enclave initializing:");
+    log_debug("Enclave initializing:");
     log_debug("    enclave id:   0x%016lx", enclave_valid_addr);
     log_debug("    mr_enclave:   %s", ALLOCA_BYTES2HEXSTR(sigstruct->body.enclave_hash.m));
 

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -442,7 +442,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
         free_area = &areas[area_num++];
     }
 
-    log_warning("Adding pages to SGX enclave, this may take some time...");
+    log_debug("Adding pages to SGX enclave, this may take some time...");
     for (int i = 0; i < area_num; i++) {
         if (areas[i].data_src == ELF_FD) {
             ret = load_enclave_binary(&enclave_secs, areas[i].fd, areas[i].addr, areas[i].prot);
@@ -517,7 +517,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
             goto out;
         }
     }
-    log_warning("Added all pages to SGX enclave");
+    log_debug("Added all pages to SGX enclave");
 
     ret = init_enclave(&enclave_secs, &enclave_sigstruct, &enclave_token);
     if (ret < 0) {
@@ -626,7 +626,6 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
     char* log_file = NULL;
     char errbuf[256];
 
-    log_always("Parsing TOML manifest file, this may take some time...");
     manifest_root = toml_parse(manifest, errbuf, sizeof(errbuf));
     if (!manifest_root) {
         log_error("PAL failed at parsing the manifest: %s", errbuf);
@@ -895,7 +894,6 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
         }
     }
     g_urts_log_level = log_level;
-    log_warning("Parsed TOML manifest file successfully");
 
     ret = 0;
 
@@ -924,11 +922,16 @@ static int load_enclave(struct pal_enclave* enclave, char* args, size_t args_siz
     DO_SYSCALL(gettimeofday, &tv, NULL);
     start_time = tv.tv_sec * 1000000UL + tv.tv_usec;
 
+    if (parent_stream_fd < 0) {
+        /* only print during main process's startup (note that this message is always printed) */
+        log_always("Gramine is starting. Parsing TOML manifest file, this may take some time...");
+    }
     ret = parse_loader_config(enclave->raw_manifest_data, enclave);
     if (ret < 0) {
         log_error("Parsing manifest failed");
         return -EINVAL;
     }
+    log_debug("Gramine parsed TOML manifest file successfully");
 
     ret = open_sgx_driver(need_gsgx);
     if (ret < 0)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The "TOML parsing" message is always printed on enclave startup (because we cannot rely on the `log_level` specified in the manifest at startup). Previously, it was annoyingly printed for every child enclave.

## How to test this PR? <!-- (if applicable) -->

An example of R, that calls `rm` and <some other utility> upon termination:

- before this PR:
```
~/gramineproject/examples/r$ gramine-sgx ./R --slave --vanilla -f scripts/sample.r
Parsing TOML manifest file, this may take some time...
-----------------------------------------------------------------------------------------------------------------------
Gramine detected the following insecure configurations:

  - loader.insecure__use_cmdline_argv = true   (forwarding command-line args from untrusted host to the app)
  - sgx.allowed_files = [ ... ]                (some files are passed through from untrusted host without verification)

Gramine will continue application execution, but this configuration must not be used in production!
-----------------------------------------------------------------------------------------------------------------------

[P1:T1:] error: Detected deprecated syntax: 'fs.mount'. Consider converting to the new array syntax: 'fs.mounts = [{ type = "chroot", uri = "...", path = "..." }]'.
[1] 3 2 1
[1] 3 1 2
[1] 3 5 2 5
 [1] 2 2 2 2 1 2 2 2 2 2
[1] "success"
Parsing TOML manifest file, this may take some time...
Parsing TOML manifest file, this may take some time...
```

- with this PR:
```
~/gramineproject/examples/r$ gramine-sgx ./R --slave --vanilla -f scripts/sample.r
Gramine starts. Parsing TOML manifest file, this may take some time...
-----------------------------------------------------------------------------------------------------------------------
Gramine detected the following insecure configurations:

  - loader.insecure__use_cmdline_argv = true   (forwarding command-line args from untrusted host to the app)
  - sgx.allowed_files = [ ... ]                (some files are passed through from untrusted host without verification)

Gramine will continue application execution, but this configuration must not be used in production!
-----------------------------------------------------------------------------------------------------------------------

[P1:T1:] error: Detected deprecated syntax: 'fs.mount'. Consider converting to the new array syntax: 'fs.mounts = [{ type = "chroot", uri = "...", path = "..." }]'.
[1] 3 2 1
[1] 3 1 2
[1] 2 3 5 5
 [1] 2 2 2 2 2 2 2 2 1 2
[1] "success"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/501)
<!-- Reviewable:end -->
