### PR TITLE
[common & PAL] Restrict a #define and a function to x86_64

### DIFF
--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -34,9 +34,11 @@ PAL_NUM DkMemoryAvailableQuota(void) {
     return (PAL_NUM)quota;
 }
 
+#if defined(__x86_64__)
 int DkCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) {
     return _DkCpuIdRetrieve(leaf, subleaf, values);
 }
+#endif
 
 int DkAttestationReport(const void* user_report_data, PAL_NUM* user_report_data_size,
                         void* target_info, PAL_NUM* target_info_size, void* report,

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
@@ -23,7 +23,9 @@
 #define MBEDTLS_GENPRIME
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_SSE2
+#if defined(__x86_64__)
 #define MBEDTLS_HAVE_X86_64
+#endif
 #define MBEDTLS_HKDF_C
 #define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 #define MBEDTLS_MD_C


### PR DESCRIPTION
This PR provides 2 patches that restrict a #define and a function to only be used and built when building for x86_64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/601)
<!-- Reviewable:end -->
