### PR TITLE
[tests] Introduce tests for syscalls

### DIFF
--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -17,6 +17,7 @@ tests = {
             nasm_gen.process('call_auxiliary.nasm')
         ],
     },
+    'syscall_fpu': {},
     'syscall_registers': {},
 }
 

--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -19,6 +19,7 @@ tests = {
     },
     'syscall_fpu': {},
     'syscall_registers': {},
+    'syscall_sse': {},
 }
 
 install_dir = join_paths(pkglibdir, 'tests', 'libos', 'entrypoint')

--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -1,6 +1,6 @@
 common_lib = static_library('common_lib',
     'common.c',
-    nasm_gen.process('exit.nasm')
+    nasm_gen.process('exit.nasm'),
 )
 
 tests = {

--- a/LibOS/shim/test/abi/x86_64/meson.build
+++ b/LibOS/shim/test/abi/x86_64/meson.build
@@ -17,6 +17,7 @@ tests = {
             nasm_gen.process('call_auxiliary.nasm')
         ],
     },
+    'syscall_registers': {},
 }
 
 install_dir = join_paths(pkglibdir, 'tests', 'libos', 'entrypoint')

--- a/LibOS/shim/test/abi/x86_64/syscall_fpu.nasm
+++ b/LibOS/shim/test/abi/x86_64/syscall_fpu.nasm
@@ -1,0 +1,58 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; This test verifies that the system call layer doesn't change x87 unit flags.
+; AMD64 ABI document defines this behavior. This test uses the getpid(2)
+; syscall, as this syscall is very simple and shouldn't introduce significant
+; overhead and overcomplication. The goal is to test the common part of the
+; syscall layer.
+; The x87 FPU Control Word register:
+; +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+; | R| R| R| X|   RC|   PC| R| R|PM|UM|OM|ZM|DM|IM|
+; +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+; 5 bits in x87 FPU flags are reserved, so we must ignore them in the test.
+; The reserved bits are marked with the letter 'R.'
+
+extern    test_exit
+global    _start
+
+%define   __NR_getpid   39
+
+section   .text
+
+; bool check_fpu_after_getpid(uint64_t fpuvalue)
+check_fpu_after_getpid:
+    push  rbp
+    mov   rbp, rsp
+
+    mov   [rbp - 8], rdi
+    fldcw [rbp - 8]
+
+    mov   rax, __NR_getpid
+    syscall
+    xor   rax, rax
+
+    fstcw [rbp - 16]
+    mov   rdi, [rbp - 16]
+    and   rdi, 0b00011100111111
+    cmp   rdi, [rbp - 8]
+    sete  al
+
+    pop   rbp
+    ret
+
+_start:
+    mov  rdi, 0xF
+    call check_fpu_after_getpid
+    mov  rdi, 1
+    cmp  rax, 0
+    je   test_exit
+
+    ; Make sure syscall has not set the FPU unit to the value from the previous
+    ; test.
+    mov  rdi, 0x0
+    call check_fpu_after_getpid
+    mov  rdi, rax
+    xor  rdi, 1
+    jmp  test_exit

--- a/LibOS/shim/test/abi/x86_64/syscall_registers.nasm
+++ b/LibOS/shim/test/abi/x86_64/syscall_registers.nasm
@@ -1,0 +1,74 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; This test verifies that the system call layer doesn't change the value
+; of R12-R15, RBX, and RBP. It also confirms indirectly confirms that
+; the RSP register has not changed. AMD64 ABI document defines this behavior.
+; This test uses the getpid(2) syscall, as this syscall is very simple and
+; shouldn't introduce significant overhead and overcomplication.
+
+extern    test_exit
+global    _start
+
+%define   __NR_getpid   39
+
+section   .text
+
+; bool check_registers_after_getpid(uint64_t val)
+check_registers_after_getpid:
+    push  rbp
+    mov   rbp, rdi
+    mov   rbx, rdi
+    mov   r12, rdi
+    mov   r13, rdi
+    mov   r14, rdi
+    mov   r15, rdi
+
+    push  rdi
+    mov   rax, __NR_getpid
+    syscall
+    pop   rdi
+    mov   rax, 1
+    xor   rsi, rsi
+
+    cmp   rbp, rdi
+    sete  sil
+    and   rax, rsi
+
+    cmp   rbx, rdi
+    sete  sil
+    and   rax, rsi
+
+    cmp   r12, rdi
+    sete  sil
+    and   rax, rsi
+
+    cmp   r13, rdi
+    sete  sil
+    and   rax, rsi
+
+    cmp   r14, rdi
+    sete  sil
+    and   rax, rsi
+
+    cmp   r15, rdi
+    sete  sil
+    and   rax, rsi
+
+    pop   rbp
+    ret
+
+_start:
+    mov  rdi, 10
+    call check_registers_after_getpid
+    mov  rdi, 1
+    cmp  rax, 0
+    je   test_exit
+
+    ; Verify that it's not set to 10 by syscall.
+    mov  rdi, 1337
+    call check_registers_after_getpid
+    mov  rdi, rax
+    xor  rdi, 1
+    jmp  test_exit

