### PR TITLE
[common] Create `FIRST_TIME()` macro

### DIFF
--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -153,8 +153,7 @@ noreturn void process_exit(int error_code, int term_signal) {
 
     /* If process_exit is invoked multiple times, only a single invocation proceeds past this
      * point. */
-    static int first = 0;
-    if (__atomic_exchange_n(&first, 1, __ATOMIC_RELAXED) != 0) {
+    if (!FIRST_TIME()) {
         /* Just exit current thread. */
         thread_exit(error_code, term_signal);
     }

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -325,8 +325,7 @@ long shim_do_mincore(void* addr, size_t len, unsigned char* vec) {
     if (!is_user_memory_writable(vec, pages))
         return -EFAULT;
 
-    static unsigned int warned = 0;
-    if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
+    if (FIRST_TIME()) {
         log_warning("mincore emulation always tells pages are _NOT_ in RAM. This may cause "
                     "issues.");
     }

--- a/LibOS/shim/src/sys/shim_sleep.c
+++ b/LibOS/shim/src/sys/shim_sleep.c
@@ -91,8 +91,7 @@ long shim_do_clock_nanosleep(clockid_t clock_id, int flags, struct __kernel_time
     }
 
     if (clock_id == CLOCK_PROCESS_CPUTIME_ID) {
-        static unsigned int warned = 0;
-        if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
+        if (FIRST_TIME()) {
             log_warning("Per-process CPU-time clock is not supported in clock_nanosleep(); "
                         "it is replaced with system-wide real-time clock.");
         }

--- a/LibOS/shim/src/sys/shim_time.c
+++ b/LibOS/shim/src/sys/shim_time.c
@@ -62,8 +62,7 @@ long shim_do_clock_gettime(clockid_t which_clock, struct timespec* tp) {
         return -EFAULT;
 
     if (which_clock == CLOCK_PROCESS_CPUTIME_ID || which_clock == CLOCK_THREAD_CPUTIME_ID) {
-        static unsigned int warned = 0;
-        if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
+        if (FIRST_TIME()) {
             log_warning("Per-process and per-thread CPU-time clocks are not supported in "
                         "clock_gettime(); they are replaced with system-wide real-time clock.");
         }
@@ -86,8 +85,7 @@ long shim_do_clock_getres(clockid_t which_clock, struct timespec* tp) {
         return -EINVAL;
 
     if (which_clock == CLOCK_PROCESS_CPUTIME_ID || which_clock == CLOCK_THREAD_CPUTIME_ID) {
-        static unsigned int warned = 0;
-        if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
+        if (FIRST_TIME()) {
             log_warning("Per-process and per-thread CPU-time clocks are not supported in "
                         "clock_getres(); they are replaced with system-wide real-time clock.");
         }

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -111,8 +111,7 @@ static void save_pal_context(PAL_CONTEXT* ctx, sgx_cpu_context_t* uc,
 }
 
 static void emulate_rdtsc_and_print_warning(sgx_cpu_context_t* uc) {
-    static int first = 0;
-    if (__atomic_exchange_n(&first, 1, __ATOMIC_RELAXED) == 0) {
+    if (FIRST_TIME()) {
         /* if we end up emulating RDTSC/RDTSCP instruction, we cannot use invariant TSC */
         extern uint64_t g_tsc_hz;
         g_tsc_hz = 0;
@@ -166,8 +165,7 @@ static bool handle_ud(sgx_cpu_context_t* uc) {
         return false;
     } else if (instr[0] == 0x0f && instr[1] == 0x05) {
         /* syscall: LibOS may know how to handle this */
-        static int log_once = 1;
-        if (__atomic_exchange_n(&log_once, 0, __ATOMIC_RELAXED)) {
+        if (FIRST_TIME()) {
             log_always("Emulating a raw syscall instruction. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -87,8 +87,7 @@ static void perform_signal_handling(enum pal_event event, bool is_in_pal, PAL_NU
 static void handle_sync_signal(int signum, siginfo_t* info, struct ucontext* uc) {
     if (info->si_signo == SIGSYS && info->si_code == SYS_SECCOMP) {
         ucontext_revert_syscall(uc, info->si_arch, info->si_syscall, info->si_call_addr);
-        static int log_once = 1;
-        if (__atomic_exchange_n(&log_once, 0, __ATOMIC_RELAXED)) {
+        if (FIRST_TIME()) {
             log_always("Emulating a raw system/supervisor call. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -192,6 +192,13 @@ typedef ptrdiff_t ssize_t;
 
 #define IS_IN_RANGE_INCL(value, start, end) (((value) < (start) || (value) > (end)) ? false : true)
 
+/* Each occurence of this macro in the source code will return `true` only once per process.
+ *
+ * We use __ATOMIC_RELAXED here, as a consistent ordering within the accesses to `first` is enough
+ * for us — FIRST_TIME is not a synchronization primitive, as the macro returning `false` doesn't
+ * actually guarantee that the code path entered when it returned `true` has finished executing. */
+#define FIRST_TIME() ({ static uint8_t first = 0; __atomic_exchange_n(&first, 1, __ATOMIC_RELAXED) == 0; })
+
 /* LibC functions */
 
 /* LibC string functions */


### PR DESCRIPTION
## Description of the changes

In #525, @boryspoplawski suggested that a macro like this would be too complicated to be worthwhile. Having actually drafted an implementation, I don't think it looks too bad. In fact, I believe this turns the preferred approach of doing something once per enclave into something you have a chance of remembering.

## How to test this PR?

You may run a program that triggers once of the warnings that make use of `DO_ONCE`, and verify that the warning, indeed, happens once. For example:

```c
#include <stdint.h>
#include <sys/mman.h>

int main(void) {
    unsigned char output[16];
    uintptr_t addr = (uintptr_t) main;
    addr &= ~0xfff;
    mincore((void*)addr, 4096, output);
    mincore((void*)addr, 4096, output);
    mincore((void*)addr, 4096, output);
    return 0;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/572)
<!-- Reviewable:end -->
