### PR TITLE
[tests] Introduce entrypoint tests

### DIFF
--- a/.ci/lib/stage-clean-check.jenkinsfile
+++ b/.ci/lib/stage-clean-check.jenkinsfile
@@ -22,6 +22,12 @@ stage('clean-check') {
 
         make -C LibOS/shim/test/regression clean
         make -C LibOS/shim/test/fs clean
+
+        gramine-test -C LibOS/shim/test/abi/x86_64 clean
+        rm -rf LibOS/shim/test/abi/x86_64/.pytest_cache \
+               LibOS/shim/test/abi/x86_64/__pycache__ \
+               LibOS/shim/test/abi/x86_64/*.xml
+
         make -C Pal/regression clean
 
         make -C CI-Examples/helloworld clean

--- a/.ci/lib/stage-test.jenkinsfile
+++ b/.ci/lib/stage-test.jenkinsfile
@@ -43,6 +43,18 @@ stage('test') {
     timeout(time: 15, unit: 'MINUTES') {
         try {
             sh '''
+                cd LibOS/shim/test/abi/x86_64
+                gramine-test build -v
+                python3 -m pytest -v --junit-xml abi.xml
+            '''
+        } finally {
+            junit 'LibOS/shim/test/abi/x86_64/*.xml'
+        }
+    }
+
+    timeout(time: 15, unit: 'MINUTES') {
+        try {
+            sh '''
                 cd LibOS/shim/test/fs
                 gramine-test build -v
                 python3 -m pytest -v --junit-xml fs.xml

--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     linux-headers-4.15.0-20-generic \
     musl \
     musl-tools \
+    nasm \
     net-tools \
     netcat-openbsd \
     ninja-build \

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     linux-headers-generic \
     musl \
     musl-tools \
+    nasm \
     net-tools \
     netcat-openbsd \
     ninja-build \

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -31,9 +31,9 @@ Update and install the required packages for Gramine::
 
    sudo apt-get update
    sudo apt-get install -y build-essential \
-       autoconf bison gawk libcurl4-openssl-dev libprotobuf-c-dev ninja-build \
-       pkg-config protobuf-c-compiler python3 python3-click python3-jinja2 \
-       python3-pip python3-protobuf wget
+       autoconf bison gawk libcurl4-openssl-dev libprotobuf-c-dev nasm \
+       ninja-build pkg-config protobuf-c-compiler python3 python3-click \
+       python3-jinja2 python3-pip python3-protobuf wget
    sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
 
 Gramine requires the kernel to support FSGSBASE x86 instructions. Older Azure

--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -37,8 +37,8 @@ Common dependencies
 Run the following command on Ubuntu LTS to install dependencies::
 
     sudo apt-get install -y build-essential \
-        autoconf bison gawk ninja-build python3 python3-click python3-jinja2 \
-        wget
+        autoconf bison gawk nasm ninja-build python3 python3-click \
+        python3-jinja2 wget
     sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
 
 You can also install Meson and python3-toml from apt instead of pip, but only if

--- a/LibOS/shim/test/abi/meson.build
+++ b/LibOS/shim/test/abi/meson.build
@@ -1,0 +1,3 @@
+if host_machine.cpu_family() == 'x86_64'
+    subdir(host_machine.cpu_family())
+endif

--- a/LibOS/shim/test/abi/x86_64/.gitignore
+++ b/LibOS/shim/test/abi/x86_64/.gitignore
@@ -1,0 +1,5 @@
+/*.manifest
+/*.xml
+
+/build.ninja
+/.ninja_*

--- a/LibOS/shim/test/abi/x86_64/atexit_func.asm
+++ b/LibOS/shim/test/abi/x86_64/atexit_func.asm
@@ -1,0 +1,15 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; rdx contains a function pointer that the application should register with atexit.
+; Gramine sets rdx to NULL - it does not use this feature at all.
+
+extern    test_exit
+global    _start
+
+section   .text
+
+_start:
+    mov   rdi, rdx
+    jmp   test_exit

--- a/LibOS/shim/test/abi/x86_64/common.c
+++ b/LibOS/shim/test/abi/x86_64/common.c
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+ */
+
+/*
+ * We have to add a function declaration to avoid warnings.
+ * This function is used with NASM, so creating a header is pointless.
+ */
+int test_str_neq(const char* orig, const char* new);
+
+int test_str_neq(const char* orig, const char* new) {
+    if (orig == new)
+        return 0;
+
+    while (*orig && *orig == *new) {
+        orig++;
+        new++;
+    }
+
+    return *orig != *new;
+}

--- a/LibOS/shim/test/abi/x86_64/exit.asm
+++ b/LibOS/shim/test/abi/x86_64/exit.asm
@@ -1,0 +1,17 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+global    test_exit
+
+%define   __NR_exit   60
+
+section   .text
+
+test_exit:
+    xor   rax, rax
+    test  rdi, rdi
+    setne al
+    mov   rdi, rax
+    mov   rax, __NR_exit
+    syscall

--- a/LibOS/shim/test/abi/x86_64/fpu_control_word.asm
+++ b/LibOS/shim/test/abi/x86_64/fpu_control_word.asm
@@ -1,0 +1,27 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; The x87 FPU Control Word register:
+; +--+--+--+--+--+--+--+--+--+--+--+--+--+
+; | X|   RC|   PC| R| R|PM|UM|OM|ZM|DM|IM|
+; +--+--+--+--+--+--+--+--+--+--+--+--+--+
+; The x87 FPU Control Word should be set as follow:
+; +--+--+--+--+--+--+--+--+--+--+--+--+--+
+; | X| 0  0| 1  1| X| X| 1| 1| 1| 1| 1| 1|
+; +--+--+--+--+--+--+--+--+--+--+--+--+--+
+
+extern    test_exit
+global    _start
+
+section   .text
+
+_start:
+    fstcw [rsp]
+
+    mov   ax, [rsp]
+    mov   rdi, rax
+    and   rdi, 0b0111100111111
+    xor   rdi, 0b0001100111111
+
+    jmp   test_exit

--- a/LibOS/shim/test/abi/x86_64/manifest.template
+++ b/LibOS/shim/test/abi/x86_64/manifest.template
@@ -1,0 +1,23 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+# We set the argv[0] to the name of the entrypoint.
+# This is crucial for stack tests as otherwise argv[0] contains an absolute path
+# to the binary, and tests become unreliable.
+loader.argv0_override = "{{ entrypoint }}"
+loader.insecure__use_cmdline_argv = true
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.nonpie_binary = true
+sgx.debug = true
+sgx.thread_num = 4
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+  "file:{{ gramine.runtimedir() }}/",
+]

