### PR TITLE
[Docs] Fix `git clone <branch>` shallow copy

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -60,7 +60,7 @@ from there:
 
 .. parsed-literal::
 
-   git clone --depth 1 \https://github.com/gramineproject/gramine.git |stable-checkout|
+   git clone --depth 1 |stable-checkout| \https://github.com/gramineproject/gramine.git
 
 To build the HelloWorld application, we need the ``gcc`` compiler and the
 ``make`` build system::

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -83,7 +83,7 @@ if 'READTHEDOCS' in os.environ:
     rtd_current_version = os.environ['READTHEDOCS_VERSION']
 
     if rtd_current_version.startswith('v'):
-        rst_stable_checkout = rtd_current_version
+        rst_stable_checkout = f'--branch {rtd_current_version}'
 
     elif rtd_current_version == 'stable':
         # we don't have a version, we may be able to check from git
@@ -91,7 +91,7 @@ if 'READTHEDOCS' in os.environ:
             tags = [tag for tag in subprocess.check_output(
                     ['git', 'tag', '--points-at']).decode().strip().split()
                 if tag.startswith('v')]
-            rst_stable_checkout = tags.pop()
+            rst_stable_checkout = f'--branch {tags.pop()}'
         except (subprocess.CalledProcessError, IndexError):
             pass
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -64,7 +64,7 @@ Gramine installation, we clone the Gramine repo:
 
 .. parsed-literal::
 
-   git clone --depth 1 \https://github.com/gramineproject/gramine.git |stable-checkout|
+   git clone --depth 1 |stable-checkout| \https://github.com/gramineproject/gramine.git
 
 We don't want to build Gramine (it is already installed on the system). Instead,
 we want to build and run the HelloWorld example. To build the HelloWorld


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

By mistake, our Quick start guide and Cloud deployment pages contained:
```
git clone https://github.com/gramineproject/gramine.git <branch>
```

This is supposed to clone a single commit of Gramine (for CI-Examples testing). But this command clones the master branch of Gramine into a directory named `<branch>`. The correct form should be:
```
git clone https://github.com/gramineproject/gramine.git --branch <branch>
```

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/624)
<!-- Reviewable:end -->
