### PR TITLE
[Pal] fix `getsockname` of unbind connected tcp socket

### DIFF
--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -186,6 +186,23 @@ static void client(void) {
         exit(1);
     }
 
+    char local_ip[16];
+    unsigned int local_port;
+    struct sockaddr_in local_addr;
+    bzero(&local_addr, sizeof(local_addr));
+    socklen_t len = sizeof(local_addr);
+
+    if (getsockname(server_socket, (struct sockaddr*)&local_addr, &len) < 0) {
+        perror("getsockname");
+        exit(1);
+    }
+
+    inet_ntop(AF_INET, &local_addr.sin_addr, local_ip, sizeof(local_ip));
+    local_port = ntohs(local_addr.sin_port);
+
+    printf("[client] local ip address: %s\n", local_ip);
+    printf("[client] local port : %u\n", local_port);
+
     /* we specify dummy MSG_DONTWAIT and MSG_WAITALL just to test these flags */
     printf("[client] receiving with MSG_PEEK: ");
     count = client_recv(server_socket, buffer, sizeof(buffer),

--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -186,8 +186,8 @@ static void client(void) {
         exit(1);
     }
 
-    char local_ip[16];
-    unsigned int local_port;
+    char local_ip[INET_ADDRSTRLEN];
+    uint16_t local_port;
     struct sockaddr_in local_addr;
     bzero(&local_addr, sizeof(local_addr));
     socklen_t len = sizeof(local_addr);
@@ -200,7 +200,7 @@ static void client(void) {
     inet_ntop(AF_INET, &local_addr.sin_addr, local_ip, sizeof(local_ip));
     local_port = ntohs(local_addr.sin_port);
 
-    printf("[client] local ip address: %s\n", local_ip);
+    printf("[client] local IP address: %s\n", local_ip);
     printf("[client] local port : %u\n", local_port);
 
     /* we specify dummy MSG_DONTWAIT and MSG_WAITALL just to test these flags */

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -1186,7 +1186,6 @@ class TC_80_Socket(RegressionTestCase):
 
     def test_300_socket_tcp_msg_peek(self):
         stdout, _ = self.run_binary(['tcp_msg_peek'], timeout=50)
-        self.assertIn('[client] local ip address: 127.0.0.1', stdout)
         self.assertNotIn('[client] local port : 11111', stdout)
         self.assertIn('[client] receiving with MSG_PEEK: Hello from server!', stdout)
         self.assertIn('[client] receiving with MSG_PEEK again: Hello from server!', stdout)

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -1186,6 +1186,8 @@ class TC_80_Socket(RegressionTestCase):
 
     def test_300_socket_tcp_msg_peek(self):
         stdout, _ = self.run_binary(['tcp_msg_peek'], timeout=50)
+        self.assertIn('[client] local ip address: 127.0.0.1', stdout)
+        self.assertNotIn('[client] local port : 11111', stdout)
         self.assertIn('[client] receiving with MSG_PEEK: Hello from server!', stdout)
         self.assertIn('[client] receiving with MSG_PEEK again: Hello from server!', stdout)
         self.assertIn('[client] receiving without MSG_PEEK: Hello from server!', stdout)


### PR DESCRIPTION
## Description of the changes

in Linux-SGX Pal, `getsockname`  is called in `ocall_connect` when `bind_addr` buffer is not NULL.
Current code set `bind_addr` NULL when URL is "addr:port". This is the case that `connect` called without `bind`.

Update Linux-SGX Pal and a test case to cover `getsockname`.

fixes #500

## How to test this PR
`gramine-test pytest -v -k test_300_socket_tcp_msg_peek` in `LibOS/shim/test/regression`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/506)
<!-- Reviewable:end -->