--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -1,0 +1,37 @@
+common_lib = static_library('common_lib',
+    'common.c',
+    nasm_gen.process('exit.asm')
+)
+
+tests = {
+    'atexit_func': {},
+    'fpu_control_word': {},
+    'mxcsr': {},
+    'rflags': {},
+    'stack': {},
+    'stack_arg': {},
+}
+
+install_dir = join_paths(pkglibdir, 'tests', 'libos', 'entrypoint')
+
+foreach name, params : tests
+    filename = ''
+    if (params.get('type', 'asm') == 'asm')
+        filename = nasm_gen.process('@0@.asm'.format(name))
+    else
+        filename = '@0@.c'.format(name)
+    endif
+
+    exe = executable(name,
+        filename,
+
+        link_with: [
+            params.get('link_with', [common_lib]),
+        ],
+
+        link_args: params.get('link_args', ['-nostdlib', '-static']),
+
+        install: true,
+        install_dir: install_dir,
+    )
+endforeach

--- a/LibOS/shim/test/abi/x86_64/mxcsr.asm
+++ b/LibOS/shim/test/abi/x86_64/mxcsr.asm
@@ -1,0 +1,27 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; The MXCSR register:
+; +--+--+--+--+--+--+--+--+--+---+--+--+--+--+--+--+
+; |FZ|   RC|PM|UM|OM|ZM|DM|IM|DAZ|PE|UE|OE|ZE|DE|IE|
+; +--+--+--+--+--+--+--+--+--+---+--+--+--+--+--+--+
+; The MXCSR should be set as follow:
+; +--+--+--+--+--+--+--+--+--+---+--+--+--+--+--+--+
+; | 0| 0  0| 1| 1| 1| 1| 1| 1|  0| X| X| X| X| X| X|
+; +--+--+--+--+--+--+--+--+--+---+--+--+--+--+--+--+
+
+extern    test_exit
+
+global    _start
+
+section   .text
+
+_start:
+    stmxcsr [rsp]
+
+    mov     edi, [rsp]
+    and     rdi, 0b1111111111000000
+    xor     rdi, 0b0001111110000000
+
+    jmp     test_exit

--- a/LibOS/shim/test/abi/x86_64/rflags.asm
+++ b/LibOS/shim/test/abi/x86_64/rflags.asm
@@ -1,0 +1,28 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; The rFlags should be cleared.
+; Verify OF, DF, SF, ZF, AF, PF, CF
+; The EFLAGS:
+; +--+--+--+--+--+--+--+--+--+--+--+--+
+; |OF|DF|IF|TF|SF|ZF| 0|AF| 0|PF| 1|CF|
+; +--+--+--+--+--+--+--+--+--+--+--+--+
+; Mask to get interesting bits:
+; +--+--+--+--+--+--+--+--+--+--+--+--+
+; | 1| 1| 0| 0| 1| 1| 0| 1| 0| 1| 0| 1|
+; +--+--+--+--+--+--+--+--+--+--+--+--+
+
+extern    test_exit
+
+global    _start
+
+section   .text
+
+_start:
+    pushfq
+    pop   rdi
+
+    and   rdi, 0b110011010101
+
+    jmp   test_exit

