### PR TITLE
[tests] Respect the change dir option

### DIFF
--- a/python/gramine-test
+++ b/python/gramine-test
@@ -11,20 +11,22 @@ import click
 
 from graminelibos import util_tests, _CONFIG_SGX_ENABLED
 
+def change_dir(_ctx, _param, value):
+    if value:
+        os.chdir(value)
 
 @click.group(help='Helper program for running Gramine tests.')
 @click.option('--sgx/--no-sgx', default=(os.environ.get('SGX') == '1'),
               help='Enable SGX mode (you can also set SGX=1 before running)')
 @click.option('--conf-file-name', '-n', type=click.Path(exists=True, dir_okay=False),
               default='tests.toml', help='Configuration file name to use')
-@click.option('--directory', '-C', metavar='dir', type=click.Path(file_okay=False),
+@click.option('--directory', '-C', callback=change_dir, expose_value=False, is_eager=True,
+              metavar='dir', type=click.Path(file_okay=False),
               help='Change directory before running')
 @click.pass_context
-def main(ctx, sgx, conf_file_name, directory):
+def main(ctx, sgx, conf_file_name):
     if sgx and not _CONFIG_SGX_ENABLED:
         raise click.ClickException('This version of Gramine is built without SGX')
-    if directory:
-        os.chdir(directory)
     ctx.obj = {
         'sgx': sgx,
         'conf_file_name': conf_file_name,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously in Gramine, the `-C` option (change dir) and `-n` option (configure file name) were incompatible.
The gramine-test first confirms the file's existence and later changes the current working directory.

The verification is done by option library predefined type `click.Path`. The verification is done before the gramine-test
changes the directory, so it always checks the file's existence in the current working directory.

The workaround for this problem is to use a callback.
When the `-C` option is passed, change the directory as fast as possible and not wait until the command function is called.
Additionally, the argument `is_eager` will cause the library to parse the change dir option before anything else.

## Useful links for reviewers
[Callbacks and Eager Options](https://click.palletsprojects.com/en/8.1.x/options/#callbacks-and-eager-options)

## How to test this PR? <!-- (if applicable) -->
```
$ gramine-test -C LibOS/shim/test/fs/ pytest
$ gramine-test -n tests.toml -C LibOS/shim/test/fs/ pytest
$ gramine-test -C LibOS/shim/test/fs/ -n tests.toml pytest
$ cd LibOS/shim/test/fs/; gramine-test pytest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/551)
<!-- Reviewable:end -->
