### PR TITLE
[pal/linux-sgx]use MAP_FIXED_NOREPLACE instead of MAP_FIXED

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -139,9 +139,9 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
     uint64_t addr = DO_SYSCALL(mmap, request_mmap_addr, request_mmap_size,
                                PROT_NONE, /* newer DCAP driver requires such initial mmap */
 #ifdef SGX_DCAP
-                               MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+                               MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #else
-                               MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
+                               MAP_FIXED_NOREPLACE | MAP_SHARED, g_isgx_device, 0);
 #endif
 
     if (IS_PTR_ERR(addr)) {

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -530,7 +530,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     struct enclave_dbginfo* dbg = (void*)DO_SYSCALL(mmap, DBGINFO_ADDR,
                                                     sizeof(struct enclave_dbginfo),
                                                     PROT_READ | PROT_WRITE,
-                                                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+                                                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
     if (IS_PTR_ERR(dbg)) {
         log_warning("Cannot allocate debug information (GDB will not work)");
     } else {
@@ -1055,7 +1055,7 @@ __attribute((constructor(0)))
 __attribute_no_sanitize_address
 static void setup_asan(void) {
     int prot = PROT_READ | PROT_WRITE;
-    int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED;
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED_NOREPLACE;
     void* addr = (void*)DO_SYSCALL(mmap, (void*)ASAN_SHADOW_START, ASAN_SHADOW_LENGTH, prot, flags,
                                    /*fd=*/-1, /*offset=*/0);
     if (IS_PTR_ERR(addr)) {


### PR DESCRIPTION
Signed-off-by: junjungu <junjun.gu@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
gramine-sgx uses MAP_FIXED flag to reserve memory for enclave.
If requested memory range collides with an existing mapping, MAP_FIXED will clobber the existing mapped range, and MAP_FIXED_NOREPLACE will fail withe error EEXIST.
So it's better to use MAP_FIXED_NOREPLACE instead of MAP_FIXED.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/543)
<!-- Reviewable:end -->
