### PR TITLE
[python] Use `platform.machine()`, not `platform.processor()`

### DIFF
--- a/python/graminelibos/util_tests.py
+++ b/python/graminelibos/util_tests.py
@@ -50,7 +50,7 @@ class TestConfig:
         data = toml.load(path)
 
         self.manifests = self.get_manifests(data)
-        arch = platform.processor()
+        arch = platform.machine()
         arch_data = data.get('arch', {}).get(arch, {})
         self.manifests += self.get_manifests(arch_data)
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This translates to `uname -m` instead of `uname -p`. The latter is non-POSIX and does not work in some Linux distributions:

https://unix.stackexchange.com/a/307960

Bug found by @omeg.

## How to test this PR? <!-- (if applicable) -->

Without this PR, on Debian, `gramine-test build` inside LibOS regression tests does not build manifests for `x86_64` tests (e.g. `cpuid`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/509)
<!-- Reviewable:end -->
