### PR TITLE
[CI-Examples] Do not rebuild the rust example on reach run

### DIFF
--- a/CI-Examples/rust/Makefile
+++ b/CI-Examples/rust/Makefile
@@ -59,7 +59,7 @@ GRAMINE = gramine-sgx
 endif
 
 .PHONY: start-gramine-server
-start-gramine-server: all
+start-gramine-server:
 	$(GRAMINE) rust-hyper-http-server
 
 .PHONY: clean


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously Makefile rule running the example contained a dependency on the actual example app file. We use `cargo` to build it, but we do not track any dependencies (for simplicity). This resulted in `cargo build` being issued each time this example is run and sometimes caused timeouts in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/627)
<!-- Reviewable:end -->
