### PR TITLE
Add missing section declarations to toplevel inline assembly

### DIFF
--- a/LibOS/shim/src/arch/x86_64/shim_context.c
+++ b/LibOS/shim/src/arch/x86_64/shim_context.c
@@ -144,6 +144,7 @@ __attribute__((used)) static int is_xstate_extended(const struct shim_xstate* xs
 /* Written in asm because we need to make sure it does not touch FPU/SSE after restoring their
  * state. Older gcc versions do not support `naked` attribute on x86, hence: */
 __asm__(
+".pushsection .text\n"
 ".global shim_xstate_restore\n"
 ".type shim_xstate_restore, @function\n"
 "shim_xstate_restore:\n"
@@ -161,6 +162,7 @@ __asm__(
     ".Lnot_xstate:\n"
     "fxrstor64 (%rdi)\n"
     "ret\n"
+".popsection\n"
 );
 
 /* Copies FPU state. Returns whether the copied state was xsave-made. */

--- a/LibOS/shim/test/regression/bootstrap_cpp.cpp
+++ b/LibOS/shim/test/regression/bootstrap_cpp.cpp
@@ -13,6 +13,7 @@ extern "C" void f1();
  * to check if the memory address is valid).
  */
 __asm__ (
+".pushsection .text\n"
 ".global f1\n"
 ".type f1, @function\n"
 "f1:\n"
@@ -29,6 +30,7 @@ __asm__ (
 ".cfi_restore %rbp\n"
 "ret\n"
 ".cfi_endproc\n"
+".popsection\n"
 );
 
 int main() {

--- a/Pal/src/host/Linux-SGX/sgx_syscall.c
+++ b/Pal/src/host/Linux-SGX/sgx_syscall.c
@@ -17,6 +17,7 @@ static_assert(offsetof(PAL_TCB_URTS, last_async_event) == PAL_TCB_URTS_LAST_ASYN
               "error");
 
 __asm__ (
+".pushsection .text\n"
 ".global do_syscall_intr\n"
 ".type do_syscall_intr, @function\n"
 ".global do_syscall_intr_after_check1\n"
@@ -42,4 +43,5 @@ __asm__ (
 "do_syscall_intr_eintr:\n"
     "mov $" XSTRINGIFY(-EINTR) ", %rax\n"
     "ret\n"
+".popsection\n"
 );


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Otherwise on GCC the snippets landed in whatever section we currently were.

## How to test this PR? <!-- (if applicable) -->

Add `static const int asdf = 1;` to `pal_topology.h` and run `gramine-sgx`. The old code will segfault trying to execute `do_syscall_intr` from `.rodata`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/523)
<!-- Reviewable:end -->
