### PR TITLE
[CI-Examples] python: Add `sgx-quote.py` script

### DIFF
--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -9,7 +9,7 @@ stage('test-sgx') {
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
             cd CI-Examples/python
-            make ${MAKEOPTS}
+            RA_CLIENT_SPID=${ra_client_spid} make ${MAKEOPTS}
             make ${MAKEOPTS} check
         '''
     }

--- a/CI-Examples/python/Makefile
+++ b/CI-Examples/python/Makefile
@@ -36,6 +36,9 @@ check: all
 	@grep -q "Success 2/4" TEST_STDOUT
 	@grep -q "Success 3/4" TEST_STDOUT
 	@grep -q "Success 4/4" TEST_STDOUT
+ifeq ($(SGX),1)
+	@grep -q "Success SGX quote" TEST_STDOUT
+endif
 
 .PHONY: clean
 clean:

--- a/CI-Examples/python/README.md
+++ b/CI-Examples/python/README.md
@@ -34,22 +34,17 @@ make PYTHONPATH=<python install path> PYTHONVERSION=python3.6 SGX=1
 # Run Python with Gramine
 
 Here's an example of running Python scripts under Gramine:
-
-Without SGX:
-```
-gramine-direct ./python scripts/helloworld.py
-gramine-direct ./python scripts/test-numpy.py
-gramine-direct ./python scripts/test-scipy.py
-```
-
-With SGX:
 ```
 gramine-sgx ./python scripts/helloworld.py
 gramine-sgx ./python scripts/test-numpy.py
 gramine-sgx ./python scripts/test-scipy.py
+gramine-sgx ./python scripts/sgx-quote.py
 ```
 
 You can also manually run included tests:
 ```
 SGX=1 ./run-tests.sh
 ```
+
+To run Gramine in non-SGX (direct) mode, replace `gramine-sgx` with
+`gramine-direct` and remove `SGX=1` in the commands above.

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -28,6 +28,10 @@ sgx.enclave_size = "512M"
 sys.stack.size = "2M"
 sgx.thread_num = 32
 
+sgx.remote_attestation = true
+sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
+sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",

--- a/CI-Examples/python/run-tests.sh
+++ b/CI-Examples/python/run-tests.sh
@@ -40,3 +40,11 @@ rm OUTPUT
 $GRAMINE ./python scripts/test-scipy.py > OUTPUT
 grep -q "cholesky: " OUTPUT && echo "[ Success 4/4 ]"
 rm OUTPUT
+
+# === SGX quote ===
+if test -n "$SGX"
+then
+    $GRAMINE ./python scripts/sgx-quote.py > OUTPUT
+    grep -q "Extracted SGX quote" OUTPUT && echo "[ Success SGX quote ]"
+    rm OUTPUT
+fi

--- a/CI-Examples/python/scripts/sgx-quote.py
+++ b/CI-Examples/python/scripts/sgx-quote.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+def tohex(b):
+    return ''.join(format(x, '02x') for x in b)
+
+if not os.path.exists("/dev/attestation/user_report_data"):
+    print("Cannot find `/dev/attestation/user_report_data`; "
+          "are you running under SGX?")
+    sys.exit(1)
+
+with open("/dev/attestation/user_report_data", "wb") as f:
+    f.write(b'\0'*64)
+
+with open("/dev/attestation/quote", "rb") as f:
+    quote = f.read()
+
+print(f"Extracted SGX quote with size = {len(quote)} and the following fields:")
+print(f"  ATTRIBUTES.FLAGS: {quote[96:104].hex()}  [ Debug bit: {quote[96] & 2 > 0} ]")
+print(f"  ATTRIBUTES.XFRM:  {quote[104:112].hex()}")
+print(f"  MRENCLAVE:        {quote[112:144].hex()}")
+print(f"  MRSIGNER:         {quote[176:208].hex()}")
+print(f"  ISVPRODID:        {quote[304:306].hex()}")
+print(f"  ISVSVN:           {quote[306:308].hex()}")
+print(f"  REPORTDATA:       {quote[368:400].hex()}")
+print(f"                    {quote[400:432].hex()}")


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This script shows how to generate an SGX quote in Python.

Kudos to @lejunzhu for providing the initial Python script.

## How to test this PR? <!-- (if applicable) -->

The test is added to the CI (via `run-tests.sh`).

When I run manually, the output looks like this:
```
~/gramineproject/gramine/CI-Examples/python$ gramine-sgx python scripts/sgx-quote.py
...
Extracted SGX quote with size = 4578 and the following fields:
  ATTRIBUTES.FLAGS: 0700000000000000  [ Debug bit: True ]
  ATTRIBUTES.XFRM:  0700000000000000
  MRENCLAVE:        ac0415220cee87830641234cafc26139814c5fc4a3ba75fc1bd63acefa5548f8
  MRSIGNER:         0dedbe47afb6955e5f6109637c1fbd9cc4b4e073e1396da8ce2091075e5b0a3b
  ISVPRODID:        0000
  ISVSVN:           0000
  REPORTDATA:       0000000000000000000000000000000000000000000000000000000000000000
                    0000000000000000000000000000000000000000000000000000000000000000
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/521)
<!-- Reviewable:end -->
