### PR TITLE
Introduce `sgx.remote_attestation = "[none|epid|dcap]"`

### DIFF
--- a/.ci/lib/config.jenkinsfile
+++ b/.ci/lib/config.jenkinsfile
@@ -7,6 +7,7 @@ env.PYTHONPATH = python_platlib + ':' + env.WORKSPACE + '/Scripts'
 env.XDG_CONFIG_HOME = env.WORKSPACE + '/XDG_CONFIG_HOME'
 env.CARGO_HOME = env.WORKSPACE + '/CARGO_HOME'
 
+env.RA_TYPE = 'epid'
 env.RA_TLS_ALLOW_OUTDATED_TCB_INSECURE = '1'
 env.RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE = '1'
 

--- a/CI-Examples/busybox/README.md
+++ b/CI-Examples/busybox/README.md
@@ -3,6 +3,30 @@
 This directory contains the Makefile and the template manifest for the most
 recent version of Busybox (as of this writing, commit ac78f2ac96).
 
+## Building with SGX remote attestation
+
+If you want to try out `/dev/attestation/` files, you must build the example
+with SGX remote attestation enabled. By default, the example is built *without*
+remote attestation.
+
+If you want to build the example for DCAP attestation, first make sure you have
+a working DCAP setup. Then build the example as follows:
+```
+RA_TYPE=dcap make SGX=1
+```
+
+Otherwise, you will probably want to use EPID attestation. For this, you will
+additionally need to provide an SPID and specify whether it is set up for
+linkable quotes or not:
+```
+RA_TYPE=epid RA_CLIENT_SPID=12345678901234567890123456789012 RA_CLIENT_LINKABLE=0 make SGX=1
+```
+
+The above dummy values will suffice for simple experiments, but if you wish to
+run `sgx-quote.py` and verify the output, you will need to provide an
+[SPID recognized by Intel][spid].
+
+
 # Quick Start
 
 ```sh

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -22,6 +22,10 @@ fs.mounts = [
 
 sgx.debug = true
 
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
+sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
+sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:busybox",

--- a/CI-Examples/python/README.md
+++ b/CI-Examples/python/README.md
@@ -18,18 +18,24 @@ Run `make` (non-debug) or `make DEBUG=1` (debug) in the directory.
 
 ## Building for SGX
 
-To facilitate the `scripts/sgx-quote.py` example, the enclave is set up for
-remote attestation. By default it will be built for DCAP attestation, which
-means that you need a working DCAP setup to launch the enclave.
+Run `make SGX=1` (non-debug) or `make SGX=1 DEBUG=1` (debug) in the directory.
 
-If you do have DCAP set up, run `make SGX=1` (non-debug) or
-`make SGX=1 DEBUG=1` (debug) in this directory.
+If you want to run the `scripts/sgx-quote.py` script, you must build the example
+with SGX remote attestation enabled. By default, the example is built *without*
+remote attestation.
+
+If you want to build the example for DCAP attestation, first make sure you have
+a working DCAP setup. Then build the example as follows:
+```
+RA_TYPE=dcap make SGX=1
+```
 
 Otherwise, you will probably want to use EPID attestation. For this, you will
-need to provide an SPID and specify whether it is set up for linkable quotes or not:
+additionally need to provide an SPID and specify whether it is set up for
+linkable quotes or not:
 
 ```
