### PR TITLE
[docs] Add information about ABI tests

### DIFF
--- a/Documentation/devel/onboarding.rst
+++ b/Documentation/devel/onboarding.rst
@@ -395,6 +395,11 @@ fine on native Linux but fails under Gramine::
          $ gramine-test pytest -v
          $ gramine-test --sgx pytest -v
 
+         # build and run LibOS ABI tests (currently only for x86_64)
+         $ cd LibOS/shim/test/abi/${arch}
+         $ gramine-test pytest -v
+         $ gramine-test --sgx pytest -v
+
          # build and run LibOS FS tests
          $ cd LibOS/shim/test/fs
          $ gramine-test pytest -v


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Gramine project recently added a test suit for x86_64 ABI. In the onboarding subpage, the project state that the user should "run the whole test suite", but we omitted the ABI part. This PR address that.

## How to test this PR? <!-- (if applicable) -->
Not tested.