--- a/LibOS/shim/test/abi/x86_64/syscall_sse.nasm
+++ b/LibOS/shim/test/abi/x86_64/syscall_sse.nasm
@@ -1,0 +1,87 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+;                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+
+; This test verifies that the system call layer doesn't change SSE values.
+; AMD64 ABI document defines this behavior. The goal is to test the common part
+; of the syscall layer. This test uses the getpid(2) syscall, as this syscall is
+; very simple and shouldn't introduce significant overhead and overcomplication.
+; The test uses the FXSAVE operand to get the current state of XMM registers.
+; The XMM registers are saved on bytes from 160 to 415.
+; It also verifies the MXCSR register.
+
+default   rel
+
+extern    test_exit
+global    _start
+
+%define   __NR_getpid   39
+
+section   .text
+
+; bool check_sse_after_getpid()
+check_sse_after_getpid:
+    push      rbp
+    mov       rbp, rsp
+
+    fxsave64  [rbp - 512]
+    stmxcsr   [rbp - 1028]
+
+    mov       rax, __NR_getpid
+    syscall
+    xor       rax, rax
+
+    fxsave64  [rbp - 1024]
+    lea       rsi, [rbp - 512 + 160]
+    lea       rdi, [rbp - 1024 + 160]
+    mov       rcx, 256
+    repe      cmpsb
+    ; The ZF will be cleared if there is a mismatch.
+    setz      al
+
+    stmxcsr   [rbp - 1032]
+    mov       esi, [rbp - 1028]
+    cmp       esi, [rbp - 1032]
+    setz      dil
+
+    and       al, dil
+
+    pop       rbp
+    ret
+
+_start:
+    call check_sse_after_getpid
+    mov  rdi, 1
+    cmp  rax, 0
+    je   test_exit
+
+    ; Verify that it's not initialized to default values.
+    mov  rax,  1337
+    movq xmm0, rax
+    movq xmm1, rax
+    movq xmm2, rax
+    movq xmm3, rax
+    movq xmm4, rax
+    movq xmm5, rax
+    movq xmm6, rax
+    movq xmm7, rax
+    movq xmm8, rax
+    movq xmm9, rax
+    movq xmm10, rax
+    movq xmm11, rax
+    movq xmm12, rax
+    movq xmm13, rax
+    movq xmm14, rax
+    movq xmm15, rax
+    ldmxcsr [mxcsr_test_val]
+
+    call check_sse_after_getpid
+    mov  rdi, rax
+    xor  rdi, 1
+    jmp  test_exit
+
+section   .data
+
+; The mxcsr.nasm test verifies that mxcsr is not 0, so we can use
+; 0 as test data here.
+mxcsr_test_val      db    0x00

--- a/LibOS/shim/test/abi/x86_64/test_entrypoint.py
+++ b/LibOS/shim/test/abi/x86_64/test_entrypoint.py
@@ -29,3 +29,6 @@ class TC_00_Entrypoint(RegressionTestCase):
 
     def test_090_syscall_registers(self):
         self.run_binary(['syscall_registers'])
+
+    def test_100_syscall_fpu(self):
+        self.run_binary(['syscall_fpu'])

--- a/LibOS/shim/test/abi/x86_64/test_entrypoint.py
+++ b/LibOS/shim/test/abi/x86_64/test_entrypoint.py
@@ -26,3 +26,6 @@ class TC_00_Entrypoint(RegressionTestCase):
 
     def test_080_auxv(self):
         self.run_binary(['stack_auxiliary'])
+
+    def test_090_syscall_registers(self):
+        self.run_binary(['syscall_registers'])

--- a/LibOS/shim/test/abi/x86_64/test_entrypoint.py
+++ b/LibOS/shim/test/abi/x86_64/test_entrypoint.py
@@ -32,3 +32,6 @@ class TC_00_Entrypoint(RegressionTestCase):
 
     def test_100_syscall_fpu(self):
         self.run_binary(['syscall_fpu'])
+
+    def test_110_syscall_sse(self):
+        self.run_binary(['syscall_sse'])

--- a/LibOS/shim/test/abi/x86_64/tests.toml
+++ b/LibOS/shim/test/abi/x86_64/tests.toml
@@ -9,4 +9,5 @@ manifests = [
   "stack_arg",
   "stack_env",
   "stack_auxiliary",
+  "syscall_registers",
 ]

--- a/LibOS/shim/test/abi/x86_64/tests.toml
+++ b/LibOS/shim/test/abi/x86_64/tests.toml
@@ -11,4 +11,5 @@ manifests = [
   "stack_auxiliary",
   "syscall_fpu",
   "syscall_registers",
+  "syscall_sse",
 ]

--- a/LibOS/shim/test/abi/x86_64/tests.toml
+++ b/LibOS/shim/test/abi/x86_64/tests.toml
@@ -9,5 +9,6 @@ manifests = [
   "stack_arg",
   "stack_env",
   "stack_auxiliary",
+  "syscall_fpu",
   "syscall_registers",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR introduces another round of ABI tests. The idea for these tests is to make it easier to switch from `GCC assembly to `NASM` and have a solid baseline for further improvements.
According to the AMD64 ABI document, after syscall fallowing things shouldn't be changed:
- Registers: `RBP`, `RSP`, `RBX`, `r12-r15`
- `MXCRS`
- x87 control word
- SSE units
Those three tests verify these assumptions.
In the case of SSE units, we verify only the `XMM` registers and `MXCRS.` I have thought about verifying the flags in the `cr0` and `cr4` registers, but those are not exposed to the userland. If you have any other ideas about tests for SSE units, I'm very open to them.

## Useful links for reviewers
* [System V Application Binary Interface - AMD64 Architecture Processor Supplement](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)
* [Streaming SIMD Extensions (SSE)](https://wiki.osdev.org/SSE)
* [fxsave64](https://www.felixcloutier.com/x86/fxsave)

## How to test this PR? 
Tested with clang and gcc
```
$ gramine-test --sgx pytest
$ gramine-test  pytest
```