-RA_CLIENT_SPID=12345678901234567890123456789012 RA_CLIENT_LINKABLE=0 make SGX=1
+RA_TYPE=epid RA_CLIENT_SPID=12345678901234567890123456789012 RA_CLIENT_LINKABLE=0 make SGX=1
 ```
 
 The above dummy values will suffice for simple experiments, but if you wish to

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -28,7 +28,7 @@ sgx.enclave_size = "512M"
 sys.stack.size = "2M"
 sgx.thread_num = 32
 
-sgx.remote_attestation = true
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
 sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
 sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 

--- a/CI-Examples/python/scripts/sgx-quote.py
+++ b/CI-Examples/python/scripts/sgx-quote.py
@@ -8,7 +8,7 @@ def tohex(b):
 
 if not os.path.exists("/dev/attestation/user_report_data"):
     print("Cannot find `/dev/attestation/user_report_data`; "
-          "are you running under SGX?")
+          "are you running under SGX and did you enable remote attestation?")
     sys.exit(1)
 
 with open("/dev/attestation/user_report_data", "wb") as f:

--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -3,11 +3,6 @@ GRAMINE_PKGLIBDIR ?= /usr/lib/x86_64-linux-gnu/gramine # this is debian/ubuntu s
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-# for EPID attestation, specify your SPID and linkable/unlinkable attestation policy;
-# for DCAP/ECDSA attestation, specify SPID as empty string (linkable value is ignored)
-RA_CLIENT_SPID ?=
-RA_CLIENT_LINKABLE ?= 0
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 CFLAGS += -O0 -ggdb3
@@ -93,8 +88,6 @@ server.manifest: server.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dra_client_spid=$(RA_CLIENT_SPID) \
-		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< > $@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),

--- a/CI-Examples/ra-tls-mbedtls/README.md
+++ b/CI-Examples/ra-tls-mbedtls/README.md
@@ -88,7 +88,8 @@ kill %%
 
 ```sh
 make clean
-RA_CLIENT_SPID=<your SPID> RA_CLIENT_LINKABLE=<1 if SPID is linkable, else 0> make app epid
+RA_TYPE=epid RA_CLIENT_SPID=<your SPID> RA_CLIENT_LINKABLE=<1 if SPID is linkable, else 0> \
+    make app epid
 
 gramine-sgx ./server epid &
 
@@ -109,7 +110,7 @@ kill %%
 
 ```sh
 make clean
-make app dcap
+RA_TYPE=dcap make app dcap
 
 gramine-sgx ./server dcap &
 
@@ -129,7 +130,7 @@ kill %%
 
 ```sh
 make clean
-make app dcap
+RA_TYPE=dcap make app dcap
 
 gramine-sgx ./server dcap &
 
@@ -147,7 +148,7 @@ kill %%
 
 ```sh
 make clean
-make app dcap
+RA_TYPE=dcap make app dcap
 
 gramine-sgx ./server dcap dummy-option &
 ./client dcap
@@ -165,7 +166,8 @@ as `RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE`, `RA_TLS_ALLOW_OUTDATED_TCB_INSECURE`,
 
 ```sh
 make clean
-RA_CLIENT_SPID=<your SPID> RA_CLIENT_LINKABLE=<1 if SPID is linkable, else 0> make app client_epid.manifest.sgx
+RA_TYPE=epid RA_CLIENT_SPID=<your SPID> RA_CLIENT_LINKABLE=<1 if SPID is linkable, else 0> \
+    make app client_epid.manifest.sgx
 
 gramine-sgx ./server epid &
 
