### PR TITLE
[LibOS] Add `O_PATH` support to `open` syscall

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -126,10 +126,6 @@ struct shim_fs_ops {
     /* seek: the content from the file opened as handle */
     file_off_t (*seek)(struct shim_handle* hdl, file_off_t offset, int whence);
 
-    /* move, copy: rename or duplicate the file */
-    int (*move)(const char* trim_old_name, const char* trim_new_name);
-    int (*copy)(const char* trim_old_name, const char* trim_new_name);
-
     /* Returns 0 on success, -errno on error */
     int (*truncate)(struct shim_handle* hdl, file_off_t len);
 
@@ -138,14 +134,6 @@ struct shim_fs_ops {
 
     /* setflags: set flags of the file */
     int (*setflags)(struct shim_handle* hdl, int flags);
-
-    /*
-     * \brief Deallocate handle data.
-     *
-     * Deallocates any filesystem-specific resources associated with the handle. Called just before
-     * destroying the handle.
-     */
-    void (*hdrop)(struct shim_handle* hdl);
 
     /* lock and unlock the file */
     int (*lock)(const char* trim_name);
@@ -898,6 +886,7 @@ extern struct shim_fs socket_builtin_fs;
 extern struct shim_fs epoll_builtin_fs;
 extern struct shim_fs eventfd_builtin_fs;
 extern struct shim_fs synthetic_builtin_fs;
+extern struct shim_fs path_builtin_fs;
 
 struct shim_fs* find_fs(const char* name);
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -39,6 +39,7 @@ enum shim_handle_type {
     TYPE_PSEUDO,     /* pseudo nodes (currently directories), handled by `pseudo_*` functions */
     TYPE_TMPFS,      /* string-based files (with data inside dentry), used by `tmpfs` filesystem */
     TYPE_SYNTHETIC,  /* synthetic files, used by `synthetic` filesystem */
+    TYPE_PATH,       /* path to a file (the file is not actually opened) */
 
     /* Pipes and sockets: */
     TYPE_PIPE,       /* pipes, used by `pipe` filesystem */

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -243,4 +243,8 @@ struct shim_lock {
 #define EPOLLNVAL ((uint32_t)0x00000020)
 #endif
 
+#ifndef O_ASYNC
+#define O_ASYNC 020000
+#endif
+
 #endif /* _SHIM_TYPES_H_ */

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -503,9 +503,6 @@ void put_handle(struct shim_handle* hdl) {
             hdl->info.sock.peek_buffer = NULL;
         }
 
-        if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->hdrop)
-            hdl->fs->fs_ops->hdrop(hdl);
-
         free(hdl->uri);
 
         if (hdl->pal_handle) {

--- a/LibOS/shim/src/fs/chroot/encrypted.c
+++ b/LibOS/shim/src/fs/chroot/encrypted.c
@@ -384,16 +384,18 @@ static int chroot_encrypted_flush(struct shim_handle* hdl) {
     return ret;
 }
 
-static void chroot_encrypted_hdrop(struct shim_handle* hdl) {
+static int chroot_encrypted_close(struct shim_handle* hdl) {
     assert(hdl->type == TYPE_CHROOT_ENCRYPTED);
     if (hdl->inode->type != S_IFREG)
-        return;
+        return 0;
 
     struct shim_encrypted_file* enc = hdl->inode->data;
 
     lock(&hdl->inode->lock);
     encrypted_file_put(enc);
     unlock(&hdl->inode->lock);
+
+    return 0;
 }
 
 static ssize_t chroot_encrypted_read(struct shim_handle* hdl, void* buf, size_t count,
@@ -473,7 +475,7 @@ struct shim_fs_ops chroot_encrypted_fs_ops = {
     .hstat      = &generic_inode_hstat,
     .truncate   = &chroot_encrypted_truncate,
     .poll       = &generic_inode_poll,
-    .hdrop      = &chroot_encrypted_hdrop,
+    .close      = &chroot_encrypted_close,
     .checkpoint = &chroot_encrypted_checkpoint,
     .migrate    = &chroot_encrypted_migrate,
     .mmap       = &generic_emulated_mmap,

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -131,7 +131,7 @@ static ssize_t pipe_write(struct shim_handle* hdl, const void* buf, size_t count
 }
 
 static int pipe_hstat(struct shim_handle* hdl, struct stat* stat) {
-    /* XXX: Is any of this right?
+    /* XXX: DOES THIS WORK LOL
      * Shouldn't we be using hdl to figure something out?
      * if stat is NULL, should we not return -EFAULT?
      */

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -30,6 +30,7 @@ struct shim_fs* builtin_fs[] = {
     &eventfd_builtin_fs,
     &pseudo_builtin_fs,
     &synthetic_builtin_fs,
+    &path_builtin_fs,
 };
 
 static struct shim_lock mount_mgr_lock;

--- a/LibOS/shim/src/fs/shim_fs_path.c
+++ b/LibOS/shim/src/fs/shim_fs_path.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+
+#include "shim_fs.h"
+
+static int hstat(struct shim_handle* handle, struct stat* buf) {
+    if (!handle->inode) {
+        return -EINVAL;
+    }
+    return generic_inode_hstat(handle, buf);
+}
+
+static struct shim_fs_ops path_fs_ops = {
+    .hstat = hstat,
+};
+
+static struct shim_d_ops path_d_ops = {};
+
+struct shim_fs path_builtin_fs = {
+    .name = "path",
+    .fs_ops = &path_fs_ops,
+    .d_ops = &path_d_ops,
+};

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -445,13 +445,31 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
 
     ret = path_lookupat(start, path, lookup_flags, &dent);
     if (ret < 0)
-        goto err;
+        goto out;
+
+    if (flags & O_PATH) {
+        if (!dent->inode) {
+            ret = -ENOENT;
+            goto out;
+        }
+
+        assoc_handle_with_dentry(hdl, dent, flags);
+        if (dent->inode->type == S_IFDIR) {
+            hdl->is_dir = true;
+            hdl->dir_info.dents = NULL;
+        }
+
+        hdl->type = TYPE_PATH;
+        hdl->fs = &path_builtin_fs;
+        ret = 0;
+        goto out;
+    }
 
     if (dent->inode && dent->inode->type == S_IFDIR) {
         if (flags & O_WRONLY || flags & O_RDWR ||
                 ((flags & O_CREAT) && !(flags & O_DIRECTORY) && !(flags & O_EXCL))) {
             ret = -EISDIR;
-            goto err;
+            goto out;
         }
     }
 
@@ -459,18 +477,16 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
         /*
          * Can happen if user specified O_NOFOLLOW, or O_TRUNC | O_EXCL. Posix requires us to fail
          * with -ELOOP when trying to open a symlink.
-         *
-         * (Linux allows opening a symlink with O_PATH, but Gramine does not support it yet).
          */
         ret = -ELOOP;
-        goto err;
+        goto out;
     }
 
     bool need_open = true;
     if (!dent->inode) {
         if (!(flags & O_CREAT)) {
             ret = -ENOENT;
-            goto err;
+            goto out;
         }
 
         /* Check the parent permission first */
@@ -478,7 +494,7 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
         if (dir) {
             ret = check_permissions(dir, MAY_WRITE | MAY_EXEC);
             if (ret < 0)
-                goto err;
+                goto out;
         }
 
         struct shim_fs* fs = dent->mount->fs;
@@ -487,19 +503,19 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
         if (flags & O_DIRECTORY) {
             if (!fs->d_ops->mkdir) {
                 ret = -EINVAL;
-                goto err;
+                goto out;
             }
             ret = fs->d_ops->mkdir(dent, mode & ~S_IFMT);
             if (ret < 0)
-                goto err;
+                goto out;
         } else {
             if (!fs->d_ops->creat) {
                 ret = -EINVAL;
-                goto err;
+                goto out;
             }
             ret = fs->d_ops->creat(hdl, dent, flags, mode & ~S_IFMT);
             if (ret < 0)
-                goto err;
+                goto out;
             assoc_handle_with_dentry(hdl, dent, flags);
             need_open = false;
         }
@@ -507,36 +523,37 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
         /* The file exists. This is not permitted if both O_CREAT and O_EXCL are set. */
         if ((flags & O_CREAT) && (flags & O_EXCL)) {
             ret = -EEXIST;
-            goto err;
+            goto out;
         }
 
         /* Check permissions. Note that we do it only if the file already exists: a newly created
          * file is allowed to have a mode that's incompatible with `acc_mode`. */
         ret = check_permissions(dent, acc_mode);
         if (ret < 0)
-            goto err;
+            goto out;
     }
 
     if (hdl && need_open) {
         ret = dentry_open(hdl, dent, flags);
         if (ret < 0)
-            goto err;
+            goto out;
     }
 
+    ret = 0;
+
+out:
     if (found) {
-        *found = dent;
-    } else {
-        put_dentry(dent);
+        if (ret == 0) {
+            assert(dent);
+            get_dentry(dent);
+            *found = dent;
+        } else {
+            *found = NULL;
+        }
     }
-    unlock(&g_dcache_lock);
-    return 0;
 
-err:
     if (dent)
         put_dentry(dent);
-
-    if (found)
-        *found = NULL;
 
     unlock(&g_dcache_lock);
     return ret;
@@ -727,7 +744,7 @@ int get_dirfd_dentry(int dirfd, struct shim_dentry** dir) {
         return -EBADF;
     }
 
-    if (!hdl->is_dir) {
+    if (!hdl->is_dir && hdl->type != TYPE_PATH) {
         put_handle(hdl);
         return -ENOTDIR;
     }

--- a/LibOS/shim/src/meson.build
+++ b/LibOS/shim/src/meson.build
@@ -31,6 +31,7 @@ libos_sources = files(
     'fs/shim_fs_hash.c',
     'fs/shim_fs_lock.c',
     'fs/shim_fs_mem.c',
+    'fs/shim_fs_path.c',
     'fs/shim_fs_pseudo.c',
     'fs/shim_fs_synthetic.c',
     'fs/shim_fs_util.c',

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -106,8 +106,13 @@ long shim_do_creat(const char* path, mode_t mode) {
 }
 
 long shim_do_openat(int dfd, const char* filename, int flags, int mode) {
+    /* Clear invalid flags. */
+    flags &= O_ACCMODE | O_APPEND | O_ASYNC | O_CLOEXEC | O_CREAT | O_DIRECT | O_DIRECTORY | O_DSYNC
+             | O_EXCL | O_LARGEFILE | O_NOATIME | O_NOCTTY | O_NOFOLLOW | O_NONBLOCK | O_PATH
+             | O_SYNC | O_TMPFILE | O_TRUNC;
+
     if (flags & O_PATH) {
-        return -EINVAL;
+        flags &= O_PATH | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW;
     }
 
     if (!is_user_string_readable(filename))

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -265,15 +265,15 @@ skip = yes
 [execve05]
 skip = yes
 
-# copy child
+# execveat not implemented
 [execveat01]
 skip = yes
 
-# copy child
+# execveat not implemented
 [execveat02]
 skip = yes
 
-# copy child
+# execveat not implemented
 [execveat03]
 skip = yes
 
@@ -1283,7 +1283,7 @@ skip = yes
 [open12]
 skip = yes
 
-# Requires touch() support
+# Requires `utime*` syscall support
 [open13]
 skip = yes
 

--- a/LibOS/shim/test/regression/common.h
+++ b/LibOS/shim/test/regression/common.h
@@ -6,10 +6,20 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
+#include "err.h"
+
 #define OVERFLOWS(type, val)                        \
     ({                                              \
         type __dummy;                               \
         __builtin_add_overflow((val), 0, &__dummy); \
     })
+
+#define CHECK(x) ({                                     \
+    __typeof__(x) _x = (x);                             \
+    if (_x == -1) {                                     \
+        err(1, "error at %s (line %d)", #x, __LINE__);  \
+    }                                                   \
+    _x;                                                 \
+})
 
 #endif /* COMMON_H_ */

--- a/LibOS/shim/test/regression/epoll_test.c
+++ b/LibOS/shim/test/regression/epoll_test.c
@@ -7,13 +7,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define CHECK(x) ({                             \
-    __typeof__(x) _x = (x);                     \
-    if (_x == -1) {                             \
-        err(1, "error at line %d", __LINE__);   \
-    }                                           \
-    _x;                                         \
-})
+#include "common.h"
 
 #define ERR(msg, args...) \
     errx(1, "%d: " msg, __LINE__, ##args)

--- a/LibOS/shim/test/regression/meson.build
+++ b/LibOS/shim/test/regression/meson.build
@@ -63,6 +63,7 @@ tests = {
     'mprotect_file_fork': {},
     'mprotect_prot_growsdown': {},
     'multi_pthread': {},
+    'open_opath': {},
     'openmp': {
         # NOTE: This will use `libgomp` in GCC and `libomp` in Clang.
         'c_args': '-fopenmp',

--- a/LibOS/shim/test/regression/open_opath.c
+++ b/LibOS/shim/test/regression/open_opath.c
@@ -1,0 +1,55 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "rw_file.h"
+
+static char g_expected_buf[] = "XXXXX";
+
+static void check_file_contents(const char* path) {
+    char buf[sizeof(g_expected_buf) * 2];
+    ssize_t got = CHECK(posix_file_read(path, buf, sizeof(buf)));
+    if (got != sizeof(g_expected_buf)) {
+        errx(1, "short read from file \"%s\" - got %zd, expected %zu", path, got,
+             sizeof(g_expected_buf));
+    }
+    if (memcmp(buf, g_expected_buf, sizeof(g_expected_buf))) {
+        errx(1, "got unexpected data");
+    }
+}
+
+static void write_expected_to_file(int dir_fd, const char* path) {
+    int fd = CHECK(openat(dir_fd, path, O_WRONLY | O_CREAT | O_EXCL, 0777));
+    ssize_t got = CHECK(posix_fd_write(fd, g_expected_buf, sizeof(g_expected_buf)));
+    if (got != sizeof(g_expected_buf)) {
+        errx(1, "short write from file \"%s\" - got %zd, expected %zu", path, got,
+             sizeof(g_expected_buf));
+    }
+    CHECK(close(fd));
+}
+
+int main(void) {
+    int root_fd = CHECK(open("/", O_PATH));
+    int mnt_dir_fd = CHECK(openat(root_fd, "mnt", O_PATH | O_DIRECTORY | O_NOFOLLOW));
+    CHECK(close(root_fd));
+
+    /* Test a file on Gramine built-in tmpfs. */
+    write_expected_to_file(mnt_dir_fd, "tmpfs/A");
+    check_file_contents("/mnt/tmpfs/A");
+    /* File inside built-in tmpfs, no need to remove it. */
+
+    /* Test a file on host fs. */
+    write_expected_to_file(mnt_dir_fd, "../tmp/B");
+    check_file_contents("/tmp/B");
+
+    CHECK(unlinkat(mnt_dir_fd, "../tmp/B", 0));
+
+    CHECK(close(mnt_dir_fd));
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -937,6 +937,14 @@ class TC_40_FileSystem(RegressionTestCase):
         stdout, _ = self.run_binary(['proc_path'])
         self.assertIn('proc path test success', stdout)
 
+    def test_011_open_opath(self):
+        try:
+            stdout, _ = self.run_binary(['open_opath'])
+        finally:
+            if os.path.exists("tmp/B"):
+                os.remove("tmp/B")
+        self.assertIn('TEST OK', stdout)
+
     def test_020_cpuinfo(self):
         stdout, _ = self.run_binary(['proc_cpuinfo'])
 

--- a/LibOS/shim/test/regression/tests.toml
+++ b/LibOS/shim/test/regression/tests.toml
@@ -65,6 +65,7 @@ manifests = [
   "mprotect_prot_growsdown",
   "multi_pthread",
   "multi_pthread_exitless",
+  "open_opath",
   "openmp",
   "pipe",
   "pipe_nonblocking",

--- a/LibOS/shim/test/regression/tests_musl.toml
+++ b/LibOS/shim/test/regression/tests_musl.toml
@@ -67,6 +67,7 @@ manifests = [
   "mprotect_prot_growsdown",
   "multi_pthread",
   "multi_pthread_exitless",
+  "open_opath",
   "openmp",
   "pipe",
   "pipe_nonblocking",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
I'm not sure if this doesn't break something - couldn't wrap my head around semantics of some fs operations in Gramine. Hopefully it's all fine...

## How to test this PR? <!-- (if applicable) -->
Added a new test.