### PR TITLE
[LibOS] Do not flush unopened Encrypted File during checkpoint

### DIFF
--- a/LibOS/src/fs/shim_fs_encrypted.c
+++ b/LibOS/src/fs/shim_fs_encrypted.c
@@ -739,9 +739,11 @@ BEGIN_CP_FUNC(encrypted_file) {
     struct shim_encrypted_file* enc = obj;
     struct shim_encrypted_file* new_enc = NULL;
 
-    int ret = encrypted_file_flush(enc);
-    if (ret < 0)
-        return ret;
+    if (enc->pf) {
+        int ret = encrypted_file_flush(enc);
+        if (ret < 0)
+            return ret;
+    }
 
     size_t off = ADD_CP_OFFSET(sizeof(struct shim_encrypted_file));
     new_enc = (struct shim_encrypted_file*)(base + off);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Without this check, the called `encrypted_file_flush(enc)` assumes that the Encrypted File is opened and fails on an assert / with a segfault because it tries to access `enc->pf`.

Kudos to Anees Sahib <anees.a.sahib@intel.com> for root causing the bug.

## How to test this PR? <!-- (if applicable) -->

A manual check looks something like this: add an `"encrypted"` FS mount pointing to some specific encrypted file in the manifest file, then create/use an app that first opens and then closes this encrypted file and then spawns a child process. You'll hit this bug.

We hit it on the PyTorch PPML tutorial. @aneessahib is working on an update to this tutorial, so he found and root caused the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/662)
<!-- Reviewable:end -->
