### PR TITLE
Rewrite sysfs topology support

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -399,22 +399,6 @@ Start (current working) directory
 This syntax specifies the start (current working) directory. If not specified,
 then Gramine sets the root directory as the start directory (see ``fs.root``).
 
-Experimental sysfs topology support
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    fs.experimental__enable_sysfs_topology = [true|false]
-    (Default: false)
-
-This syntax enables sysfs topology feature in Gramine: pseudo-files under
-``/sys/devices/system/cpu`` and ``/sys/devices/system/node``.
-
-.. warning::
-   This feature is still under development and may contain security
-   vulnerabilities. This is temporary; the feature will be enabled in future
-   after thorough validation and this syntax will be removed then.
-
 SGX syntax
 ----------
 
@@ -883,3 +867,12 @@ FS mount points (deprecated syntax)
 
 This syntax used a TOML table schema with keys for each mount. It has been
 replaced with the ``fs.mounts`` TOML array.
+
+Experimental sysfs topology support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    fs.experimental__enable_sysfs_topology = [true|false]
+
+This feature is now enabled by default and the option was removed.

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -175,15 +175,13 @@ static int mount_sys(void) {
     if (ret < 0)
         return ret;
 
-    if (g_pal_public_state->enable_sysfs_topology) {
-        ret = mount_fs(&(struct shim_mount_params){
-            .type = "pseudo",
-            .path = "/sys",
-            .uri = "sys",
-        });
-        if (ret < 0)
-            return ret;
-    }
+    ret = mount_fs(&(struct shim_mount_params){
+        .type = "pseudo",
+        .path = "/sys",
+        .uri = "sys",
+    });
+    if (ret < 0)
+        return ret;
 
     return 0;
 }

--- a/LibOS/shim/src/fs/sys/cache_info.c
+++ b/LibOS/shim/src/fs/sys/cache_info.c
@@ -8,33 +8,54 @@
  * sub-directories.
  */
 
+#include <stdbool.h>
+
 #include "api.h"
 #include "shim_fs.h"
 #include "shim_fs_pseudo.h"
 
+struct callback_arg {
+    size_t cache_id_to_match; // index in global caches list (topo_info->caches[])
+    size_t cache_class; // index in ids_of_caches[]
+};
+
+static bool is_same_cache(size_t idx, const void* _arg) {
+    const struct callback_arg* arg = _arg;
+    const struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[idx];
+    return thread->is_online
+           && thread->ids_of_caches[arg->cache_class] == arg->cache_id_to_match;
+}
+
 int sys_cache_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
 
-    unsigned int cache_num;
-    ret = sys_resource_find(dent, "cache", &cache_num);
+    unsigned int cache_class;
+    ret = sys_resource_find(dent, "cache", &cache_class);
     if (ret < 0)
         return ret;
 
-    unsigned int cpu_num;
-    ret = sys_resource_find(dent, "cpu", &cpu_num);
+    unsigned int thread_id;
+    ret = sys_resource_find(dent, "cpu", &thread_id);
     if (ret < 0)
         return ret;
 
     const char* name = dent->name;
