### PR TITLE
[LibOS] Reimplement call to elf entrypoint

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
@@ -3,27 +3,6 @@
 #ifndef _SHIM_INTERNAL_ARCH_H_
 #define _SHIM_INTERNAL_ARCH_H_
 
-/*
- * The System V ABI (see section 3.4.1) expects us to set the following before jumping to the entry
- * point:
- *
- * - RDX: function pointer to be registered with `atexit` (we pass 0)
- * - RSP: the initial stack, contains program arguments and environment
- * - FLAGS: should be zeroed out
- */
-#define CALL_ELF_ENTRY(ENTRY, ARGP)         \
-    do {                                    \
-        __asm__ volatile(                   \
-            "pushq $0\r\n"                  \
-            "popfq\r\n"                     \
-            "movq %1, %%rsp\r\n"            \
-            "jmp *%0\r\n"                   \
-            :                               \
-            : "r"(ENTRY), "r"(ARGP), "d"(0) \
-            : "memory", "cc");              \
-        __builtin_unreachable();            \
-    } while(0)
-
 #define SHIM_ELF_HOST_MACHINE EM_X86_64
 
 #endif /* _SHIM_INTERNAL_ARCH_H_ */

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -286,4 +286,16 @@ void maybe_epoll_et_trigger(struct shim_handle* handle, int ret, bool in, bool w
 void* allocate_stack(size_t size, size_t protect_size, bool user);
 int init_stack(const char** argv, const char** envp, const char*** out_argp, elf_auxv_t** out_auxv);
 
+/*!
+ * \brief Jump to the defined entry point.
+ *
+ * \param entry  Address defined in the elf entry point.
+ * \param argp   Pointer to the initial stack, contains program arguments and environment.
+ *
+ * This function does not return.
+ *
+ * The implementation of this function depends on the used architecture.
+ */
+noreturn void call_elf_entry(elf_addr_t entry, void* argp);
+
 #endif /* _SHIM_INTERNAL_H_ */

--- a/LibOS/shim/src/arch/x86_64/meson.build
+++ b/LibOS/shim/src/arch/x86_64/meson.build
@@ -1,9 +1,20 @@
-libos_sources_arch = files(
-    'shim_arch_prctl.c',
-    'shim_context.c',
-    'shim_table.c',
-    'start.S',
-    'syscallas.S',
-)
+libos_sources_arch_list = {
+    'shim_arch_prctl.c': {},
+    'shim_elf_entry.nasm': { 'type': 'nasm' },
+    'shim_context.c': {},
+    'shim_table.c': {},
+    'start.S': {},
+    'syscallas.S': {},
+}
+
+libos_sources_arch = files()
+
+foreach src, params : libos_sources_arch_list
+    if params.get('type', '') == 'nasm'
+        libos_sources_arch += nasm_gen.process(src)
+    else
+        libos_sources_arch += files(src)
+    endif
+endforeach
 
 shim_lds = join_paths(meson.current_source_dir(), 'shim.lds')

--- a/LibOS/shim/src/arch/x86_64/shim_elf_entry.nasm
+++ b/LibOS/shim/src/arch/x86_64/shim_elf_entry.nasm
@@ -1,0 +1,20 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; The System V ABI (see section 3.4.1) expects us to set the following before jumping to the entry
+; point:
+;
+; - RDX: function pointer to be registered with `atexit` (we pass 0)
+; - RSP: the initial stack, contains program arguments and environment
+; - FLAGS: should be zeroed out
+
+global    call_elf_entry
+
+; noreturn void call_elf_entry(elf_addr_t entry, void* argp)
+call_elf_entry:
+    xor     rdx, rdx ; set RDX to 0
+    push    0x202
+    popf             ; set lower part of rFLAGS to 0
+    mov     rsp, rsi ; set stack pointer to second arg
+    jmp     rdi      ; jmp to entry point (first arg)

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -834,7 +834,7 @@ noreturn static void cleanup_and_call_elf_entry(elf_addr_t entry, void* argp) {
                          SHIM_THREAD_LIBOS_STACK_SIZE);
 
 #endif
-    CALL_ELF_ENTRY(entry, argp);
+    call_elf_entry(entry, argp);
 }
 
 noreturn void execute_elf_object(struct link_map* exec_map, void* argp, elf_auxv_t* auxp) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
As mentioned in https://github.com/gramineproject/gramine/pull/541, we would like to convert an AT&T assembly to Intel one. As I was working mainly with the entrypoint, I think this is an excellent start to experiment with it. Gramine already has all entrypoint tests, so it is easier to verify that this change doesn't break anything.

We don't set a register to any particular addresses, as the ABI document doesn't require that. After this change, the value of registers hasn't been changed.

## How to test this PR?
```
gramine-test -C LibOS/shim/test/abi/x86_64/ pytest
gramine-test --sgx -C LibOS/shim/test/abi/x86_64/ pytest

gramine-test -C LibOS/shim/test/fs pytest
gramine-test --sgx -C LibOS/shim/test/fs pytest
gramine-test -C LibOS/shim/test/regression pytest
gramine-test --sgx -C LibOS/shim/test/regression pytest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/569)
<!-- Reviewable:end -->
