### PR TITLE
[Pal] Allow `arch_prctl(ARCH_REQ_XCOMP_PERM)` to return `-ENOTSUPP`

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -200,11 +200,12 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
      * will inherit the permission, but here for simplicity we call it in every child process as
      * well. Some deployment environments run Linux systems earlier than v5.16 but with
      * an AMX-specific patch; this patch doesn't introduce `arch_prctl(ARCH_REQ_XCOMP_PERM)`
-     * syscall so an attempt to call it may return EINVAL, EOPNOTSUPP or ENOSYS. In this case,
-     * we simply ignore the result of this syscall. */
+     * syscall so an attempt to call it may return EINVAL, ENOTSUPP, EOPNOTSUPP or ENOSYS. In this
+     * case, we simply ignore the result of this syscall. */
     if (secs->attributes.xfrm & (1 << AMX_TILEDATA)) {
         ret = DO_SYSCALL(arch_prctl, ARCH_REQ_XCOMP_PERM, AMX_TILEDATA);
-        if (ret < 0 && ret != -EINVAL && ret != -EOPNOTSUPP && ret != -ENOSYS) {
+        if (ret < 0 && ret != -EINVAL && ret != /*-ENOTSUPP*/-524 && ret != -EOPNOTSUPP &&
+                ret != -ENOSYS) {
             log_error("Requesting AMX permission failed: %d", ret);
             return ret;
         }

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -222,7 +222,8 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
          * by issuing an AMX-permission request, so call arch_prctl() to request AMX permission
          * unconditionally. For more details, see similar code in Linux-SGX PAL. */
         ret = DO_SYSCALL(arch_prctl, ARCH_REQ_XCOMP_PERM, AMX_TILEDATA);
-        if (ret < 0 && ret != -EINVAL && ret != -EOPNOTSUPP && ret != -ENOSYS) {
+        if (ret < 0 && ret != -EINVAL && ret != /*-ENOTSUPP*/-524 && ret != -EOPNOTSUPP &&
+                ret != -ENOSYS) {
             INIT_FAIL(unix_to_pal_error(-ret), "Requesting AMX permission failed");
         }
 #endif


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This syscall was introduced for CPUs with Intel AMX. On some Linux kernels with the pre-upstreamed AMX patch, this syscall erroneously returns `-ENOTSUPP` instead of `-EOPNOTSUPP`. This commit is to allow
running Gramine on such patched Linux kernels, otherwise Gramine fails with "Requesting AMX permission failed".

I'm not sure if we want this "work around weird patched Linux" PR. But since I found this, I decided to create an immediate PR.

## How to test this PR? <!-- (if applicable) -->

This was found on a patched Linux 5.12 kernel (with one of the earlier AMX patches that exhibits this wrong errno).

Here is an snippet from the strace of Gramine, when it tries to do this syscall:
```
arch_prctl(0x1023 /* ARCH_??? */, 0x12) = -1 ENOTSUPP (Unknown error 524)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/540)
<!-- Reviewable:end -->
