### PR TITLE
[LibOS] Emulate get cpu affinity

### DIFF
--- a/libos/include/libos_table.h
+++ b/libos/include/libos_table.h
@@ -154,9 +154,9 @@ long libos_syscall_gettid(void);
 long libos_syscall_tkill(int pid, int sig);
 long libos_syscall_time(time_t* tloc);
 long libos_syscall_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val3);
-long libos_syscall_sched_setaffinity(pid_t pid, unsigned int cpumask_size,
+long libos_syscall_sched_setaffinity(pid_t pid, unsigned int user_mask_size,
                                      unsigned long* user_mask_ptr);
-long libos_syscall_sched_getaffinity(pid_t pid, unsigned int cpumask_size,
+long libos_syscall_sched_getaffinity(pid_t pid, unsigned int user_mask_size,
                                      unsigned long* user_mask_ptr);
 long libos_syscall_set_tid_address(int* tidptr);
 long libos_syscall_fadvise64(int fd, loff_t offset, size_t len, int advice);

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -128,6 +128,9 @@ struct libos_thread {
     libos_tcb_t* libos_tcb;
     void* frameptr;
 
+    /* Current CPU affinity mask for this thread. */
+    uint64_t* cpumask;
+
     REFTYPE ref_count;
     struct libos_lock lock;
 };

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -129,7 +129,8 @@ struct libos_thread {
     void* frameptr;
 
     /* Current CPU affinity mask for this thread. */
-    uint64_t* cpumask;
+    unsigned long* cpumask;
+    size_t cpumask_size;
 
     REFTYPE ref_count;
     struct libos_lock lock;

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -20,6 +20,10 @@
 #include "pal.h"
 
 #define WAKE_QUEUE_TAIL ((void*)1)
+
+#define GET_CPUMASK_SIZE() \
+    (BITS_TO_LONGS(g_pal_public_state->topo_info.threads_cnt) * sizeof(unsigned long))
+
 /* If next is NULL, then this node is not on any queue.
  * Otherwise it is a valid pointer to the next node or WAKE_QUEUE_TAIL. */
 struct wake_queue_node {
@@ -130,7 +134,6 @@ struct libos_thread {
 
     /* Current CPU affinity mask for this thread. */
     unsigned long* cpumask;
-    size_t cpumask_size;
 
     REFTYPE ref_count;
     struct libos_lock lock;

--- a/libos/src/sys/libos_sched.c
+++ b/libos/src/sys/libos_sched.c
@@ -166,7 +166,8 @@ long libos_syscall_sched_setaffinity(pid_t pid, unsigned int user_mask_size,
     }
 
     /* User mask is being manipulated below, so make a local copy of the mask */
-    unsigned long* cpumask = malloc(user_mask_size);
+    size_t mask_count = ALIGN_UP(user_mask_size, sizeof(unsigned long)) / sizeof(unsigned long);
+    unsigned long* cpumask = calloc(mask_count, sizeof(unsigned long));
     if (!cpumask) {
         put_thread(thread);
         return -ENOMEM;
@@ -181,7 +182,7 @@ long libos_syscall_sched_setaffinity(pid_t pid, unsigned int user_mask_size,
         if (cpumask[idx] & 1UL << (i % BITS_IN_TYPE(unsigned long))) {
             if (!g_pal_public_state->topo_info.threads[i].is_online) {
                  /* User-supplied cpumask contains a CPU that is currently offline, so remove it
-                  * from the local copy `cpumask` */
+                  * from the local copy (`cpumask`) */
                 cpumask[idx] &= ~(1UL << (i % BITS_IN_TYPE(unsigned long)));
             } else {
                 cores_cnt++;

--- a/pal/src/host/linux-sgx/pal_threading.c
+++ b/pal/src/host/linux-sgx/pal_threading.c
@@ -183,11 +183,11 @@ int _PalThreadGetCpuAffinity(PAL_HANDLE thread, size_t cpumask_size, unsigned lo
     for (size_t i = 0; i < threads_cnt; i++) {
         size_t idx = i / BITS_IN_TYPE(unsigned long);
         if ((cpu_mask[idx] & 1UL << (i % BITS_IN_TYPE(unsigned long)))
-            && !g_pal_public_state.topo_info.threads[i].is_online) {
-                /* cpumask contains a CPU that is currently offline */
-                return -PAL_ERROR_INVAL;
-            }
+                && !g_pal_public_state.topo_info.threads[i].is_online) {
+            /* cpumask contains a CPU that is currently offline */
+            return -PAL_ERROR_INVAL;
         }
+    }
 
     return 0;
 }

--- a/pal/src/host/linux-sgx/pal_threading.c
+++ b/pal/src/host/linux-sgx/pal_threading.c
@@ -173,7 +173,24 @@ int _PalThreadSetCpuAffinity(PAL_HANDLE thread, size_t cpumask_size, unsigned lo
 
 int _PalThreadGetCpuAffinity(PAL_HANDLE thread, size_t cpumask_size, unsigned long* cpu_mask) {
     int ret = ocall_sched_getaffinity(thread->thread.tcs, cpumask_size, cpu_mask);
-    return ret < 0 ? unix_to_pal_error(ret) : ret;
+    if (ret < 0)
+        return unix_to_pal_error(ret);
+
+    size_t threads_cnt = g_pal_public_state.topo_info.threads_cnt;
+    assert(cpumask_size * sizeof(unsigned long) >= threads_cnt);
+
+    /* Verify validity of the CPU affinity (e.g. that it contains no offlined cores). */
+    for (size_t i = 0; i < threads_cnt; i++) {
+        size_t idx = i / BITS_IN_TYPE(unsigned long);
+        if (cpu_mask[idx] & 1UL << (i % BITS_IN_TYPE(unsigned long))) {
+            if (!g_pal_public_state.topo_info.threads[i].is_online) {
+                /* cpumask contains a CPU that is currently offline */
+                return -PAL_ERROR_INVAL;
+            }
+        }
+    }
+
+    return 0;
 }
 
 struct handle_ops g_thread_ops = {

--- a/pal/src/host/linux-sgx/pal_threading.c
+++ b/pal/src/host/linux-sgx/pal_threading.c
@@ -177,18 +177,17 @@ int _PalThreadGetCpuAffinity(PAL_HANDLE thread, size_t cpumask_size, unsigned lo
         return unix_to_pal_error(ret);
 
     size_t threads_cnt = g_pal_public_state.topo_info.threads_cnt;
-    assert(cpumask_size * sizeof(unsigned long) >= threads_cnt);
+    assert(cpumask_size * BITS_IN_BYTE >= threads_cnt);
 
     /* Verify validity of the CPU affinity (e.g. that it contains no offlined cores). */
     for (size_t i = 0; i < threads_cnt; i++) {
         size_t idx = i / BITS_IN_TYPE(unsigned long);
-        if (cpu_mask[idx] & 1UL << (i % BITS_IN_TYPE(unsigned long))) {
-            if (!g_pal_public_state.topo_info.threads[i].is_online) {
+        if ((cpu_mask[idx] & 1UL << (i % BITS_IN_TYPE(unsigned long)))
+            && !g_pal_public_state.topo_info.threads[i].is_online) {
                 /* cpumask contains a CPU that is currently offline */
                 return -PAL_ERROR_INVAL;
             }
         }
-    }
 
     return 0;
 }

--- a/pal/src/host/linux/pal_threading.c
+++ b/pal/src/host/linux/pal_threading.c
@@ -258,7 +258,7 @@ int _PalThreadSetCpuAffinity(PAL_HANDLE thread, size_t cpumask_size, unsigned lo
 int _PalThreadGetCpuAffinity(PAL_HANDLE thread, size_t cpumask_size, unsigned long* cpu_mask) {
     int ret = DO_SYSCALL(sched_getaffinity, thread->thread.tid, cpumask_size, cpu_mask);
 
-    return ret < 0 ? unix_to_pal_error(ret) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 
 struct handle_ops g_thread_ops = {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commit stores per thread cpu affinity in the LibOS and returns it when queried from the user after validation. This is done as the cpu affinity returned from the host cannot be trusted.


## How to test this PR? <!-- (if applicable) -->
Please run `LibOS` and `PAL` regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/631)
<!-- Reviewable:end -->
