### PR TITLE
[tests] Add test for environment variables and auxiliary vector

### DIFF
--- a/LibOS/shim/test/abi/x86_64/call_auxiliary.asm
+++ b/LibOS/shim/test/abi/x86_64/call_auxiliary.asm
@@ -1,0 +1,24 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; Verify auxiliary which should be in:
+; 'rsp + 8 + (8 * (argc + 1)) + (8 * (env_count + 1))'
+; In this test we don't pass any additional arguments so argc is 1,
+; we also should not have any environment variables so env_count is 0.
+
+extern    test_exit
+extern    verify_auxiliary
+global    _start
+
+%define    argc      1
+%define    env_count 0
+
+section   .text
+
+_start:
+    lea   rdi, [rsp + 8 + 8 * (argc + 1) + 8 * (env_count + 1)]
+    call  verify_auxiliary
+
+    mov   rdi, rax
+    jmp   test_exit

--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -11,26 +11,35 @@ tests = {
     'stack': {},
     'stack_arg': {},
     'stack_env': {},
+    'stack_auxiliary': {
+        'filenames': [
+            'stack_auxiliary.c',
+            nasm_gen.process('call_auxiliary.asm')
+        ],
+    },
 }
 
 install_dir = join_paths(pkglibdir, 'tests', 'libos', 'entrypoint')
 
 foreach name, params : tests
-    filename = ''
-    if (params.get('type', 'asm') == 'asm')
-        filename = nasm_gen.process('@0@.asm'.format(name))
+    filenames = ''
+    if (params.has_key('filenames'))
+        filenames = params.get('filenames')
+    elif (params.get('type', 'asm') == 'asm')
+        filenames = nasm_gen.process('@0@.asm'.format(name))
     else
