### PR TITLE
[LibOS] fs/encrypted: Fix crash on dropping a directory handle

### DIFF
--- a/LibOS/shim/src/fs/chroot/encrypted.c
+++ b/LibOS/shim/src/fs/chroot/encrypted.c
@@ -367,7 +367,8 @@ out:
 
 static int chroot_encrypted_flush(struct shim_handle* hdl) {
     assert(hdl->type == TYPE_CHROOT_ENCRYPTED);
-    assert(hdl->inode->type == S_IFREG);
+    if (hdl->inode->type != S_IFREG)
+        return 0;
 
     struct shim_encrypted_file* enc = hdl->inode->data;
 
@@ -385,7 +386,8 @@ static int chroot_encrypted_flush(struct shim_handle* hdl) {
 
 static void chroot_encrypted_hdrop(struct shim_handle* hdl) {
     assert(hdl->type == TYPE_CHROOT_ENCRYPTED);
-    assert(hdl->inode->type == S_IFREG);
+    if (hdl->inode->type != S_IFREG)
+        return;
 
     struct shim_encrypted_file* enc = hdl->inode->data;
 
@@ -397,7 +399,10 @@ static void chroot_encrypted_hdrop(struct shim_handle* hdl) {
 static ssize_t chroot_encrypted_read(struct shim_handle* hdl, void* buf, size_t count,
                                      file_off_t* pos) {
     assert(hdl->type == TYPE_CHROOT_ENCRYPTED);
-    assert(hdl->inode->type == S_IFREG);
+    if (hdl->inode->type != S_IFREG) {
+        assert(hdl->inode->type == S_IFDIR);
+        return -EISDIR;
+    }
 
     struct shim_encrypted_file* enc = hdl->inode->data;
     size_t actual_count;
@@ -416,7 +421,10 @@ static ssize_t chroot_encrypted_read(struct shim_handle* hdl, void* buf, size_t 
 static ssize_t chroot_encrypted_write(struct shim_handle* hdl, const void* buf, size_t count,
                                       file_off_t* pos) {
     assert(hdl->type == TYPE_CHROOT_ENCRYPTED);
-    assert(hdl->inode->type == S_IFREG);
+    if (hdl->inode->type != S_IFREG) {
+        assert(hdl->inode->type == S_IFDIR);
+        return -EISDIR;
+    }
 
     struct shim_encrypted_file* enc = hdl->inode->data;
     size_t actual_count;
@@ -439,7 +447,10 @@ out:
 
 static int chroot_encrypted_truncate(struct shim_handle* hdl, file_off_t size) {
     assert(hdl->type == TYPE_CHROOT_ENCRYPTED);
-    assert(hdl->inode->type == S_IFREG);
+    if (hdl->inode->type != S_IFREG) {
+        assert(hdl->inode->type == S_IFDIR);
+        return -EISDIR;
+    }
 
     int ret;
     struct shim_encrypted_file* enc = hdl->inode->data;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `hdrop` callback incorrectly assumed a that handle pointed to a regular file.

This commit also removes this assumption from other callbacks: while in most cases they should not be called for a directory handle, this is not yet a part of a documented contract.

Bug reported in https://github.com/gramineproject/gramine/issues/371#issuecomment-1116161688.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->



<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

* Modify the manifest for `busybox` as specified in https://github.com/gramineproject/gramine/issues/371#issuecomment-1116161688
* Create `/tmp/testdir` on host
* Run `gramine-direct busybox ls /tmp/testdir`

This crashes on master, and is fixed in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/564)
<!-- Reviewable:end -->
