### PR TITLE
[CI-Examples/rust] Only run cargo when necessary

### DIFF
--- a/CI-Examples/rust/.cargo/config.toml
+++ b/CI-Examples/rust/.cargo/config.toml
@@ -1,0 +1,3 @@
+# Emit the .d file with paths relative to the project directory, so that Make
+# understands that they refer to the same target that we wrote in the Makefile.
+build.dep-info-basedir = "."

--- a/CI-Examples/rust/Makefile
+++ b/CI-Examples/rust/Makefile
@@ -1,7 +1,9 @@
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
+SELF_EXE = target/release/rust-hyper-http-server
+
 .PHONY: all
-all: build-rust rust-hyper-http-server.manifest
+all: $(SELF_EXE) rust-hyper-http-server.manifest
 ifeq ($(SGX),1)
 all: rust-hyper-http-server.manifest.sgx rust-hyper-http-server.sig rust-hyper-http-server.token
 endif
@@ -12,23 +14,13 @@ else
 GRAMINE_LOG_LEVEL = error
 endif
 
-# We don't attempt to instruct Make on when the executable is stale and needs rebuilding.
-# Instead, we make use of Cargo's own incremental compilation, liberally executing Cargo
-# itself, with the understanding that it won't actually compile anything in most cases.
-#
-# One could also integrate Make with the dependency (.d) files Cargo generates within target/
-# to only run Cargo when strictly necessary. We have decided that, in this case, the additional
-# complexity is not worth it.
-#
-# Also note that we're compiling in release mode regardless of the DEBUG setting passed
+# Note that we're compiling in release mode regardless of the DEBUG setting passed
 # to Make, as compiling in debug mode results in an order of magnitude's difference in
 # performance that makes testing by running a benchmark with ab painful. The primary goal
 # of the DEBUG setting is to control Gramine's loglevel.
-.PHONY: build-rust
-build-rust:
+-include $(SELF_EXE).d # See also: .cargo/config.toml
+$(SELF_EXE): Cargo.toml
 	cargo build --release
-
-SELF_EXE = target/release/rust-hyper-http-server
 
 rust-hyper-http-server.manifest: rust-hyper-http-server.manifest.template
 	gramine-manifest \
@@ -43,7 +35,7 @@ rust-hyper-http-server.manifest.sgx rust-hyper-http-server.sig: sgx_sign
 	@:
 
 .INTERMEDIATE: sgx_sign
-sgx_sign: rust-hyper-http-server.manifest build-rust
+sgx_sign: rust-hyper-http-server.manifest $(SELF_EXE)
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As it turns out, running `cargo` only to have it decide that no files have changed and no work needs to be done is, at least on some of our CI machines, not as fast as we'd expect. Thus it's actually worth it to make use of the `.d` files generated by Cargo to only run it when the source code has actually changed.

Closes #627.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Run `make` twice and note that only the first run executes cargo. Modify the source code and verify that it does trigger a rebuild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/628)
<!-- Reviewable:end -->