-        filename = '@0@.c'.format(name)
+        filenames = '@0@.c'.format(name)
     endif
 
     exe = executable(name,
-        filename,
+        filenames,
 
         link_with: [
             params.get('link_with', [common_lib]),
         ],
 
         link_args: params.get('link_args', ['-nostdlib', '-static']),
+        include_directories: params.get('include_directories', []),
 
         install: true,
         install_dir: install_dir,

--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -10,6 +10,7 @@ tests = {
     'rflags': {},
     'stack': {},
     'stack_arg': {},
+    'stack_env': {},
 }
 
 install_dir = join_paths(pkglibdir, 'tests', 'libos', 'entrypoint')

--- a/LibOS/shim/test/abi/x86_64/stack_auxiliary.c
+++ b/LibOS/shim/test/abi/x86_64/stack_auxiliary.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+ */
+
+#include <elf.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * We have to add a function declaration to avoid warnings.
+ * This function is used with NASM, so creating a header is pointless.
+ */
+int verify_auxiliary(Elf64_auxv_t* auxv);
+
+/*
+ * Set up in: LibOS/shim/src/shim_rtld.c: execute_elf_object()
+ */
+static struct {
+    uint64_t type;
+    bool exists;
+} auxv_gramine_defaults[] = {
+    { AT_PHDR, false },
+    { AT_PHNUM, false },
+    { AT_PAGESZ, false },
+    { AT_ENTRY, false },
+    { AT_BASE, false },
+    { AT_RANDOM, false },
+    { AT_PHENT, false },
+    { AT_SYSINFO_EHDR, false },
+};
+
+int verify_auxiliary(Elf64_auxv_t* auxv) {
+    size_t count = sizeof(auxv_gramine_defaults) / sizeof(auxv_gramine_defaults[0]);
+
+    for (; auxv->a_type != AT_NULL; auxv++) {
+        for (size_t i = 0; i < count; i++) {
+            if (auxv_gramine_defaults[i].type == auxv->a_type) {
+                /* Check for duplicates */
+                if (auxv_gramine_defaults[i].exists) {
+                    return 1;
+                }
+                auxv_gramine_defaults[i].exists = true;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        if (!auxv_gramine_defaults[i].exists) {
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/abi/x86_64/stack_env.asm
+++ b/LibOS/shim/test/abi/x86_64/stack_env.asm
@@ -1,0 +1,40 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; Verify envp which should be in 'rsp + 8 + 8 * (argc + 1)'
+; In this test we don't pass any additional arguments so argc is 1.
+
+default   rel
+
+extern    test_exit
+extern    test_str_neq
+
+global    _start
+
+%define    argc     1
+
+section   .text
+
+_start:
+    lea   rdi, [env0]
+    mov   rsi, [rsp + 8 + 8 * (argc + 1)]
+    call  test_str_neq
+    mov   rdi, rax
+    cmp   rdi, 1
+    je    test_exit
+
+    lea   rdi, [env1]
+    mov   rsi, [rsp + 8 + 8 * (argc + 2)]
+    call  test_str_neq
+    mov   rdi, rax
+    cmp   rdi, 1
+    je    test_exit
+
+    mov   rdi, [rsp + 8 + 8 * (argc + 3)]
+    jmp   test_exit
+
+section   .data
+
+env0    db    "foo=bar", 0x00
+env1    db    "env0=val0", 0x00

--- a/LibOS/shim/test/abi/x86_64/stack_env.manifest.template
+++ b/LibOS/shim/test/abi/x86_64/stack_env.manifest.template
@@ -1,0 +1,22 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.foo = "bar"
+loader.env.env0 = "val0"
+
+loader.insecure__use_cmdline_argv = true
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.nonpie_binary = true
+sgx.debug = true
+sgx.thread_num = 4
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+  "file:{{ gramine.runtimedir() }}/",
+]

--- a/LibOS/shim/test/abi/x86_64/test_entrypoint.py
+++ b/LibOS/shim/test/abi/x86_64/test_entrypoint.py
@@ -20,3 +20,6 @@ class TC_00_Entrypoint(RegressionTestCase):
 
     def test_060_arg(self):
         self.run_binary(['stack_arg', 'foo', 'bar'])
+
+    def test_070_env(self):
+        self.run_binary(['stack_env'])

--- a/LibOS/shim/test/abi/x86_64/test_entrypoint.py
+++ b/LibOS/shim/test/abi/x86_64/test_entrypoint.py
@@ -23,3 +23,6 @@ class TC_00_Entrypoint(RegressionTestCase):
 
     def test_070_env(self):
         self.run_binary(['stack_env'])
+
+    def test_080_auxv(self):
+        self.run_binary(['stack_auxiliary'])

--- a/LibOS/shim/test/abi/x86_64/tests.toml
+++ b/LibOS/shim/test/abi/x86_64/tests.toml
@@ -8,4 +8,5 @@ manifests = [
   "stack",
   "stack_arg",
   "stack_env",
+  "stack_auxiliary",
 ]

--- a/LibOS/shim/test/abi/x86_64/tests.toml
+++ b/LibOS/shim/test/abi/x86_64/tests.toml
@@ -7,4 +7,5 @@ manifests = [
   "rflags",
   "stack",
   "stack_arg",
+  "stack_env",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This change adds tests for verifying the environment variables and auxiliary vector.
Those additional tests were requested during the review of PR https://github.com/gramineproject/gramine/pull/541.

The environment variables test is straightforward. The only difference is a custom manifest file, which
sets up the environment variables. Please notice that we care about the order in this test, which isn't required by the ABI documentation. Removing this requirement would be over complication without any additional value.

In the case of the auxiliary vector, the ABI document doesn't specify which types are required.
I decided that the best approach would be to strictly verify the types that Gramine is setting up at this time.

- Lack of any auxiliary entry will cause the test to fail.
- Duplicate entries will cause the test to fail.
- Any additional entries will _NOT_ cause the test to fail.

I decided that the nine entries we have at this point are the minimum required for Gramine to work.
One of the reasons for the missing entry might be that the stack was corrupted.
Another situation of missing entry is that the Gramine developer has changed the vector, which means that the test requires an update. I thought about strict verification of the auxiliary vector. As a strict verification I mean don't allow allow any additional values. But I haven't reached any decisive conclusion.

Please take a moment also to consider the choice of data structure in this test. At this point, we are using an array that behaves like a list. I was thinking about converting this to be an indexed array where we can verify existence using indexing `exists[AT_TYPE]`. The issue with this is that the numbers of the auxiliary vector are split, and an actual number of them is unknown. At this point, I decided that making a list was a good enough approach because the list itself is quite small.

The next step for these tests is to verify if non of the CPU flags hasn't changed during normal syscalls and "LibOS syscalls".

## Useful links for reviewers
[System V Application Binary Interface - AMD64 Architecture Processor Supplement](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)

## Useful places in code
[Initialization of auxiliary vector](https://github.com/gramineproject/gramine/blob/2628ef6ba7df94fcdee811641d72bf2b835ca5d9/LibOS/shim/src/shim_rtld.c#L875)

## How to test this PR? <!-- (if applicable) -->
```
gramine-test pytest
gramine-test --sgx pytest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/565)
<!-- Reviewable:end -->
