### PR TITLE
[LibOS] Propagate errors when writing to pseudo-files

### DIFF
--- a/LibOS/shim/include/shim_fs_pseudo.h
+++ b/LibOS/shim/include/shim_fs_pseudo.h
@@ -133,7 +133,18 @@ struct pseudo_node {
              */
             int (*load)(struct shim_dentry* dent, char** out_data, size_t* out_size);
 
-            /* Invoked when saving a modified file (on `close` or `flush`). Optional. */
+            /*
+             * Invoked on every write operation.
+             *
+             * This is used to implement writable files similar to the ones in Linux sysfs. The
+             * callback is triggered on write, not on close, because otherwise there is no good way
+             * to report errors to the application (which might even exit without closing the file
+             * explicitly).
+             *
+             * As a consequence, pseudo-files that implement `save` are meant to be written using a
+             * single `write` operation. For consistency with later reads, for such files we replace
+             * existing content on every write.
+             */
             int (*save)(struct shim_dentry* dent, const char* data, size_t size);
         } str;
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -151,7 +151,6 @@ struct shim_dir_handle {
 
 struct shim_str_handle {
     struct shim_mem_file mem;
-    bool dirty;
 };
 
 DEFINE_LISTP(shim_epoll_item);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This changes semantics of `/dev/attestation` writable files so that `write` (not flush/close) triggers an action. See #502 for discussion why this is adequate. 

Fixes #502.

## How to test this PR? <!-- (if applicable) -->

See #502 for a manual test. The next PR (#504) also contains automated test for the error case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/508)
<!-- Reviewable:end -->
