### PR TITLE
[LTP] Fix an incorrect usage of sets in "test_ltp.py"

### DIFF
--- a/LibOS/shim/test/ltp/test_ltp.py
+++ b/LibOS/shim/test/ltp/test_ltp.py
@@ -174,7 +174,7 @@ def check_must_pass(passed, failed, must_pass):
 
     if must_pass_failed or must_pass_unknown:
         pytest.fail('Failed or unknown subtests specified in must-pass: {}'.format(
-            must_pass_failed + must_pass_unknown))
+            must_pass_failed | must_pass_unknown))
 
     if not failed and passed == must_pass_passed:
         pytest.fail('The must-pass list specifies all tests, remove it from config')


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Sets in Python do not have `+` operator, `union` method must be used instead.

## How to test this PR? <!-- (if applicable) -->
Add a bug to Gramine which will fail some LTP test that has `must-pass` in config and try running it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/581)
<!-- Reviewable:end -->
