### PR TITLE
[LibOS] Support special keys (MRENCLAVE, MRSIGNER) in `encrypted` fs

### DIFF
--- a/LibOS/shim/src/fs/chroot/encrypted.c
+++ b/LibOS/shim/src/fs/chroot/encrypted.c
@@ -25,7 +25,6 @@
  *
  * TODO (most items are needed for feature parity with PAL protected files):
  *
- * - mounting with special keys (SGX MRENCLAVE and MRSIGNER)
  * - mmap
  * - truncate (the current `truncate` operation works only for extending the file, support for
  *   truncation needs to be added to the `protected_files` module)

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -18,6 +18,8 @@ fs.mounts = [
 
   { type = "tmpfs", path = "/mnt/tmpfs" },
   { type = "encrypted", path = "/tmp_enc", uri = "file:tmp_enc", key_name = "my_custom_key" },
+  { type = "encrypted", path = "/encrypted_file_mrenclave.dat", uri = "file:encrypted_file_mrenclave.dat", key_name = "_sgx_mrenclave" },
+  { type = "encrypted", path = "/encrypted_file_mrsigner.dat", uri = "file:encrypted_file_mrsigner.dat", key_name = "_sgx_mrsigner" },
 ]
 
 sgx.thread_num = 16

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -985,45 +985,48 @@ class TC_40_FileSystem(RegressionTestCase):
 
     @unittest.skipUnless(HAS_SGX, 'Sealed (protected) files are only available with SGX')
     def test_050_sealed_file_mrenclave(self):
-        pf_path = 'sealed_file_mrenclave.dat'
-        if os.path.exists(pf_path):
-            os.remove(pf_path)
+        # Test both old and new implementation
+        for pf_path in ['sealed_file_mrenclave.dat', 'encrypted_file_mrenclave.dat']:
+            if os.path.exists(pf_path):
+                os.remove(pf_path)
 
-        stdout, _ = self.run_binary(['sealed_file', pf_path])
-        self.assertIn('CREATION OK', stdout)
-        stdout, _ = self.run_binary(['sealed_file', pf_path])
-        self.assertIn('READING OK', stdout)
+            stdout, _ = self.run_binary(['sealed_file', pf_path])
+            self.assertIn('CREATION OK', stdout)
+            stdout, _ = self.run_binary(['sealed_file', pf_path])
+            self.assertIn('READING OK', stdout)
 
     @unittest.skipUnless(HAS_SGX, 'Sealed (protected) files are only available with SGX')
     def test_051_sealed_file_mrsigner(self):
-        pf_path = 'sealed_file_mrsigner.dat'
-        if os.path.exists(pf_path):
-            os.remove(pf_path)
+        # Test both old and new implementation
+        for pf_path in ['sealed_file_mrsigner.dat', 'encrypted_file_mrsigner.dat']:
+            if os.path.exists(pf_path):
+                os.remove(pf_path)
 
-        stdout, _ = self.run_binary(['sealed_file', pf_path])
-        self.assertIn('CREATION OK', stdout)
-        stdout, _ = self.run_binary(['sealed_file_mod', pf_path])
-        self.assertIn('READING FROM MODIFIED ENCLAVE OK', stdout)
+            stdout, _ = self.run_binary(['sealed_file', pf_path])
+            self.assertIn('CREATION OK', stdout)
+            stdout, _ = self.run_binary(['sealed_file_mod', pf_path])
+            self.assertIn('READING FROM MODIFIED ENCLAVE OK', stdout)
 
     @unittest.skipUnless(HAS_SGX, 'Sealed (protected) files are only available with SGX')
     def test_052_sealed_file_mrenclave_bad(self):
-        # Negative test: Seal MRENCLAVE-bound file in one enclave -> opening this file in another
-        # enclave (with different MRENCLAVE) should fail
-        pf_path = 'sealed_file_mrenclave.dat'
-        if os.path.exists(pf_path):
-            os.remove(pf_path)
+        # Test both old and new implementation
+        for pf_path in ['sealed_file_mrenclave.dat', 'encrypted_file_mrenclave.dat']:
+            # Negative test: Seal MRENCLAVE-bound file in one enclave -> opening this file in
+            # another enclave (with different MRENCLAVE) should fail
+            if os.path.exists(pf_path):
+                os.remove(pf_path)
 
-        stdout, _ = self.run_binary(['sealed_file', pf_path])
-        self.assertIn('CREATION OK', stdout)
+            stdout, _ = self.run_binary(['sealed_file', pf_path])
+            self.assertIn('CREATION OK', stdout)
 
