### PR TITLE
[LibOS,Pal] Weed out unnecessary `unistd.h` includes

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -440,11 +440,9 @@ struct shim_mount {
 extern struct shim_dentry* g_dentry_root;
 
 #define F_OK 0
-// XXX: Duplicate definition; should probably weed out includes of host system
-// include of unistd.h in future work
-//#define R_OK        001
-//#define W_OK        002
-//#define X_OK        004
+#define R_OK        001
+#define W_OK        002
+#define X_OK        004
 #define MAY_EXEC  001
 #define MAY_WRITE 002
 #define MAY_READ  004

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -12,7 +12,6 @@
 #include <asm/resource.h>
 #include <linux/in.h>
 #include <linux/in6.h>
-#include <linux/shm.h>
 #include <linux/un.h>
 #include <stdalign.h>
 #include <stdbool.h>

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <asm/errno.h>
 #include <asm/poll.h>
 #include <asm/posix_types.h>
 #include <asm/siginfo.h>
@@ -19,7 +20,6 @@
 #include <linux/msg.h>
 #include <linux/perf_event.h>
 #include <linux/sem.h>
-#include <linux/shm.h>
 #include <linux/times.h>
 #include <linux/timex.h>
 #include <linux/types.h>

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -18,6 +18,7 @@
 #include <linux/wait.h>
 
 #include "api.h"
+#include "shim_fs.h"
 #include "shim_internal.h"
 #include "shim_syscalls.h"
 #include "shim_table.h"

--- a/Pal/src/host/Linux-common/file_utils.c
+++ b/Pal/src/host/Linux-common/file_utils.c
@@ -5,7 +5,7 @@
 
 #include <asm/errno.h>
 #include <asm/fcntl.h>
-#include <unistd.h>
+#include <linux/fs.h>
 
 #include "api.h"
 #include "linux_utils.h"

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -12,7 +12,6 @@
 #include <stdint.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include "list.h"
 #include "pal.h"

--- a/common/include/crypto.h
+++ b/common/include/crypto.h
@@ -13,7 +13,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <unistd.h>
+
+#include "api.h"
 
 #define SHA256_DIGEST_LEN 32
 #define DH_SIZE           384 /* DH_SIZE is tied to the choice of parameters in mbedtls_adapter.c */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
They are not needed and wrong (we are mostly no-std env).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/533)
<!-- Reviewable:end -->
