### PR TITLE
[Docs] Describe new `SECRET_PROVISION_SET_KEY` envvar in attestation

### DIFF
--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -436,13 +436,21 @@ environment variables if available:
   starts. By default, it is not set, thus secret provisioning must be explicitly
   requested by the application.
 
-- ``SECRET_PROVISION_SET_PF_KEY`` (optional) -- set it to ``1/true/TRUE`` to
-  indicate that the provisioned secret is a protected-files master key. The key
-  must be a 32-char null-terminated AES-GCM encryption key in hex format,
-  similar to ``sgx.insecure__protected_files_key`` manifest option. This
-  environment variable is checked only if ``SECRET_PROVISION_CONSTRUCTOR`` is
-  set. The library puts the provisioned key into
-  ``/dev/attestation/protected_files_key`` so that Gramine recognizes it.
+- ``SECRET_PROVISION_SET_KEY`` (optional) -- set it to the name of the key that
+  will be provisioned into the Gramine enclave as the secret. For example,
+  setting this environment variable to ``default`` will install the provisioned
+  key as the default encryption key for encrypted files. The key must be sent
+  (by the secret provisioning service) as a 32-char null-terminated AES-GCM
+  encryption key in hex format, similar to ``fs.insecure__keys.[KEY_NAME]``
+  manifest option. This environment variable is checked only if
+  ``SECRET_PROVISION_CONSTRUCTOR`` is set. The library puts the provisioned key
+  into ``/dev/attestation/keys/<key_name>`` so that Gramine recognizes it.
+
+.. note::
+   Previously, ``SECRET_PROVISION_SET_PF_KEY = 1/true/TRUE`` was used for
+   setting the ``default`` encryption key, and Gramine still supports that
+   environment variable for backward compatibility. It is deprecated and will be
+   removed in the next releases of Gramine.
 
 - ``SECRET_PROVISION_SERVERS`` (optional) -- a comma, semicolon or space
   separated list of server names with ports to connect to for secret


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit "[Pal/Linux-SGX] Adapt for the new encrypted files API" deprecated the `SECRET_PROVISION_SET_PF_KEY` envvar and introduced the new `SECRET_PROVISION_SET_KEY` envvar instead. However, that commit forgot to update the Attestation documentation page.

The mentioned commit:
- https://github.com/gramineproject/gramine/commit/fbfd07c522a0b190c0a97158ea406e35c82fa0e0
- https://github.com/gramineproject/gramine/pull/587

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/643)
<!-- Reviewable:end -->
