### PR TITLE
[CI-Examples] Increase enclave size in "ra-tls-secret-prov"

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -16,6 +16,7 @@ fs.mounts = [
   { path = "/etc", uri = "file:/etc" },
 ]
 
+sgx.enclave_size = "512M"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -20,6 +20,7 @@ fs.mounts = [
   { path = "/etc", uri = "file:/etc" },
 ]
 
+sgx.enclave_size = "512M"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -22,6 +22,7 @@ fs.mounts = [
   { path = "/files/input.txt", uri = "file:files/input.txt", type = "encrypted" },
 ]
 
+sgx.enclave_size = "512M"
 sgx.debug = true
 sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ ra_client_spid }}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This example sometimes runs out of memory when trying to map a large shared library. Encountered on #612 where the app sometimes failed to map `libm.so`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/617)
<!-- Reviewable:end -->
