### PR TITLE
[LibOS] Don't use PAL trusted/protected files in `encrypted` fs

### DIFF
--- a/LibOS/shim/src/fs/shim_fs_encrypted.c
+++ b/LibOS/shim/src/fs/shim_fs_encrypted.c
@@ -157,8 +157,8 @@ static int encrypted_file_internal_open(struct shim_encrypted_file* enc, PAL_HAN
 
     if (!pal_handle) {
         enum pal_create_mode create_mode = create ? PAL_CREATE_ALWAYS : PAL_CREATE_NEVER;
-        ret = DkStreamOpen(enc->uri, PAL_ACCESS_RDWR, share_flags, create_mode, /*options=*/0,
-                           &pal_handle);
+        ret = DkStreamOpen(enc->uri, PAL_ACCESS_RDWR, share_flags, create_mode,
+                           PAL_OPTION_PASSTHROUGH, &pal_handle);
         if (ret < 0) {
             log_warning("%s: DkStreamOpen failed: %d", __func__, ret);
             return pal_to_unix_errno(ret);

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -7,6 +7,7 @@
 /trusted_testfile
 
 /tmp
+/tmp_enc
 
 /build.ninja
 /.ninja_*

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -16,4 +16,5 @@ clean:
 		*.xml \
 		testfile \
 		trusted_testfile \
-		tmp/*
+		tmp/* \
+		tmp_enc/*

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -17,7 +17,7 @@ fs.mounts = [
   { path = "/bin", uri = "file:/bin" },
 
   { type = "tmpfs", path = "/mnt/tmpfs" },
-  { type = "encrypted", path = "/tmp/enc", uri = "file:tmp/enc", key_name = "my_custom_key" },
+  { type = "encrypted", path = "/tmp_enc", uri = "file:tmp_enc", key_name = "my_custom_key" },
 ]
 
 sgx.thread_num = 16

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -241,8 +241,8 @@ class TC_01_Bootstrap(RegressionTestCase):
                 os.unlink(path)
 
     def test_222_send_handle_enc(self):
-        path = 'tmp/enc/send_handle_test'
-        os.makedirs('tmp/enc', exist_ok=True)
+        path = 'tmp_enc/send_handle_test'
+        os.makedirs('tmp_enc', exist_ok=True)
         # Delete the file: the test truncates the file anyway, but it may fail to open a malformed
         # encrypted file.
         if os.path.exists(path):
@@ -623,9 +623,9 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('TEST OK', stdout)
 
     def test_035_rename_unlink_enc(self):
-        os.makedirs('tmp/enc', exist_ok=True)
-        file1 = 'tmp/enc/file1'
-        file2 = 'tmp/enc/file2'
+        os.makedirs('tmp_enc', exist_ok=True)
+        file1 = 'tmp_enc/file1'
+        file2 = 'tmp_enc/file2'
         # Delete the files: the test overwrites them anyway, but it may fail if they are malformed.
         for path in [file1, file2]:
             if os.path.exists(path):

--- a/Pal/include/host/Linux-common/pal_flags_conv.h
+++ b/Pal/include/host/Linux-common/pal_flags_conv.h
@@ -64,7 +64,7 @@ static inline int PAL_CREATE_TO_LINUX_OPEN(enum pal_create_mode create) {
 }
 
 static inline int PAL_OPTION_TO_LINUX_OPEN(pal_stream_options_t options) {
-    assert(WITHIN_MASK(options, PAL_OPTION_CLOEXEC | PAL_OPTION_NONBLOCK));
+    assert(WITHIN_MASK(options, PAL_OPTION_CLOEXEC | PAL_OPTION_NONBLOCK | PAL_OPTION_PASSTHROUGH));
     return (options & PAL_OPTION_CLOEXEC  ? O_CLOEXEC  : 0) |
            (options & PAL_OPTION_NONBLOCK ? O_NONBLOCK : 0);
 }

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -254,11 +254,12 @@ enum pal_create_mode {
 
 /*! stream misc flags */
 typedef uint32_t pal_stream_options_t; /* bitfield */
-#define PAL_OPTION_CLOEXEC         1
-#define PAL_OPTION_EFD_SEMAPHORE   2 /*!< specific to `eventfd` syscall */
-#define PAL_OPTION_NONBLOCK        4
-#define PAL_OPTION_DUALSTACK       8 /*!< Create dual-stack socket (opposite of IPV6_V6ONLY) */
-#define PAL_OPTION_MASK          0xF
+#define PAL_OPTION_CLOEXEC         0x1
+#define PAL_OPTION_EFD_SEMAPHORE   0x2 /*!< specific to `eventfd` syscall */
+#define PAL_OPTION_NONBLOCK        0x4
+#define PAL_OPTION_DUALSTACK       0x8 /*!< Create dual-stack socket (opposite of IPV6_V6ONLY) */
+#define PAL_OPTION_PASSTHROUGH    0x10 /*!< Disregard `sgx.{allowed,trusted,protected}_files` */
+#define PAL_OPTION_MASK           0x1F
 
 /*!
  * \brief Open/create a stream resource specified by `uri`.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The new mount syntax supersedes `sgx.{allowed,trusted,protected}_files`, and the `encrypted` filesystem should always create "passthrough" PAL handles. This is ensured by introducing a special option to `DkStreamOpen`.

(I think that this option is temporary - if we manage to move all of trusted/protected files to LibOS, then all PAL handles will be "passthrough").

## How to test this PR? <!-- (if applicable) -->

The LibOS regression tests worked only because we mounted `tmp/enc`, and we happened to include `tmp/` in the list of allowed files. Instead, the tests for encrypted files use a separate host directory (`tmp_enc/`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/534)
<!-- Reviewable:end -->
