### PR TITLE
[CI-Examples] Increase Bash enclave size to 512M

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -20,7 +20,7 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.nonpie_binary = true
-sgx.enclave_size = "256M"
+sgx.enclave_size = "512M"
 sgx.thread_num = 4
 
 sgx.trusted_files = [


### PR DESCRIPTION
Enclave size of 256M is insufficient for Bash on CentOS.
This started to manifest itself with the new Glibc 2.35.

Signed-off-by: Aniket Borkar <aniketx.borkar@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/630)
<!-- Reviewable:end -->