@@ -179,7 +181,7 @@ kill %%
 
 ```sh
 make clean
-make app dcap
+RA_TYPE=dcap make app dcap
 
 gramine-sgx ./server dcap &
 

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -1,4 +1,4 @@
-# Client manifest file (both for EPID and DCAP)
+# Client manifest file
 
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "client"
@@ -6,8 +6,9 @@ libos.entrypoint = "client"
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
-loader.env.RA_TLS_CLIENT_INSIDE_SGX = "1"
 loader.env.LC_ALL = "C"
+
+loader.env.RA_TLS_CLIENT_INSIDE_SGX = "1"
 
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
@@ -20,9 +21,10 @@ fs.mounts = [
 ]
 
 sgx.debug = true
-sgx.remote_attestation = true
 sgx.enclave_size = "256M"
 sgx.thread_num = 4
+
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -19,9 +19,10 @@ fs.mounts = [
 ]
 
 sgx.debug = true
-sgx.remote_attestation = true
-sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
+
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
+sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
+sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -3,11 +3,6 @@ GRAMINE_PKGLIBDIR ?= /usr/lib/x86_64-linux-gnu/gramine # this is debian/ubuntu s
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-# for EPID attestation, specify your SPID and linkable/unlinkable attestation policy;
-# for DCAP/ECDSA attestation, specify SPID as empty string (linkable value is ignored)
-RA_CLIENT_SPID ?=
-RA_CLIENT_LINKABLE ?= 0
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 CFLAGS += -O0 -ggdb3
@@ -78,8 +73,6 @@ secret_prov_client.manifest: secret_prov_client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dra_client_spid=$(RA_CLIENT_SPID) \
-		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< > $@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
@@ -102,8 +95,6 @@ secret_prov_min_client.manifest: secret_prov_min_client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dra_client_spid=$(RA_CLIENT_SPID) \
-		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< > $@
 
 secret_prov_min_client.manifest.sgx secret_prov_min_client.sig: sgx_sign_secret_prov_min_client
@@ -129,8 +120,6 @@ secret_prov_pf_client.manifest: secret_prov_pf_client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dra_client_spid=$(RA_CLIENT_SPID) \
-		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< > $@
 
 secret_prov_pf_client.manifest.sgx secret_prov_pf_client.sig: sgx_sign_secret_prov_pf_client

--- a/CI-Examples/ra-tls-secret-prov/README.md
+++ b/CI-Examples/ra-tls-secret-prov/README.md
@@ -29,8 +29,7 @@ build time.
 
 Because this example builds and uses debug SGX enclaves (`sgx.debug` is set
 to `true`), we use environment variable `RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1`.
-Note that in production environments,
-you must *not* use this option!
+Note that in production environments, you must *not* use this option!
 
 Moreover, we set `RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1`, to allow performing
 the tests when some of Intel's security advisories haven't been addressed (for
@@ -70,7 +69,8 @@ build time.
 [spid]: https://gramine.readthedocs.io/en/latest/sgx-intro.html#term-spid
 
 ```sh
-RA_CLIENT_SPID=<your SPID> RA_CLIENT_LINKABLE=<1 if SPID is linkable, else 0> make app epid files/input.txt
+RA_TYPE=epid RA_CLIENT_SPID=<your SPID> RA_CLIENT_LINKABLE=<1 if SPID is linkable, else 0> \
+    make app epid files/input.txt
 
 RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
