### PR TITLE
[LibOS] Pass the restorer if SA_RESTORER flag is set

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -747,8 +747,6 @@ bool handle_signal(PAL_CONTEXT* context) {
     }
     if (handler != SIG_IGN) {
         /* User provided handler. */
-        assert(sa->sa_flags & SA_RESTORER);
-
         long sysnr = shim_get_tcb()->context.syscall_nr;
         if (sysnr >= 0) {
             switch (pal_context_get_retval(context)) {
@@ -786,7 +784,8 @@ bool handle_signal(PAL_CONTEXT* context) {
         set_sig_mask(current, &new_mask);
         unlock(&current->lock);
 
-        prepare_sigframe(context, &signal.siginfo, handler, sa->sa_restorer,
+        prepare_sigframe(context, &signal.siginfo, handler,
+                         sa->sa_flags & SA_RESTORER ? sa->sa_restorer : NULL,
                          !!(sa->sa_flags & SA_ONSTACK), &old_mask);
 
         if (sa->sa_flags & SA_RESETHAND) {

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -38,12 +38,12 @@ long shim_do_rt_sigaction(int signum, const struct __kernel_sigaction* act,
     if (oldact && !is_user_memory_writable(oldact, sizeof(*oldact)))
         return -EFAULT;
 
+#if defined(__x86_64__)
     if (act && !(act->sa_flags & SA_RESTORER)) {
-        /* XXX: This might not be true for all architectures (but is for x86_64)...
-         * Check `shim_signal.c` if you update this! */
         log_warning("rt_sigaction: SA_RESTORER flag is required!");
         return -EINVAL;
     }
+#endif
 
     struct shim_thread* cur = get_cur_thread();
 


### PR DESCRIPTION
Only pass the restorer to prepare_sigframe() if the SA_RESTORER flag is
set, otherwise pass NULL. Not all architectures support the restorer,
such as ppc64, and will never have that flag set.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/597)
<!-- Reviewable:end -->
