### PR TITLE
[CI-Examples] Fix a typo in busybox Makefile

### DIFF
--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -54,7 +54,7 @@ sgx_sign: busybox.manifest busybox
 		--manifest $< \
 		--output $<.sgx
 
-busybox.token: busybox.sig:
+busybox.token: busybox.sig
 	gramine-sgx-get-token \
 		--output $@ --sig $<
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
A typo slipped through review

## How to test this PR? <!-- (if applicable) -->
Try building busybox example with and without this PR, both in normal and SGX version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/602)
<!-- Reviewable:end -->