--- a/LibOS/shim/test/abi/x86_64/stack.asm
+++ b/LibOS/shim/test/abi/x86_64/stack.asm
@@ -1,0 +1,20 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; "The end of the input argument area shall be aligned on a 16..."
+
+extern    test_exit
+
+global    _start
+
+section   .text
+
+_start:
+    xor   rdi, rdi
+
+    mov   rax, rsp
+    and   rax, 0xF
+    setne dil
+
+    jmp   test_exit

--- a/LibOS/shim/test/abi/x86_64/stack_arg.asm
+++ b/LibOS/shim/test/abi/x86_64/stack_arg.asm
@@ -1,0 +1,50 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; Verify argv which should be in rsp + 8.
+
+default   rel
+
+extern    test_exit
+extern    test_str_neq
+
+global    _start
+
+section   .text
+
+_start:
+    mov   rdi, [rsp]        ; Verify argc
+    cmp   rdi, 3
+    mov   rdi, 1
+    jne   test_exit
+
+    lea   rdi, [argv0]      ; Verify argv[0]
+    mov   rsi, [rsp + 8 * 1]
+    call  test_str_neq
+    mov   rdi, rax
+    cmp   rdi, 1
+    je    test_exit
+
+    lea   rdi, [argv1]      ; Verify argv[1]
+    mov   rsi, [rsp + 8 * 2]
+    call  test_str_neq
+    mov   rdi, rax
+    cmp   rdi, 1
+    je    test_exit
+
+    lea   rdi, [argv2]      ; Verify argv[2]
+    mov   rsi, [rsp + 8 * 3]
+    call  test_str_neq
+    mov   rdi, rax
+    cmp   rdi, 1
+    je    test_exit
+
+    mov   rdi, [rsp + 8 * 4]
+    jmp   test_exit
+
+section   .data
+
+argv0    db    "stack_arg", 0x00
+argv1    db    "foo", 0x00
+argv2    db    "bar", 0x00

--- a/LibOS/shim/test/abi/x86_64/test_entrypoint.py
+++ b/LibOS/shim/test/abi/x86_64/test_entrypoint.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from graminelibos.regression import RegressionTestCase
+
+class TC_00_Entrypoint(RegressionTestCase):
+    def test_000_atexit_func(self):
+        self.run_binary(['atexit_func'])
+
+    def test_000_fpu_control_word(self):
+        self.run_binary(['fpu_control_word'])
+
+    def test_000_rflags(self):
+        self.run_binary(['rflags'])
+
+    def test_000_mxcsr(self):
+        self.run_binary(['mxcsr'])
+
+    def test_000_stack(self):
+        self.run_binary(['stack'])
+
+    def test_000_arg(self):
+        self.run_binary(['stack_arg', 'foo', 'bar'])

--- a/LibOS/shim/test/abi/x86_64/tests.toml
+++ b/LibOS/shim/test/abi/x86_64/tests.toml
@@ -1,0 +1,10 @@
+binary_dir = "@GRAMINE_PKGLIBDIR@/tests/libos/entrypoint"
+
+manifests = [
+  "atexit_func",
+  "fpu_control_word",
+  "mxcsr",
+  "rflags",
+  "stack",
+  "stack_arg",
+]

--- a/LibOS/shim/test/meson.build
+++ b/LibOS/shim/test/meson.build
@@ -1,2 +1,3 @@
+subdir('abi')
 subdir('regression')
 subdir('fs')

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,20 @@ python3_pkgdir = join_paths(python3_platlib, 'graminelibos')
 
 pkgconfig = import('pkgconfig')
 
+nasm_gen = generator(
+    find_program('nasm'),
+    output: '@BASENAME@.o',
+    depfile: '@BASENAME@.dep',
+    arguments: [
+        '-f', 'elf64',
+        '-I', '@0@/'.format(meson.current_build_dir()),
+        '-MQ', '@OUTPUT@', '-MF', '@DEPFILE@',
+        '@EXTRA_ARGS@',
+        '@INPUT@',
+        '-o', '@OUTPUT@'
+    ]
+)
+
 add_project_arguments(
     '-Wa,--noexecstack',
 


### PR DESCRIPTION
## Description of the changes
Add NASM compiler to the project - I believe we will want to move from GCC assembly to NASM in the future, so this is the first step.

The second change adds tests for the entry point. These tests verify the process initialization state as described n section 3.4 of System V Application Binary Interface. I also plan to add another ABI test regarding syscalls ABI. The new tests will also appear in the `abi_x86_64` directory. In the feature, if somebody else is interested, he can add analogous tests for other architectures using the similar naming pattern.

## Useful links for reviewers
* [System V Application Binary Interface - AMD64 Architecture Processor Supplement](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)

## How to test this PR?
```
gramine-test pytest
gramine-test --sgx pytest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/541)
<!-- Reviewable:end -->
