### PR TITLE
[LTP] Run timeout-prone tests with unbufferred output

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -9,6 +9,7 @@ stage('test-direct') {
             // separately
             sh '''
                 cd LibOS/shim/test/ltp
+                export GRAMINE_LTP_LIVE_OUTPUT=fcntl14,fdatasync01
                 python3 -m pytest -v -n4 --junit-xml=ltp.xml
             '''
         }

--- a/LibOS/shim/test/ltp/test_ltp.py
+++ b/LibOS/shim/test/ltp/test_ltp.py
@@ -183,7 +183,7 @@ def check_must_pass(passed, failed, must_pass):
         pytest.fail('All subtests skipped, replace must-pass with skip')
 
 
-def test_ltp(cmd, section):
+def test_ltp(cmd, section, capsys):
     must_pass = section.getintset('must-pass')
 
     loader = 'gramine-sgx' if HAS_SGX else 'gramine-direct'
@@ -193,7 +193,12 @@ def test_ltp(cmd, section):
     logging.info('command: %s', full_cmd)
     logging.info('must_pass: %s', list(must_pass) if must_pass else 'all')
 
-    returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
+    live_output = os.getenv('GRAMINE_LTP_LIVE_OUTPUT') or ''
+    if section.name in live_output.split(','):
+        with capsys.disabled():
+            returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
+    else:
+        returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
 
     # Parse output regardless of whether `must_pass` is specified: unfortunately some tests
     # do not exit with non-zero code when failing, because they rely on `MAP_SHARED` (which


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

To diagnose the LTP tests that sometimes time out, modify the test script such that CI timestamps each subtest getting executed. This will tell us if it's a hang, or if the machine is just slightly too slow for the current timeout values.
 
## How to test this PR? <!-- (if applicable) -->

CI should suffice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/632)
<!-- Reviewable:end -->
