### PR TITLE
[LibOS] shim_fs_pseudo: Make it easier to specify optional files

### DIFF
--- a/LibOS/shim/include/shim_fs_pseudo.h
+++ b/LibOS/shim/include/shim_fs_pseudo.h
@@ -72,7 +72,13 @@ struct shim_dev_ops {
 
 /*
  * A node of the pseudo filesystem. A single node can describe either a single file, or a family of
- * files (see `name_exists` and `list_names` below).
+ * files:
+ *
+ * - For a single file with a pre-determined name, set `name`
+ * - For a single file with a pre-determined name that, depending on circumstances, might not exist,
+ *   set `name` and provide the `name_exists` callback
+ * - For any other case (e.g. a dynamically-generated list of files), keep `name` set to NULL, and
+ *   provide both `name_exists` and `list_names` callbacks
  *
  * The constructors for `pseudo_node` (`pseudo_add_*`) take arguments for most commonly used fields.
  * The node can then be further customized by directly modifying other fields.
@@ -95,7 +101,8 @@ struct pseudo_node {
     /* File name. Can be NULL if the node provides the below callbacks. */
     const char* name;
 
-    /* Returns true if a file with a given name exists. */
+    /* Returns true if a file with a given name exists. If both `name` and `name_exists` are
+     * provided, both are used to determine if the file exists. */
     bool (*name_exists)(struct shim_dentry* parent, const char* name);
 
     /* Retrieves all file names for this node. Works the same as `readdir`. */

--- a/LibOS/shim/src/fs/sys/cpu_info.c
+++ b/LibOS/shim/src/fs/sys/cpu_info.c
@@ -82,19 +82,3 @@ bool sys_cpu_online_name_exists(struct shim_dentry* parent, const char* name) {
 
     return cpu_num != 0;
 }
-
-int sys_cpu_online_list_names(struct shim_dentry* parent, readdir_callback_t callback, void* arg) {
-    int ret;
-    unsigned int cpu_num;
-    ret = sys_resource_find(parent, "cpu", &cpu_num);
-    if (ret < 0)
-        return ret;
-
-    if (cpu_num != 0) {
-        ret = callback("online", arg);
-        if (ret < 0)
-            return ret;
-    }
-
-    return 0;
-}

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -199,11 +199,9 @@ static void init_cpu_dir(struct pseudo_node* cpu) {
     cpuX->name_exists = &sys_resource_name_exists;
     cpuX->list_names = &sys_resource_list_names;
 
-    /* Create a node for `cpu/cpuX/online`. We provide name callbacks instead of a hardcoded name,
-     * because we want the file to exist for all CPUs *except* `cpu0`. */
-    struct pseudo_node* online = pseudo_add_str(cpuX, NULL, &sys_cpu_load);
+    /* `cpu/cpuX/online` exists for all CPUs *except* `cpu0`. */
+    struct pseudo_node* online = pseudo_add_str(cpuX, "online", &sys_cpu_load);
     online->name_exists = &sys_cpu_online_name_exists;
-    online->list_names = &sys_cpu_online_list_names;
 
     struct pseudo_node* topology = pseudo_add_dir(cpuX, "topology");
     pseudo_add_str(topology, "core_id", &sys_cpu_load);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This is a slight improvement of the pseudo-filesystem. As discussed with @mkow, it should be useful for the sysfs rewrite.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/527)
<!-- Reviewable:end -->
