### PR TITLE
[LibOS] Fix `newfstatat` not calculating inode numbers

### DIFF
--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -237,13 +237,7 @@ static int do_fstatat_empty_path(int dirfd, struct stat* statbuf) {
         goto out;
     }
 
-    struct shim_d_ops* d_ops = dent->inode->fs->d_ops;
-    if (!(d_ops && d_ops->stat)) {
-        ret = -EACCES;
-        goto out;
-    }
-
-    ret = d_ops->stat(dent, statbuf);
+    ret = do_stat(dent, statbuf);
 out:
     unlock(&g_dcache_lock);
     put_dentry(dent);
@@ -289,13 +283,7 @@ long shim_do_newfstatat(int dirfd, const char* pathname, struct stat* statbuf, i
     if (ret < 0)
         goto out;
 
-    struct shim_d_ops* d_ops = dent->inode->fs->d_ops;
-    if (!(d_ops && d_ops->stat)) {
-        ret = -EACCES;
-        goto out;
-    }
-
-    ret = d_ops->stat(dent, statbuf);
+    ret = do_stat(dent, statbuf);
 out:
     unlock(&g_dcache_lock);
     if (dent)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes programs (such as GCC) that compare device and inode numbers obtained using `newfstatat` to check if two files are the same.

## How to test this PR? <!-- (if applicable) -->

Quick check using the `python` example:

```
gramine-direct python -c "import os; print(os.stat('.', dir_fd=os.open('/usr', os.O_DIRECTORY)).st_ino)"
```

This should print zero on master, non-zero on this branch.

