### PR TITLE
[LibOS] Move procfs cpuinfo display code into functions

### DIFF
--- a/LibOS/shim/include/shim_fs_proc.h
+++ b/LibOS/shim/include/shim_fs_proc.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University
+ * Copyright (C) 2022 IBM Corporation
+ */
+
+#ifndef SHIM_PROC_H_
+#define SHIM_PROC_H_
+
+int print_to_str(char** str, size_t off, size_t* size, const char* fmt, ...);
+
+/* every architecture must implement the following 2 functions */
+int proc_cpuinfo_display_cpu(char** str, size_t* size, size_t* max,
+                             const struct pal_topo_info* topo,
+                             const struct pal_cpu_info* cpu, size_t i,
+                             struct pal_cpu_thread_info* thread);
+
+int proc_cpuinfo_display_tail(char** str, size_t* size, size_t* max,
+                              const struct pal_cpu_info* cpu);
+
+#endif /* SHIM_PROC_H_ */

--- a/LibOS/shim/src/arch/x86_64/fs_proc/info.c
+++ b/LibOS/shim/src/arch/x86_64/fs_proc/info.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University
+ * Copyright (C) 2022 IBM Corporation
+ */
+
+#include "api.h"
+#include "pal.h"
+#include "shim_fs_proc.h"
+
+#define ADD_INFO(fmt, ...)                                            \
+    do {                                                              \
+        int ret = print_to_str(str, *size, max, fmt, ##__VA_ARGS__);  \
+        if (ret < 0) {                                                \
+            return ret;                                               \
+        }                                                             \
+        *size += ret;                                                 \
+    } while (0)
+
+int proc_cpuinfo_display_cpu(char** str, size_t* size, size_t* max,
+                             const struct pal_topo_info* topo,
+                             const struct pal_cpu_info* cpu, size_t i,
+                             struct pal_cpu_thread_info* thread) {
+    struct pal_cpu_core_info* core = &topo->cores[thread->core_id];
+    /* Below strings must match exactly the strings retrieved from /proc/cpuinfo
+     * (see Linux's arch/x86/kernel/cpu/proc.c) */
+    ADD_INFO("processor\t: %lu\n",   i);
+    ADD_INFO("vendor_id\t: %s\n",    cpu->cpu_vendor);
+    ADD_INFO("cpu family\t: %lu\n",  cpu->cpu_family);
+    ADD_INFO("model\t\t: %lu\n",     cpu->cpu_model);
+    ADD_INFO("model name\t: %s\n",   cpu->cpu_brand);
+    ADD_INFO("stepping\t: %lu\n",    cpu->cpu_stepping);
+    ADD_INFO("physical id\t: %zu\n", core->socket_id);
+
+    /* Linux keeps this numbering socket-local, but we can use a different one, and it's
+     * documented as "hardware platform's identifier (rather than the kernel's)" anyways. */
+    ADD_INFO("core id\t\t: %lu\n",   thread->core_id);
+
+    size_t cores_in_socket = 0;
+    for (size_t j = 0; j < topo->cores_cnt; j++) { // slow, but shouldn't matter
+        if (topo->cores[j].socket_id == core->socket_id)
+            cores_in_socket++;
+    }
+    ADD_INFO("cpu cores\t: %zu\n", cores_in_socket);
+    double bogomips = cpu->cpu_bogomips;
+    // Apparently Gramine snprintf cannot into floats.
+    ADD_INFO("bogomips\t: %lu.%02lu\n", (unsigned long)bogomips,
+             (unsigned long)(bogomips * 100.0 + 0.5) % 100);
+    ADD_INFO("\n");
+
+    return 0;
+}
+
+int proc_cpuinfo_display_tail(char** str, size_t* size, size_t* max,
+                              const struct pal_cpu_info* cpu) {
+    __UNUSED(str);
+    __UNUSED(size);
+    __UNUSED(max);
+    __UNUSED(cpu);
+
+    return 0;
+}

--- a/LibOS/shim/src/arch/x86_64/meson.build
+++ b/LibOS/shim/src/arch/x86_64/meson.build
@@ -1,4 +1,5 @@
 libos_sources_arch_list = {
+    'fs_proc/info.c': {},
     'shim_arch_prctl.c': {},
     'shim_elf_entry.nasm': { 'type': 'nasm' },
     'shim_context.c': {},


### PR DESCRIPTION
Move the code for generating the output of /proc/cpuinfo so that it
is easier to adapt it to other architectures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/607)
<!-- Reviewable:end -->
