### PR TITLE
[python] Calculate SHA256 hash of trusted files in chunks

### DIFF
--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -28,7 +28,8 @@ class ManifestError(Exception):
 def hash_file_contents(path):
     with open(path, 'rb') as f:
         sha = hashlib.sha256()
-        sha.update(f.read())
+        for chunk in iter(lambda: f.read(128 * sha.block_size), b''):
+            sha.update(chunk)
         return sha.hexdigest()
 
 def uri2path(uri):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the `manifest.py` tool read the whole trusted file in memory and only then calculated the hash over it. In case of some huge file, the tool could fail with `MemoryError`. Now we read the file in chunks.

A related StackOverflow question and replies: https://stackoverflow.com/questions/1131220/get-md5-hash-of-big-files-in-python

## How to test this PR? <!-- (if applicable) -->

This was detected on some workload with huge files and small amount of RAM. The error was like this:
```
gramine-sgx-sign \
--key enclave-key.pem \
--manifest python.manifest \
--output python.manifest.sgx
Traceback (most recent call last):
File "/usr/bin/gramine-sgx-sign", line 70, in <module>
main() # pylint: disable=no-value-for-parameter
...
File "/usr/bin/gramine-sgx-sign", line 30, in main
expanded = manifest.expand_all_trusted_files()
File "/usr/lib/python3/dist-packages/graminelibos/manifest.py", line 193, in expand_all_trusted_files
append_trusted_dir_or_file(trusted_files, tf, expanded)
File "/usr/lib/python3/dist-packages/graminelibos/manifest.py", line 68, in append_trusted_dir_or_file
append_tf(trusted_files, f'file:{sub_path}', hash_file_contents(sub_path))
File "/usr/lib/python3/dist-packages/graminelibos/manifest.py", line 33, in hash_file_contents
sha.update(f.read())

MemoryError
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/555)
<!-- Reviewable:end -->