-    struct pal_core_cache_info* cache_info =
-        &g_pal_public_state->topo_info.core_topo_arr[cpu_num].cache_info_arr[cache_num];
+
+    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    size_t cache_idx = topo->threads[thread_id].ids_of_caches[cache_class];
+    const struct pal_cache_info* cache = &topo->caches[cache_idx];
     char str[PAL_SYSFS_MAP_FILESZ] = {'\0'};
     if (strcmp(name, "shared_cpu_map") == 0) {
-        ret = sys_convert_ranges_to_cpu_bitmap_str(&cache_info->shared_cpu_map, str, sizeof(str));
+        struct callback_arg callback_arg = {
+            .cache_id_to_match = cache_idx,
+            .cache_class = cache_class,
+        };
+        ret = sys_print_as_bitmask(str, sizeof(str), topo->threads_cnt,
+                                   is_same_cache, &callback_arg);
     } else if (strcmp(name, "level") == 0) {
-        ret = snprintf(str, sizeof(str), "%zu\n", cache_info->level);
+        ret = snprintf(str, sizeof(str), "%zu\n", cache->level);
     } else if (strcmp(name, "type") == 0) {
-        switch (cache_info->type) {
+        switch (cache->type) {
             case CACHE_TYPE_DATA:
                 ret = snprintf(str, sizeof(str), "Data\n");
                 break;
@@ -45,16 +66,16 @@ int sys_cache_load(struct shim_dentry* dent, char** out_data, size_t* out_size) 
                 ret = snprintf(str, sizeof(str), "Unified\n");
                 break;
             default:
-                ret = -ENOENT;
+                __builtin_unreachable();
         }
     } else if (strcmp(name, "size") == 0) {
-        ret = snprintf(str, sizeof(str), "%zuK\n", cache_info->size >> 10);
+        ret = snprintf(str, sizeof(str), "%zuK\n", cache->size >> 10);
     } else if (strcmp(name, "coherency_line_size") == 0) {
-        ret = snprintf(str, sizeof(str), "%zu\n", cache_info->coherency_line_size);
+        ret = snprintf(str, sizeof(str), "%zu\n", cache->coherency_line_size);
     } else if (strcmp(name, "number_of_sets") == 0) {
-        ret = snprintf(str, sizeof(str), "%zu\n", cache_info->number_of_sets);
+        ret = snprintf(str, sizeof(str), "%zu\n", cache->number_of_sets);
     } else if (strcmp(name, "physical_line_partition") == 0) {
-        snprintf(str, sizeof(str), "%zu\n", cache_info->physical_line_partition);
+        snprintf(str, sizeof(str), "%zu\n", cache->physical_line_partition);
     } else {
         log_debug("unrecognized file: %s", name);
         ret = -ENOENT;

--- a/LibOS/shim/src/fs/sys/cpu_info.c
+++ b/LibOS/shim/src/fs/sys/cpu_info.c
@@ -12,17 +12,27 @@
 #include "shim_fs.h"
 #include "shim_fs_pseudo.h"
 
+static bool is_online(size_t ind, const void* arg) {
+    __UNUSED(arg);
+    return g_pal_public_state->topo_info.threads[ind].is_online;
+}
+
+static bool return_true(size_t ind, const void* arg) {
+    __UNUSED(ind);
+    __UNUSED(arg);
+    return true;
+}
+
 int sys_cpu_general_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
+    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
     const char* name = dent->name;
-    char str[PAL_SYSFS_BUF_FILESZ] = {'\0'};
+    char str[PAL_SYSFS_BUF_FILESZ];
 
     if (strcmp(name, "online") == 0) {
-        ret = sys_convert_ranges_to_str(&g_pal_public_state->topo_info.online_logical_cores, ",",
-                                        str, sizeof(str));
+        ret = sys_print_as_ranges(str, sizeof(str), topo->threads_cnt, is_online, NULL);
     } else if (strcmp(name, "possible") == 0) {
-        ret = sys_convert_ranges_to_str(&g_pal_public_state->topo_info.possible_logical_cores, ",",
-                                        str, sizeof(str));
+        ret = sys_print_as_ranges(str, sizeof(str), topo->threads_cnt, return_true, NULL);
     } else {
         log_debug("unrecognized file: %s", name);
         ret = -ENOENT;
@@ -34,31 +44,60 @@ int sys_cpu_general_load(struct shim_dentry* dent, char** out_data, size_t* out_
     return sys_load(str, out_data, out_size);
 }
 
-int sys_cpu_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
+static bool is_in_same_core(size_t thread_id, const void* _arg) {
+    size_t arg_id = *(const size_t*)_arg;
+    struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[thread_id];
+    return thread->is_online && thread->core_id == arg_id;
+}
+
+static bool is_in_same_socket(size_t thread_id, const void* _arg) {
+    size_t arg_id = *(const size_t*)_arg;
+    struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[thread_id];
+    return thread->is_online
+        && g_pal_public_state->topo_info.cores[thread->core_id].socket_id == arg_id;
+}
+
+int sys_cpu_load_online(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
-    unsigned int cpu_num;
-    ret = sys_resource_find(dent, "cpu", &cpu_num);
+    unsigned int thread_id;
+
+    assert(!strcmp(dent->name, "online"));
+
+    ret = sys_resource_find(dent, "cpu", &thread_id);
+    if (ret < 0)
+        return ret;
+
+    /* `cpu/cpuX/online` is not present for cpu0 */
+    if (thread_id == 0)
+        return -ENOENT;
+
+    struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[thread_id];
+    return sys_load(thread->is_online ? "1\n" : "0\n", out_data, out_size);
+}
+
+int sys_cpu_load_topology(struct shim_dentry* dent, char** out_data, size_t* out_size) {
+    int ret;
+    unsigned int thread_id;
+    ret = sys_resource_find(dent, "cpu", &thread_id);
     if (ret < 0)
         return ret;
 
     const char* name = dent->name;
-    struct pal_core_topo_info* core_topology =
-        &g_pal_public_state->topo_info.core_topo_arr[cpu_num];
+    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    struct pal_cpu_thread_info* thread = &topo->threads[thread_id];
+    assert(thread->is_online); // `cpuX/topology/` should not exist for offline threads.
+    struct pal_cpu_core_info* core = &topo->cores[thread->core_id];
     char str[PAL_SYSFS_MAP_FILESZ] = {'\0'};
-    if (strcmp(name, "online") == 0) {
-        /* `cpu/cpuX/online` is not present for cpu0 */
-        if (cpu_num == 0)
-            return -ENOENT;
-        ret = snprintf(str, sizeof(str), "%d\n", core_topology->is_logical_core_online);
-    } else if (strcmp(name, "core_id") == 0) {
-        ret = snprintf(str, sizeof(str), "%zu\n", core_topology->core_id);
+    if (strcmp(name, "core_id") == 0) {
+        ret = snprintf(str, sizeof(str), "%zu\n", thread->core_id);
     } else if (strcmp(name, "physical_package_id") == 0) {
-        ret = snprintf(str, sizeof(str), "%zu\n", core_topology->socket_id);
-    } else if (strcmp(name, "core_siblings") == 0) {
-        ret = sys_convert_ranges_to_cpu_bitmap_str(&core_topology->core_siblings, str, sizeof(str));
+        ret = snprintf(str, sizeof(str), "%zu\n", core->socket_id);
     } else if (strcmp(name, "thread_siblings") == 0) {
-        ret = sys_convert_ranges_to_cpu_bitmap_str(&core_topology->thread_siblings, str,
-                                                   sizeof(str));
+        ret = sys_print_as_bitmask(str, sizeof(str), topo->threads_cnt, is_in_same_core,
+                                   &thread->core_id);
+    } else if (strcmp(name, "core_siblings") == 0) {
+        ret = sys_print_as_bitmask(str, sizeof(str), topo->threads_cnt, is_in_same_socket,
+                                   &core->socket_id);
     } else {
         log_debug("unrecognized file: %s", name);
         ret = -ENOENT;
@@ -75,10 +114,22 @@ bool sys_cpu_online_name_exists(struct shim_dentry* parent, const char* name) {
         return false;
 
     int ret;
-    unsigned int cpu_num;
-    ret = sys_resource_find(parent, "cpu", &cpu_num);
+    unsigned int thread_id;
+    ret = sys_resource_find(parent, "cpu", &thread_id);
     if (ret < 0)
         return false;
 
-    return cpu_num != 0;
+    return thread_id != 0;
+}
+
+bool sys_cpu_exists_only_if_online(struct shim_dentry* parent, const char* name) {
+    __UNUSED(name);
+    int ret;
+    unsigned int thread_id;
+    ret = sys_resource_find(parent, "cpu", &thread_id);
+    if (ret < 0)
+        return false;
+
+    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    return topo->threads[thread_id].is_online;
 }

--- a/LibOS/shim/src/fs/sys/node_info.c
+++ b/LibOS/shim/src/fs/sys/node_info.c
@@ -1,53 +1,90 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
-/* Copyright (C) 2021 Intel Corporation
+/* Copyright (C) 2022 Intel Corporation
  *                    Vijay Dhanraj <vijay.dhanraj@intel.com>
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
  */
 
 /*
  * This file contains the implementation of `/sys/devices/system/node` and its sub-directories.
  */
 
+#include <stdbool.h>
+
 #include "api.h"
 #include "shim_fs.h"
 #include "shim_fs_pseudo.h"
 
+static bool is_online(size_t ind, const void* arg) {
+    __UNUSED(arg);
+    return g_pal_public_state->topo_info.numa_nodes[ind].is_online;
+}
+
+static bool return_true(size_t ind, const void* arg) {
+    __UNUSED(ind);
+    __UNUSED(arg);
+    return true;
+}
+
 int sys_node_general_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
+    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
     const char* name = dent->name;
-    if (strcmp(name, "online") != 0) {
+    char str[PAL_SYSFS_BUF_FILESZ];
+    if (strcmp(name, "online") == 0) {
+        ret = sys_print_as_ranges(str, sizeof(str), topo->numa_nodes_cnt, is_online, NULL);
+    } else if (strcmp(name, "possible") == 0) {
+        ret = sys_print_as_ranges(str, sizeof(str), topo->numa_nodes_cnt, return_true, NULL);
+    } else {
         log_debug("unrecognized file: %s", name);
         return -ENOENT;
     }
 
-    char str[PAL_SYSFS_BUF_FILESZ] = {'\0'};
-    ret = sys_convert_ranges_to_str(&g_pal_public_state->topo_info.online_nodes, ",", str,
-                                    sizeof(str));
     if (ret < 0)
         return ret;
 
     return sys_load(str, out_data, out_size);
 }
 
+static bool is_in_same_node(size_t idx, const void* _arg) {
+    unsigned int arg_node_id = *(const unsigned int*)_arg;
+    if (!g_pal_public_state->topo_info.threads[idx].is_online)
+        return false;
+    size_t core_id = g_pal_public_state->topo_info.threads[idx].core_id;
+    size_t node_id = g_pal_public_state->topo_info.cores[core_id].node_id;
+    return node_id == arg_node_id;
+}
+
 int sys_node_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
-    unsigned int node_num;
-    ret = sys_resource_find(dent, "node", &node_num);
+    unsigned int node_id;
+    ret = sys_resource_find(dent, "node", &node_id);
     if (ret < 0)
         return ret;
 
     const char* name = dent->name;
-    struct pal_numa_topo_info* numa_topo = &g_pal_public_state->topo_info.numa_topo_arr[node_num];
-    char str[PAL_SYSFS_MAP_FILESZ] = {'\0'};
-    if (strcmp(name, "cpumap" ) == 0) {
-        ret = sys_convert_ranges_to_cpu_bitmap_str(&numa_topo->cpumap, str, sizeof(str));
+    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_numa_node_info* numa_node = &topo->numa_nodes[node_id];
+    char str[PAL_SYSFS_MAP_FILESZ] = {0};
+    if (strcmp(name, "cpumap") == 0) {
+        ret = sys_print_as_bitmask(str, sizeof(str), topo->threads_cnt, is_in_same_node, &node_id);
     } else if (strcmp(name, "distance") == 0) {
-        ret = sys_convert_ranges_to_str(&numa_topo->distance, " ", str, sizeof(str));
+        size_t* distances = topo->numa_distance_matrix + node_id * topo->numa_nodes_cnt;
+        size_t str_pos = 0;
+        for (size_t i = 0; i < topo->numa_nodes_cnt; i++) {
+            ret = snprintf(str + str_pos, sizeof(str) - str_pos,
+                           "%zu%s", distances[i], i != (topo->numa_nodes_cnt - 1) ? " " : "\n");
+            if (ret < 0)
+                return ret;
+            if ((size_t)ret >= sizeof(str) - str_pos)
+                return -EOVERFLOW;
+            str_pos += ret;
+        }
     } else if (strcmp(name, "nr_hugepages") == 0) {
         const char* parent_name = dent->parent->name;
         if (strcmp(parent_name, "hugepages-2048kB") == 0) {
-            ret = snprintf(str, sizeof(str), "%zu\n", numa_topo->nr_hugepages[HUGEPAGES_2M]);
+            ret = snprintf(str, sizeof(str), "%zu\n", numa_node->nr_hugepages[HUGEPAGES_2M]);
         } else if (strcmp(parent_name, "hugepages-1048576kB") == 0) {
-            ret = snprintf(str, sizeof(str), "%zu\n", numa_topo->nr_hugepages[HUGEPAGES_1G]);
+            ret = snprintf(str, sizeof(str), "%zu\n", numa_node->nr_hugepages[HUGEPAGES_1G]);
         } else {
             log_debug("unrecognized hugepage file: %s", parent_name);
             ret = -ENOENT;

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -175,7 +175,7 @@ long shim_do_sched_setaffinity(pid_t pid, unsigned int cpumask_size, unsigned lo
 
 long shim_do_sched_getaffinity(pid_t pid, unsigned int cpumask_size, unsigned long* user_mask_ptr) {
     int ret;
-    size_t cpu_cnt = g_pal_public_state->topo_info.online_logical_cores.resource_cnt;
+    size_t threads_cnt = g_pal_public_state->topo_info.threads_cnt;
 
     /* Check if user_mask_ptr is valid */
     if (!is_user_memory_writable(user_mask_ptr, cpumask_size))
@@ -183,7 +183,7 @@ long shim_do_sched_getaffinity(pid_t pid, unsigned int cpumask_size, unsigned lo
 
     /* Linux kernel bitmap is based on long. So according to its implementation, round up the result
      * to sizeof(long) */
-    size_t bitmask_size_in_bytes = BITS_TO_LONGS(cpu_cnt) * sizeof(long);
+    size_t bitmask_size_in_bytes = BITS_TO_LONGS(threads_cnt) * sizeof(long);
     if (cpumask_size < bitmask_size_in_bytes) {
         log_warning("size of cpumask must be at least %lu but supplied cpumask is %u",
                     bitmask_size_in_bytes, cpumask_size);

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -17,7 +17,6 @@ fs.mounts = [
   { path = "/tmp", uri = "file:/tmp" },
 ]
 
-fs.experimental__enable_sysfs_topology = true
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/sysfs_common.manifest.template
+++ b/LibOS/shim/test/regression/sysfs_common.manifest.template
@@ -9,8 +9,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-fs.experimental__enable_sysfs_topology = true
-
 sgx.nonpie_binary = true
 sgx.debug = true
 

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -125,8 +125,6 @@ struct pal_public_state {
     size_t mem_total;
 
     struct pal_cpu_info cpu_info;
-
-    bool enable_sysfs_topology;
     struct pal_topo_info topo_info; /* received from untrusted host, but sanitized */
 };
 

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -36,7 +36,7 @@ int main(int argc, char** argv, char** envp) {
         pal_printf("User Address Range OK\n");
 
     const struct pal_cpu_info* ci = &pal_public_state->cpu_info;
-    pal_printf("CPU num: %zu\n",      pal_public_state->topo_info.online_logical_cores.resource_cnt);
+    pal_printf("CPU num: %zu\n",      pal_public_state->topo_info.threads_cnt);
     pal_printf("CPU vendor: %s\n",    ci->cpu_vendor);
     pal_printf("CPU brand: %s\n",     ci->cpu_brand);
     pal_printf("CPU family: %ld\n",   ci->cpu_family);

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -528,15 +528,12 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     }
     g_pal_public_state.mem_total = _DkMemoryQuota();
 
-    /* TODO: temporary measure, remove it once sysfs topology is thoroughly validated */
-    bool enable_sysfs_topology;
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "fs.experimental__enable_sysfs_topology",
-                       /*defaultval=*/false, &enable_sysfs_topology);
-    if (ret < 0) {
-        INIT_FAIL_MANIFEST(PAL_ERROR_INVAL, "Cannot parse 'fs.experimental__enable_sysfs_topology' "
-                                            "(the value must be `true` or `false`)");
+    if (toml_key_exists(g_pal_public_state.manifest_root,
+                        "fs.experimental__enable_sysfs_topology")) {
+        // TODO: Deprecation started in v1.2, drop in 2 releases.
+        log_warning("fs.experimental__enable_sysfs_topology is deprecated and sysfs topology is "
+                    "enabled by default now.");
     }
-    g_pal_public_state.enable_sysfs_topology = enable_sysfs_topology;
 
     ret = load_entrypoint(entrypoint_name);
     if (ret < 0)

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University
- * Copyright (C) 2021 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
  *                    Vijay Dhanraj <vijay.dhanraj@intel.com>
  */
 
@@ -73,13 +74,9 @@ static const char** make_argv_list(void* uptr_src, size_t src_size) {
         return argv;
     }
 
-    char* data = malloc(src_size);
+    char* data = sgx_import_to_enclave(uptr_src, src_size);
     if (!data) {
         return NULL;
-    }
-
-    if (!sgx_copy_to_enclave(data, src_size, uptr_src, src_size)) {
-        goto fail;
     }
     data[src_size - 1] = '\0';
 
@@ -116,491 +113,146 @@ fail:
     return NULL;
 }
 
-/* This function doesn't clean up resources on failure as we terminate the process anyway. */
-static int copy_resource_range_to_enclave(struct pal_res_range_info* src,
-                                          struct pal_res_range_info* dest) {
-    size_t ranges_arr_size;
-    if (__builtin_mul_overflow(src->ranges_cnt, sizeof(struct pal_range_info), &ranges_arr_size)) {
-        log_error("Overflow detected with size of ranges_arr memory allocation request");
-        return -1;
-    }
-
-    struct pal_range_info* ranges_arr = malloc(ranges_arr_size);
-    if (!ranges_arr) {
-        log_error("Range allocation failed");
-        return -1;
-    }
-
-    /* Even though `src` points to a safe in-enclave object, the `src->ranges_arr` pointer is
-     * untrusted and may maliciously point inside the enclave; thus need to use
-     * `sgx_copy_to_enclave()` function */
-    if (!sgx_copy_to_enclave(ranges_arr, ranges_arr_size,
-                             src->ranges_arr, src->ranges_cnt * sizeof(*src->ranges_arr))) {
-        log_error("Copying ranges into the enclave failed");
-        return -1;
-    }
-
-    dest->ranges_arr = ranges_arr;
-    dest->ranges_cnt = src->ranges_cnt;
-    dest->resource_cnt = src->resource_cnt;
-    return 0;
+/* Without this, `(int)imported_bool` may actually return something outside of {0, 1}. */
+static void coerce_untrusted_bool(bool* ptr) {
+    static_assert(sizeof(bool) == sizeof(unsigned char), "Unsupported compiler");
+    *ptr = !!READ_ONCE(*(unsigned char*)ptr);
 }
 
-/* This function doesn't clean up resources on failure as we terminate the process anyway. */
-static int sgx_copy_core_topo_to_enclave(struct pal_core_topo_info* uptr_src,
-                                         size_t online_logical_cores_cnt,
-                                         size_t cache_indices_cnt,
-                                         struct pal_core_topo_info** out_core_topo_arr) {
-    assert(out_core_topo_arr);
+/* `*topo_info` should already be deep-copied into the enclave. */
+static int sanitize_topo_info(struct pal_topo_info* topo_info) {
+    for (size_t i = 0; i < topo_info->caches_cnt; i++) {
+        struct pal_cache_info* cache = &topo_info->caches[i];
+        if (cache->type != CACHE_TYPE_DATA &&
+            cache->type != CACHE_TYPE_INSTRUCTION &&
+            cache->type != CACHE_TYPE_UNIFIED) {
+            return -PAL_ERROR_INVAL;
+        }
 
-    struct pal_core_topo_info* temp_core_topo_arr =
-        malloc(online_logical_cores_cnt * sizeof(*temp_core_topo_arr));
-    if (!temp_core_topo_arr) {
-        log_error("Allocation for shallow copy of core_topo_arr failed");
-        return -1;
+        if (   !IS_IN_RANGE_INCL(cache->level, 1, 3)
+            || !IS_IN_RANGE_INCL(cache->size, 1, 1 << 30)
+            || !IS_IN_RANGE_INCL(cache->coherency_line_size, 1, 1 << 16)
+            || !IS_IN_RANGE_INCL(cache->number_of_sets, 1, 1 << 30)
+            || !IS_IN_RANGE_INCL(cache->physical_line_partition, 1, 1 << 16))
+            return -PAL_ERROR_INVAL;
     }
 
-    /* Shallow copy contents of core_topo_arr (uptr_src) into enclave */
-    if (!sgx_copy_to_enclave(temp_core_topo_arr,
-                             online_logical_cores_cnt * sizeof(*temp_core_topo_arr), uptr_src,
-                             online_logical_cores_cnt * sizeof(*uptr_src))) {
-        log_error("Shallow copy of core_topo_arr into the enclave failed");
-        return -1;
+    if (topo_info->threads_cnt == 0 || !topo_info->threads[0].is_online) {
+        // Linux requires this
+        return -PAL_ERROR_INVAL;
     }
 
-    /* Allocate enclave memory to store core topo info */
-    struct pal_core_topo_info* core_topo_arr =
-        malloc(online_logical_cores_cnt * sizeof(*core_topo_arr));
-    if (!core_topo_arr) {
-        log_error("Allocation for core topology array failed");
-        return -1;
-    }
-
-    for (size_t idx = 0; idx < online_logical_cores_cnt; idx++) {
-        core_topo_arr[idx].is_logical_core_online =
-            temp_core_topo_arr[idx].is_logical_core_online;
-        core_topo_arr[idx].core_id = temp_core_topo_arr[idx].core_id;
-        core_topo_arr[idx].socket_id = temp_core_topo_arr[idx].socket_id;
-
-        int ret = copy_resource_range_to_enclave(&temp_core_topo_arr[idx].core_siblings,
-                                                 &core_topo_arr[idx].core_siblings);
-        if (ret < 0) {
-            log_error("Copying core_topo_arr[%zu].core_siblings failed", idx);
-            return -1;
-        }
-
-        ret = copy_resource_range_to_enclave(&temp_core_topo_arr[idx].thread_siblings,
-                                             &core_topo_arr[idx].thread_siblings);
-        if (ret < 0) {
-            log_error("Copying core_topo_arr[%zu].thread_siblings failed", idx);
-            return -1;
-        }
-
-        /* Shallow copy contents of cache_info_arr (untrusted pointer) into enclave */
-        struct pal_core_cache_info* temp_cache_info_arr =
-            malloc(cache_indices_cnt * sizeof(*temp_cache_info_arr));
-        if (!temp_cache_info_arr) {
-            log_error("Allocation for shallow copy of cache_info_arr failed");
-            return -1;
-        }
-
-        if (!sgx_copy_to_enclave(temp_cache_info_arr,
-                                 cache_indices_cnt * sizeof(*temp_cache_info_arr),
-                                 temp_core_topo_arr->cache_info_arr,
-                                 cache_indices_cnt *
-                                 sizeof(*temp_core_topo_arr->cache_info_arr))) {
-            log_error("Shallow copy of cache_info_arr into the enclave failed");
-            return -1;
-        }
-
-        /* Allocate enclave memory to store cache info */
-        struct pal_core_cache_info* cache_info_arr =
-            malloc(cache_indices_cnt * sizeof(*cache_info_arr));
-        if (!cache_info_arr) {
-            log_error("Allocation for cache_info_arr failed");
-            return -1;
-        }
-
-        for (size_t lvl = 0; lvl < cache_indices_cnt; lvl++) {
-            cache_info_arr[lvl].level = temp_cache_info_arr[lvl].level;
-            cache_info_arr[lvl].type = temp_cache_info_arr[lvl].type;
-            cache_info_arr[lvl].size = temp_cache_info_arr[lvl].size;
-            cache_info_arr[lvl].coherency_line_size = temp_cache_info_arr[lvl].coherency_line_size;
-            cache_info_arr[lvl].number_of_sets = temp_cache_info_arr[lvl].number_of_sets;
-            cache_info_arr[lvl].physical_line_partition =
-                 temp_cache_info_arr[lvl].physical_line_partition;
-
-            ret = copy_resource_range_to_enclave(&temp_cache_info_arr[lvl].shared_cpu_map,
-                                                 &cache_info_arr[lvl].shared_cpu_map);
-            if (ret < 0) {
-                log_error("Copying cache_info_arr[%zu].shared_cpu_map failed", lvl);
-                return -1;
+    for (size_t i = 0; i < topo_info->threads_cnt; i++) {
+        struct pal_cpu_thread_info* thread = &topo_info->threads[i];
+        coerce_untrusted_bool(&thread->is_online);
+        if (thread->is_online) {
+            if (thread->core_id >= topo_info->cores_cnt)
+                return -PAL_ERROR_INVAL;
+            /* Verify that the cache array has no holes... */
+            for (size_t j = 0; j < MAX_CACHES - 1; j++)
+                if (thread->ids_of_caches[j] == (size_t)-1
+                        && thread->ids_of_caches[j + 1] != (size_t)-1)
+                    return -PAL_ERROR_INVAL;
+            /* ...and valid indices. */
+            for (size_t j = 0; j < MAX_CACHES; j++) {
+                if (thread->ids_of_caches[j] != (size_t)-1
+                    && thread->ids_of_caches[j] >= topo_info->caches_cnt)
+                    return -PAL_ERROR_INVAL;
             }
-        }
-
-        core_topo_arr[idx].cache_info_arr = cache_info_arr;
-        free(temp_cache_info_arr);
-    }
-
-    *out_core_topo_arr = core_topo_arr;
-
-    free(temp_core_topo_arr);
-    return 0;
-}
-
-/* This function doesn't clean up resources on failure as we terminate the process anyway. */
-static int sgx_copy_numa_topo_to_enclave(struct pal_numa_topo_info* uptr_src,
-                                         size_t online_nodes_cnt,
-                                         struct pal_numa_topo_info** out_numa_topo_arr) {
-    assert(out_numa_topo_arr);
-
-    struct pal_numa_topo_info* temp_numa_topo_arr =
-        malloc(online_nodes_cnt * sizeof(*temp_numa_topo_arr));
-    if (!temp_numa_topo_arr) {
-        log_error("Allocation for shallow copy of numa_topo_arr failed");
-        return -1;
-    }
-
-    /* Shallow copy contents of numa_topo_arr (uptr_src) into enclave */
-    if (!sgx_copy_to_enclave(temp_numa_topo_arr,
-                             online_nodes_cnt * sizeof(*temp_numa_topo_arr), uptr_src,
-                             online_nodes_cnt * sizeof(*uptr_src))) {
-        log_error("Shallow copy of numa_topo_arr into the enclave failed");
-        return -1;
-    }
-
-    struct pal_numa_topo_info* numa_topo_arr = malloc(online_nodes_cnt * sizeof(*numa_topo_arr));
-    if (!numa_topo_arr) {
-        log_error("Allocation for numa_topo_arr failed");
-        return -1;
-    }
-
-    for (size_t idx = 0; idx < online_nodes_cnt; idx++) {
-        numa_topo_arr[idx].nr_hugepages[HUGEPAGES_2M] =
-            temp_numa_topo_arr[idx].nr_hugepages[HUGEPAGES_2M];
-        numa_topo_arr[idx].nr_hugepages[HUGEPAGES_1G] =
-            temp_numa_topo_arr[idx].nr_hugepages[HUGEPAGES_1G];
-
-        int ret = copy_resource_range_to_enclave(&temp_numa_topo_arr[idx].cpumap,
-                                                 &numa_topo_arr[idx].cpumap);
-        if (ret < 0) {
-            log_error("Copying numa_topo_arr[%zu].cpumap failed", idx);
-            return -1;
-        }
-
-        ret = copy_resource_range_to_enclave(&temp_numa_topo_arr[idx].distance,
-                                             &numa_topo_arr[idx].distance);
-        if (ret < 0) {
-            log_error("Copying numa_topo_arr[%zu].distance failed", idx);
-            return -1;
-        }
-    }
-
-    *out_numa_topo_arr = numa_topo_arr;
-
-    free(temp_numa_topo_arr);
-    return 0;
-}
-
-/* This function does the following 3 sanitizations for a given resource range:
- * 1. Ensures the resource as well as range count doesn't exceed limits.
- * 2. Ensures that ranges don't overlap like "1-5, 3-4".
- * 3. Ensures the ranges aren't malformed like "1-5, 7-1".
- * Returns -1 error on failure and 0 on success.
- */
-static int sanitize_hw_resource_range(struct pal_res_range_info* res_info, size_t res_min_limit,
-                                      size_t res_max_limit, size_t range_min_limit,
-                                      size_t range_max_limit) {
-    size_t resource_cnt = res_info->resource_cnt;
-    if (!IS_IN_RANGE_INCL(resource_cnt, res_min_limit, res_max_limit)) {
-        log_error("Invalid resource count: %zu", resource_cnt);
-        return -1;
-    }
-
-    size_t ranges_cnt = res_info->ranges_cnt;
-    if (!IS_IN_RANGE_INCL(ranges_cnt, 1, 1 << 7)) {
-        log_error("Invalid range count: %zu", ranges_cnt);
-        return -1;
-    }
-
-    if (!res_info->ranges_arr)
-        return -1;
-
-    bool check_for_overlaps = false;
-    size_t previous_end = 0;
-    size_t resource_cnt_from_ranges = 0;
-    for (size_t i = 0; i < ranges_cnt; i++) {
-
-        size_t start = res_info->ranges_arr[i].start;
-        size_t end = res_info->ranges_arr[i].end;
-
-        /* Ensure start and end fall within range limits */
-        if (!IS_IN_RANGE_INCL(start, range_min_limit, range_max_limit)) {
-            log_error("Invalid start of range: %zu", start);
-            return -1;
-        }
-
-        if ((start != end) && !IS_IN_RANGE_INCL(end, start + 1, range_max_limit)) {
-            log_error("Invalid end of range: %zu", end);
-            return -1;
-        }
-
-        resource_cnt_from_ranges += end - start + 1;
-
-        /* check for overlaps like "1-5, 3-4". Note: we skip this check for first time as
-         *`previous_end` is not yet initialized. */
-        if (check_for_overlaps && previous_end >= start) {
-            log_error("Overlapping ranges: previous_end = %zu, current start = %zu", previous_end,
-                      start);
-            return -1;
-        }
-        previous_end = end;
-
-        /* Start checking for overlaps after the first range */
-        check_for_overlaps = true;
-    }
-
-    if (resource_cnt_from_ranges != resource_cnt) {
-        log_error("Mismatch between resource_cnt and resource_cnt_from_ranges");
-        return -1;
-    }
-
-    return 0;
-}
-
-static int sanitize_cache_topology_info(struct pal_core_cache_info* cache_info_arr,
-                                        size_t online_logical_cores_cnt, size_t cache_indices_cnt) {
-    for (size_t lvl = 0; lvl < cache_indices_cnt; lvl++) {
-        if (cache_info_arr[lvl].type != CACHE_TYPE_DATA &&
-            cache_info_arr[lvl].type != CACHE_TYPE_INSTRUCTION &&
-            cache_info_arr[lvl].type != CACHE_TYPE_UNIFIED) {
-            return -1;
-        }
-
-        size_t max_limit;
-        if (cache_info_arr[lvl].type == CACHE_TYPE_DATA ||
-                cache_info_arr[lvl].type == CACHE_TYPE_INSTRUCTION) {
-            /* Taking HT into account */
-            max_limit = MAX_HYPERTHREADS_PER_CORE;
         } else {
-            /* if unified cache then it can range up to total number of cores. */
-            max_limit = online_logical_cores_cnt;
-        }
-
-        /* Recall that `shared_cpu_map` shows this core + its siblings (if HT is enabled), for
-         * example: /sys/devices/system/cpu/cpu1/cache/index1/shared_cpu_map: 00000000,00000002 */
-        int ret = sanitize_hw_resource_range(&cache_info_arr[lvl].shared_cpu_map, 1, max_limit, 0,
-                                             online_logical_cores_cnt);
-        if (ret < 0) {
-            log_error("Invalid cache[%zu].shared_cpu_map", lvl);
-            return -1;
-        }
-
-        if (!IS_IN_RANGE_INCL(cache_info_arr[lvl].level, 1, MAX_CACHE_LEVELS))
-            return -1;
-
-        if (!IS_IN_RANGE_INCL(cache_info_arr[lvl].size, 1, 1 << 30))
-            return -1;
-
-        if (!IS_IN_RANGE_INCL(cache_info_arr[lvl].coherency_line_size, 1, 1 << 16))
-            return -1;
-
-        if (!IS_IN_RANGE_INCL(cache_info_arr[lvl].number_of_sets, 1, 1 << 30))
-            return -1;
-
-        if (!IS_IN_RANGE_INCL(cache_info_arr[lvl].physical_line_partition, 1, 1 << 16))
-            return -1;
-    }
-    return 0;
-}
-
-/* For each socket, cross-verify that its set of cores is the same as the core topology's
- * core-siblings:
- * - Pick the first core in the socket.
- * - Find its core-siblings in the core topology.
- * - Verify that the "cores in the socket info" array is exactly the same as "core-siblings
- *   present in core topology" array.
- */
-static int sanitize_socket_info(struct pal_core_topo_info* core_topo_arr,
-                                struct pal_res_range_info* socket_info_arr, size_t sockets_cnt) {
-    for (size_t idx = 0; idx < sockets_cnt; idx++) {
-        if (!socket_info_arr[idx].ranges_cnt || !socket_info_arr[idx].ranges_arr) {
-            return -1;
-        }
-
-        size_t core_in_socket = socket_info_arr[idx].ranges_arr[0].start;
-        struct pal_res_range_info* core_siblings = &core_topo_arr[core_in_socket].core_siblings;
-
-        if (core_siblings->ranges_cnt != socket_info_arr[idx].ranges_cnt) {
-            return -1;
-        }
-
-        for (size_t j = 0; j < core_siblings->ranges_cnt; j++) {
-            if (socket_info_arr[idx].ranges_arr[j].start != core_siblings->ranges_arr[j].start ||
-                    socket_info_arr[idx].ranges_arr[j].end != core_siblings->ranges_arr[j].end) {
-                return -1;
-            }
+            // Not required, just a hardening in case we accidentally accessed offline CPU's fields.
+            thread->core_id = 0;
+            for (size_t j = 0; j < MAX_CACHES; j++)
+                thread->ids_of_caches[j] = 0;
         }
     }
 
-    return 0;
-}
+    for (size_t i = 0; i < topo_info->cores_cnt; i++) {
+        if (topo_info->cores[i].socket_id >= topo_info->sockets_cnt)
+            return -PAL_ERROR_INVAL;
+        if (topo_info->cores[i].node_id >= topo_info->numa_nodes_cnt)
+            return -PAL_ERROR_INVAL;
+    }
 
-/* This function doesn't clean up resources on failure as we terminate the process anyway. */
-static int sanitize_core_topology_info(struct pal_core_topo_info* core_topo_arr,
-                                       size_t online_logical_cores_cnt, size_t cache_indices_cnt,
-                                       size_t sockets_cnt) {
-    int ret;
+    if (!topo_info->numa_nodes[0].is_online) {
+        // Linux requires this
+        return -PAL_ERROR_INVAL;
+    }
 
-    struct pal_res_range_info* socket_info_arr = calloc(sockets_cnt, sizeof(*socket_info_arr));
-    if (!socket_info_arr)
-        return -1;
-
-    for (size_t idx = 0; idx < online_logical_cores_cnt; idx++) {
-        if (core_topo_arr[idx].core_id > online_logical_cores_cnt - 1) {
-            ret = -1;
-            goto out;
-        }
-
-        ret = sanitize_hw_resource_range(&core_topo_arr[idx].core_siblings, 1,
-                                         online_logical_cores_cnt, 0, online_logical_cores_cnt);
-        if (ret < 0) {
-            log_error("Invalid core_topo_arr[%zu].core_siblings", idx);
-            goto out;
-        }
-
-        /* Max. SMT siblings currently supported on x86 processors is 4 */
-        ret = sanitize_hw_resource_range(&core_topo_arr[idx].thread_siblings, 1,
-                                         MAX_HYPERTHREADS_PER_CORE, 0, online_logical_cores_cnt);
-        if (ret < 0) {
-            log_error("Invalid core_topo_arr[%zu].thread_siblings", idx);
-            goto out;
-        }
-
-        ret = sanitize_cache_topology_info(core_topo_arr[idx].cache_info_arr,
-                                           online_logical_cores_cnt, cache_indices_cnt);
-        if (ret < 0) {
-            log_error("Invalid core_topo_arr[%zu].cache_info_arr", idx);
-            goto out;
-        }
-
-        /* To sanitize the socket, there are 2 steps:
-         * #1. From the socket_id of each core, create a range of cores present in each socket.
-         * #2. Compare array of cores in each socket against the array of core-siblings from
-         *     the core topology.
-         */
-        size_t socket_id = core_topo_arr[idx].socket_id;
-        if (socket_id > sockets_cnt - 1) {
-            ret = -1;
-            goto out;
-        }
-
-        /* Step #1 */
-        static size_t prev_socket_id = UINT32_MAX;
-        if (socket_id != prev_socket_id) {
-            socket_info_arr[socket_id].ranges_cnt++;
-            size_t new_size = sizeof(struct pal_range_info) * socket_info_arr[socket_id].ranges_cnt;
-            size_t old_size = new_size - sizeof(struct pal_range_info);
-            /* TODO: Optimize realloc by doing some overestimation and trimming later once the
-             * range count is known */
-            struct pal_range_info* tmp = malloc(new_size);
-            if (!tmp) {
-                ret = -1;
-                goto out;
+    for (size_t i = 0; i < topo_info->numa_nodes_cnt; i++) {
+        struct pal_numa_node_info* node = &topo_info->numa_nodes[i];
+        coerce_untrusted_bool(&node->is_online);
+        if (node->is_online) {
+            for (size_t j = 0; j < HUGEPAGES_MAX; j++) {
+                size_t unused; // can't use __builtin_mul_overflow_p because clang doesn't have it.
+                if (__builtin_mul_overflow(node->nr_hugepages[j], hugepage_size[j], &unused))
+                    return -PAL_ERROR_INVAL;
             }
-
-            if (socket_info_arr[socket_id].ranges_arr) {
-                memcpy(tmp, socket_info_arr[socket_id].ranges_arr, old_size);
-                free(socket_info_arr[socket_id].ranges_arr);
-            }
-            socket_info_arr[socket_id].ranges_arr = tmp;
-
-            size_t range_idx = socket_info_arr[socket_id].ranges_cnt - 1;
-            socket_info_arr[socket_id].ranges_arr[range_idx].start = idx;
-            socket_info_arr[socket_id].ranges_arr[range_idx].end = idx;
-            prev_socket_id = socket_id;
         } else {
-            size_t range_idx = socket_info_arr[socket_id].ranges_cnt - 1;
-            socket_info_arr[socket_id].ranges_arr[range_idx].end = idx;
+            /* Not required, just a hardening in case we accidentally accessed offline node's
+             * fields. */
+            for (size_t j = 0; j < HUGEPAGES_MAX; j++)
+                node->nr_hugepages[j] = 0;
         }
     }
 
-    /* Step #2 */
-    ret = sanitize_socket_info(core_topo_arr, socket_info_arr, sockets_cnt);
-    if (ret < 0)
-        goto out;
-
-    ret = 0;
-out:
-    for (size_t i = 0; i < sockets_cnt; i++) {
-        if (socket_info_arr[i].ranges_arr)
-            free(socket_info_arr[i].ranges_arr);
+    for (size_t i = 0; i < topo_info->numa_nodes_cnt; i++) {
+        /* Note: Linux doesn't guarantee that distance i -> i is 0, so we aren't checking this (it's
+         * actually non-zero on all machines we have). */
+        for (size_t j = 0; j < topo_info->numa_nodes_cnt; j++) {
+            if (   topo_info->numa_distance_matrix[i*topo_info->numa_nodes_cnt + j]
+                != topo_info->numa_distance_matrix[j*topo_info->numa_nodes_cnt + i])
+                return -PAL_ERROR_INVAL;
+        }
     }
-    free(socket_info_arr);
-    return ret;
+    return 0;
 }
 
-/* This function doesn't clean up resources on failure as we terminate the process anyway. */
-static int sanitize_numa_topology_info(struct pal_numa_topo_info* numa_topo_arr,
-                                       size_t online_nodes_cnt, size_t online_logical_cores_cnt,
-                                       size_t possible_logical_cores_cnt) {
-    int ret;
-    size_t cpumask_cnt = BITS_TO_UINT32S(possible_logical_cores_cnt);
-
-    uint32_t* bitmap = calloc(cpumask_cnt, sizeof(*bitmap));
-    if (!bitmap)
-        return -1;
-
-    size_t total_cores_in_numa = 0;
-    for (size_t idx = 0; idx < online_nodes_cnt; idx++) {
-        ret = sanitize_hw_resource_range(&numa_topo_arr[idx].cpumap, 1,
-                                         online_logical_cores_cnt, 0, online_logical_cores_cnt);
-        if (ret < 0) {
-            log_error("Invalid numa_topo_arr[%zu].cpumap", idx);
-            goto out;
-        }
-
-        /* Ensure that each NUMA has unique cores */
-        for (size_t i = 0; i < numa_topo_arr[idx].cpumap.ranges_cnt; i++) {
-            size_t start = numa_topo_arr[idx].cpumap.ranges_arr[i].start;
-            size_t end = numa_topo_arr[idx].cpumap.ranges_arr[i].end;
-            for (size_t j = start; j <= end; j++) {
-                size_t index = j / BITS_IN_TYPE(uint32_t);
-                if (index >= cpumask_cnt) {
-                    log_error("Invalid numa topology: Core %zu is beyond CPU mask limit", j);
-                    ret = -1;
-                    goto out;
-                }
-
-                if (bitmap[index] & (1U << (j % BITS_IN_TYPE(uint32_t)))) {
-                    log_error("Invalid numa_topology: Core %zu found in multiple numa nodes", j);
-                    ret = -1;
-                    goto out;
-                }
-                bitmap[index] |= 1U << (j % BITS_IN_TYPE(uint32_t));
-                total_cores_in_numa++;
-            }
-        }
-
-        size_t distances = numa_topo_arr[idx].distance.resource_cnt;
-        if (distances != online_nodes_cnt) {
-            log_error("Distance count is not same as the NUMA nodes count");
-            ret = -1;
-            goto out;
-        }
+static int import_and_sanitize_topo_info(struct pal_topo_info* uptr_topo_info) {
+    /* Import topology information via an untrusted pointer. This is only a shallow copy and we use
+     * this temp variable to do deep copy into `g_pal_public_state.topo_info` */
+    struct pal_topo_info shallow_topo_info;
+    if (!sgx_copy_to_enclave(&shallow_topo_info, sizeof(shallow_topo_info),
+                             uptr_topo_info, sizeof(*uptr_topo_info))) {
+        return -PAL_ERROR_DENIED;
     }
 
-    if (total_cores_in_numa != online_logical_cores_cnt) {
-        log_error("Invalid numa_topology: Mismatch between NUMA cores and online cores count");
-        ret = -1;
-        goto out;
+    struct pal_topo_info* topo_info = &g_pal_public_state.topo_info;
+
+    size_t caches_cnt     = shallow_topo_info.caches_cnt;
+    size_t threads_cnt    = shallow_topo_info.threads_cnt;
+    size_t cores_cnt      = shallow_topo_info.cores_cnt;
+    size_t sockets_cnt    = shallow_topo_info.sockets_cnt;
+    size_t numa_nodes_cnt = shallow_topo_info.numa_nodes_cnt;
+
+    struct pal_cache_info*      caches     = sgx_import_array_to_enclave(shallow_topo_info.caches,     sizeof(*caches),     caches_cnt);
+    struct pal_cpu_thread_info* threads    = sgx_import_array_to_enclave(shallow_topo_info.threads,    sizeof(*threads),    threads_cnt);
+    struct pal_cpu_core_info*   cores      = sgx_import_array_to_enclave(shallow_topo_info.cores,      sizeof(*cores),      cores_cnt);
+    struct pal_socket_info*     sockets    = sgx_import_array_to_enclave(shallow_topo_info.sockets,    sizeof(*sockets),    sockets_cnt);
+    struct pal_numa_node_info*  numa_nodes = sgx_import_array_to_enclave(shallow_topo_info.numa_nodes, sizeof(*numa_nodes), numa_nodes_cnt);
+
+    size_t* distances = sgx_import_array2d_to_enclave(shallow_topo_info.numa_distance_matrix,
+                                                      sizeof(*distances),
+                                                      numa_nodes_cnt,
+                                                      numa_nodes_cnt);
+    if (!caches || !threads || !cores || !sockets || !numa_nodes || !distances) {
+        return -PAL_ERROR_NOMEM;
     }
 
-    ret = 0;
+    topo_info->caches = caches;
+    topo_info->threads = threads;
+    topo_info->cores = cores;
+    topo_info->sockets = sockets;
+    topo_info->numa_nodes = numa_nodes;
+    topo_info->numa_distance_matrix = distances;
 
-out:
-    free(bitmap);
-    return ret;
+    topo_info->caches_cnt = caches_cnt;
+    topo_info->threads_cnt = threads_cnt;
+    topo_info->cores_cnt = cores_cnt;
+    topo_info->sockets_cnt = sockets_cnt;
+    topo_info->numa_nodes_cnt = numa_nodes_cnt;
+
+    return sanitize_topo_info(topo_info);
 }
 
 extern void* g_enclave_base;
@@ -625,7 +277,6 @@ static int print_warnings_on_insecure_configs(PAL_HANDLE parent_process) {
     bool use_allowed_files    = g_allowed_files_warn;
     bool protected_files_key  = false;
     bool encrypted_files_keys = false;
-    bool enable_sysfs_topo    = false;
 
     char* log_level_str = NULL;
     char* protected_files_key_str = NULL;
@@ -684,14 +335,9 @@ static int print_warnings_on_insecure_configs(PAL_HANDLE parent_process) {
         }
     }
 
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "fs.experimental__enable_sysfs_topology",
-                       /*defaultval=*/false, &enable_sysfs_topo);
-    if (ret < 0)
-        goto out;
-
     if (!verbose_log_level && !sgx_debug && !use_cmdline_argv && !use_host_env && !disable_aslr &&
             !allow_eventfd && !allow_all_files && !use_allowed_files && !protected_files_key &&
-            !encrypted_files_keys && !enable_sysfs_topo) {
+            !encrypted_files_keys) {
         /* there are no insecure configurations, skip printing */
         ret = 0;
         goto out;
@@ -741,10 +387,6 @@ static int print_warnings_on_insecure_configs(PAL_HANDLE parent_process) {
         log_always("  - fs.insecure__keys.* = \"...\"                "
                    "(keys hardcoded in manifest)");
 
-    if (enable_sysfs_topo)
-        log_always("  - fs.experimental__enable_sysfs_topology = true "
-                   "(forwarding sysfs topology from untrusted host to the app)");
-
     log_always("\nGramine will continue application execution, but this configuration must not be "
                "used in production!");
     log_always("-------------------------------------------------------------------------------"
@@ -755,128 +397,6 @@ out:
     free(log_level_str);
     free(protected_files_key_str);
     return ret;
-}
-
-static int copy_and_sanitize_topo_info(struct pal_topo_info* uptr_topo_info,
-                                       bool enable_sysfs_topology) {
-    int ret;
-
-    /* Extract topology information from untrusted pointer. Note this is only a shallow copy
-     * and we use this temp variable to do deep copy into `topo_info` struct part of
-     * g_pal_public_state */
-    struct pal_topo_info temp_topo_info;
-    if (!sgx_copy_to_enclave(&temp_topo_info, sizeof(temp_topo_info),
-                             uptr_topo_info, sizeof(*uptr_topo_info))) {
-        log_error("Copying topo_info into the enclave failed");
-        return -1;
-    }
-
-    struct pal_topo_info* topo_info = &g_pal_public_state.topo_info;
-
-    ret = copy_resource_range_to_enclave(&temp_topo_info.possible_logical_cores,
-                                         &topo_info->possible_logical_cores);
-    if (ret < 0) {
-        log_error("Copying possible_logical_cores failed");
-        return -1;
-    }
-    ret = sanitize_hw_resource_range(&topo_info->possible_logical_cores, 1, 1 << 16, 0, 1 << 16);
-    if (ret < 0) {
-        log_error("Invalid possible_logical_cores received from the host");
-        return -1;
-    }
-
-    ret = copy_resource_range_to_enclave(&temp_topo_info.online_logical_cores,
-                                         &topo_info->online_logical_cores);
-    if (ret < 0) {
-        log_error("Copying online_logical_cores failed");
-        return -1;
-    }
-    ret = sanitize_hw_resource_range(&topo_info->online_logical_cores, 1, 1 << 16, 0, 1 << 16);
-    if (ret < 0) {
-        log_error("Invalid online_logical_cores received from the host");
-        return -1;
-    }
-
-    size_t online_logical_cores_cnt = topo_info->online_logical_cores.resource_cnt;
-    size_t possible_logical_cores_cnt = topo_info->possible_logical_cores.resource_cnt;
-    if (online_logical_cores_cnt > possible_logical_cores_cnt) {
-        log_error("Impossible configuration: more online cores (%zu) than possible cores (%zu)",
-                   online_logical_cores_cnt, possible_logical_cores_cnt);
-        return -1;
-    }
-
-    topo_info->physical_cores_per_socket = temp_topo_info.physical_cores_per_socket;
-    if (!IS_IN_RANGE_INCL(topo_info->physical_cores_per_socket, 1, 1 << 13)) {
-        log_error("Invalid physical_cores_per_socket: %zu received from the host",
-                   topo_info->physical_cores_per_socket);
-        return -1;
-    }
-
-    /* Advanced host topology information */
-    if (!enable_sysfs_topology) {
-        /* TODO: temporary measure, remove it once sysfs topology is thoroughly validated */
-        return 0;
-    }
-
-    topo_info->sockets_cnt = temp_topo_info.sockets_cnt;
-    /* Virtual environments such as QEMU may assign each core to a separate socket/package with
-     * one or more NUMA nodes. So we check against the number of online logical cores. */
-    if (!IS_IN_RANGE_INCL(topo_info->sockets_cnt, 1, online_logical_cores_cnt)) {
-        log_error("Invalid sockets_cnt: %zu received from the host", topo_info->sockets_cnt);
-        return -1;
-    }
-
-    topo_info->cache_indices_cnt = temp_topo_info.cache_indices_cnt;
-    if (!IS_IN_RANGE_INCL(topo_info->cache_indices_cnt, 1, 1 << 4)) {
-        log_error("Invalid cache_indices_cnt: %zu received from the host",
-                   topo_info->cache_indices_cnt);
-        return -1;
-    }
-
-    /* Allocate enclave memory to store core topology info */
-    ret = sgx_copy_core_topo_to_enclave(temp_topo_info.core_topo_arr, online_logical_cores_cnt,
-                                        topo_info->cache_indices_cnt,
-                                        &topo_info->core_topo_arr);
-    if (ret < 0) {
-        log_error("Copying core_topo_arr into the enclave failed");
-        return -1;
-    }
-
-    ret = sanitize_core_topology_info(topo_info->core_topo_arr, online_logical_cores_cnt,
-                                      topo_info->cache_indices_cnt, topo_info->sockets_cnt);
-    if (ret < 0) {
-        log_error("Sanitization of core_topology failed");
-        return -1;
-    }
-
-    ret = copy_resource_range_to_enclave(&temp_topo_info.online_nodes, &topo_info->online_nodes);
-    if (ret < 0) {
-        log_error("Copying online_nodes into the enclave failed");
-        return -1;
-    }
-
-    ret = sanitize_hw_resource_range(&topo_info->online_nodes, 1, 1 << 16, 0, 1 << 16);
-    if (ret < 0) {
-        log_error("Invalid online_nodes received from the host");
-        return -1;
-    }
-
-    size_t online_nodes_cnt = topo_info->online_nodes.resource_cnt;
-    ret = sgx_copy_numa_topo_to_enclave(temp_topo_info.numa_topo_arr, online_nodes_cnt,
-                                        &topo_info->numa_topo_arr);
-    if (ret < 0) {
-        log_error("Copying numa_topo_arr into the enclave failed");
-        return -1;
-    }
-
-    ret = sanitize_numa_topology_info(topo_info->numa_topo_arr, online_nodes_cnt,
-                                      online_logical_cores_cnt, possible_logical_cores_cnt);
-    if (ret < 0) {
-        log_error("Sanitization of numa_topo_arr failed");
-        return -1;
-    }
-
-    return 0;
 }
 
 __attribute_no_sanitize_address
@@ -1040,17 +560,8 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_pal_common_state.raw_manifest_data = manifest_addr;
     g_pal_public_state.manifest_root = manifest_root;
 
-    /* parse and store host topology info into g_pal_linuxsgx_state struct */
-    bool enable_sysfs_topology; /* TODO: remove this manifest option once sysfs topo is stable */
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "fs.experimental__enable_sysfs_topology",
-                       /*defaultval=*/false, &enable_sysfs_topology);
-    if (ret < 0) {
-        log_error("Cannot parse 'fs.experimental__enable_sysfs_topology' (the value must be `true` "
-                  "or `false`)");
-        ocall_exit(1, /*is_exitgroup=*/true);
-    }
-
-    ret = copy_and_sanitize_topo_info(uptr_topo_info, enable_sysfs_topology);
+    /* parse and store host topology info into g_pal_public_state struct */
+    ret = import_and_sanitize_topo_info(uptr_topo_info);
     if (ret < 0) {
         log_error("Failed to copy and sanitize topology information");
         ocall_exit(1, /*is_exitgroup=*/true);

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -143,6 +143,35 @@ bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usi
     return true;
 }
 
+void* sgx_import_to_enclave(const void* uptr, size_t usize) {
+    if (!sgx_is_completely_outside_enclave(uptr, usize))
+        return NULL;
+
+    void* buf = malloc(usize);
+    if (!buf)
+        return NULL;
+
+    memcpy(buf, uptr, usize);
+    return buf;
+}
+
+void* sgx_import_array_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt) {
+    size_t size;
+    if (__builtin_mul_overflow(elem_size, elem_cnt, &size))
+        return NULL;
+
+    return sgx_import_to_enclave(uptr, size);
+}
+
+void* sgx_import_array2d_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt1,
+                                    size_t elem_cnt2) {
+    size_t elem_cnt;
+    if (__builtin_mul_overflow(elem_cnt1, elem_cnt2, &elem_cnt))
+        return NULL;
+
+    return sgx_import_array_to_enclave(uptr, elem_size, elem_cnt);
+}
+
 static void print_report(sgx_report_t* r) {
     log_debug("  cpu_svn:     %s",     ALLOCA_BYTES2HEXSTR(r->body.cpu_svn.svn));
     log_debug("  mr_enclave:  %s",     ALLOCA_BYTES2HEXSTR(r->body.mr_enclave.m));

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -1890,8 +1890,10 @@ int ocall_sched_setaffinity(void* tcs, size_t cpumask_size, void* cpu_mask) {
 }
 
 static bool is_cpumask_valid(void* cpu_mask, size_t cpumask_size) {
+    /* Linux seems to allow setting affinity to offline threads, so we only need to check against
+     * the count of possible threads. */
     size_t max_cpumask_bits = cpumask_size * BITS_IN_BYTE;
-    size_t valid_cpumask_bits = g_pal_public_state.topo_info.online_logical_cores.resource_cnt;
+    size_t valid_cpumask_bits = g_pal_public_state.topo_info.threads_cnt;
     size_t invalid_bits = max_cpumask_bits - valid_cpumask_bits;
 
     if (invalid_bits == 0)

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -19,6 +19,10 @@ void sgx_reset_ustack(const void* old_ustack);
 
 bool sgx_copy_ptr_to_enclave(void** ptr, void* uptr, size_t size);
 bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize);
+void* sgx_import_to_enclave(const void* uptr, size_t usize);
+void* sgx_import_array_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt);
+void* sgx_import_array2d_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt1,
+                                    size_t elem_cnt2);
 
 /*!
  * \brief Low-level wrapper around EREPORT instruction leaf.


### PR DESCRIPTION
## Description of the changes

This PR completely rewrites all three parts of sysfs topology handling:
- parsing sysfs files on the host (`topo_info.c`),
- passing them to LibOS, possibly across a security boundary (`Linux-SGX/db_main.c`),
- generating sysfs files inside LibOS based on the topology information (`fs/sys/*`).

The overall idea of the rewrite is to simplify and normalize the data structures passing through the untrusted interface, to ensure they are properly handled and sanitized. Effectively, this PR shifts as much complexity as possible to either untrusted side or to the part working on already sanitized, in-enclave data.

The reason for this change is the number of security issues found in the old code and review difficulty of sanitization in the old approach (despite multiple review passes I kept finding new issues).

I plan some more changes for future PRs, but they aren't strictly related to the code changed here (e.g. adding a proper test suite for sysfs topology).

Fixes #483.
Fixes https://github.com/gramineproject/graphene/issues/2105.

## Functional changes

- Added support for offline CPU threads (but no hot-plug, the state is snapshotted at the start).
- `/sys/devices/system/cpu/cpu<n>/topology/core_id` values have changed - they aren't socket-local anymore, but are globally unique. This shouldn't matter, as this node is documented in Linux as "the hardware platform’s identifier (rather than the kernel’s). The actual value is architecture and platform dependent.".

## Rough edges

The worst part of this PR is probably `Linux-common/topo_info.c`, but I don't see any other way to write this. This is something where we just need lambdas, but C doesn't have them. Anyways, if you have some ideas how to make it better, then please add them to the review.

Also, please be careful when reading the code around topology structures. `pal_cpu_thread_info` and `pal_numa_node_info` fields are valid _only_ for online nodes. Technically, we could remove offline nodes and pretend they don't exist (as we don't support hot-plug and probably never will), but that won't make the implementation any simpler (because we'd need to translate indices in parser code).

## Useful links for reviewers

- https://www.kernel.org/doc/html/latest/admin-guide/cputopology.html
- https://www.kernel.org/doc/html/latest/admin-guide/abi-stable.html

## sysfs mysteries

The format used in Linux sysfs is quite obscure and the documentation is partial at best. Things I don't know:
- What's the different between "die" and "package" in their terminology?
- Can a NUMA node actually be turned offline? I never succeeded in shutting down one, even after shutting down all CPUs inside the node it shows up as online on `node/online` list. If that's the case, then what's the purpose of `node/online` on Linux?

## How to test this PR?

This PR requires extensive testing, although it should be quite safe to merge - it contains less assumptions than the old implementation, at the same time refusing all internally inconsistent topology data. Despite this, there may be something I didn't think of :)

To anyone reading this who has some unusual environment (i.e. something more than boring 8-threaded single CPU) and have a moment: please try out this branch, just starting Gramine built from it on any binary should be enough. If you have more time, checking if contents of `/sys/devices/system/` make sense would be helpful.

I'm especially looking for:
- machines with more than 1 NUMA node,
- virtualized environments,
- machines with non-default configuration (e.g. some CPUs shut down or disabled).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/530)
<!-- Reviewable:end -->
