### PR TITLE
[CI-Examples] Fix build issue of busybox on non-SGX systems

### DIFF
--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -43,6 +43,7 @@ busybox.manifest: busybox.manifest.template
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< > $@
 
+ifeq ($(SGX),1)
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
 # see the helloworld example for details on this workaround.
 busybox.manifest.sgx busybox.sig: sgx_sign
@@ -57,6 +58,7 @@ sgx_sign: busybox.manifest busybox
 busybox.token: busybox.sig:
 	gramine-sgx-get-token \
 		--output $@ --sig $<
+endif
 
 # Copy Busybox binary to our root directory for simplicity.
 busybox: $(SRCDIR)/busybox


### PR DESCRIPTION
Condition some rules only relevant for SGX on the SGX build variable to
avoid the following build error with GNU Make 4.2.1:

Makefile:57: *** target pattern contains no '%'.  Stop.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/598)
<!-- Reviewable:end -->
