### PR TITLE
[mbedtls] Patch sources to use `fcntl` syscall directly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -252,7 +252,7 @@ tomlc99_src = tomlc99_proj.get_variable('tomlc99_src')
 
 uthash_dep = subproject('uthash-2.1.0').get_variable('uthash_dep')
 
-mbedtls_proj = subproject('mbedtls-mbedtls-2.26.0-1')
+mbedtls_proj = subproject('mbedtls-mbedtls-2.26.0-2')
 mbedtls_static_dep = mbedtls_proj.get_variable('mbedtls_static_dep')
 mbedtls_pal_dep = mbedtls_proj.get_variable('mbedtls_pal_dep')
 

--- a/subprojects/mbedtls-mbedtls-2.26.0-2.wrap
+++ b/subprojects/mbedtls-mbedtls-2.26.0-2.wrap
@@ -1,10 +1,10 @@
-# NOTE: We use a custom version number (the `-1` suffix) to force Meson to rebuild when there is a
+# NOTE: We use a custom version number (the `-2` suffix) to force Meson to rebuild when there is a
 # breaking change to the interface between mbedTLS and Gramine. The important part is that the
 # directory in `subprojects` has to change (`subprojects/mbedtls-mbedtls-2.26.0-1`,
 # `subprojects/mbedtls-mbedtls-2.26.0-2` etc.)
 
 [wrap-file]
-directory = mbedtls-mbedtls-2.26.0-1
+directory = mbedtls-mbedtls-2.26.0-2
 source_url = https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.26.0.tar.gz
 source_fallback_url = https://packages.gramineproject.io/distfiles/mbedtls-2.26.0.tar.gz
 source_filename = mbedtls-2.26.0.tar.gz
@@ -12,5 +12,5 @@ source_hash = 35d8d87509cd0d002bddbd5508b9d2b931c5e83747d087234cc7ad551d53fe05
 
 patch_directory = mbedtls
 
-# this unpacks the sources to `mbedtls-mbedtls-2.26.0-1/mbedtls-mbedtls-2.26.0`
+# this unpacks the sources to `mbedtls-mbedtls-2.26.0-2/mbedtls-mbedtls-2.26.0`
 lead_directory_missing = true

--- a/subprojects/packagefiles/mbedtls/compile.sh
+++ b/subprojects/packagefiles/mbedtls/compile.sh
@@ -25,6 +25,7 @@ rm -rf "$PRIVATE_DIR"
 cp -ar "$VENDOR_SOURCE_DIR" "$PRIVATE_DIR"
 cp "$CURRENT_SOURCE_DIR"/include/mbedtls/*.h "$PRIVATE_DIR"/include/mbedtls/
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/gramine.patch
+patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/fcntl.patch
 
 make -C "$PRIVATE_DIR" lib "$@"
 

--- a/subprojects/packagefiles/mbedtls/fcntl.patch
+++ b/subprojects/packagefiles/mbedtls/fcntl.patch
@@ -1,0 +1,49 @@
+# Workaround for missing `fcntl64` symbol.
+# When built on a newer distro (e.g. Ubuntu 20.04) which has glibc in version >= 2.28, Gramine
+# failed to work on distros with older glibc (e.g. Ubuntu 18.04 - glibc 2.27). This is due to symbol
+# incompatibility, namely `fcntl` - since glibc 2.28 there is a newer version `fcntl64`,
+# which is not present on older versions. As a workaround we just changed each usage of `fcntl` to
+# a direct syscall - these calls just check and/or change `O_NONBLOCK` flag.
+# Note that building with this patch might throw a warning about missing `syscall` declaration.
+# We did not bother fixing this, because it will be always present and this is a hack anyway.
+# TODO: remove this patch after we drop Ubuntu 18.04 support
+
+diff --git a/library/net_sockets.c b/library/net_sockets.c
+index 17a9e4a5760bb19270af584f9acc861c2f9ab4c7..b02b4c99f15c4881876bf8a061748056f1161b86 100644
+--- a/library/net_sockets.c
++++ b/library/net_sockets.c
+@@ -92,6 +92,7 @@ static int wsa_init_done = 0;
+ #include <fcntl.h>
+ #include <netdb.h>
+ #include <errno.h>
++#include <sys/syscall.h>
+ 
+ #define IS_EINTR( ret ) ( ( ret ) == EINTR )
+ 
+@@ -313,7 +314,7 @@ static int net_would_block( const mbedtls_net_context *ctx )
+     /*
+      * Never return 'WOULD BLOCK' on a blocking socket
+      */
+-    if( ( fcntl( ctx->fd, F_GETFL ) & O_NONBLOCK ) != O_NONBLOCK )
++    if( ( syscall( SYS_fcntl, ctx->fd, F_GETFL ) & O_NONBLOCK ) != O_NONBLOCK )
+     {
+         errno = err;
+         return( 0 );
+@@ -462,7 +463,7 @@ int mbedtls_net_set_block( mbedtls_net_context *ctx )
+     u_long n = 0;
+     return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
+ #else
+-    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL ) & ~O_NONBLOCK ) );
++    return( syscall( SYS_fcntl, ctx->fd, F_SETFL, syscall(SYS_fcntl, ctx->fd, F_GETFL ) & ~O_NONBLOCK ) );
+ #endif
+ }
+ 
+@@ -473,7 +474,7 @@ int mbedtls_net_set_nonblock( mbedtls_net_context *ctx )
+     u_long n = 1;
+     return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
+ #else
+-    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL ) | O_NONBLOCK ) );
++    return( syscall( SYS_fcntl, ctx->fd, F_SETFL, syscall( SYS_fcntl, ctx->fd, F_GETFL ) | O_NONBLOCK ) );
+ #endif
+ }
+ 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Due to symbol incompatibility on different glibc versions (`fcntl` vs `fcntl64`), `ra-tls-mbedtls` examble could not be built on Ubuntu18.04 if Gramine was build on any newer distro.

## How to test this PR? <!-- (if applicable) -->
Try building Gramine on Ubuntu20.04 and installing + running `ra-tls-mbedtls` example on Ubuntu18.04

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/611)
<!-- Reviewable:end -->