@@ -92,7 +92,7 @@ kill %%
 - Secret Provisioning flows, ECDSA-based (DCAP) attestation:
 
 ```sh
-make app dcap files/input.txt
+RA_TYPE=dcap make app dcap files/input.txt
 
 RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -18,9 +18,10 @@ fs.mounts = [
 
 sgx.enclave_size = "512M"
 sgx.debug = true
-sgx.remote_attestation = true
-sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
+
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
+sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
+sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -22,9 +22,10 @@ fs.mounts = [
 
 sgx.enclave_size = "512M"
 sgx.debug = true
-sgx.remote_attestation = true
-sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
+
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
+sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
+sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -24,9 +24,10 @@ fs.mounts = [
 
 sgx.enclave_size = "512M"
 sgx.debug = true
-sgx.remote_attestation = true
-sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
+
+sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
+sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
+sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -222,6 +222,15 @@ encryption keys (see also :doc:`manifest-syntax`):
    32-character hex value, and the new files
    (``/dev/attestation/keys/<key_name>``) use a 16-byte raw binary value.
 
+Finally, the ``/dev/attestation`` pseudo-filesystem exposes a pseudo-file that
+indicates the type of attestation used:
+
+- ``/dev/attestation/attestation_type`` file contains the name of the
+  attestation scheme used, currently one of ``none``, ``epid``, ``dcap`` and
+  ``unclear`` (the latter is used when attestation type cannot be identified).
+  The contents of the file end with a newline, so applications are advised to
+  strip the newline symbol (``\n``) from the read characters.
+
 Mid-level RA-TLS interface
 --------------------------
 
@@ -278,15 +287,13 @@ certificate. The library is *not* thread-safe.
 The library expects the following information in the manifest for EPID based
 attestation:
 
-- ``sgx.remote_attestation = true`` -- remote attestation is enabled.
+- ``sgx.remote_attestation = "epid"`` -- EPID remote attestation is enabled.
 - ``sgx.ra_client_spid`` -- client SPID for EPID remote attestation.
 - ``sgx.ra_client_linkable`` -- client linkable/unlinkable attestation mode.
 
 For DCAP/ECDSA based attestation, the library expects instead:
 
-- ``sgx.remote_attestation = true`` -- remote attestation is enabled.
-- ``sgx.ra_client_spid = ""`` -- hints that this is a DCAP attestation, *not*
-  EPID attestation.
+- ``sgx.remote_attestation = "dcap"`` -- DCAP remote attestation is enabled.
 
 The library uses the following environment variables if available:
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -722,22 +722,23 @@ Attestation and quotes
 
 ::
 
-    sgx.remote_attestation = [true|false]
-    (Default: false)
+    sgx.remote_attestation = "[none|epid|dcap]"
+    (Default: "none")
 
     sgx.ra_client_linkable = [true|false]
     sgx.ra_client_spid     = "[HEX]"
+    (Only for EPID based attestation)
 
-This syntax specifies the parameters for remote attestation. To enable it,
-``remote_attestation`` must be set to ``true``.
+This syntax specifies the parameters for remote attestation. By default it is
+not enabled.
 
-For EPID based attestation, ``ra_client_linkable`` and ``ra_client_spid`` must
-be filled with your registered Intel SGX EPID Attestation Service credentials
+For EPID based attestation, ``remote_attestation`` must be set to ``epid``.
+In addition, ``ra_client_linkable`` and ``ra_client_spid`` must be filled with
+your registered Intel SGX EPID Attestation Service credentials
 (linkable/unlinkable mode and SPID of the client respectively).
 
-For DCAP/ECDSA based attestation, ``ra_client_spid`` must be an empty string
-(this is a hint to Gramine to use DCAP instead of EPID) and
-``ra_client_linkable`` is ignored.
+For DCAP/ECDSA based attestation, ``remote_attestation`` must be set to
+``dcap``. ``ra_client_spid`` and ``ra_client_linkable`` are ignored.
 
 Pre-heating enclave
 ^^^^^^^^^^^^^^^^^^^
@@ -935,3 +936,16 @@ replaced with ``type = "encrypted"`` mounts (see :ref:`encrypted-files`).
 This syntax allowed specifying the default encryption key for protected files.
 It has been replaced by ``fs.insecure__keys.[KEY_NAME]]``. Note that both old
 and new syntax are suitable for debugging purposes only.
+
+Attestation and quotes (deprecated syntax)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.remote_attestation = [true|false]
+
+This syntax specified whether to enable SGX remote attestation. The boolean
+value has been replaced with the string value. The ``none`` value in the new
+syntax corresponds to the ``false`` boolean value in the deprecated syntax. The
+explicit ``epid`` and ``dcap`` values in the new syntax replace the ambiguous
+``true`` boolean value in the deprecated syntax.

--- a/Documentation/tutorials/pytorch/index.rst
+++ b/Documentation/tutorials/pytorch/index.rst
@@ -495,7 +495,7 @@ re-use the same ``ssl/`` directory and specify ``localhost``. For more info on
 the used environment variables and other manifest options, see `here
 <https://github.com/gramineproject/gramine/tree/master/Pal/src/host/Linux-SGX/tools#secret-provisioning-libraries>`__::
 
-   sgx.remote_attestation = true
+   sgx.remote_attestation = "dcap"
 
    loader.env.LD_PRELOAD = "libsecret_prov_attest.so"
    loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -15,8 +15,10 @@
  * be generally single-threaded and therefore do not introduce synchronization here.
  */
 
