### PR TITLE
[LibOS] Implement `mmap` for encrypted and tmpfs files 

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -82,9 +82,43 @@ struct shim_fs_ops {
      */
     ssize_t (*write)(struct shim_handle* hdl, const void* buf, size_t count, file_off_t* pos);
 
-    /* mmap: mmap handle to address */
-    int (*mmap)(struct shim_handle* hdl, void** addr, size_t size, int prot, int flags,
+    /*
+     * \brief Map file at an address.
+     *
+     * \param hdl     File handle.
+     * \param addr    Address of the memory region. Cannot be NULL.
+     * \param size    Size of the memory region.
+     * \param prot    Permissions for the memory region (`PROT_*`).
+     * \param flags   `mmap` flags (`MAP_*`).
+     * \param offset  Offset in file.
+     *
+     * Maps the file at given address. This might involve mapping directly (`DkStreamMap`), or
+     * mapping anonymous memory (`DkVirtualMemoryAlloc`) and writing data.
+     *
+     * `addr`, `offset` and `size` must be alloc-aligned (see `IS_ALLOC_ALIGNED*` macros in
+     * `shim_internal.h`).
+     */
+    int (*mmap)(struct shim_handle* hdl, void* addr, size_t size, int prot, int flags,
                 uint64_t offset);
+
+    /*
+     * \brief Write back mapped memory to file.
+     *
+     * \param hdl     File handle.
+     * \param addr    Address of the memory region. Cannot be NULL.
+     * \param size    Size of the memory region.
+     * \param prot    Permissions for the memory region (`PROT_*`).
+     * \param flags   `mmap` flags (`MAP_*`).
+     * \param offset  Offset in file.
+     *
+     * Writes back any changes made by the user.
+     *
+     * The parameters should describe either a region originally mapped with `mmap` callback, or a
+     * part of that region. This function should only be called for a shared mapping, i.e. `flags`
+     * must contain `MAP_SHARED`.
+     */
+    int (*msync)(struct shim_handle* hdl, void* addr, size_t size, int prot, int flags,
+                 uint64_t offset);
 
     /* flush: flush out user buffer */
     int (*flush)(struct shim_handle* hdl);
@@ -888,6 +922,11 @@ int generic_inode_stat(struct shim_dentry* dent, struct stat* buf);
 int generic_inode_hstat(struct shim_handle* hdl, struct stat* buf);
 file_off_t generic_inode_seek(struct shim_handle* hdl, file_off_t offset, int origin);
 int generic_inode_poll(struct shim_handle* hdl, int poll_type);
+
+int generic_emulated_mmap(struct shim_handle* hdl, void* addr, size_t size, int prot, int flags,
+                          uint64_t offset);
+int generic_emulated_msync(struct shim_handle* hdl, void* addr, size_t size, int prot, int flags,
+                           uint64_t offset);
 
 int synthetic_setup_dentry(struct shim_dentry* dent, mode_t type, mode_t perm);
 

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -124,6 +124,12 @@ void free_vma_info_array(struct shim_vma_info* vma_infos, size_t count);
 /* Implementation of madvise(MADV_DONTNEED) syscall */
 int madvise_dontneed_range(uintptr_t begin, uintptr_t end);
 
+/* Call `msync` for file mappings in given range (should be page-aligned) */
+int msync_range(uintptr_t begin, uintptr_t end);
+
+/* Call `msync` for file mappings of `hdl` */
+int msync_handle(struct shim_handle* hdl);
+
 void debug_print_all_vmas(void);
 
 #endif /* _SHIM_VMA_H_ */

--- a/LibOS/shim/src/fs/chroot/encrypted.c
+++ b/LibOS/shim/src/fs/chroot/encrypted.c
@@ -396,7 +396,7 @@ static ssize_t chroot_encrypted_read(struct shim_handle* hdl, void* buf, size_t 
     size_t actual_count;
 
     lock(&hdl->inode->lock);
-    int ret = encrypted_file_read(enc, buf, count, hdl->pos, &actual_count);
+    int ret = encrypted_file_read(enc, buf, count, *pos, &actual_count);
     unlock(&hdl->inode->lock);
 
     if (ret < 0)
@@ -416,7 +416,7 @@ static ssize_t chroot_encrypted_write(struct shim_handle* hdl, const void* buf, 
 
     lock(&hdl->inode->lock);
 
-    int ret = encrypted_file_write(enc, buf, count, hdl->pos, &actual_count);
+    int ret = encrypted_file_write(enc, buf, count, *pos, &actual_count);
     if (ret < 0)
         goto out;
 

--- a/LibOS/shim/src/fs/shim_fs_util.c
+++ b/LibOS/shim/src/fs/shim_fs_util.c
@@ -4,6 +4,7 @@
  */
 
 #include "cpu.h"
+#include "shim_flags_conv.h"
 #include "shim_fs.h"
 #include "shim_lock.h"
 #include "stat.h"
@@ -133,5 +134,114 @@ int generic_inode_poll(struct shim_handle* hdl, int poll_type) {
 
     unlock(&hdl->inode->lock);
     unlock(&hdl->pos_lock);
+    return ret;
+}
+
+int generic_emulated_mmap(struct shim_handle* hdl, void* addr, size_t size, int prot, int flags,
+                          uint64_t offset) {
+    assert(addr);
+
+    int ret;
+
+    pal_prot_flags_t pal_prot = LINUX_PROT_TO_PAL(prot, flags);
+    pal_prot_flags_t pal_prot_writable = pal_prot | PAL_PROT_WRITE;
+
+    void* actual_addr = addr;
+    ret = DkVirtualMemoryAlloc(&actual_addr, size, /*alloc_type=*/0, pal_prot_writable);
+    if (ret < 0)
+        return pal_to_unix_errno(ret);
+
+    assert(actual_addr == addr);
+
+    size_t read_size = size;
+    char* read_addr = addr;
+    file_off_t pos = offset;
+    while (read_size > 0) {
+        ssize_t count = hdl->fs->fs_ops->read(hdl, read_addr, read_size, &pos);
+        if (count < 0) {
+            if (count == -EINTR)
+                continue;
+            ret = count;
+            goto err;
+        }
+
+        if (count == 0)
+            break;
+
+        assert((size_t)count <= read_size);
+        read_size -= count;
+        read_addr += count;
+    }
+
+    if (pal_prot != pal_prot_writable) {
+        ret = DkVirtualMemoryProtect(addr, size, pal_prot);
+        if (ret < 0) {
+            ret = pal_to_unix_errno(ret);
+            goto err;
+        }
+    }
+
+    return 0;
+
+err:;
+    int free_ret = DkVirtualMemoryFree(addr, size);
+    if (free_ret < 0) {
+        log_debug("%s: DkVirtualMemoryFree failed on cleanup: %d", __func__, free_ret);
+        BUG();
+    }
+    return ret;
+}
+
+int generic_emulated_msync(struct shim_handle* hdl, void* addr, size_t size, int prot, int flags,
+                           uint64_t offset) {
+    assert(!(flags & MAP_PRIVATE));
+
+    lock(&hdl->inode->lock);
+    file_off_t file_size = hdl->inode->size;
+    unlock(&hdl->inode->lock);
+
+    pal_prot_flags_t pal_prot = LINUX_PROT_TO_PAL(prot, flags);
+    pal_prot_flags_t pal_prot_readable = pal_prot | PAL_PROT_READ;
+
+    int ret;
+    if (pal_prot != pal_prot_readable) {
+        ret = DkVirtualMemoryProtect(addr, size, pal_prot_readable);
+        if (ret < 0)
+            return pal_to_unix_errno(ret);
+    }
+
+    size_t write_size = offset > (uint64_t)file_size ? 0 : MIN(size, (uint64_t)file_size - offset);
+    char* write_addr = addr;
+    file_off_t pos = offset;
+    while (write_size > 0) {
+        ssize_t count = hdl->fs->fs_ops->write(hdl, write_addr, write_size, &pos);
+        if (count < 0) {
+            if (count == -EINTR)
+                continue;
+            ret = count;
+            goto out;
+        }
+
+        if (count == 0) {
+            log_debug("%s: Failed to write back the whole mapping", __func__);
+            ret = -EIO;
+            goto out;
+        }
+
+        assert((size_t)count <= write_size);
+        write_size -= count;
+        write_addr += count;
+    }
+
+    ret = 0;
+
+out:
+    if (pal_prot != pal_prot_readable) {
+        int protect_ret = DkVirtualMemoryProtect(addr, size, pal_prot);
+        if (protect_ret < 0) {
+            log_debug("%s: DkVirtualMemoryProtect failed on cleanup: %d", __func__, protect_ret);
+            BUG();
+        }
+    }
     return ret;
 }

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -261,7 +261,7 @@ static int execute_loadcmd(const struct loadcmd* c, elf_addr_t base_diff,
             return ret;
         }
 
-        if ((ret = file->fs->fs_ops->mmap(file, &map_start, map_size, c->prot, map_flags,
+        if ((ret = file->fs->fs_ops->mmap(file, map_start, map_size, c->prot, map_flags,
                                           c->map_off)) < 0) {
             log_debug("%s: failed to map segment: %d", __func__, ret);
             return ret;

--- a/LibOS/shim/test/fs/test_tmpfs.py
+++ b/LibOS/shim/test/fs/test_tmpfs.py
@@ -66,17 +66,17 @@ class TC_10_Tmpfs(test_fs.TC_00_FileSystem):
     def verify_copy_content(self, input_path, output_path):
         pass
 
-    @unittest.skip("mmap is not yet implemented in tmpfs")
+    # This overrides parent class to remove @expectedFailureIf(HAS_SGX)
     def test_204_copy_dir_mmap_whole(self):
-        test_fs.TC_00_FileSystem.test_204_copy_dir_mmap_whole(self)
+        self.do_copy_test('copy_mmap_whole', 30)
 
-    @unittest.skip("mmap is not yet implemented in tmpfs")
+    # This overrides parent class to remove @expectedFailureIf(HAS_SGX)
     def test_205_copy_dir_mmap_seq(self):
-        test_fs.TC_00_FileSystem.test_205_copy_dir_mmap_seq(self)
+        self.do_copy_test('copy_mmap_seq', 60)
 
-    @unittest.skip("mmap is not yet implemented in tmpfs")
+    # This overrides parent class to remove @expectedFailureIf(HAS_SGX)
     def test_206_copy_dir_mmap_rev(self):
-        test_fs.TC_00_FileSystem.test_206_copy_dir_mmap_rev(self)
+        self.do_copy_test('copy_mmap_rev', 60)
 
     @unittest.skip("not applicable for tmpfs")
     def test_210_copy_dir_mounted(self):

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -58,6 +58,7 @@ tests = {
     'mkfifo': {},
     'mmap_file': {},
     'mmap_file_backed': {},
+    'mmap_file_emulated': {},
     'mprotect_file_fork': {},
     'mprotect_prot_growsdown': {},
     'multi_pthread': {},

--- a/LibOS/shim/test/regression/mmap_file_emulated.c
+++ b/LibOS/shim/test/regression/mmap_file_emulated.c
@@ -1,0 +1,147 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Test file mapping emulated by Gramine (encrypted, tmpfs): try reading and writing a file through
+ * a mapping.
+ */
+
+#define _POSIX_C_SOURCE 200112 /* for ftruncate */
+#include <assert.h>
+#include <err.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "rw_file.h"
+
+/* NOTE: these two messages should have equal length */
+#define MESSAGE1 "hello world\n  "
+#define MESSAGE2 "goodbye world\n"
+#define MESSAGE_LEN (sizeof(MESSAGE1) - 1)
+
+int main(int argc, char** argv) {
+    if (argc != 2)
+        errx(1, "Usage: %s path", argv[0]);
+
+    const char* path = argv[1];
+
+    setbuf(stdout, NULL);
+
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0)
+        err(1, "sysconf");
+
+    assert(MESSAGE_LEN + 1 <= (size_t)page_size);
+    size_t mmap_size = page_size;
+    size_t file_size = page_size + MESSAGE_LEN;
+
+    /* Create a new file */
+
+    int fd = open(path, O_WRONLY | O_CREAT, 0666);
+    if (fd < 0)
+        err(1, "open");
+
+    ssize_t ret = ftruncate(fd, file_size);
+    if (ret < 0)
+        err(1, "ftruncate");
+
+    /* Write MESSAGE1 at position 0 */
+
+    ret = posix_fd_write(fd, MESSAGE1, MESSAGE_LEN);
+    if (ret < 0)
+        err(1, "failed to write file");
+    if ((size_t)ret < MESSAGE_LEN)
+        errx(1, "not enough bytes written");
+
+    /* Write MESSAGE2 at position `page_size` */
+
+    ret = lseek(fd, page_size, SEEK_SET);
+    if (ret < 0)
+        err(1, "lseek");
+
+    ret = posix_fd_write(fd, MESSAGE2, MESSAGE_LEN);
+    if (ret < 0)
+        err(1, "failed to write file");
+    if ((size_t)ret < MESSAGE_LEN)
+        errx(1, "not enough bytes written");
+
+    ret = close(fd);
+    if (ret < 0)
+        err(1, "close");
+
+    puts("CREATE OK");
+
+    /* Open and map it: MAP_SHARED at offset 0, MAP_PRIVATE at offset `page_size` */
+
+    fd = open(path, O_RDWR, 0);
+    if (fd < 0)
+        err(1, "open");
+
+    char* addr_shared = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (addr_shared == MAP_FAILED)
+        err(1, "mmap");
+
+    char* addr_private = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, page_size);
+    if (addr_private == MAP_FAILED)
+        err(1, "mmap");
+
+    /* Close the FD early, so that we know `munmap(addr_shared)` will flush changes */
+    ret = close(fd);
+    if (ret == -1)
+        err(1, "close");
+
+    if (memcmp(addr_shared, MESSAGE1, MESSAGE_LEN))
+        errx(1, "wrong mapping content at addr_shared (%s)", addr_shared);
+
+    if (memcmp(addr_private, MESSAGE2, MESSAGE_LEN))
+        errx(1, "wrong mapping content at addr_private (%s)", addr_private);
+
+    for (size_t i = MESSAGE_LEN; i < mmap_size; i++) {
+        if (addr_shared[i] != 0)
+            errx(1, "unexpected non-zero byte at addr_shared[%zu]", i);
+        if (addr_private[i] != 0)
+            errx(1, "unexpected non-zero byte at addr_private[%zu]", i);
+    }
+
+    puts("MAP OK");
+
+    /* Write new message through mmap, then close it */
+
+    strcpy(addr_shared, MESSAGE2);
+    strcpy(addr_private, MESSAGE1);
+
+    ret = munmap(addr_shared, mmap_size);
+    if (ret < 0)
+        err(1, "munmap");
+
+    ret = munmap(addr_private, mmap_size);
+    if (ret < 0)
+        err(1, "munmap");
+
+    puts("WRITE OK");
+
+    /* Verify the file: only the first write should be applied */
+
+    char buf[file_size];
+
+    ret = posix_file_read(path, buf, sizeof(buf));
+    if (ret < 0)
+        err(1, "failed to read file");
+    if ((size_t)ret < file_size)
+        errx(1, "not enough bytes read");
+
+    if (memcmp(&buf[0], MESSAGE2, MESSAGE_LEN))
+        errx(1, "wrong file content");
+
+    if (memcmp(&buf[page_size], MESSAGE2, MESSAGE_LEN))
+        errx(1, "wrong file content");
+
+    puts("TEST OK");
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -729,17 +729,34 @@ class TC_30_Syscall(RegressionTestCase):
             # This test generates a 4 GB file, don't leave it in FS.
             os.remove('testfile')
 
-    def test_055_mprotect_file_fork(self):
+    def test_055_mmap_emulated_tmpfs(self):
+        path = '/mnt/tmpfs/test_mmap'
+        stdout, _ = self.run_binary(['mmap_file_emulated', path])
+        self.assertIn('TEST OK', stdout)
+
+    def test_056_mmap_emulated_enc(self):
+        path = 'tmp_enc/test_mmap'
+        os.makedirs('tmp_enc', exist_ok=True)
+        if os.path.exists(path):
+            os.remove(path)
+        try:
+            stdout, _ = self.run_binary(['mmap_file_emulated', path])
+            self.assertIn('TEST OK', stdout)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_057_mprotect_file_fork(self):
         stdout, _ = self.run_binary(['mprotect_file_fork'])
 
         self.assertIn('Test successful!', stdout)
 
-    def test_056_mprotect_prot_growsdown(self):
+    def test_058_mprotect_prot_growsdown(self):
         stdout, _ = self.run_binary(['mprotect_prot_growsdown'])
 
         self.assertIn('TEST OK', stdout)
 
-    def test_057_madvise(self):
+    def test_059_madvise(self):
         stdout, _ = self.run_binary(['madvise'])
         self.assertIn('TEST OK', stdout)
 

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -59,6 +59,7 @@ manifests = [
   "mkfifo",
   "mmap_file",
   "mmap_file_backed",
+  "mmap_file_emulated",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -61,6 +61,7 @@ manifests = [
   "mkfifo",
   "mmap_file",
   "mmap_file_backed",
+  "mmap_file_emulated",
   "mprotect_file_fork",
   "mprotect_prot_growsdown",
   "multi_pthread",


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

This adds support for "emulated" memory mappings in LibOS. Memory is written back to the file using a new `msync` callback.

This (and #539) bring us to feature parity with SGX protected files, so the next step will be to replace the old implementation (see issue: #371).

## How to test this PR? <!-- (if applicable) -->

There is a new LibOS regression test, `mmap_file_emulated`, that checks reading and writing an emulated file. In addition, some tmpfs tests are now unskipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/550)
<!-- Reviewable:end -->
