### PR TITLE
[LibOS] Make `debug_print_vma` print regardless of the log level

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1436,16 +1436,16 @@ END_CP_FUNC_NO_RS(all_vmas)
 
 
 static void debug_print_vma(struct shim_vma* vma) {
-    log_debug("[0x%lx-0x%lx] prot=0x%x flags=0x%x%s%s file=%p (offset=%ld)%s%s",
-              vma->begin, vma->end,
-              vma->prot,
-              vma->flags & ~(VMA_INTERNAL | VMA_UNMAPPED),
-              vma->flags & VMA_INTERNAL ? "(INTERNAL " : "(",
-              vma->flags & VMA_UNMAPPED ? "UNMAPPED)" : ")",
-              vma->file,
-              vma->offset,
-              vma->comment[0] ? " comment=" : "",
-              vma->comment[0] ? vma->comment : "");
+    log_always("[0x%lx-0x%lx] prot=0x%x flags=0x%x%s%s file=%p (offset=%ld)%s%s",
+               vma->begin, vma->end,
+               vma->prot,
+               vma->flags & ~(VMA_INTERNAL | VMA_UNMAPPED),
+               vma->flags & VMA_INTERNAL ? "(INTERNAL " : "(",
+               vma->flags & VMA_UNMAPPED ? "UNMAPPED)" : ")",
+               vma->file,
+               vma->offset,
+               vma->comment[0] ? " comment=" : "",
+               vma->comment[0] ? vma->comment : "");
 }
 
 void debug_print_all_vmas(void) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Whenever I used this function I always make this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/616)
<!-- Reviewable:end -->