+#include "api.h"
 #include "shim_fs_encrypted.h"
 #include "shim_fs_pseudo.h"
+#include "toml_utils.h"
 
 /* user_report_data, target_info and quote are opaque blobs of predefined maximum sizes. Currently
  * these sizes are overapproximations of SGX requirements (report_data is 64B, target_info is
@@ -32,6 +34,8 @@ static char g_target_info[TARGET_INFO_MAX_SIZE] = {0};
 static size_t g_target_info_size = 0;
 
 static size_t g_report_size = 0;
+
+char* g_attestation_type_str = NULL;
 
 static int init_attestation_struct_sizes(void) {
     if (g_user_report_data_size && g_target_info_size && g_report_size) {
@@ -236,6 +240,24 @@ static int quote_load(struct shim_dentry* dent, char** out_data, size_t* out_siz
     return 0;
 }
 
+/*!
+ * \brief Get remote attestation type used.
+ *
+ * In case of SGX, same as `sgx.remote_attestation` manifest option.
+ */
+static int attestation_type_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
+    __UNUSED(dent);
+
+    assert(g_attestation_type_str);
+    char* str = alloc_concat(g_attestation_type_str, /*a_len=*/-1, "\n", /*b_len=*/-1);
+    if (!str)
+        return -ENOMEM;
+
+    *out_data = str;
+    *out_size = strlen(str) + 1;
+    return 0;
+}
+
 static int deprecated_pfkey_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     __UNUSED(dent);
 
@@ -364,32 +386,71 @@ static int key_save(struct shim_dentry* dent, const char* data, size_t size) {
     return 0;
 }
 
