### PR TITLE
[LibOS,PAL] Clean up hex parsing

### DIFF
--- a/LibOS/shim/src/fs/shim_fs_encrypted.c
+++ b/LibOS/shim/src/fs/shim_fs_encrypted.c
@@ -205,14 +205,10 @@ int parse_pf_key(const char* key_str, pf_key_t* pf_key) {
     }
 
     pf_key_t tmp_pf_key;
-    for (size_t i = 0; i < len; i += 2) {
-        int8_t hi = hex2dec(key_str[i]);
-        int8_t lo = hex2dec(key_str[i+1]);
-        if (hi < 0 || lo < 0) {
-            log_warning("%s: unexpected character encountered", __func__);
-            return -EINVAL;
-        }
-        tmp_pf_key[i / 2] = hi * 16 + lo;
+    char* bytes = hex2bytes(key_str, len, tmp_pf_key, sizeof(tmp_pf_key));
+    if (!bytes) {
+        log_warning("%s: unexpected character encountered", __func__);
+        return -EINVAL;
     }
     memcpy(pf_key, &tmp_pf_key, sizeof(tmp_pf_key));
     return 0;
@@ -222,7 +218,7 @@ int dump_pf_key(const pf_key_t* pf_key, char* buf, size_t buf_size) {
     if (buf_size < sizeof(*pf_key) * 2 + 1)
         return -EINVAL;
 
-    __bytes2hexstr(pf_key, sizeof(*pf_key), buf, buf_size);
+    bytes2hex(pf_key, sizeof(*pf_key), buf, buf_size);
     return 0;
 }
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -515,7 +515,7 @@ static int get_256b_random_hex_string(char* buf, size_t size) {
     if (ret < 0)
         return pal_to_unix_errno(ret);
 
-    BYTES2HEXSTR(random, buf, size);
+    bytes2hex(random, sizeof(random), buf, size);
     return 0;
 }
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -436,7 +436,7 @@ static void hash_dentry_path(struct shim_dentry* dent, char* buf, size_t size) {
     assert(size >= sizeof(hashbytes) * 2 + 1);
     memcpy(hashbytes, &hash, sizeof(hash));
 
-    BYTES2HEXSTR(hashbytes, buf, size);
+    bytes2hex(hashbytes, sizeof(hashbytes), buf, size);
 }
 
 /*

--- a/Pal/regression/Hex.c
+++ b/Pal/regression/Hex.c
@@ -11,7 +11,7 @@ static_assert(sizeof(x) <= sizeof(y), "array x is longer than array y");
 char hex_buf[sizeof(y) * 2 + 1];
 
 int main(void) {
-    pal_printf("Hex test 1 is %s\n", BYTES2HEXSTR(x, hex_buf, sizeof(hex_buf)));
-    pal_printf("Hex test 2 is %s\n", BYTES2HEXSTR(y, hex_buf, sizeof(hex_buf)));
+    pal_printf("Hex test 1 is %s\n", bytes2hex(x, sizeof(x), hex_buf, sizeof(hex_buf)));
+    pal_printf("Hex test 2 is %s\n", bytes2hex(y, sizeof(y), hex_buf, sizeof(hex_buf)));
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -567,15 +567,13 @@ int _DkAttestationQuote(const void* user_report_data, size_t user_report_data_si
             return -PAL_ERROR_INVAL;
         }
 
-        for (size_t i = 0; i < strlen(ra_client_spid_str); i++) {
-            int8_t val = hex2dec(ra_client_spid_str[i]);
-            if (val < 0) {
-                log_error("Malformed 'sgx.ra_client_spid' value in the manifest: %s",
-                          ra_client_spid_str);
-                free(ra_client_spid_str);
-                return -PAL_ERROR_INVAL;
-            }
-            spid[i / 2] = spid[i / 2] * 16 + (uint8_t)val;
+        char* bytes = hex2bytes(ra_client_spid_str, strlen(ra_client_spid_str), spid,
+                                sizeof(spid));
+        if (!bytes) {
+            log_error("Malformed 'sgx.ra_client_spid' value in the manifest: %s",
+                      ra_client_spid_str);
+            free(ra_client_spid_str);
+            return -PAL_ERROR_INVAL;
         }
 
         /* read sgx.ra_client_linkable from manifest */

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -60,18 +60,21 @@ int read_enclave_token(int token_file, sgx_arch_token_t* token) {
 #ifdef SGX_DCAP
     log_debug("Read dummy DCAP token");
 #else
+    char hex[64 * 2 + 1]; /* large enough to hold any of the below fields */
+#define BYTES2HEX(bytes) (bytes2hex(bytes, sizeof(bytes), hex, sizeof(hex)))
     log_debug("Read token:");
     log_debug("    valid:                 0x%08x",   token->body.valid);
     log_debug("    attr.flags:            0x%016lx", token->body.attributes.flags);
     log_debug("    attr.xfrm:             0x%016lx", token->body.attributes.xfrm);
-    log_debug("    mr_enclave:            %s",       ALLOCA_BYTES2HEXSTR(token->body.mr_enclave.m));
-    log_debug("    mr_signer:             %s",       ALLOCA_BYTES2HEXSTR(token->body.mr_signer.m));
-    log_debug("    LE cpu_svn:            %s",       ALLOCA_BYTES2HEXSTR(token->cpu_svn_le.svn));
+    log_debug("    mr_enclave:            %s",       BYTES2HEX(token->body.mr_enclave.m));
+    log_debug("    mr_signer:             %s",       BYTES2HEX(token->body.mr_signer.m));
+    log_debug("    LE cpu_svn:            %s",       BYTES2HEX(token->cpu_svn_le.svn));
     log_debug("    LE isv_prod_id:        %02x",     token->isv_prod_id_le);
     log_debug("    LE isv_svn:            %02x",     token->isv_svn_le);
     log_debug("    LE masked_misc_select: 0x%08x",   token->masked_misc_select_le);
     log_debug("    LE attr.flags:         0x%016lx", token->attributes_le.flags);
     log_debug("    LE attr.xfrm:          0x%016lx", token->attributes_le.xfrm);
+#undef BYTES2HEX
 #endif
 
     return 0;
@@ -383,9 +386,12 @@ int init_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct,
 #endif
     unsigned long enclave_valid_addr = secs->base + secs->size - g_page_size;
 
+    char hex[sizeof(sigstruct->body.enclave_hash.m) * 2 + 1];
     log_debug("Enclave initializing:");
     log_debug("    enclave id:   0x%016lx", enclave_valid_addr);
-    log_debug("    mr_enclave:   %s", ALLOCA_BYTES2HEXSTR(sigstruct->body.enclave_hash.m));
+    log_debug("    mr_enclave:   %s", bytes2hex(sigstruct->body.enclave_hash.m,
+                                                sizeof(sigstruct->body.enclave_hash.m),
+                                                hex, sizeof(hex)));
 
     struct sgx_enclave_init param = {
 #ifndef SGX_DCAP


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit removes macros `BYTES2HEXSTR` and `ALLOCA_BYTES2HEXSTR`, as well as introduces the `hex2bytes()` function instead of ad-hoc code snippets in LibOS and PAL codebase.

I promised this during the review of https://github.com/gramineproject/gramine/pull/638.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/644)
<!-- Reviewable:end -->
