### PR TITLE
[Pal] Remove unused `disconnected` field from PAL_STREAM_ATTR structure

### DIFF
--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -411,7 +411,6 @@ int DkReceiveHandle(PAL_HANDLE source_process, PAL_HANDLE* out_cargo);
 /* stream attribute structure */
 typedef struct _PAL_STREAM_ATTR {
     PAL_IDX handle_type;
-    bool disconnected;
     bool nonblocking;
     pal_share_flags_t share_flags;
     PAL_NUM pending_size;

--- a/Pal/src/host/Linux-SGX/db_eventfd.c
+++ b/Pal/src/host/Linux-SGX/db_eventfd.c
@@ -111,7 +111,6 @@ static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) 
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->eventfd.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = ocall_fionread(handle->eventfd.fd);

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -673,7 +673,6 @@ static inline int file_stat_type(struct stat* stat) {
 /* copy attr content from POSIX stat struct to PAL_STREAM_ATTR */
 static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
     attr->handle_type  = file_stat_type(stat);
-    attr->disconnected = false;
     attr->nonblocking  = false;
     attr->share_flags  = stat->st_mode & PAL_SHARE_MASK;
     attr->pending_size = stat->st_size;

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -463,7 +463,6 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->pipe.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading (doesn't make sense for "listening" pipes) */
     attr->pending_size = 0;

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -364,7 +364,6 @@ static int proc_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->process.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = ocall_fionread(handle->process.stream);

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -687,7 +687,6 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type              = HANDLE_HDR(handle)->type;
     attr->nonblocking              = handle->sock.nonblocking;
-    attr->disconnected             = handle->flags & PAL_HANDLE_FD_ERROR;
 
     attr->socket.linger            = handle->sock.linger;
     attr->socket.receivebuf        = handle->sock.receivebuf;

--- a/Pal/src/host/Linux/db_eventfd.c
+++ b/Pal/src/host/Linux/db_eventfd.c
@@ -113,7 +113,6 @@ static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) 
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->eventfd.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = DO_SYSCALL(ioctl, handle->eventfd.fd, FIONREAD, &val);

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -198,7 +198,6 @@ static inline int file_stat_type(struct stat* stat) {
 /* copy attr content from POSIX stat struct to PAL_STREAM_ATTR */
 static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
     attr->handle_type  = file_stat_type(stat);
-    attr->disconnected = false;
     attr->nonblocking  = false;
     attr->share_flags  = stat->st_mode & PAL_SHARE_MASK;
     attr->pending_size = stat->st_size;

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -323,7 +323,6 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->pipe.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading (doesn't make sense for "listening" pipes) */
     attr->pending_size = 0;

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -344,7 +344,6 @@ static int proc_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->process.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     /* get number of bytes available for reading */
     ret = DO_SYSCALL(ioctl, handle->process.stream, FIONREAD, &val);

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -931,7 +931,6 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     attr->handle_type  = HANDLE_HDR(handle)->type;
     attr->nonblocking  = handle->sock.nonblocking;
-    attr->disconnected = handle->flags & PAL_HANDLE_FD_ERROR;
 
     attr->socket.linger            = handle->sock.linger;
     attr->socket.receivebuf        = handle->sock.receivebuf;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Not used anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/505)
<!-- Reviewable:end -->