+static int init_sgx_attestation(struct pseudo_node* attestation) {
+    int ret;
+
+    if (strcmp(g_pal_public_state->host_type, "Linux-SGX"))
+        return 0;
+
+    ret = toml_string_in(g_manifest_root, "sgx.remote_attestation", &g_attestation_type_str);
+    if (ret < 0) {
+        /* TODO: Bool syntax is deprecated in v1.3, remove 2 versions later. */
+        bool sgx_remote_attestation_enabled;
+        ret = toml_bool_in(g_manifest_root, "sgx.remote_attestation", /*defaultval=*/false,
+                           &sgx_remote_attestation_enabled);
+        if (ret < 0) {
+            log_error("Cannot parse 'sgx.remote_attestation'");
+            return ret;
+        }
+        if (sgx_remote_attestation_enabled)
+            g_attestation_type_str = strdup("unclear"); /* don't bother, it's deprecated anyway */
+        else
+            g_attestation_type_str = strdup("none");
+    }
+
+    if (!g_attestation_type_str)
+        g_attestation_type_str = strdup("none");
+
+    /* always add /dev/attestation/attestation_type file, even if it is "none" */
+    pseudo_add_str(attestation, "attestation_type", &attestation_type_load);
+
+    if (!strcmp(g_attestation_type_str, "none")) {
+        log_debug("host is Linux-SGX but remote attestation type is 'none', adding only "
+                  "/dev/attestation/attestation_type file and skipping others (report, etc.)");
+        return 0;
+    }
+
+    log_debug("host is Linux-SGX and remote attestation type is '%s', adding SGX-specific "
+              "/dev/attestation files: report, quote, etc.", g_attestation_type_str);
+
+    struct pseudo_node* user_report_data = pseudo_add_str(attestation, "user_report_data", NULL);
+    user_report_data->perm = PSEUDO_PERM_FILE_RW;
+    user_report_data->str.save = &user_report_data_save;
+
+    struct pseudo_node* target_info = pseudo_add_str(attestation, "target_info", NULL);
+    target_info->perm = PSEUDO_PERM_FILE_RW;
+    target_info->str.save = &target_info_save;
+
+    pseudo_add_str(attestation, "my_target_info", &my_target_info_load);
+    pseudo_add_str(attestation, "report", &report_load);
+    pseudo_add_str(attestation, "quote", &quote_load);
+
+    /* TODO: This file is deprecated in v1.2, remove 2 versions later. */
+    struct pseudo_node* deprecated_pfkey = pseudo_add_str(attestation, "protected_files_key",
+            &deprecated_pfkey_load);
+    deprecated_pfkey->perm = PSEUDO_PERM_FILE_RW;
+    deprecated_pfkey->str.save = &deprecated_pfkey_save;
+
+    return 0;
+}
 
 int init_attestation(struct pseudo_node* dev) {
+    int ret;
     struct pseudo_node* attestation = pseudo_add_dir(dev, "attestation");
 
-    if (!strcmp(g_pal_public_state->host_type, "Linux-SGX")) {
-        log_debug("host is Linux-SGX, adding SGX-specific /dev/attestation files: "
-                  "report, quote, etc.");
-
-        struct pseudo_node* user_report_data = pseudo_add_str(attestation, "user_report_data", NULL);
-        user_report_data->perm = PSEUDO_PERM_FILE_RW;
-        user_report_data->str.save = &user_report_data_save;
-
-        struct pseudo_node* target_info = pseudo_add_str(attestation, "target_info", NULL);
-        target_info->perm = PSEUDO_PERM_FILE_RW;
-        target_info->str.save = &target_info_save;
-
-        pseudo_add_str(attestation, "my_target_info", &my_target_info_load);
-        pseudo_add_str(attestation, "report", &report_load);
-        pseudo_add_str(attestation, "quote", &quote_load);
-
-        /* TODO: This file is deprecated in v1.2, remove 2 versions later. */
-        struct pseudo_node* deprecated_pfkey = pseudo_add_str(attestation, "protected_files_key",
-                                                              &deprecated_pfkey_load);
-        deprecated_pfkey->perm = PSEUDO_PERM_FILE_RW;
-        deprecated_pfkey->str.save = &deprecated_pfkey_save;
-    }
+    ret = init_sgx_attestation(attestation);
+    if (ret < 0)
+        return ret;
 
     struct pseudo_node* keys = pseudo_add_dir(attestation, "keys");
     struct pseudo_node* key = pseudo_add_str(keys, /*name=*/NULL, &key_load);

--- a/LibOS/shim/test/regression/attestation_deprecated_syntax.manifest.template
+++ b/LibOS/shim/test/regression/attestation_deprecated_syntax.manifest.template
@@ -1,3 +1,5 @@
+{% set entrypoint = "attestation" -%}
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
@@ -5,24 +7,25 @@ loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 
-fs.mounts = [
-  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
-  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
-]
+# Keep the deprecated `fs.mount` syntax for test purposes
+# TODO: this syntax is deprecated in v1.2 and will be removed two versions after it.
 
-fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:{{ gramine.runtimedir(libc) }}"
+
+fs.mount.entrypoint.type = "chroot"
+fs.mount.entrypoint.path = "{{ entrypoint }}"
+fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
+
+sgx.insecure__protected_files_key = "ffeeddccbbaa99887766554433221100"
 
 sgx.nonpie_binary = true
 sgx.debug = true
 
-sgx.remote_attestation = "{{ env.get('RA_TYPE', 'none') }}"
+sgx.remote_attestation = true
 sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
 sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
-
-# below three entries are irrelevant, only for test purposes
-sgx.seal_key.flags_mask = "0xffffffffffffffff"
-sgx.seal_key.xfrm_mask  = "0xfffffffffff9ff1b"
-sgx.seal_key.misc_mask  = "0xffffffff"
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -489,6 +489,18 @@ class TC_04_Attestation(RegressionTestCase):
         self.assertIn("Test local attestation... SUCCESS", stdout)
         self.assertIn("Test quote interface... SUCCESS", stdout)
 
+    def test_002_attestation(self):
+        stdout, _ = self.run_binary(['attestation_deprecated_syntax'], timeout=60)
+        self.assertIn("Test resource leaks in attestation filesystem... SUCCESS", stdout)
+        self.assertIn("Test local attestation... SUCCESS", stdout)
+        self.assertIn("Test quote interface... SUCCESS", stdout)
+
+    def test_003_attestation_stdio(self):
+        stdout, _ = self.run_binary(['attestation_deprecated_syntax', 'test_stdio'], timeout=60)
+        self.assertIn("Test resource leaks in attestation filesystem... SUCCESS", stdout)
+        self.assertIn("Test local attestation... SUCCESS", stdout)
+        self.assertIn("Test quote interface... SUCCESS", stdout)
+
 class TC_30_Syscall(RegressionTestCase):
     def test_000_getcwd(self):
         stdout, _ = self.run_binary(['getcwd'])

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -123,4 +123,5 @@ manifests = [
 
 manifests = [
   "attestation",
+  "attestation_deprecated_syntax",
 ]

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -37,6 +37,13 @@ uint16_t htons(uint16_t shortval);
 uint32_t ntohl(uint32_t longval);
 uint16_t ntohs(uint16_t shortval);
 
+enum sgx_attestation_type {
+    SGX_ATTESTATION_NONE,
+    SGX_ATTESTATION_EPID,
+    SGX_ATTESTATION_DCAP,
+    SGX_ATTESTATION_UNCLEAR,  /* to support legacy `sgx.remote_attestation = true` (EPID or DCAP) */
+};
+
 struct pal_enclave {
     /* attributes */
     bool is_first_process; // Initial process in Gramine namespace is special.
@@ -49,9 +56,7 @@ struct pal_enclave {
     unsigned long rpc_thread_num;
     unsigned long ssa_frame_size;
     bool nonpie_binary;
-    bool remote_attestation_enabled;
-    bool use_epid_attestation; /* Valid only if `remote_attestation_enabled` is true, selects
-                                * EPID/DCAP attestation scheme. */
+    enum sgx_attestation_type attestation_type;
     char* libpal_uri; /* Path to the PAL binary */
 
 #ifdef DEBUG

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -75,7 +75,7 @@ static int connect_aesm_service(void) {
 
 err:
     DO_SYSCALL(close, sock);
-    log_error("Cannot connect to aesm_service (tried " AESM_SOCKET_NAME_LEGACY " and "
+    log_error("Cannot connect to AESM service (tried " AESM_SOCKET_NAME_LEGACY " and "
               AESM_SOCKET_NAME_NEW " UNIX sockets).\nPlease check its status! (`service aesmd "
               "status` on Ubuntu)");
     return ret;
@@ -124,7 +124,7 @@ out:
     free(res_buf);
     DO_SYSCALL(close, aesm_socket);
     if (ret < 0) {
-        log_error("Cannot communicate with aesm_service (read/write returned error %d).\n"
+        log_error("Cannot communicate with AESM service (read/write returned error %d).\n"
                   "Please check its status! (`service aesmd status` on Ubuntu)", ret);
     }
     return ret;
@@ -146,13 +146,15 @@ int init_quoting_enclave_targetinfo(bool is_epid, sgx_target_info_t* qe_targetin
 
         ret = -EPERM;
         if (!res->initquoteres) {
-            log_error("aesm_service returned wrong message");
+            log_error("AESM service returned wrong message");
             goto failed;
         }
 
         Response__InitQuoteResponse* r = res->initquoteres;
         if (r->errorcode != 0) {
-            log_error("aesm_service returned error: %d", r->errorcode);
+            log_error("AESM service returned error %d; this may indicate that Gramine requested "
+                      "an unsupported SGX remote attestation type (EPID), please verify "
+                      "'sgx.remote_attestation' option in your manifest", r->errorcode);
             goto failed;
         }
 
@@ -183,13 +185,15 @@ int init_quoting_enclave_targetinfo(bool is_epid, sgx_target_info_t* qe_targetin
 
         ret = -EPERM;
         if (!res->initquoteexres) {
-            log_error("aesm_service returned wrong message");
+            log_error("AESM service returned wrong message");
             goto failed;
         }
 
         Response__InitQuoteExResponse* r = res->initquoteexres;
         if (r->errorcode != 0) {
-            log_error("aesm_service returned error: %d", r->errorcode);
+            log_error("AESM service returned error %d; this may indicate that Gramine requested "
+                      "an unsupported SGX remote attestation type (DCAP/ECDSA), please verify "
+                      "'sgx.remote_attestation' option in your manifest", r->errorcode);
             goto failed;
         }
 
@@ -244,18 +248,18 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
 
         ret = -EPERM;
         if (!res->getquoteexres) {
-            log_error("aesm_service returned wrong message");
+            log_error("AESM service returned wrong message");
             goto out;
         }
 
         Response__GetQuoteExResponse* r = res->getquoteexres;
         if (r->errorcode != 0) {
-            log_error("aesm_service returned error: %d", r->errorcode);
+            log_error("AESM service returned error %d", r->errorcode);
             goto out;
         }
 
         if (!r->has_quote || r->quote.len < sizeof(sgx_quote_t)) {
-            log_error("aesm_service returned invalid quote");
+            log_error("AESM service returned invalid quote");
             goto out;
         }
 
@@ -282,18 +286,18 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
 
         ret = -EPERM;
         if (!res->getquoteres) {
-            log_error("aesm_service returned wrong message");
+            log_error("AESM service returned wrong message");
             goto out;
         }
 
         Response__GetQuoteResponse* r = res->getquoteres;
         if (r->errorcode != 0) {
-            log_error("aesm_service returned error: %d", r->errorcode);
+            log_error("AESM service returned error %d", r->errorcode);
             goto out;
         }
 
         if (!r->has_quote || r->quote.len < sizeof(sgx_quote_t)) {
-            log_error("aesm_service returned invalid quote");
+            log_error("AESM service returned invalid quote");
             goto out;
         }
 

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -89,7 +89,7 @@ class Manifest:
         sgx.setdefault('thread_num', DEFAULT_THREAD_NUM)
         sgx.setdefault('isvprodid', 0)
         sgx.setdefault('isvsvn', 0)
-        sgx.setdefault('remote_attestation', False)
+        sgx.setdefault('remote_attestation', "none")
         sgx.setdefault('debug', False)
         sgx.setdefault('require_avx', False)
         sgx.setdefault('require_avx512', False)

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -489,13 +489,11 @@ def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
         print(f'    misc_select: {attr["misc_select"]:#x}')
 
         if manifest_sgx['remote_attestation']:
+            attestation_type = manifest_sgx['remote_attestation']
             spid = manifest_sgx.get('ra_client_spid', '')
             linkable = manifest_sgx.get('ra_client_linkable', False)
             print('SGX remote attestation:')
-            if not spid:
-                print('    DCAP/ECDSA')
-            else:
-                print(f'    EPID (spid = {spid}, linkable = {linkable})')
+            print(f'    {attestation_type}, spid = `{spid}`, linkable = {linkable}')
 
     # Populate memory areas
     memory_areas = get_memory_areas(attr, libpal)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR deprecates ambiguous `sgx.remote_attestation = true` in favor of an explicit attestation-type string. The first side benefit of this change is that the weird logic "if ra_client_spid is set, then it is EPID otherwise DCAP" is gone. The second side benefit is that this allows us to add more remote attestation schemes in the future, if needed (for example, Microsoft Azure Attestation).

Also, a new pseudo-file `/dev/attestation/attestation_type` is introduced at the LibOS level. It helps the application to determine
which attestation scheme should be used.

Several CI examples are rewritten to use the new syntax: Python, ra-tls-mbedlts, ra-tls-secret-prov, Busybox (the latter is purely for testing purposes). The `attestation` LibOS regression test also uses the new syntax; the old syntax is tested via the newly added test `attestation_deprecated_syntax`.

## How to test this PR? <!-- (if applicable) -->

CI and manually (e.g., look around via `gramine-sgx busybox sh`).