### PR TITLE
[Pal/Linux-SGX] On SIGILL, specify where in app code it happened

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -171,7 +171,10 @@ static bool handle_ud(sgx_cpu_context_t* uc) {
         }
         return false;
     }
-    log_error("Unknown or illegal instruction executed");
+
+    char buf[LOCATION_BUF_SIZE];
+    pal_describe_location(uc->rip, buf, sizeof(buf));
+    log_warning("Unknown or illegal instruction executed at %s", buf);
     return false;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The user may use this hint to disassemble the app binaries and find the offending instruction.

## How to test this PR? <!-- (if applicable) -->

I didn't add a new test because I don't think it deserves it. Here is my manual testing:

- Add `ud2` in Helloworld:
```diff
diff --git a/LibOS/shim/test/regression/helloworld.c b/LibOS/shim/test/regression/helloworld.c
 int main(int argc, char** argv) {
     printf("Hello world!\n");
+    __asm__ volatile("ud2\n");
     return 0;
 }
```

- Run this test with at least `loader.log_level = "warning"`, you'll see:
```
warning: Unknown or illegal instruction executed (at 0x4004fb)
```

- Look at the Helloworld executable:
```bash
gramine/built-debug/lib/x86_64-linux-gnu/gramine/tests/libos/regression$
objdump -D helloworld | grep 4004fb

  4004fb:       0f 0b                   ud2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/577)
<!-- Reviewable:end -->
