### PR TITLE
[LibOS,Pal] Do not pass error codes to `DkProcessExit`

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -191,7 +191,7 @@ enum {
             tmp = NEXT_CP_ENTRY();                     \
         if (!tmp) {                                    \
             log_error("cannot find checkpoint entry"); \
-            DkProcessExit(EINVAL);                     \
+            DkProcessExit(1);                          \
         }                                              \
         tmp->cp_val;                                   \
     })
@@ -278,7 +278,7 @@ struct shim_cp_map_entry* get_cp_map_entry(void* map, void* addr, bool create);
         struct shim_cp_map_entry* e = get_cp_map_entry(store->cp_map, obj, true); \
         if (!e) {                                                                 \
             log_error("cannot extend checkpoint map buffer");                     \
-            DkProcessExit(ENOMEM);                                                \
+            DkProcessExit(1);                                                     \
         }                                                                         \
         e->off = (off);                                                           \
     } while (0)

--- a/LibOS/shim/include/shim_sync.h
+++ b/LibOS/shim/include/shim_sync.h
@@ -148,7 +148,7 @@
 #define uthash_fatal(msg)                      \
     do {                                       \
         log_error("uthash error: %s", msg);    \
-        DkProcessExit(ENOMEM);                 \
+        DkProcessExit(1);                      \
     } while (0)
 #include "uthash.h"
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -365,7 +365,7 @@ static int read_environs(const char** envp) {
         int _err = CALL_INIT(func, ##__VA_ARGS__);                           \
         if (_err < 0) {                                                      \
             log_error("Error during shim_init() in " #func " (%d)", _err);   \
-            DkProcessExit(-_err);                                            \
+            DkProcessExit(1);                                                \
         }                                                                    \
     } while (0)
 
@@ -389,7 +389,7 @@ noreturn void* shim_init(int argc, const char** argv, const char** envp) {
 
     if (!IS_POWER_OF_2(ALLOC_ALIGNMENT)) {
         log_error("Error during shim_init(): PAL allocation alignment not a power of 2");
-        DkProcessExit(EINVAL);
+        DkProcessExit(1);
     }
 
     g_manifest_root = g_pal_public_state->manifest_root;
@@ -398,7 +398,7 @@ noreturn void* shim_init(int argc, const char** argv, const char** envp) {
 
     if (!create_lock(&__master_lock)) {
         log_error("Error during shim_init(): failed to allocate __master_lock");
-        DkProcessExit(ENOMEM);
+        DkProcessExit(1);
     }
 
     RUN_INIT(init_vma);

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -265,17 +265,16 @@ int _DkAttestationQuote(const void* user_report_data, size_t user_report_data_si
                         size_t* quote_size);
 int _DkGetSpecialKey(const char* name, void* key, size_t* key_size);
 
-#define INIT_FAIL(exitcode, reason)                                                              \
-    do {                                                                                         \
-        log_error("PAL failed at " __FILE__ ":%s:%u (exitcode = %u, reason=%s)", __FUNCTION__,   \
-                  (unsigned int)__LINE__, (unsigned int)(exitcode), reason);                     \
-        _DkProcessExit(exitcode);                                                                \
+#define INIT_FAIL(msg, ...)                                                         \
+    do {                                                                            \
+        log_error("PAL failed at %s:%d: " msg, __FILE__, __LINE__, ##__VA_ARGS__);  \
+        _DkProcessExit(1);                                                          \
     } while (0)
 
-#define INIT_FAIL_MANIFEST(exitcode, reason)                           \
-    do {                                                               \
-        log_error("PAL failed at parsing the manifest: %s", reason);   \
-        _DkProcessExit(exitcode);                                      \
+#define INIT_FAIL_MANIFEST(reason)                                      \
+    do {                                                                \
+        log_error("PAL failed at parsing the manifest: %s", reason);    \
+        _DkProcessExit(1);                                              \
     } while (0)
 
 void init_slab_mgr(char* mem_pool, size_t mem_pool_size);
@@ -308,7 +307,7 @@ const char* pal_event_name(enum pal_event event);
 #define uthash_fatal(msg)                      \
     do {                                       \
         log_error("uthash error: %s", msg);    \
-        _DkProcessExit(PAL_ERROR_NOMEM);       \
+        _DkProcessExit(1);                     \
     } while (0)
 #include "uthash.h"
 

--- a/Pal/regression/printf_test.c
+++ b/Pal/regression/printf_test.c
@@ -1,10 +1,10 @@
 #include "api.h"
 #include "pal_regression.h"
 
-#define FAIL(code, fmt...) ({   \
-    pal_printf(fmt);            \
-    pal_printf("\n");           \
-    DkProcessExit(code);        \
+#define FAIL(fmt...) ({ \
+    pal_printf(fmt);    \
+    pal_printf("\n");   \
+    DkProcessExit(1);   \
 })
 
 #define TEST(output_str, fmt...) ({                                                                \
@@ -13,11 +13,10 @@
     int x = snprintf(buf, sizeof(buf) - 1,  fmt);                                                  \
     buf[sizeof(buf) - 1] = 0;                                                                      \
     if (x < 0 || (size_t)x != output_len) {                                                        \
-        FAIL(1, "wrong return val at %d, expected %zu, got %d", __LINE__, output_len, x);          \
+        FAIL("wrong return val at %d, expected %zu, got %d", __LINE__, output_len, x);             \
     }                                                                                              \
     if (strcmp(buf, output_str)) {                                                                 \
-        FAIL(1, "wrong output string at %d, expected \"%s\", got \"%s\"", __LINE__, output_str,    \
-                buf);                                                                              \
+        FAIL("wrong output string at %d, expected \"%s\", got \"%s\"", __LINE__, output_str, buf); \
     }                                                                                              \
 })
 
@@ -95,17 +94,17 @@ int main(void) {
     int ret = DkVirtualMemoryAlloc((void**)&ptr, 2 * PAGE_SIZE, PAL_ALLOC_INTERNAL,
                                    PAL_PROT_READ | PAL_PROT_WRITE);
     if (ret < 0) {
-        FAIL(1, "DkVirtualMemoryAlloc failed: %d", ret);
+        FAIL("DkVirtualMemoryAlloc failed: %d", ret);
     }
     ret = DkVirtualMemoryProtect(ptr + PAGE_SIZE, PAGE_SIZE, /*prot=*/0);
     if (ret < 0) {
-        FAIL(1, "DkVirtualMemoryProtect failed: %d", ret);
+        FAIL("DkVirtualMemoryProtect failed: %d", ret);
     }
     memset(ptr + PAGE_SIZE - 7, 'a', 7);
 
     ret = snprintf(ptr, PAGE_SIZE - 8, "%.7s", ptr + PAGE_SIZE - 7);
     if (ret != 7) {
-        FAIL(1, "snprintf at %d returned %d, expected %d", __LINE__, ret, 7);
+        FAIL("snprintf at %d returned %d, expected %d", __LINE__, ret, 7);
     }
 
     pal_printf("TEST OK\n");

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -27,7 +27,7 @@ void DkSetExceptionHandler(pal_event_handler_t handler, enum pal_event event) {
  * functions and by assert.h's assert() defined in the common library. Thus it might be called by
  * any PAL thread. */
 noreturn void pal_abort(void) {
-    _DkProcessExit(ENOTRECOVERABLE);
+    _DkProcessExit(1);
 }
 
 const char* pal_event_name(enum pal_event event) {

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -50,7 +50,7 @@ void init_untrusted_slab_mgr(void) {
 
     untrusted_slabmgr = create_slab_mgr();
     if (!untrusted_slabmgr)
-        INIT_FAIL(PAL_ERROR_NOMEM, "cannot initialize slab manager");
+        INIT_FAIL("cannot initialize slab manager");
 }
 
 void* malloc_untrusted(size_t size) {

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -227,11 +227,11 @@ void signal_setup(bool is_first_process, uintptr_t vdso_start, uintptr_t vdso_en
     if (is_first_process) {
         ret = setup_seccomp(vdso_start, vdso_end);
         if (ret < 0) {
-            INIT_FAIL(PAL_ERROR_DENIED, "Setting up seccomp for inline syscall handling failed");
+            INIT_FAIL("Setting up seccomp for inline syscall handling failed");
         }
     }
 
     return;
 err:
-    INIT_FAIL(-ret, "Cannot setup signal handlers!");
+    INIT_FAIL("Cannot setup signal handlers!: %d", ret);
 }

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -220,22 +220,22 @@ void init_child_process(int parent_stream_fd, PAL_HANDLE* parent_handle, char** 
     ret = read_all(parent_stream_fd, &proc_args, sizeof(proc_args));
     if (ret < 0) {
         ret = unix_to_pal_error(ret);
-        INIT_FAIL(-ret, "communication with parent failed");
+        INIT_FAIL("communication with parent failed: %d", ret);
     }
 
     /* a child must have parent handle and an executable */
     if (!proc_args.parent_data_size)
-        INIT_FAIL(PAL_ERROR_INVAL, "invalid process created");
+        INIT_FAIL("invalid process created");
 
     size_t data_size = proc_args.parent_data_size + proc_args.manifest_data_size;
     char* data = malloc(data_size);
     if (!data)
-        INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
+        INIT_FAIL("Out of memory");
 
     ret = read_all(parent_stream_fd, data, data_size);
     if (ret < 0) {
         ret = unix_to_pal_error(ret);
-        INIT_FAIL(-ret, "communication with parent failed");
+        INIT_FAIL("communication with parent failed: %d", ret);
     }
 
     /* now deserialize the parent_handle */
@@ -243,13 +243,13 @@ void init_child_process(int parent_stream_fd, PAL_HANDLE* parent_handle, char** 
     char* data_iter = data;
     ret = handle_deserialize(&parent, data_iter, proc_args.parent_data_size);
     if (ret < 0)
-        INIT_FAIL(-ret, "cannot deserialize parent process handle");
+        INIT_FAIL("cannot deserialize parent process handle: %d", ret);
     data_iter += proc_args.parent_data_size;
     *parent_handle = parent;
 
     char* manifest = malloc(proc_args.manifest_data_size + 1);
     if (!manifest)
-        INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
+        INIT_FAIL("Out of memory");
     memcpy(manifest, data_iter, proc_args.manifest_data_size);
     manifest[proc_args.manifest_data_size] = '\0';
     data_iter += proc_args.manifest_data_size;

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -67,7 +67,7 @@ static inline void* __malloc(size_t size) {
                                     PAL_PROT_READ | PAL_PROT_WRITE);
     if (ret < 0) {
         log_error("*** Out-of-memory in PAL (try increasing `loader.pal_internal_mem_size`) ***");
-        _DkProcessExit(ENOMEM);
+        _DkProcessExit(1);
     }
 #ifdef ASAN
     asan_poison_region((uintptr_t)addr, ALLOC_ALIGN_UP(size), ASAN_POISON_HEAP_LEFT_REDZONE);
@@ -129,7 +129,7 @@ void init_slab_mgr(char* mem_pool, size_t mem_pool_size) {
 
     g_slab_mgr = create_slab_mgr();
     if (!g_slab_mgr)
-        INIT_FAIL(PAL_ERROR_NOMEM, "cannot initialize slab manager");
+        INIT_FAIL("cannot initialize slab manager");
 }
 
 void* malloc(size_t size) {
@@ -149,7 +149,7 @@ void* malloc(size_t size) {
          * condition and must terminate the current process.
          */
         log_error("******** Out-of-memory in PAL ********");
-        _DkProcessExit(ENOMEM);
+        _DkProcessExit(1);
     }
     return ptr;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
`DkProcessExit` returns the error code to the host, which might expect just {0, 1} values. Also in most cases there is an error message printed before it, explaining what exactly happened.