### PR TITLE
Support multiple keys in encrypted files

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -35,6 +35,9 @@ struct shim_mount_params {
 
     /* PAL URI, or NULL if not applicable */
     const char* uri;
+
+    /* Key name (used by `chroot_encrypted` filesystem), or NULL if not applicable */
+    const char* key_name;
 };
 
 struct shim_fs_ops {

--- a/LibOS/shim/src/fs/chroot/encrypted.c
+++ b/LibOS/shim/src/fs/chroot/encrypted.c
@@ -26,7 +26,6 @@
  * TODO (most items are needed for feature parity with PAL protected files):
  *
  * - mounting with special keys (SGX MRENCLAVE and MRSIGNER)
- * - setting keys through /dev/attestation (and making sure they're copied to child process)
  * - mmap
  * - truncate (the current `truncate` operation works only for extending the file, support for
  *   truncation needs to be added to the `protected_files` module)
@@ -55,7 +54,7 @@ static int chroot_encrypted_mount(struct shim_mount_params* params, void** mount
     const char* key_name = params->key_name ?: "default";
 
     struct shim_encrypted_files_key* key;
-    int ret = get_encrypted_files_key(key_name, &key);
+    int ret = get_or_create_encrypted_files_key(key_name, &key);
     if (ret < 0)
         return ret;
 
@@ -76,7 +75,7 @@ static int chroot_encrypted_migrate(void* checkpoint, void** mount_data) {
     const char* name = checkpoint;
 
     struct shim_encrypted_files_key* key;
-    int ret = get_encrypted_files_key(name, &key);
+    int ret = get_or_create_encrypted_files_key(name, &key);
     if (ret < 0)
         return ret;
     *mount_data = key;

--- a/LibOS/shim/src/fs/chroot/encrypted.c
+++ b/LibOS/shim/src/fs/chroot/encrypted.c
@@ -25,7 +25,6 @@
  *
  * TODO (most items are needed for feature parity with PAL protected files):
  *
- * - mounting with other keys than "default"
  * - mounting with special keys (SGX MRENCLAVE and MRSIGNER)
  * - setting keys through /dev/attestation (and making sure they're copied to child process)
  * - mmap
@@ -53,8 +52,10 @@ static int chroot_encrypted_mount(struct shim_mount_params* params, void** mount
     if (!params->uri || !strstartswith(params->uri, URI_PREFIX_FILE))
         return -EINVAL;
 
+    const char* key_name = params->key_name ?: "default";
+
     struct shim_encrypted_files_key* key;
-    int ret = get_encrypted_files_key("default", &key);
+    int ret = get_encrypted_files_key(key_name, &key);
     if (ret < 0)
         return ret;
 

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -126,7 +126,9 @@ static int pseudo_open(struct shim_handle* hdl, struct shim_dentry* dent, int fl
                 ret = node->str.load(dent, &str, &len);
                 if (ret < 0)
                     return ret;
-                assert(str);
+
+                if (len > 0)
+                    assert(str);
             } else {
                 len = 0;
                 str = NULL;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -103,6 +103,7 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_process* process_description,
                            struct shim_thread* thread_description,
                            struct shim_ipc_ids* process_ipc_ids) {
     DEFINE_MIGRATE(process_ipc_ids, process_ipc_ids, sizeof(*process_ipc_ids));
+    DEFINE_MIGRATE(all_encrypted_files_keys, NULL, 0);
     DEFINE_MIGRATE(dentry_root, NULL, 0);
     DEFINE_MIGRATE(all_mounts, NULL, 0);
     DEFINE_MIGRATE(all_vmas, NULL, 0);

--- a/LibOS/shim/test/regression/keys.c
+++ b/LibOS/shim/test/regression/keys.c
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/* Test for setting and reading encrypted files keys (/dev/attestation/keys). */
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "rw_file.h"
+
+#define KEY_SIZE 16
+#define KEY_STR_SIZE (2 * KEY_SIZE + 1)
+
+typedef uint8_t pf_key_t[KEY_SIZE];
+
+/* Keys and values specified in `manifest.template`. */
+#define DEFAULT_KEY_PATH "/dev/attestation/keys/default"
+#define CUSTOM_KEY_PATH "/dev/attestation/keys/my_custom_key"
+
+static const pf_key_t default_key = {
+    0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00};
+
+static const pf_key_t custom_key = {
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+
+/* New value that we'll be setting. */
+static const pf_key_t new_custom_key = {
+    0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
+
+static void format_key(char buf[static KEY_STR_SIZE], const pf_key_t* key) {
+    const char* hex = "0123456789abcdef";
+
+    for (size_t i = 0; i < KEY_SIZE; i++) {
+        uint8_t byte = (*key)[i];
+        buf[i * 2]     = hex[byte / 16];
+        buf[i * 2 + 1] = hex[byte % 16];
+    }
+    buf[KEY_SIZE * 2] = '\0';
+}
+
+static void expect_key(const char* desc, const char* path, const pf_key_t* expected_key) {
+    pf_key_t key;
+
+    ssize_t n = posix_file_read(path, (char*)&key, sizeof(key));
+    if (n < 0)
+        err(1, "%s: error reading %s", desc, path);
+    if ((size_t)n < sizeof(key))
+        errx(1, "%s: file %s is too short: %zd", desc, path, n);
+
+    if (memcmp(&key, expected_key, sizeof(*expected_key))) {
+        char expected_key_str[KEY_STR_SIZE];
+        format_key(expected_key_str, expected_key);
+
+        char key_str[KEY_STR_SIZE];
+        format_key(key_str, &key);
+
+        errx(1, "%s: wrong key: expected %s, got %s", desc, expected_key_str, key_str);
+    }
+}
+
+static void write_key(const char* desc, const char* path, const pf_key_t* key) {
+    ssize_t n = posix_file_write(path, (char*)key, sizeof(*key));
+    if (n < 0)
+        err(1, "%s: error writing %s", desc, path);
+    if ((size_t)n < sizeof(*key))
+        errx(1, "%s: not enough bytes written to %s: %zd", desc, path, n);
+}
+
+int main(void) {
+    expect_key("before writing key", DEFAULT_KEY_PATH, &default_key);
+    expect_key("before writing key", CUSTOM_KEY_PATH, &custom_key);
+
+    /* Perform invalid write (size too small), Gramine's `write` syscall should fail */
+    ssize_t n = posix_file_write(CUSTOM_KEY_PATH, (char*)&new_custom_key,
+                                 sizeof(new_custom_key) - 1);
+    if (n >= 0 || (n < 0 && errno != EACCES))
+        err(1, "writing invalid key: expected EACCES");
+
+    expect_key("after writing invalid key", CUSTOM_KEY_PATH, &custom_key);
+
+    write_key("writing key", CUSTOM_KEY_PATH, &new_custom_key);
+    expect_key("after writing key", CUSTOM_KEY_PATH, &new_custom_key);
+
+    /* Check if the child process will see the updated key. */
+    pid_t pid = fork();
+    if (pid < 0)
+        err(1, "fork");
+    if (pid == 0) {
+        expect_key("in child process", DEFAULT_KEY_PATH, &default_key);
+        expect_key("in child process", CUSTOM_KEY_PATH, &new_custom_key);
+    } else {
+        int status;
+        if (waitpid(pid, &status, 0) == -1)
+            err(1, "waitpid");
+        if (!WIFEXITED(status))
+            errx(1, "child not exited");
+        if (WEXITSTATUS(status) != 0)
+            errx(1, "unexpected exit status: %d", WEXITSTATUS(status));
+        printf("TEST OK\n");
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -44,6 +44,8 @@ sgx.protected_files = [
   "file:tmp/pf/",
 ]
 
+# See the `keys.c` test.
+fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
 fs.insecure__keys.my_custom_key = "00112233445566778899aabbccddeeff"
 
 # for sealed_file_mrenclave* tests

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -17,7 +17,7 @@ fs.mounts = [
   { path = "/bin", uri = "file:/bin" },
 
   { type = "tmpfs", path = "/mnt/tmpfs" },
-  { type = "encrypted", path = "/tmp/enc", uri = "file:tmp/enc" },
+  { type = "encrypted", path = "/tmp/enc", uri = "file:tmp/enc", key_name = "my_custom_key" },
 ]
 
 sgx.thread_num = 16
@@ -44,7 +44,7 @@ sgx.protected_files = [
   "file:tmp/pf/",
 ]
 
-fs.insecure__keys.default = "00112233445566778899aabbccddeeff"
+fs.insecure__keys.my_custom_key = "00112233445566778899aabbccddeeff"
 
 # for sealed_file_mrenclave* tests
 sgx.protected_mrenclave_files = [

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -49,6 +49,7 @@ tests = {
     'helloworld': {},
     'host_root_fs': {},
     'init_fail': {},
+    'keys': {},
     'kill_all': {},
     'large_dir_read': {},
     'large_file': {},

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -268,6 +268,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         stdout, _ = self.run_binary(cmd)
         self.assertIn('TEST OK', stdout, 'test failed: {}'.format(cmd))
 
+    def test_230_keys(self):
+        stdout, _ = self.run_binary(['keys'])
+        self.assertIn('TEST OK', stdout)
+
     def test_300_shared_object(self):
         stdout, _ = self.run_binary(['shared_object'])
 

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -50,6 +50,7 @@ manifests = [
   "helloworld",
   "host_root_fs",
   "init_fail",
+  "keys",
   "kill_all",
   "large_dir_read",
   "large_file",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -52,6 +52,7 @@ manifests = [
   "helloworld",
   "host_root_fs",
   "init_fail",
+  "keys",
   "kill_all",
   "large_dir_read",
   "large_file",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This allows mounting encrypted files with `key = "..."` parameter. In addition, the keys can be now updated by application, by writing to `/dev/attestation/keys/<name>`.

## How to test this PR? <!-- (if applicable) -->

The LibOS regression tests explicitly use `key = "custom"` now. There is also a test that checks if we can set a key, if errors are handled, and if the update persists after a fork.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/504)
<!-- Reviewable:end -->