-        try:
-            self.run_binary(['sealed_file_mod', pf_path])
-            self.fail('expected to return nonzero')
-        except subprocess.CalledProcessError as e:
-            self.assertEqual(e.returncode, 1)
-            stdout = e.stdout.decode()
-            self.assertNotIn('READING FROM MODIFIED ENCLAVE OK', stdout)
-            self.assertIn('Permission denied', stdout)
+            try:
+                self.run_binary(['sealed_file_mod', pf_path])
+                self.fail('expected to return nonzero')
+            except subprocess.CalledProcessError as e:
+                self.assertEqual(e.returncode, 1)
+                stdout = e.stdout.decode()
+                self.assertNotIn('READING FROM MODIFIED ENCLAVE OK', stdout)
+                self.assertIn('Permission denied', stdout)
 
     def test_060_synthetic(self):
         stdout, _ = self.run_binary(['synthetic'])

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -763,6 +763,22 @@ int DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_si
  */
 int DkSetProtectedFilesKey(const char* pf_key_hex);
 
+/*!
+ * \brief Get special key (specific to PAL host).
+ *
+ * \param[in]     name      Key name.
+ * \param[out]    key       On success, will be set to retrieved key.
+ * \param[in,out] key_size  Caller specifies maximum size for `key`. On success, will contain actual
+ *                          size.
+ *
+ * Retrieve the value of a special key. Currently implemented for Linux-SGX PAL, which supports two
+ * such keys: `_sgx_mrenclave` and `_sgx_mrsigner`.
+ *
+ * If a given key is not supported by the current PAL host, the function will return
+ * -PAL_ERROR_NOTIMPLEMENTED.
+ */
+int DkGetSpecialKey(const char* name, void* key, size_t* key_size);
+
 #ifdef __GNUC__
 #define symbol_version_default(real, name, version) \
     __asm__(".symver " #real "," #name "@@" #version "\n")

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -233,6 +233,7 @@ int _DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data
 int _DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_size, void* quote,
                         PAL_NUM* quote_size);
 int _DkSetProtectedFilesKey(const char* pf_key_hex);
+int _DkGetSpecialKey(const char* name, void* key, size_t* key_size);
 
 #define INIT_FAIL(exitcode, reason)                                                              \
     do {                                                                                         \

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -53,3 +53,7 @@ int DkAttestationQuote(const void* user_report_data, PAL_NUM user_report_data_si
 int DkSetProtectedFilesKey(const char* pf_key_hex) {
     return _DkSetProtectedFilesKey(pf_key_hex);
 }
+
+int DkGetSpecialKey(const char* name, void* key, size_t* key_size) {
+    return _DkGetSpecialKey(name, key, key_size);
+}

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -626,6 +626,28 @@ int _DkSetProtectedFilesKey(const char* pf_key_hex) {
     return set_protected_files_key(pf_key_hex);
 }
 
+int _DkGetSpecialKey(const char* name, void* key, size_t* key_size) {
+    sgx_key_128bit_t sgx_key;
+
+    if (*key_size < sizeof(sgx_key))
+        return -PAL_ERROR_INVAL;
+
+    int ret;
+    if (!strcmp(name, "_sgx_mrenclave")) {
+        ret = sgx_get_seal_key(SGX_KEYPOLICY_MRENCLAVE, &sgx_key);
+    } else if (!strcmp(name, "_sgx_mrsigner")) {
+        ret = sgx_get_seal_key(SGX_KEYPOLICY_MRSIGNER, &sgx_key);
+    } else {
+        return -PAL_ERROR_NOTIMPLEMENTED;
+    }
+    if (ret < 0)
+        return ret;
+
+    memcpy(key, &sgx_key, sizeof(sgx_key));
+    *key_size = sizeof(sgx_key);
+    return 0;
+}
+
 /* Rest is moved from old `db_main-x86_64.c`. */
 
 #define CPUID_LEAF_INVARIANT_TSC 0x80000007

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -77,3 +77,10 @@ int _DkSetProtectedFilesKey(const char* pf_key_hex) {
     __UNUSED(pf_key_hex);
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
+
+int _DkGetSpecialKey(const char* name, void* key, size_t* key_size) {
+    __UNUSED(name);
+    __UNUSED(key);
+    __UNUSED(key_size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -57,6 +57,13 @@ int _DkSetProtectedFilesKey(const char* pf_key_hex) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
+int _DkGetSpecialKey(const char* name, void* key, size_t* key_size) {
+    __UNUSED(name);
+    __UNUSED(key);
+    __UNUSED(key_size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
 double _DkGetBogomips(void) {
     /* this has to be implemented */
     return 0.0;

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -44,5 +44,6 @@ DkDebugDescribeLocation
 DkAttestationReport
 DkAttestationQuote
 DkSetProtectedFilesKey
+DkGetSpecialKey
 DkDebugLog
 DkGetPalPublicState


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Key names beginning with `_` are considered special, and PAL is queried for these keys. This is used for SGX MRENCLAVE and MRSIGNER keys.

If a key is not supported by the current PAL, mounting will still succeed (but files will not be readable). This way, manifests using these PAL-host-specific keys can still be loaded when using other PAL hosts.

(This design is as discussed in #371).

## How to test this PR? <!-- (if applicable) -->

The existing tests for MRENCLAVE and MRSIGNER keys now also check the new implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/539)
<!-- Reviewable:end -->
