### PR TITLE
[Pal/Linux-SGX] Fix resource leak in secret_prov

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/src/secret_prov_client.c
+++ b/CI-Examples/ra-tls-secret-prov/src/secret_prov_client.c
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
     printf("--- Received secret1 = '%s', secret2 = '%s' ---\n", secret1, secret2);
     ret = 0;
 out:
-    secret_provision_destroy();
     secret_provision_close(&ctx);
+    secret_provision_destroy(&ctx);
     return ret;
 }

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov.h
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov.h
@@ -22,6 +22,7 @@
 
 struct ra_tls_ctx {
     void* ssl;
+    void* attest_resources;
 };
 
 typedef int (*verify_measurements_cb_t)(const char* mrenclave, const char* mrsigner,
@@ -98,7 +99,7 @@ int secret_provision_get(uint8_t** out_secret, size_t* out_secret_size);
  * This function zeroes out the memory where provisioned secret is stored and frees it.
  */
 __attribute__ ((visibility("default")))
-void secret_provision_destroy(void);
+void secret_provision_destroy(struct ra_tls_ctx* ctx);
 
 /*!
  * \brief Establish an RA-TLS session and retrieve first secret (client-side).

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
@@ -33,19 +33,21 @@
 #include "secret_prov.h"
 #include "util.h"
 
-/* these are globals because the user may continue using the SSL session even after invoking
- * secret_provision_start() (in the user-supplied callback) */
-static mbedtls_ctr_drbg_context g_ctr_drbg;
-static mbedtls_entropy_context g_entropy;
-static mbedtls_ssl_config g_conf;
-static mbedtls_x509_crt g_verifier_ca_chain;
-static mbedtls_net_context g_verifier_fd;
-static mbedtls_ssl_context g_ssl;
-static mbedtls_pk_context g_my_ratls_key;
-static mbedtls_x509_crt g_my_ratls_cert;
+typedef struct _secret_prov_resources_t {
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_context entropy;
+    mbedtls_ssl_config conf;
+    mbedtls_x509_crt verifier_ca_chain;
+    mbedtls_net_context verifier_fd;
+    mbedtls_ssl_context ssl;
+    mbedtls_pk_context my_ratls_key;
+    mbedtls_x509_crt my_ratls_cert;
+} secret_prov_resources_t;
 
 static uint8_t* provisioned_secret = NULL;
 static size_t provisioned_secret_size = 0;
+
+int free_secret_prov_resources(secret_prov_resources_t* _res);
 
 int secret_provision_get(uint8_t** out_secret, size_t* out_secret_size) {
     if (!out_secret || !out_secret_size)
@@ -56,16 +58,46 @@ int secret_provision_get(uint8_t** out_secret, size_t* out_secret_size) {
     return 0;
 }
 
-void secret_provision_destroy(void) {
-    if (provisioned_secret && provisioned_secret_size)
+int free_secret_prov_resources(secret_prov_resources_t* _res) {
+    if (!_res)
+        return -EINVAL;
+
+    secret_prov_resources_t* res = (secret_prov_resources_t*) _res;
+
+    mbedtls_x509_crt_free(&res->my_ratls_cert);
+    mbedtls_pk_free(&res->my_ratls_key);
+    mbedtls_net_free(&res->verifier_fd);
+    mbedtls_ssl_free(&res->ssl);
+    mbedtls_ssl_config_free(&res->conf);
+    mbedtls_x509_crt_free(&res->verifier_ca_chain);
+    mbedtls_ctr_drbg_free(&res->ctr_drbg);
+    mbedtls_entropy_free(&res->entropy);
+
+    return 0;
+}
+
+void secret_provision_destroy(struct ra_tls_ctx* ctx) {
+    /* free provisioned_secret */
+    if (provisioned_secret) {
 #ifdef __STDC_LIB_EXT1__
         memset_s(provisioned_secret, 0, provisioned_secret_size);
 #else
         memset(provisioned_secret, 0, provisioned_secret_size);
 #endif
-    free(provisioned_secret);
-    provisioned_secret      = NULL;
+        free(provisioned_secret);
+        provisioned_secret = NULL;
+    }
+
     provisioned_secret_size = 0;
+
+    if (ctx) {
+        if (ctx->attest_resources) {
+            free_secret_prov_resources(ctx->attest_resources);
+
+            free(ctx->attest_resources);
+            ctx->attest_resources = 0;
+        }
+    }
 }
 
 int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
@@ -78,19 +110,26 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
     char* connected_addr = NULL;
     char* connected_port = NULL;
 
-    mbedtls_ctr_drbg_init(&g_ctr_drbg);
-    mbedtls_entropy_init(&g_entropy);
-    mbedtls_x509_crt_init(&g_verifier_ca_chain);
+    secret_prov_resources_t* res =
+        (secret_prov_resources_t*)malloc(sizeof(secret_prov_resources_t));
+    if (!res) {
+        ret = -ENOMEM;
+        goto out;
+    }
 
-    mbedtls_pk_init(&g_my_ratls_key);
-    mbedtls_x509_crt_init(&g_my_ratls_cert);
+    mbedtls_ctr_drbg_init(&res->ctr_drbg);
+    mbedtls_entropy_init(&res->entropy);
+    mbedtls_x509_crt_init(&res->verifier_ca_chain);
 
-    mbedtls_net_init(&g_verifier_fd);
-    mbedtls_ssl_config_init(&g_conf);
-    mbedtls_ssl_init(&g_ssl);
+    mbedtls_pk_init(&res->my_ratls_key);
+    mbedtls_x509_crt_init(&res->my_ratls_cert);
+
+    mbedtls_net_init(&res->verifier_fd);
+    mbedtls_ssl_config_init(&res->conf);
+    mbedtls_ssl_init(&res->ssl);
 
     const char* pers = "secret-provisioning";
-    ret = mbedtls_ctr_drbg_seed(&g_ctr_drbg, mbedtls_entropy_func, &g_entropy,
+    ret = mbedtls_ctr_drbg_seed(&res->ctr_drbg, mbedtls_entropy_func, &res->entropy,
                                 (const uint8_t*)pers, strlen(pers));
     if (ret < 0) {
         goto out;
@@ -137,7 +176,7 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
         if (!connected_port)
             continue;
 
-        ret = mbedtls_net_connect(&g_verifier_fd, connected_addr, connected_port,
+        ret = mbedtls_net_connect(&res->verifier_fd, connected_addr, connected_port,
                                   MBEDTLS_NET_PROTO_TCP);
         if (!ret)
             break;
@@ -147,53 +186,53 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
         goto out;
     }
 
-    ret = mbedtls_ssl_config_defaults(&g_conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+    ret = mbedtls_ssl_config_defaults(&res->conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
                                       MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret < 0) {
         goto out;
     }
 
-    ret = mbedtls_x509_crt_parse_file(&g_verifier_ca_chain, ca_chain_path);
+    ret = mbedtls_x509_crt_parse_file(&res->verifier_ca_chain, ca_chain_path);
     if (ret != 0) {
         goto out;
     }
 
     char crt_issuer[256];
-    ret = mbedtls_x509_dn_gets(crt_issuer, sizeof(crt_issuer), &g_verifier_ca_chain.issuer);
+    ret = mbedtls_x509_dn_gets(crt_issuer, sizeof(crt_issuer), &res->verifier_ca_chain.issuer);
     if (ret < 0) {
         goto out;
     }
 
-    mbedtls_ssl_conf_authmode(&g_conf, MBEDTLS_SSL_VERIFY_REQUIRED);
-    mbedtls_ssl_conf_ca_chain(&g_conf, &g_verifier_ca_chain, NULL);
+    mbedtls_ssl_conf_authmode(&res->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+    mbedtls_ssl_conf_ca_chain(&res->conf, &res->verifier_ca_chain, NULL);
 
-    ret = ra_tls_create_key_and_crt(&g_my_ratls_key, &g_my_ratls_cert);
+    ret = ra_tls_create_key_and_crt(&res->my_ratls_key, &res->my_ratls_cert);
     if (ret < 0) {
         goto out;
     }
 
-    mbedtls_ssl_conf_rng(&g_conf, mbedtls_ctr_drbg_random, &g_ctr_drbg);
+    mbedtls_ssl_conf_rng(&res->conf, mbedtls_ctr_drbg_random, &res->ctr_drbg);
 
-    ret = mbedtls_ssl_conf_own_cert(&g_conf, &g_my_ratls_cert, &g_my_ratls_key);
+    ret = mbedtls_ssl_conf_own_cert(&res->conf, &res->my_ratls_cert, &res->my_ratls_key);
     if (ret < 0) {
         goto out;
     }
 
-    ret = mbedtls_ssl_setup(&g_ssl, &g_conf);
+    ret = mbedtls_ssl_setup(&res->ssl, &res->conf);
     if (ret < 0) {
         goto out;
     }
 
-    ret = mbedtls_ssl_set_hostname(&g_ssl, connected_addr);
+    ret = mbedtls_ssl_set_hostname(&res->ssl, connected_addr);
     if (ret < 0) {
         goto out;
     }
 
-    mbedtls_ssl_set_bio(&g_ssl, &g_verifier_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
+    mbedtls_ssl_set_bio(&res->ssl, &res->verifier_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
 
     ret = -1;
     while (ret < 0) {
-        ret = mbedtls_ssl_handshake(&g_ssl);
+        ret = mbedtls_ssl_handshake(&res->ssl);
         if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
             continue;
         }
@@ -202,13 +241,13 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
         }
     }
 
-    uint32_t flags = mbedtls_ssl_get_verify_result(&g_ssl);
+    uint32_t flags = mbedtls_ssl_get_verify_result(&res->ssl);
     if (flags != 0) {
         ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
         goto out;
     }
 
-    struct ra_tls_ctx ctx = {.ssl = &g_ssl};
+    struct ra_tls_ctx ctx = {.ssl = &res->ssl};
     uint8_t buf[128] = {0};
     size_t size;
 
@@ -248,12 +287,19 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
         goto out;
     }
 
-    provisioned_secret_size = received_secret_size;
-    provisioned_secret = malloc(provisioned_secret_size);
+    /* free previously one */
+    if (provisioned_secret) {
+        free(provisioned_secret);
+        provisioned_secret = 0;
+    }
+    /* size may changed, allocate new memory */
+    provisioned_secret = malloc(received_secret_size);
     if (!provisioned_secret) {
         ret = -ENOMEM;
         goto out;
     }
+    /* set size after successfully allocated memory */
+    provisioned_secret_size = received_secret_size;
 
     ret = secret_provision_read(&ctx, provisioned_secret, provisioned_secret_size);
     if (ret < 0) {
@@ -262,6 +308,7 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
 
     if (out_ctx) {
         out_ctx->ssl = ctx.ssl;
+        out_ctx->attest_resources = res;
     } else {
         secret_provision_close(&ctx);
     }
@@ -269,18 +316,13 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
     ret = 0;
 out:
     if (ret < 0) {
-        secret_provision_destroy();
+        secret_provision_destroy(0);
     }
 
     if (ret < 0 || !out_ctx) {
-        mbedtls_x509_crt_free(&g_my_ratls_cert);
-        mbedtls_pk_free(&g_my_ratls_key);
-        mbedtls_net_free(&g_verifier_fd);
-        mbedtls_ssl_free(&g_ssl);
-        mbedtls_ssl_config_free(&g_conf);
-        mbedtls_x509_crt_free(&g_verifier_ca_chain);
-        mbedtls_ctr_drbg_free(&g_ctr_drbg);
-        mbedtls_entropy_free(&g_entropy);
+        free_secret_prov_resources(res);
+        free(res);
+        res = 0;
     }
 
     free(servers);
@@ -368,6 +410,6 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
         /* put the secret into an environment variable */
         setenv(SECRET_PROVISION_SECRET_STRING, (const char*)secret, /*overwrite=*/1);
 
-        secret_provision_destroy();
+        secret_provision_destroy(0);
     }
 }


### PR DESCRIPTION
The tcp connection was created every time invoking secret_provision_start(),
but it will not close. So, there will be lots of tcp connection keeping open.
Finally, the total fd that keeping open reached 900, and it cannot open any
more file or socket.

Signed-off-by: Liang Fang <liang.a.fang@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/646)
<!-- Reviewable:end -->
