### PR TITLE
Use `#pragma once` instead of handcrafted header guards

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -95,6 +95,8 @@ Code formatting
 #. ``if``, ``else``, ``do``, ``for``, ``while``, ``switch`` and ``union`` should
    be followed by a space.
 
+#. Use ``#pragma once`` for include guards.
+
 #. Includes should be grouped and then sorted lexicographically. Groups should
    be separated using a |~| single empty line.
 

--- a/LibOS/include/arch/x86_64/gramine_entry_api.h
+++ b/LibOS/include/arch/x86_64/gramine_entry_api.h
@@ -11,6 +11,8 @@
  * GRAMINE_SYSCALL assembly macro.
  */
 
+/* We don't use `#pragma once` here because this header is used by our custom glibc build, and
+ * glibc's codebase and buildsystem is a mess. */
 #ifndef GRAMINE_ENTRY_API_H_
 #define GRAMINE_ENTRY_API_H_
 

--- a/LibOS/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/include/arch/x86_64/shim_internal-arch.h
@@ -1,8 +1,5 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
-#ifndef _SHIM_INTERNAL_ARCH_H_
-#define _SHIM_INTERNAL_ARCH_H_
+#pragma once
 
 #define SHIM_ELF_HOST_MACHINE EM_X86_64
-
-#endif /* _SHIM_INTERNAL_ARCH_H_ */

--- a/LibOS/include/arch/x86_64/shim_syscalls.h
+++ b/LibOS/include/arch/x86_64/shim_syscalls.h
@@ -3,8 +3,7 @@
  *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
  */
 
-#ifndef SHIM_SYSCALLS_H_
-#define SHIM_SYSCALLS_H_
+#pragma once
 
 /* TODO: This is required when building Gramine on systems with older headers. We should actually
  * have our own copy of headers of the kernel we emulate, not from the one which is used on the
@@ -52,5 +51,3 @@
 #ifndef __NR_syscalls
 #define __NR_syscalls 428
 #endif
-
-#endif /* SHIM_SYSCALLS_H_ */

--- a/LibOS/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/include/arch/x86_64/shim_tcb-arch.h
@@ -1,5 +1,4 @@
-#ifndef _SHIM_TCB_ARCH_H_
-#define _SHIM_TCB_ARCH_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -156,5 +155,3 @@ static inline uintptr_t get_tls(void) {
     (void)DkSegmentBaseGet(PAL_SEGMENT_FS, &addr);
     return addr;
 }
-
-#endif /* _SHIM_TCB_ARCH_H_ */

--- a/LibOS/include/arch/x86_64/shim_types-arch.h
+++ b/LibOS/include/arch/x86_64/shim_types-arch.h
@@ -1,5 +1,4 @@
-#ifndef _SHIM_TYPES_ARCH_H_
-#define _SHIM_TYPES_ARCH_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -14,5 +13,3 @@ typedef struct {
 } __sigset_t;
 
 #define RED_ZONE_SIZE 128
-
-#endif /* _SHIM_TYPES_ARCH_H_ */

--- a/LibOS/include/arch/x86_64/shim_vdso-arch.h
+++ b/LibOS/include/arch/x86_64/shim_vdso-arch.h
@@ -1,8 +1,5 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
-#ifndef _SHIM_VDSO_ARCH_H_
-#define _SHIM_VDSO_ARCH_H_
+#pragma once
 
 #define LINUX_VDSO_FILENAME "linux-vdso.so.1"
-
-#endif /* _SHIM_VDSO_ARCH_H_ */

--- a/LibOS/include/shim_checkpoint.h
+++ b/LibOS/include/shim_checkpoint.h
@@ -5,8 +5,7 @@
  * This file contains definitions and macros for checkpointing.
  */
 
-#ifndef _SHIM_CHECKPOINT_H_
-#define _SHIM_CHECKPOINT_H_
+#pragma once
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -373,5 +372,3 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
  * \returns 0 on success, negative POSIX error code on failure.
  */
 int receive_checkpoint_and_restore(struct checkpoint_hdr* hdr);
-
-#endif /* _SHIM_CHECKPOINT_H_ */

--- a/LibOS/include/shim_context.h
+++ b/LibOS/include/shim_context.h
@@ -4,11 +4,8 @@
  * This file contains definitions for CPU context.
  */
 
-#ifndef _SHIM_CONTEXT_H_
-#define _SHIM_CONTEXT_H_
+#pragma once
 
 void shim_xstate_init(void);
 uint64_t shim_xstate_size(void);
 void shim_xstate_restore(const void* xstate_extended);
-
-#endif /* _SHIM_CONTEXT_H_ */

--- a/LibOS/include/shim_defs.h
+++ b/LibOS/include/shim_defs.h
@@ -1,5 +1,4 @@
-#ifndef _SHIM_DEFS_H_
-#define _SHIM_DEFS_H_
+#pragma once
 
 #include "shim_syscalls.h"
 
@@ -25,5 +24,3 @@
 #define REQUIRED_ELF_AUXV       9  /* number of LibOS-supported vectors */
 #define REQUIRED_ELF_AUXV_SPACE 16 /* extra memory space (in bytes) */
 #define LIBOS_SYSCALL_BOUND __NR_syscalls
-
-#endif /* _SHIM_DEFS_H_ */

--- a/LibOS/include/shim_entry.h
+++ b/LibOS/include/shim_entry.h
@@ -9,8 +9,7 @@
  * The userspace wrappers for these functions are defined in `gramine_entry_api.h`.
  */
 
-#ifndef SHIM_ENTRY_H_
-#define SHIM_ENTRY_H_
+#pragma once
 
 /*!
  * \brief LibOS syscall emulation entrypoint
@@ -27,5 +26,3 @@ void syscalldb(void);
  * in `gramine_entry_api.h`.
  */
 long handle_libos_call(int number, unsigned long arg1, unsigned long arg2);
-
-#endif /* SHIM_ENTRY_H_ */

--- a/LibOS/include/shim_flags_conv.h
+++ b/LibOS/include/shim_flags_conv.h
@@ -11,8 +11,7 @@
  * For Linux-based PALs there is pal_flag_conv.h in Linux-common, mirroring those conversions.
  */
 
-#ifndef SHIM_FLAGS_CONV_H
-#define SHIM_FLAGS_CONV_H
+#pragma once
 
 #include <asm/fcntl.h>
 #include <linux/fcntl.h>
@@ -57,5 +56,3 @@ static inline pal_stream_options_t LINUX_OPEN_FLAGS_TO_PAL_OPTIONS(int flags) {
     return (flags & O_CLOEXEC  ? PAL_OPTION_CLOEXEC  : 0) |
            (flags & O_NONBLOCK ? PAL_OPTION_NONBLOCK : 0);
 }
-
-#endif /* SHIM_FLAGS_CONV_H */

--- a/LibOS/include/shim_fs.h
+++ b/LibOS/include/shim_fs.h
@@ -5,8 +5,7 @@
  * Definitions of types and functions for file system bookkeeping.
  */
 
-#ifndef _SHIM_FS_H_
-#define _SHIM_FS_H_
+#pragma once
 
 #include <asm/stat.h>
 #include <stdbool.h>
@@ -958,5 +957,3 @@ int chroot_dentry_uri(struct shim_dentry* dent, mode_t type, char** out_uri);
 
 int chroot_readdir(struct shim_dentry* dent, readdir_callback_t callback, void* arg);
 int chroot_unlink(struct shim_dentry* dent);
-
-#endif /* _SHIM_FS_H_ */

--- a/LibOS/include/shim_fs_encrypted.h
+++ b/LibOS/include/shim_fs_encrypted.h
@@ -10,8 +10,7 @@
  * NOTE: There is currently no notion of file permissions, all files are open in read-write mode.
  */
 
-#ifndef SHIM_FS_ENCRYPTED_
-#define SHIM_FS_ENCRYPTED_
+#pragma once
 
 #include <stddef.h>
 
@@ -175,5 +174,3 @@ int parse_pf_key(const char* key_str, pf_key_t* pf_key);
 
 /* TODO: This function is used only by a feature deprecated in v1.2, remove two versions later. */
 int dump_pf_key(const pf_key_t* pf_key, char* buf, size_t buf_size);
-
-#endif /* SHIM_FS_ENCRYPTED_ */

--- a/LibOS/include/shim_fs_lock.h
+++ b/LibOS/include/shim_fs_lock.h
@@ -7,9 +7,7 @@
  * File locks. Currently only POSIX locks are implemented.
  */
 
-#ifndef SHIM_FS_LOCK_H_
-#define SHIM_FS_LOCK_H_
-
+#pragma once
 
 #include <stdbool.h>
 
@@ -124,5 +122,3 @@ int posix_lock_set_from_ipc(const char* path, struct posix_lock* pl, bool wait, 
  * send the returned value and `out_pl` in an IPC response.
  */
 int posix_lock_get_from_ipc(const char* path, struct posix_lock* pl, struct posix_lock* out_pl);
-
-#endif /* SHIM_FS_LOCK_H_ */

--- a/LibOS/include/shim_fs_mem.h
+++ b/LibOS/include/shim_fs_mem.h
@@ -8,8 +8,7 @@
  * pseudo-FSes and the `tmpfs` filesystem.
  */
 
-#ifndef SHIM_FS_MEM_
-#define SHIM_FS_MEM_
+#pragma once
 
 #include "shim_types.h"
 
@@ -32,5 +31,3 @@ ssize_t mem_file_write(struct shim_mem_file* mem, file_off_t pos_start, const vo
                        size_t size);
 int mem_file_truncate(struct shim_mem_file* mem, file_off_t size);
 int mem_file_poll(struct shim_mem_file* mem, file_off_t pos, int poll_type);
-
-#endif /* SHIM_FS_MEM_ */

--- a/LibOS/include/shim_fs_proc.h
+++ b/LibOS/include/shim_fs_proc.h
@@ -3,8 +3,7 @@
  * Copyright (C) 2022 IBM Corporation
  */
 
-#ifndef SHIM_PROC_H_
-#define SHIM_PROC_H_
+#pragma once
 
 int print_to_str(char** str, size_t off, size_t* size, const char* fmt, ...);
 
@@ -16,5 +15,3 @@ int proc_cpuinfo_display_cpu(char** str, size_t* size, size_t* max,
 
 int proc_cpuinfo_display_tail(char** str, size_t* size, size_t* max,
                               const struct pal_cpu_info* cpu);
-
-#endif /* SHIM_PROC_H_ */

--- a/LibOS/include/shim_fs_pseudo.h
+++ b/LibOS/include/shim_fs_pseudo.h
@@ -29,8 +29,7 @@
  * handles.
  */
 
-#ifndef SHIM_FS_PSEUDO_H_
-#define SHIM_FS_PSEUDO_H_
+#pragma once
 
 #include "list.h"
 #include "perm.h"
@@ -256,5 +255,3 @@ int sys_print_as_ranges(char* buf, size_t buf_size, size_t count,
 int sys_print_as_bitmask(char* buf, size_t buf_size, size_t count,
                          bool (*is_present)(size_t ind, const void* arg),
                          const void* callback_arg);
-
-#endif /* SHIM_FS_PSEUDO_H_ */

--- a/LibOS/include/shim_handle.h
+++ b/LibOS/include/shim_handle.h
@@ -5,8 +5,7 @@
  * Definitions of types and functions for file/handle bookkeeping.
  */
 
-#ifndef _SHIM_HANDLE_H_
-#define _SHIM_HANDLE_H_
+#pragma once
 
 #include <asm/fcntl.h>
 #include <asm/resource.h>
@@ -283,5 +282,3 @@ int get_file_size(struct shim_handle* file, uint64_t* size);
 
 ssize_t do_handle_read(struct shim_handle* hdl, void* buf, size_t count);
 ssize_t do_handle_write(struct shim_handle* hdl, const void* buf, size_t count);
-
-#endif /* _SHIM_HANDLE_H_ */

--- a/LibOS/include/shim_internal.h
+++ b/LibOS/include/shim_internal.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef _SHIM_INTERNAL_H_
-#define _SHIM_INTERNAL_H_
+#pragma once
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -297,5 +296,3 @@ int init_stack(const char** argv, const char** envp, const char*** out_argp, elf
  * The implementation of this function depends on the used architecture.
  */
 noreturn void call_elf_entry(elf_addr_t entry, void* argp);
-
-#endif /* _SHIM_INTERNAL_H_ */

--- a/LibOS/include/shim_ipc.h
+++ b/LibOS/include/shim_ipc.h
@@ -4,8 +4,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef SHIM_IPC_H_
-#define SHIM_IPC_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -307,5 +306,3 @@ int ipc_posix_lock_clear_pid(IDTYPE pid);
 int ipc_posix_lock_set_callback(IDTYPE src, void* data, unsigned long seq);
 int ipc_posix_lock_get_callback(IDTYPE src, void* data, unsigned long seq);
 int ipc_posix_lock_clear_pid_callback(IDTYPE src, void* data, unsigned long seq);
-
-#endif /* SHIM_IPC_H_ */

--- a/LibOS/include/shim_lock.h
+++ b/LibOS/include/shim_lock.h
@@ -4,8 +4,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef SHIM_LOCK_H_
-#define SHIM_LOCK_H_
+#pragma once
 
 #include <stdbool.h>
 
@@ -111,5 +110,3 @@ static inline bool create_lock_runtime(struct shim_lock* l) {
 
     return ret;
 }
-
-#endif // SHIM_LOCK_H_

--- a/LibOS/include/shim_pollable_event.h
+++ b/LibOS/include/shim_pollable_event.h
@@ -2,8 +2,7 @@
 /* Copyright (C) 2021 Intel Corporation
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
-#ifndef SHIM_POLLABLE_EVENT_H
-#define SHIM_POLLABLE_EVENT_H
+#pragma once
 
 #include "pal.h"
 #include "spinlock.h"
@@ -27,5 +26,3 @@ int create_pollable_event(struct shim_pollable_event* event);
 void destroy_pollable_event(struct shim_pollable_event* event);
 int set_pollable_event(struct shim_pollable_event* event);
 int clear_pollable_event(struct shim_pollable_event* event);
-
-#endif // SHIM_POLLABLE_EVENT_H

--- a/LibOS/include/shim_process.h
+++ b/LibOS/include/shim_process.h
@@ -2,8 +2,7 @@
 /* Copyright (C) 2020 Intel Corporation
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
-#ifndef _SHIM_PROCESS_H
-#define _SHIM_PROCESS_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -95,5 +94,3 @@ bool mark_child_exited_by_pid(IDTYPE pid, IDTYPE child_uid, int exit_code, int s
  * Returns `true` if the process \p pid is found in the zombie list of `g_process`.
  */
 bool is_zombie_process(IDTYPE pid);
-
-#endif // _SHIM_PROCESS_H

--- a/LibOS/include/shim_signal.h
+++ b/LibOS/include/shim_signal.h
@@ -1,5 +1,4 @@
-#ifndef _SHIM_SIGNAL_H_
-#define _SHIM_SIGNAL_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -181,5 +180,3 @@ void fill_siginfo_code_and_status(siginfo_t* info, int signal, int exit_code);
 bool is_eintr_like(int ret);
 
 int do_nanosleep(uint64_t timeout_us, struct __kernel_timespec* rem);
-
-#endif /* _SHIM_SIGNAL_H_ */

--- a/LibOS/include/shim_socket.h
+++ b/LibOS/include/shim_socket.h
@@ -3,6 +3,8 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
+#pragma once
+
 #include "linux_socket.h"
 #include "shim_handle.h"
 

--- a/LibOS/include/shim_sync.h
+++ b/LibOS/include/shim_sync.h
@@ -136,8 +136,7 @@
  *   fine-grained locking
  */
 
-#ifndef SHIM_SYNC_H_
-#define SHIM_SYNC_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -269,5 +268,3 @@ void sync_client_message_callback(int code, uint64_t id, int state, size_t data_
 void sync_server_message_callback(IDTYPE src, int code, uint64_t id, int state,
                                   size_t data_size, void* data);
 void sync_server_disconnect_callback(IDTYPE src);
-
-#endif /* SHIM_SYNC_H_ */

--- a/LibOS/include/shim_table.h
+++ b/LibOS/include/shim_table.h
@@ -5,8 +5,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef _SHIM_TABLE_H_
-#define _SHIM_TABLE_H_
+#pragma once
 
 #if defined(__i386__) || defined(__x86_64__)
 #include <asm/ldt.h>
@@ -217,5 +216,3 @@ long shim_do_sysinfo(struct sysinfo* info);
 #else /* __x86_64__ */
 #error "Unsupported platform"
 #endif
-
-#endif /* _SHIM_TABLE_H_ */

--- a/LibOS/include/shim_tcb.h
+++ b/LibOS/include/shim_tcb.h
@@ -1,5 +1,4 @@
-#ifndef _SHIM_TCB_H_
-#define _SHIM_TCB_H_
+#pragma once
 
 #include "api.h"
 #include "assert.h"
@@ -56,5 +55,3 @@ static inline void shim_tcb_init(void) {
 static inline shim_tcb_t* shim_get_tcb(void) {
     return SHIM_TCB_GET(self);
 }
-
-#endif /* _SHIM_H_ */

--- a/LibOS/include/shim_thread.h
+++ b/LibOS/include/shim_thread.h
@@ -3,8 +3,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef _SHIM_THREAD_H_
-#define _SHIM_THREAD_H_
+#pragma once
 
 #include <linux/futex.h>
 #include <linux/signal.h>
@@ -334,5 +333,3 @@ noreturn void process_exit(int error_code, int term_signal);
 
 void release_robust_list(struct robust_list_head* head);
 void release_clear_child_tid(int* clear_child_tid);
-
-#endif /* _SHIM_THREAD_H_ */

--- a/LibOS/include/shim_types.h
+++ b/LibOS/include/shim_types.h
@@ -1,5 +1,4 @@
-#ifndef _SHIM_TYPES_H_
-#define _SHIM_TYPES_H_
+#pragma once
 
 #include <limits.h>
 #include <stdbool.h>
@@ -179,5 +178,3 @@ struct shim_lock {
 /* This is not defined in the older kernels e.g. the default kernel on Ubuntu 18.04. */
 #define EPOLLNVAL ((uint32_t)0x00000020)
 #endif
-
-#endif /* _SHIM_TYPES_H_ */

--- a/LibOS/include/shim_utils.h
+++ b/LibOS/include/shim_utils.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef _SHIM_UTILS_H_
-#define _SHIM_UTILS_H_
+#pragma once
 
 #include "api.h"
 #include "pal.h"
@@ -70,5 +69,3 @@ int write_exact(PAL_HANDLE handle, void* buf, size_t size);
 static inline uint64_t timespec_to_us(const struct __kernel_timespec* ts) {
     return ts->tv_sec * TIME_US_IN_S + ts->tv_nsec / TIME_NS_IN_US;
 }
-
-#endif /* _SHIM_UTILS_H */

--- a/LibOS/include/shim_vdso.h
+++ b/LibOS/include/shim_vdso.h
@@ -5,10 +5,7 @@
  *                               <isaku.yamahata at gmail.com>
  */
 
-#ifndef _SHIM_VDSO_H_
-#define _SHIM_VDSO_H_
+#pragma once
 
 extern const uint8_t vdso_so[];
 extern const size_t vdso_so_size;
-
-#endif /* _SHIM_VDSO_H_ */

--- a/LibOS/include/shim_vma.h
+++ b/LibOS/include/shim_vma.h
@@ -7,8 +7,7 @@
  * Definitions of types and functions for VMA bookkeeping.
  */
 
-#ifndef _SHIM_VMA_H_
-#define _SHIM_VMA_H_
+#pragma once
 
 #include <linux/mman.h>
 #include <stdbool.h>
@@ -131,5 +130,3 @@ int msync_range(uintptr_t begin, uintptr_t end);
 int msync_handle(struct shim_handle* hdl);
 
 void debug_print_all_vmas(void);
-
-#endif /* _SHIM_VMA_H_ */

--- a/LibOS/src/vdso/arch/x86_64/vdso.h
+++ b/LibOS/src/vdso/arch/x86_64/vdso.h
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
-#ifndef _SHIM_VDSO_X86_64_H_
-#define _SHIM_VDSO_X86_64_H_
+#pragma once
 
 #include "shim_types.h"
 
@@ -9,5 +8,3 @@ int __vdso_clock_gettime(clockid_t clock, struct timespec* t);
 int __vdso_gettimeofday(struct timeval* tv, struct timezone* tz);
 time_t __vdso_time(time_t* t);
 long __vdso_getcpu(unsigned* cpu, struct getcpu_cache* unused);
-
-#endif /* _SHIM_VDSO_X86_64_H_ */

--- a/LibOS/src/vdso/arch/x86_64/vdso_syscall.h
+++ b/LibOS/src/vdso/arch/x86_64/vdso_syscall.h
@@ -2,8 +2,7 @@
 /* Copyright (C) 2020 Intel Corporation
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
-#ifndef VDSO_SYSCALL_H_
-#define VDSO_SYSCALL_H_
+#pragma once
 
 #include "gramine_entry_api.h"
 
@@ -23,5 +22,3 @@ static inline long vdso_arch_syscall(long nr, long arg1, long arg2) {
     );
     return ret;
 }
-
-#endif // VDSO_SYSCALL_H_

--- a/LibOS/test/fs/common.h
+++ b/LibOS/test/fs/common.h
@@ -1,5 +1,4 @@
-#ifndef COMMON_H
-#define COMMON_H
+#pragma once
 
 #define _GNU_SOURCE
 #include <assert.h>
@@ -51,5 +50,3 @@ void* alloc_buffer(size_t size);
 void fill_random(void* buffer, size_t size);
 
 void copy_data(int fi, int fo, const char* input_path, const char* output_path, size_t size);
-
-#endif

--- a/LibOS/test/regression/common.h
+++ b/LibOS/test/regression/common.h
@@ -4,8 +4,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef COMMON_H_
-#define COMMON_H_
+#pragma once
 
 #include <assert.h>
 #include <err.h>
@@ -31,5 +30,3 @@
     static_assert(IS_STATIC_ARRAY(arr), "not a static array");  \
     sizeof(arr) / sizeof(arr[0]);                               \
 })
-
-#endif /* COMMON_H_ */

--- a/LibOS/test/regression/dump.h
+++ b/LibOS/test/regression/dump.h
@@ -3,8 +3,7 @@
  *                    Paweł Marczewski <pawel@invisiblethingslab.com>
  */
 
-#ifndef DUMP_H_
-#define DUMP_H_
+#pragma once
 
 /*
  * Dumps the whole directory tree, displaying link targets and file contents. In addition to
@@ -26,5 +25,3 @@
  *     dir/dir2/link: link: /link/target
  */
 int dump_path(const char* path);
-
-#endif /* DUMP_H_ */

--- a/LibOS/test/regression/futex.h
+++ b/LibOS/test/regression/futex.h
@@ -3,8 +3,7 @@
  * out and sparse annotations removed. Unfortunately we cannot use the host header, because we build
  * tests both against glibc and musl - on glibc based systems (like Ubuntu) musl cannot use it, due
  * to its location together with glibc headers. */
-#ifndef _UAPI_LINUX_FUTEX_H
-#define _UAPI_LINUX_FUTEX_H
+#pragma once
 
 /* Not seem to be needed. */
 //#include <linux/compiler.h>
@@ -154,5 +153,3 @@ struct robust_list_head {
 #define FUTEX_OP(op, oparg, cmp, cmparg) \
   (((op & 0xf) << 28) | ((cmp & 0xf) << 24)		\
    | ((oparg & 0xfff) << 12) | (cmparg & 0xfff))
-
-#endif /* _UAPI_LINUX_FUTEX_H */

--- a/LibOS/test/regression/rw_file.h
+++ b/LibOS/test/regression/rw_file.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2021 Intel Corporation */
 
-#ifndef RW_FILE_H_
-#define RW_FILE_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -29,5 +28,3 @@ ssize_t posix_fd_write(int fd, const char* buf, size_t count);
 /* Reads/writes at most `count` bytes into/from buffer `buf`. Uses stdio functions: fread/fwrite. */
 ssize_t stdio_fd_read(FILE* f, char* buf, size_t count);
 ssize_t stdio_fd_write(FILE* f, const char* buf, size_t count);
-
-#endif /* RW_FILE_H_ */

--- a/Pal/include/arch/x86_64/Linux-SGX/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux-SGX/pal_host-arch.h
@@ -4,8 +4,7 @@
  * This file contains Linux-SGX-specific functions related to the PAL.
  */
 
-#ifndef __LINUX_SGX_X86_64_PAL_HOST_ARCH_H__
-#define __LINUX_SGX_X86_64_PAL_HOST_ARCH_H__
+#pragma once
 
 /* Linux v5.16 supports Intel AMX. To enable this feature, Linux added several XSTATE-related
  * arch_prctl() commands. To support Gramine on older Linux kernels, we explicitly define
@@ -14,5 +13,3 @@
 #ifndef ARCH_REQ_XCOMP_PERM
 #define ARCH_REQ_XCOMP_PERM 0x1023
 #endif
-
-#endif /* __LINUX_SGX_X86_64_PAL_HOST_ARCH_H__ */

--- a/Pal/include/arch/x86_64/Linux-SGX/sigcontext.h
+++ b/Pal/include/arch/x86_64/Linux-SGX/sigcontext.h
@@ -4,9 +4,6 @@
  * Linux-SGX PAL uses Linux's sigcontext.h
  */
 
-#ifndef _LINUX_SGX_SIGCONTEXT_H
-#define _LINUX_SGX_SIGCONTEXT_H
+#pragma once
 
 #include "Linux/sigcontext.h"
-
-#endif /* _LINUX_SGX_SIGCONTEXT_H */

--- a/Pal/include/arch/x86_64/Linux-SGX/ucontext.h
+++ b/Pal/include/arch/x86_64/Linux-SGX/ucontext.h
@@ -4,9 +4,6 @@
  * Linux-SGX PAL uses Linux's ucontext.h
  */
 
-#ifndef _LINUX_SGX_UCONTEXT_H
-#define _LINUX_SGX_UCONTEXT_H
+#pragma once
 
 #include "Linux/ucontext.h"
-
-#endif /* _LINUX_SGX_UCONTEXT_H */

--- a/Pal/include/arch/x86_64/Linux/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux/pal_host-arch.h
@@ -4,8 +4,7 @@
  * This file contains Linux on x86_64 specific functions related to the PAL.
  */
 
-#ifndef __LINUX_X86_64_PAL_HOST_ARCH_H__
-#define __LINUX_X86_64_PAL_HOST_ARCH_H__
+#pragma once
 
 #ifdef IN_PAL
 
@@ -34,5 +33,3 @@ static inline int pal_set_tcb(PAL_TCB* tcb) {
 }
 
 #endif /* IN_PAL */
-
-#endif /* __LINUX_X86_64_PAL_HOST_ARCH_H__ */

--- a/Pal/include/arch/x86_64/Linux/sigcontext.h
+++ b/Pal/include/arch/x86_64/Linux/sigcontext.h
@@ -16,8 +16,7 @@
    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
    02111-1307 USA.  */
 
-#ifndef _LINUX_X86_64_BITS_SIGCONTEXT_H
-#define _LINUX_X86_64_BITS_SIGCONTEXT_H 1
+#pragma once
 
 #include <bits/wordsize.h>
 #include <stdint.h>
@@ -143,5 +142,3 @@ struct sigcontext {
 };
 
 #endif /* __WORDSIZE == 64 */
-
-#endif /* _LINUX_X86_64_BITS_SIGCONTEXT_H */

--- a/Pal/include/arch/x86_64/Linux/sigreturn.h
+++ b/Pal/include/arch/x86_64/Linux/sigreturn.h
@@ -1,3 +1,5 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
+#pragma once
+
 void syscall_rt_sigreturn(void);

--- a/Pal/include/arch/x86_64/Linux/sigset.h
+++ b/Pal/include/arch/x86_64/Linux/sigset.h
@@ -1,5 +1,4 @@
-#ifndef __LINUX_X86_64_SIGSET_H__
-#define __LINUX_X86_64_SIGSET_H__
+#pragma once
 
 /* __sig_atomic_t, __sigset_t, and related definitions.  Linux version.
    Copyright (C) 1991, 1992, 1994, 1996, 1997, 2007
@@ -86,5 +85,3 @@ __SIGSETFN(__sigaddset, ((__set->__val[__word] |= __mask), 0), )
 __SIGSETFN(__sigdelset, ((__set->__val[__word] &= ~__mask), 0), )
 
 #undef __SIGSETFN
-
-#endif /* __LINUX_X86_64_SIGSET_H__  */

--- a/Pal/include/arch/x86_64/Linux/ucontext.h
+++ b/Pal/include/arch/x86_64/Linux/ucontext.h
@@ -2,8 +2,7 @@
 /* Copyright (C) 2021 Intel Corporation
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
-#ifndef LINUX_X86_64_UCONTEXT_H_
-#define LINUX_X86_64_UCONTEXT_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -113,5 +112,3 @@ static inline void ucontext_revert_syscall(ucontext_t* uc, unsigned int arch, in
     assert(rip[0] == 0x0f && rip[1] == 0x05);
     __UNUSED(rip);
 }
-
-#endif /* LINUX_X86_64_UCONTEXT_H_ */

--- a/Pal/include/arch/x86_64/Skeleton/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Skeleton/pal_host-arch.h
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
+#pragma once
+
 /*
  * This file contains Skeleton-specific functions related to the PAL.
  */

--- a/Pal/include/arch/x86_64/Skeleton/sigcontext.h
+++ b/Pal/include/arch/x86_64/Skeleton/sigcontext.h
@@ -1,6 +1,3 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
-#ifndef _SKELETON_SIGCONTEXT_H
-#define _SKELETON_SIGCONTEXT_H
-
-#endif /* _SKELETON_SIGCONTEXT_H */
+#pragma once

--- a/Pal/include/arch/x86_64/Skeleton/ucontext.h
+++ b/Pal/include/arch/x86_64/Skeleton/ucontext.h
@@ -1,12 +1,8 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
+#pragma once
+
 /*
  * Skeleton uses Linux's ucontext.h (for now)
  */
-
-#ifndef _SKELETON_UCONTEXT_H
-#define _SKELETON_UCONTEXT_H
-
 #include "Linux/ucontext.h"
-
-#endif /* _SKELETON_UCONTEXT_H */

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -8,13 +8,12 @@
  * This file contains definition of x86_64-specific aspects of PAL.
  */
 
-#ifndef PAL_H
+#ifndef INSIDE_PAL_H
 // TODO: fix this
 #error This header is usable only inside pal.h (due to a cyclic dependency).
 #endif
 
-#ifndef PAL_ARCH_H
-#define PAL_ARCH_H
+#pragma once
 
 #include <assert.h>
 #include <stdint.h>
@@ -275,5 +274,3 @@ static inline void pal_context_copy(PAL_CONTEXT* dst, PAL_CONTEXT* src) {
         dst->fpcw = src->fpregs->fpstate.cwd;
     }
 }
-
-#endif /* PAL_ARCH_H */

--- a/Pal/include/arch/x86_64/pal_internal-arch.h
+++ b/Pal/include/arch/x86_64/pal_internal-arch.h
@@ -3,8 +3,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef PAL_INTERNAL_ARCH_H_
-#define PAL_INTERNAL_ARCH_H_
+#pragma once
 
 #include "assert.h"
 
@@ -21,5 +20,3 @@
         : "ri"(page_size), "c"(size / page_size)    \
         : "memory", "cc", "rdx"                     \
     )
-
-#endif // PAL_INTERNAL_ARCH_H_

--- a/Pal/include/arch/x86_64/pal_topology.h
+++ b/Pal/include/arch/x86_64/pal_topology.h
@@ -4,8 +4,7 @@
  *                    Vijay Dhanraj <vijay.dhanraj@intel.com>
  */
 
-#ifndef PAL_TOPOLOGY_H
-#define PAL_TOPOLOGY_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -115,5 +114,3 @@ struct pal_topo_info {
      * numa_distance_matrix[i*numa_nodes_cnt + j] is NUMA distance from node i to node j. */
     size_t* numa_distance_matrix;
 };
-
-#endif /* PAL_TOPOLOGY_H */

--- a/Pal/include/elf/elf.h
+++ b/Pal/include/elf/elf.h
@@ -18,8 +18,7 @@
    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
    02111-1307 USA.  */
 
-#ifndef _ELF_H
-#define _ELF_H 1
+#pragma once
 
 #include <features.h>
 #include <stdint.h>
@@ -2664,5 +2663,3 @@ typedef ElfW(Word)   elf_word_t;
 typedef ElfW(Xword)  elf_xword_t;
 
 __END_DECLS
-
-#endif /* elf.h */

--- a/Pal/include/host/Linux-common/debug_map.h
+++ b/Pal/include/host/Linux-common/debug_map.h
@@ -10,8 +10,7 @@
  * maintained in an "outer" binary instead of the main PAL binary.
  */
 
-#ifndef DEBUG_MAP_H
-#define DEBUG_MAP_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -41,5 +40,3 @@ int debug_map_init_from_proc_maps(void);
 /* Try to describe code location. Looks up the right debug map, and runs `addr2line` in a
  * subprocess. */
 int debug_describe_location(uintptr_t addr, char* buf, size_t buf_size);
-
-#endif /* DEBUG_MAP_H */

--- a/Pal/include/host/Linux-common/linux_utils.h
+++ b/Pal/include/host/Linux-common/linux_utils.h
@@ -1,5 +1,4 @@
-#ifndef _LINUX_UTILS_H
-#define _LINUX_UTILS_H
+#pragma once
 
 #include <linux/time.h>
 #include <linux/un.h>
@@ -45,5 +44,3 @@ int64_t time_ns_diff_from_now(struct timespec* ts);
 
 int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
                                  struct sockaddr_un* out_addr);
-
-#endif // _LINUX_UTILS_H

--- a/Pal/include/host/Linux-common/pal_flags_conv.h
+++ b/Pal/include/host/Linux-common/pal_flags_conv.h
@@ -11,8 +11,7 @@
  * The counterpart of this file is shim_flag_conv.h in LibOS.
  */
 
-#ifndef PAL_FLAGS_CONV_H
-#define PAL_FLAGS_CONV_H
+#pragma once
 
 #include <asm/fcntl.h>
 #include <linux/mman.h>
@@ -68,5 +67,3 @@ static inline int PAL_OPTION_TO_LINUX_OPEN(pal_stream_options_t options) {
     return (options & PAL_OPTION_CLOEXEC  ? O_CLOEXEC  : 0) |
            (options & PAL_OPTION_NONBLOCK ? O_NONBLOCK : 0);
 }
-
-#endif /* PAL_FLAGS_CONV_H */

--- a/Pal/include/host/Linux-common/syscall.h
+++ b/Pal/include/host/Linux-common/syscall.h
@@ -1,5 +1,4 @@
-#ifndef SYSCALL_H_
-#define SYSCALL_H_
+#pragma once
 
 #include <asm/unistd.h>
 #include <stdint.h>
@@ -35,5 +34,3 @@ noreturn void _DkThreadExit_asm_stub(uint32_t* thread_stack_spinlock, int* clear
 #define IS_PTR_ERR(val) ((unsigned long)(val) >= -4095UL)
 #define PTR_TO_ERR(val) ((long)(val))
 #define IS_UNIX_ERR(val) ((val) >= -133 /* EHWPOISON */ && (val) <= -1 /* EPERM */)
-
-#endif // SYSCALL_H_

--- a/Pal/include/host/Linux-common/topo_info.h
+++ b/Pal/include/host/Linux-common/topo_info.h
@@ -3,8 +3,7 @@
  *                    Vijay Dhanraj <vijay.dhanraj@intel.com>
  */
 
-#ifndef TOPO_INFO_H_
-#define TOPO_INFO_H_
+#pragma once
 
 #include "pal.h"
 
@@ -15,5 +14,3 @@ ssize_t read_file_buffer(const char* filename, char* buf, size_t count);
 
 /* Fills topo_info with CPU and NUMA topology from the host */
 int get_topology_info(struct pal_topo_info* topo_info);
-
-#endif // TOPO_INFO_H_

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -6,14 +6,16 @@
  * \brief This file contains definition of PAL host ABI.
  */
 
-#ifndef PAL_H
-#define PAL_H
+#pragma once
 
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdnoreturn.h>
+
+// TODO: fix this (but see Pal/include/arch/x86_64/pal-arch.h)
+#define INSIDE_PAL_H
 
 #if defined(__i386__) || defined(__x86_64__)
 #include "cpu.h"
@@ -926,4 +928,4 @@ void DkDebugMapRemove(void* start_addr);
  * DEBUG, falls back to raw value ("0x1234"). */
 void DkDebugDescribeLocation(uintptr_t addr, char* buf, size_t buf_size);
 
-#endif /* PAL_H */
+#undef INSIDE_PAL_H

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -5,8 +5,7 @@
  * This file contains definitions of functions, variables and data structures for internal uses.
  */
 
-#ifndef PAL_INTERNAL_H
-#define PAL_INTERNAL_H
+#pragma once
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -315,5 +314,3 @@ const char* pal_event_name(enum pal_event event);
 /* Size of PAL memory available before parsing the manifest; `loader.pal_internal_mem_size` does not
  * include this memory */
 #define PAL_INITIAL_MEM_SIZE (64 * 1024 * 1024)
-
-#endif

--- a/Pal/include/pal_rtld.h
+++ b/Pal/include/pal_rtld.h
@@ -3,8 +3,7 @@
  * Copyright (C) 2021 Intel Labs
  */
 
-#ifndef PAL_RTLD_H
-#define PAL_RTLD_H
+#pragma once
 
 #include <endian.h>
 
@@ -60,5 +59,3 @@ int find_string_and_symbol_tables(elf_addr_t ehdr_addr, elf_addr_t base_addr,
                                   uint32_t* out_symbol_table_cnt);
 
 noreturn void start_execution(const char** arguments, const char** environs);
-
-#endif /* PAL_RTLD_H */

--- a/Pal/regression/pal_regression.h
+++ b/Pal/regression/pal_regression.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2021 Intel Corporation */
 
-#ifndef PAL_REGRESSION_H
-#define PAL_REGRESSION_H
+#pragma once
 
 #include "pal.h"
 
@@ -17,5 +16,3 @@ void __attribute__((format(printf, 2, 3))) _log(int level, const char* fmt, ...)
     }                                                                   \
     _x;                                                                 \
 })
-
-#endif /* PAL_REGRESSION_H */

--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2020 Intel Corporation */
 
-#ifndef ECALL_TYPES_H
-#define ECALL_TYPES_H
+#pragma once
 
 #include <stddef.h>
 
@@ -31,5 +30,3 @@ typedef struct {
 
     struct rpc_queue*  rpc_queue; /* pointer to RPC queue in untrusted mem */
 } ms_ecall_enclave_start_t;
-
-#endif /* ECALL_TYPES_H */

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.h
@@ -1,8 +1,5 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
-#ifndef _ENCLAVE_ECALLS_H_
-#define _ENCLAVE_ECALLS_H_
+#pragma once
 
 void handle_ecall(long ecall_index, void* ecall_args, void* exit_target, void* enclave_base_addr);
-
-#endif /* _ENCLAVE_ECALLS_H_ */

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -2,6 +2,8 @@
  * This is for enclave to make ocalls to untrusted runtime.
  */
 
+#pragma once
+
 #include <asm/stat.h>
 #include <linux/poll.h>
 #include <linux/socket.h>

--- a/Pal/src/host/Linux-SGX/enclave_pages.h
+++ b/Pal/src/host/Linux-SGX/enclave_pages.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdbool.h>
 #include <stddef.h>
 

--- a/Pal/src/host/Linux-SGX/enclave_tf.h
+++ b/Pal/src/host/Linux-SGX/enclave_tf.h
@@ -16,8 +16,7 @@
 
 /* TODO: Move trusted/allowed files implementation into a separate file (`enclave_tf.c`?) */
 
-#ifndef ENCLAVE_TF_H_
-#define ENCLAVE_TF_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -79,5 +78,3 @@ int copy_and_verify_trusted_file(const char* path, uint8_t* buf, const void* ume
 
 int init_trusted_files(void);
 int init_allowed_files(void);
-
-#endif /* ENCLAVE_TF_H_ */

--- a/Pal/src/host/Linux-SGX/enclave_tf_structs.h
+++ b/Pal/src/host/Linux-SGX/enclave_tf_structs.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2021 Intel Corporation */
 
-#ifndef ENCLAVE_TF_STRUCTS_H_
-#define ENCLAVE_TF_STRUCTS_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -38,5 +37,3 @@ struct trusted_file {
     size_t uri_len;
     char uri[]; /* must be NULL-terminated */
 };
-
-#endif /* ENCLAVE_TF_STRUCTS_H_ */

--- a/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.h
+++ b/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdint.h>
 
 #define MAX_DBG_THREADS 1024

--- a/Pal/src/host/Linux-SGX/gsgx.h.in
+++ b/Pal/src/host/Linux-SGX/gsgx.h.in
@@ -3,8 +3,7 @@
  *                    Dmitrii Kuvaiskii <dmitrii.kuvaiskii@intel.com>
  */
 
-#ifndef __ARCH_GSGX_H__
-#define __ARCH_GSGX_H__
+#pragma once
 
 #ifndef __packed
 #define __packed __attribute__((packed))
@@ -60,5 +59,3 @@
 #ifndef SGX_INVALID_LICENSE
 #define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
 #endif
-
-#endif /* __ARCH_GSGX_H__ */

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -1,5 +1,4 @@
-#ifndef LINUX_TYPES_H
-#define LINUX_TYPES_H
+#pragma once
 
 #include <asm/fcntl.h>
 #include <asm/posix_types.h>
@@ -61,5 +60,3 @@ struct cmsghdr {
 #define CMSG_ALIGN(len) ALIGN_UP(len, sizeof(size_t))
 #define CMSG_SPACE(len) (CMSG_ALIGN(len) + CMSG_ALIGN(sizeof(struct cmsghdr)))
 #define CMSG_LEN(len)   (CMSG_ALIGN(sizeof(struct cmsghdr)) + (len))
-
-#endif /* LINUX_TYPES_H */

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2020 Intel Corporation */
 
-#ifndef OCALL_TYPES_H
-#define OCALL_TYPES_H
+#pragma once
 
 /*
  * These structures are used in trusted -> untrusted world calls (OCALLS).
@@ -331,5 +330,3 @@ typedef struct {
 } ms_ocall_get_quote_t;
 
 #pragma pack(pop)
-
-#endif /* OCALL_TYPES_H */

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -5,8 +5,7 @@
  * This file contains definition of PAL host ABI.
  */
 
-#ifndef PAL_HOST_H
-#define PAL_HOST_H
+#pragma once
 
 #ifndef IN_PAL
 #error "cannot be included outside PAL"
@@ -152,5 +151,3 @@ typedef struct {
 #define PAL_HANDLE_FD_WRITABLE  2
 /* Set if an error was seen on this handle. Currently only set by `_DkStreamsWaitEvents`. */
 #define PAL_HANDLE_FD_ERROR     4
-
-#endif /* PAL_HOST_H */

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef PAL_LINUX_H
-#define PAL_LINUX_H
+#pragma once
 
 #include <asm/mman.h>
 #include <linux/mman.h>
@@ -203,5 +202,3 @@ int _DkStreamSecureSave(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t** obuf, size_t* 
 void fixup_socket_handle_after_deserialization(PAL_HANDLE handle);
 
 #endif /* IN_ENCLAVE */
-
-#endif /* PAL_LINUX_H */

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -1,5 +1,4 @@
-#ifndef PAL_LINUX_DEFS_H
-#define PAL_LINUX_DEFS_H
+#pragma once
 
 #define SSA_FRAME_NUM  2 /* one frame for normal context, one frame for signal preparation */
 
@@ -29,5 +28,3 @@
 
 #define MAX_ARGS_SIZE 10000000
 #define MAX_ENV_SIZE  10000000
-
-#endif /* PAL_LINUX_DEFS_H */

--- a/Pal/src/host/Linux-SGX/pal_linux_error.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_error.h
@@ -1,5 +1,4 @@
-#ifndef PAL_LINUX_ERROR_H
-#define PAL_LINUX_ERROR_H
+#pragma once
 
 #ifdef IN_PAL
 
@@ -68,5 +67,3 @@ static __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
 }
 
 #endif /* IN_PAL */
-
-#endif /* PAL_LINUX_ERROR_H */

--- a/Pal/src/host/Linux-SGX/rpc_queue.h
+++ b/Pal/src/host/Linux-SGX/rpc_queue.h
@@ -37,8 +37,7 @@
  *
  * Prototype code was written by Meni Orenbach and adapted to Gramine by Dmitrii Kuvaiskii.
  */
-#ifndef QUEUE_H_
-#define QUEUE_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -148,5 +147,3 @@ out:
     spinlock_unlock(&q->lock);
     return ret;
 }
-
-#endif /* QUEUE_H_ */

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef SGX_API_H
-#define SGX_API_H
+#pragma once
 
 #include "sgx_arch.h"
 
@@ -38,5 +37,3 @@ int sgx_report(const sgx_target_info_t* targetinfo, const void* reportdata, sgx_
  * Caller is responsible for parameter alignment: 512B for `keyrequest` and 16B for `key`.
  */
 int64_t sgx_getkey(sgx_key_request_t* keyrequest, sgx_key_128bit_t* key);
-
-#endif /* SGX_API_H */

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef SGX_ARCH_H
-#define SGX_ARCH_H
+#pragma once
 
 #define RED_ZONE_SIZE 128
 
@@ -435,4 +434,3 @@ typedef uint8_t sgx_key_128bit_t[16];
 #define RFLAGS_AC (1 << 18)
 
 #pragma pack(pop)
-#endif /* SGX_ARCH_H */

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2017, Texas A&M University */
 
-#ifndef SGX_ATTEST_H
-#define SGX_ATTEST_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -94,5 +93,3 @@ int sgx_get_quote(const sgx_spid_t* spid, const sgx_quote_nonce_t* nonce,
                   size_t* quote_len);
 
 #pragma pack(pop)
-
-#endif /* SGX_ATTEST_H */

--- a/Pal/src/host/Linux-SGX/sgx_enclave.h
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stddef.h>
 
 #include "sgx_arch.h"

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -5,8 +5,7 @@
  * This file contains definitions of functions, variables and data structures for internal uses.
  */
 
-#ifndef SGX_INTERNAL_H
-#define SGX_INTERNAL_H
+#pragma once
 
 #include <sys/syscall.h>
 
@@ -188,5 +187,3 @@ int pd_event_sample_simple(struct perf_data* pd, uint64_t ip, uint32_t pid, uint
 /* Write PERF_RECORD_SAMPLE (with stack sample, at most PD_STACK_SIZE bytes) */
 int pd_event_sample_stack(struct perf_data* pd,  uint64_t ip, uint32_t pid, uint32_t tid,
                           uint64_t period, sgx_pal_gpr_t* gpr, void* stack, size_t stack_size);
-
-#endif

--- a/Pal/src/host/Linux-SGX/sgx_log.h
+++ b/Pal/src/host/Linux-SGX/sgx_log.h
@@ -8,8 +8,7 @@
  * initialized) should output at the level and to the file specified in manifest.
  */
 
-#ifndef SGX_LOG_H_
-#define SGX_LOG_H_
+#pragma once
 
 extern int g_urts_log_level;
 extern int g_urts_log_fd;
@@ -19,5 +18,3 @@ int urts_log_init(const char* path);
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
 void pal_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-
-#endif /* SGX_LOG_H_ */

--- a/Pal/src/host/Linux-SGX/sgx_process.h
+++ b/Pal/src/host/Linux-SGX/sgx_process.h
@@ -3,11 +3,8 @@
  *                    Wojtek Porczyk <woju@invisiblethingslab.com>
  */
 
-#ifndef SGX_PROCESS_H
-#define SGX_PROCESS_H
+#pragma once
 
 #include <stddef.h>
 
 int sgx_create_process(size_t nargs, const char** args, const char* manifest, int* out_stream_fd);
-
-#endif /* SGX_PROCESS_H */

--- a/Pal/src/host/Linux-SGX/sgx_syscall.h
+++ b/Pal/src/host/Linux-SGX/sgx_syscall.h
@@ -1,5 +1,4 @@
-#ifndef SGX_SYSCALL_H_
-#define SGX_SYSCALL_H_
+#pragma once
 
 #include "syscall.h"
 
@@ -9,5 +8,3 @@ void do_syscall_intr_after_check2(void);
 void do_syscall_intr_eintr(void);
 
 #define DO_SYSCALL_INTERRUPTIBLE(name, args...) do_syscall_intr(__NR_##name, ##args)
-
-#endif // SGX_SYSCALL_H_

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -1,5 +1,4 @@
-#ifndef __SGX_TLS_H__
-#define __SGX_TLS_H__
+#pragma once
 
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -122,5 +121,3 @@ static inline PAL_TCB_URTS* get_tcb_urts(void) {
 extern bool g_sgx_enable_stats;
 void update_and_print_stats(bool process_wide);
 #endif /* IN_ENCLAVE */
-
-#endif /* __SGX_TLS_H__ */

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.h
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.h
@@ -3,8 +3,7 @@
  *                    Rafal Wojdyla <omeg@invisiblethingslab.com>
  */
 
-#ifndef ATTESTATION_H
-#define ATTESTATION_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -76,5 +75,3 @@ int verify_quote_body(const sgx_quote_body_t* quote_body, const char* mr_signer,
  *  \return 0 on successful verification, negative value on error.
  */
 int verify_quote_body_enclave_attributes(sgx_quote_body_t* quote_body, bool allow_debug_enclave);
-
-#endif /* ATTESTATION_H */

--- a/Pal/src/host/Linux-SGX/tools/common/ias.h
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.h
@@ -3,8 +3,7 @@
  *                    Rafal Wojdyla <omeg@invisiblethingslab.com>
  */
 
-#ifndef _IAS_H
-#define _IAS_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -91,4 +90,3 @@ int ias_verify_quote_raw(struct ias_context_t* context, const void* quote, size_
                          const char* nonce, char** report_data_ptr, size_t* report_data_size,
                          char** sig_data_ptr, size_t* sig_data_size, char** cert_data_ptr,
                          size_t* cert_data_size);
-#endif /* _IAS_H */

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.h
@@ -3,8 +3,7 @@
  *                    Rafal Wojdyla <omeg@invisiblethingslab.com>
  */
 
-#ifndef PF_UTIL_H
-#define PF_UTIL_H
+#pragma once
 
 #include "protected_files.h"
 
@@ -46,5 +45,3 @@ pf_status_t mbedtls_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv, cons
 
 /*! Load PF wrap key from file */
 int load_wrap_key(const char* wrap_key_path, pf_key_t* wrap_key);
-
-#endif

--- a/Pal/src/host/Linux-SGX/tools/common/util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/util.h
@@ -3,8 +3,7 @@
  *                    Rafal Wojdyla <omeg@invisiblethingslab.com>
  */
 
-#ifndef UTIL_H
-#define UTIL_H
+#pragma once
 
 #define _GNU_SOURCE
 
@@ -102,5 +101,3 @@ void hexdump_mem(const void* data, size_t size);
  *  \details Unless the string contains exactly 2 * buffer_size hexdigits, an error will be raised.
  */
 int parse_hex(const char* hex, void* buffer, size_t buffer_size, const char* mask);
-
-#endif /* UTIL_H */

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls.h
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2020 Intel Labs */
 
+#pragma once
+
 #include <mbedtls/x509_crt.h>
 #include <stdint.h>
 

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov.h
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2020 Intel Labs */
 
+#pragma once
+
 #include <stdint.h>
 
 /* envvars for client (attester) */

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -5,8 +5,7 @@
  * This file contains definition of PAL host ABI.
  */
 
-#ifndef PAL_HOST_H
-#define PAL_HOST_H
+#pragma once
 
 #ifndef IN_PAL
 #error "cannot be included outside PAL"
@@ -124,5 +123,3 @@ typedef struct {
 int arch_do_rt_sigprocmask(int sig, int how);
 int arch_do_rt_sigaction(int sig, void* handler,
                          const int* async_signals, size_t async_signals_cnt);
-
-#endif /* PAL_HOST_H */

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef PAL_LINUX_H
-#define PAL_LINUX_H
+#pragma once
 
 #include <asm/fcntl.h>
 #include <asm/stat.h>
@@ -127,5 +126,3 @@ struct linux_dirent64 {
 #define DT_WHT     14
 
 #define DIRBUF_SIZE 1024
-
-#endif /* PAL_LINUX_H */

--- a/Pal/src/host/Linux/pal_linux_defs.h
+++ b/Pal/src/host/Linux/pal_linux_defs.h
@@ -1,10 +1,7 @@
-#ifndef PAL_LINUX_DEFS_H
-#define PAL_LINUX_DEFS_H
+#pragma once
 
 /* mmap minimum address cannot start at zero (modern OSes do not allow this) */
 #define MMAP_MIN_ADDR 0x10000
 
 #define THREAD_STACK_SIZE (PRESET_PAGESIZE * 16) /* 64KB user stack */
 #define ALT_STACK_SIZE    (PRESET_PAGESIZE * 16) /* 64KB signal stack */
-
-#endif /* PAL_LINUX_DEFS_H */

--- a/Pal/src/host/Linux/pal_linux_error.h
+++ b/Pal/src/host/Linux/pal_linux_error.h
@@ -1,5 +1,4 @@
-#ifndef PAL_LINUX_ERROR_H
-#define PAL_LINUX_ERROR_H
+#pragma once
 
 #ifdef IN_PAL
 
@@ -68,5 +67,3 @@ static __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
 }
 
 #endif /* IN_PAL */
-
-#endif /* PAL_LINUX_ERROR_H */

--- a/Pal/src/host/Skeleton/pal_host.h
+++ b/Pal/src/host/Skeleton/pal_host.h
@@ -5,8 +5,7 @@
  * This file contains definition of PAL host ABI.
  */
 
-#ifndef PAL_HOST_H
-#define PAL_HOST_H
+#pragma once
 
 #ifndef IN_PAL
 #error "cannot be included outside PAL"
@@ -36,5 +35,3 @@ typedef struct {
      * implementation.
      */
 }* PAL_HANDLE;
-
-#endif /* PAL_HOST_H */

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -1,13 +1,14 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
-#ifndef API_H
-#define API_H
+#pragma once
 
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#define INSIDE_API_H
 
 #ifdef USE_STDLIB
 #include <assert.h>
@@ -445,4 +446,4 @@ static inline bool access_ok(const volatile void* addr, size_t size) {
 # include "api_fortified.h"
 #endif
 
-#endif /* API_H */
+#undef INSIDE_API_H

--- a/common/include/api_fortified.h
+++ b/common/include/api_fortified.h
@@ -28,10 +28,9 @@
  *     #include "api.h"
  */
 
-#ifndef _API_FORTIFIED_H_
-#define _API_FORTIFIED_H_
+#pragma once
 
-#ifndef API_H
+#ifndef INSIDE_API_H
 # error This file should only be included inside api.h.
 #endif
 
@@ -52,6 +51,3 @@
 
 #define snprintf(buf, buf_size, fmt...) \
     __builtin___snprintf_chk(buf, buf_size, __USE_FORTIFY_LEVEL - 1, __api_bos(buf), fmt)
-
-
-#endif /* _API_FORTIFIED_H_ */

--- a/common/include/arch/x86_64/cpu.h
+++ b/common/include/arch/x86_64/cpu.h
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
-#ifndef CPU_H
-#define CPU_H
+#pragma once
 
 #include <stdint.h>
 #include <stdnoreturn.h>
@@ -102,5 +101,3 @@ static inline noreturn void die_or_inf_loop(void) {
 #define MB()  __asm__ __volatile__("mfence" ::: "memory")
 #define RMB() __asm__ __volatile__("lfence" ::: "memory")
 #define WMB() __asm__ __volatile__("sfence" ::: "memory")
-
-#endif /* CPU_H */

--- a/common/include/asan.h
+++ b/common/include/asan.h
@@ -87,8 +87,7 @@
  * Note that we rely on the fact that no Gramine code runs on the user stack.
  */
 
-#ifndef ASAN_H_
-#define ASAN_H_
+#pragma once
 
 /* All ASan code should be guarded by `#ifdef ASAN`. */
 #ifdef ASAN
@@ -273,5 +272,3 @@ void* __asan_memset(void *s, int c, size_t n);
 void* __asan_memmove(void* dest, const void* src, size_t n);
 
 #endif /* ASAN */
-
-#endif /* ASAN_H */

--- a/common/include/assert.h
+++ b/common/include/assert.h
@@ -5,8 +5,7 @@
  * Define a common interface for assertions that builds for both the PAL and libOS.
  */
 
-#ifndef ASSERT_H
-#define ASSERT_H
+#pragma once
 
 #include "callbacks.h"
 #include "log.h"
@@ -30,5 +29,3 @@
 #else
 #define assert(expr) ((void)0)
 #endif
-
-#endif /* ASSERT_H */

--- a/common/include/atomic.h
+++ b/common/include/atomic.h
@@ -1,5 +1,4 @@
-#ifndef _ATOMIC_H_
-#define _ATOMIC_H_
+#pragma once
 
 /* Copyright (C) 2014 Stony Brook University
  * Copyright (C) 2017 Fortanix Inc, and University of North Carolina at Chapel Hill.
@@ -48,5 +47,3 @@ struct atomic_int {
 };
 
 #define ATOMIC_INIT(i)      { (i) }
-
-#endif /* _ATOMIC_H_ */

--- a/common/include/avl_tree.h
+++ b/common/include/avl_tree.h
@@ -1,5 +1,4 @@
-#ifndef AVL_TREE_H
-#define AVL_TREE_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -96,5 +95,3 @@ struct avl_tree_node* avl_tree_lower_bound_fn(struct avl_tree* tree, void* cmp_a
 struct avl_tree_node* avl_tree_lower_bound(struct avl_tree* tree, struct avl_tree_node* cmp_arg);
 
 bool debug_avl_tree_is_balanced(struct avl_tree* tree);
-
-#endif // AVL_TREE_H

--- a/common/include/callbacks.h
+++ b/common/include/callbacks.h
@@ -17,8 +17,7 @@
  * `describe_location`.
  */
 
-#ifndef COMMON_CALLBACKS_H
-#define COMMON_CALLBACKS_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -68,5 +67,3 @@ void describe_location(uintptr_t addr, char* buf, size_t buf_size);
 /* This is the default implementation of `describe_location`, and returns only the raw value
  * ("0x1234"). Your implementation might call it when it fails to determine more information. */
 void default_describe_location(uintptr_t addr, char* buf, size_t buf_size);
-
-#endif /* COMMON_CALLBACKS_H */

--- a/common/include/crypto.h
+++ b/common/include/crypto.h
@@ -7,8 +7,7 @@
  * by providing a small crypto library adaptor implementing these methods.
  */
 
-#ifndef CRYPTO_H
-#define CRYPTO_H
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -108,5 +107,3 @@ int lib_SSLHandshake(LIB_SSL_CONTEXT* ssl_ctx);
 int lib_SSLRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t buf_size);
 int lib_SSLWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t buf_size);
 int lib_SSLSave(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t buf_size, size_t* out_size);
-
-#endif /* CRYPTO_H */

--- a/common/include/generated-offsets-build.h
+++ b/common/include/generated-offsets-build.h
@@ -15,8 +15,7 @@
  * as sizes or masks). Consider changing it.
  */
 
-#ifndef GENERATED_OFFSETS_BUILD_H
-#define GENERATED_OFFSETS_BUILD_H
+#pragma once
 
 #include <stdint.h>
 
@@ -34,5 +33,3 @@ extern const char* generated_offsets_name;
 #define OFFSET_T(name, str_t, member) DEFINE(name, offsetof(str_t, member))
 
 #define OFFSET_END { NULL, 0 }
-
-#endif /* GENERATED_OFFSETS_BUILD_H */

--- a/common/include/hex.h
+++ b/common/include/hex.h
@@ -4,8 +4,7 @@
  *               2022 Intel Corporation
  */
 
-#ifndef HEX_H
-#define HEX_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -52,5 +51,3 @@ static inline void* hex2bytes(const char* hex, size_t hex_len, void* bytes, size
 
     return bytes;
 }
-
-#endif // HEX_H

--- a/common/include/init.h
+++ b/common/include/init.h
@@ -3,8 +3,7 @@
  *                    Paweł Marczewski <pawel@invisiblethingslab.com>
  */
 
-#ifndef INIT_H_
-#define INIT_H_
+#pragma once
 
 /*
  * Call the constructors specified in `.init_array`. Should be called during initialization.
@@ -13,5 +12,3 @@
  * Linux-SGX untrusted runtime) should not call this.
  */
 void call_init_array(void);
-
-#endif /* INIT_H_ */

--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -3,8 +3,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#ifndef GRAMINE_LINUX_SOCKET_H
-#define GRAMINE_LINUX_SOCKET_H
+#pragma once
 
 #include <asm/fcntl.h>
 #include <linux/in.h>
@@ -93,5 +92,3 @@ struct linger {
 #define SHUT_RD 0
 #define SHUT_WR 1
 #define SHUT_RDWR 2
-
-#endif /* GRAMINE_LINUX_SOCKET_H */

--- a/common/include/list.h
+++ b/common/include/list.h
@@ -5,8 +5,7 @@
  * This file defines the list API for the PAL and Library OS.
  */
 
-#ifndef LIST_H
-#define LIST_H
+#pragma once
 
 // Use a new list implementation
 
@@ -345,5 +344,3 @@
         LISTP_DEL_INIT(NODE, OLD, FIELD);      \
         LISTP_ADD_TAIL(NODE, NEW, FIELD);      \
     } while (0)
-
-#endif  // LIST_H

--- a/common/include/log.h
+++ b/common/include/log.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2021 Intel Corporation */
 
-#ifndef COMMON_LOG_H
-#define COMMON_LOG_H
+#pragma once
 
 #include "callbacks.h"
 
@@ -21,5 +20,3 @@ enum {
 #define log_warning(fmt...)  _log(LOG_LEVEL_WARNING, fmt)
 #define log_debug(fmt...)    _log(LOG_LEVEL_DEBUG, fmt)
 #define log_trace(fmt...)    _log(LOG_LEVEL_TRACE, fmt)
-
-#endif /* COMMON_LOG_H */

--- a/common/include/memmgr.h
+++ b/common/include/memmgr.h
@@ -5,8 +5,7 @@
  * This file contains implementation of fixed-size memory allocator.
  */
 
-#ifndef MEMMGR_H
-#define MEMMGR_H
+#pragma once
 
 #include <sys/mman.h>
 
@@ -267,5 +266,3 @@ static inline void free_mem_obj_to_mgr(MEM_MGR mgr, OBJ_TYPE* obj) {
     CHECK_LIST_HEAD(MEM_OBJ, &mgr->free_list, __list);
     SYSTEM_UNLOCK();
 }
-
-#endif /* MEMMGR_H */

--- a/common/include/pal_error.h
+++ b/common/include/pal_error.h
@@ -5,8 +5,7 @@
  * This file contains definitions of PAL error codes.
  */
 
-#ifndef PAL_ERROR_H
-#define PAL_ERROR_H
+#pragma once
 
 #include <stddef.h>
 
@@ -62,5 +61,3 @@ typedef enum _pal_error_t {
 
 /* err - value of error code, either positive or negative */
 const char* pal_strerror(int err);
-
-#endif

--- a/common/include/perm.h
+++ b/common/include/perm.h
@@ -8,8 +8,7 @@
  * Inspired by Linux patch by Ingo Molnar (https://lwn.net/Articles/696231/).
  */
 
-#ifndef PERM_H
-#define PERM_H
+#pragma once
 
 #define PERM_r________  0400
 #define PERM_r__r_____  0440
@@ -30,5 +29,3 @@
 #define PERM_rwxr_xr_x  0755
 #define PERM_rwxrwxr_x  0775
 #define PERM_rwxrwxrwx  0777
-
-#endif /* PERM_H */

--- a/common/include/seqlock.h
+++ b/common/include/seqlock.h
@@ -17,8 +17,7 @@
  *     } while (read_seqretry(&foo, seq));
  */
 
-#ifndef _SEQLOCK_H
-#define _SEQLOCK_H
+#pragma once
 
 #include "api.h"
 #include "cpu.h"
@@ -85,5 +84,3 @@ static inline void write_seqend(seqlock_t* sl) {
     __atomic_add_fetch(&sl->sequence, 1, __ATOMIC_RELAXED);
     spinlock_unlock(&sl->lock);
 }
-
-#endif // _SEQLOCK_H

--- a/common/include/slabmgr.h
+++ b/common/include/slabmgr.h
@@ -5,8 +5,7 @@
  * This file contains implementation of SLAB (variable-size) memory allocator.
  */
 
-#ifndef SLABMGR_H
-#define SLABMGR_H
+#pragma once
 
 #include <errno.h>
 #include <sys/mman.h>
@@ -444,5 +443,3 @@ static inline void slab_free(SLAB_MGR mgr, void* obj) {
     LISTP_ADD_TAIL(mobj, &mgr->free_list[level], __list);
     SYSTEM_UNLOCK();
 }
-
-#endif /* SLABMGR_H */

--- a/common/include/socket_utils.h
+++ b/common/include/socket_utils.h
@@ -3,6 +3,8 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
+#pragma once
+
 #include "linux_socket.h"
 
 void pal_to_linux_sockaddr(const struct pal_socket_addr* pal_addr,

--- a/common/include/spinlock.h
+++ b/common/include/spinlock.h
@@ -4,8 +4,7 @@
  *       must ensure that returning prematurely from such a spinlock leads only to DoS and not to
  *       data corruptions. */
 
-#ifndef _SPINLOCK_H
-#define _SPINLOCK_H
+#pragma once
 
 #include "api.h"
 #include "cpu.h"
@@ -186,5 +185,3 @@ static inline bool spinlock_is_locked(spinlock_t* lock) {
 #endif // DEBUG_SPINLOCKS_SHIM
 
 #endif // DEBUG_SPINLOCKS
-
-#endif // _SPINLOCK_H

--- a/common/include/stat.h
+++ b/common/include/stat.h
@@ -7,8 +7,7 @@
  * Linux file type permission macros.
  */
 
-#ifndef STAT_H
-#define STAT_H
+#pragma once
 
 #ifdef S_IFREG
 #error "Do not include <linux/stat.h> or <sys/stat.h> together with this file."
@@ -48,5 +47,3 @@
 #define S_IROTH 00004
 #define S_IWOTH 00002
 #define S_IXOTH 00001
-
-#endif /* STAT_H */

--- a/common/include/toml_utils.h
+++ b/common/include/toml_utils.h
@@ -3,8 +3,7 @@
  *                    Paweł Marczewski <pawel@invisiblethingslab.com>
  */
 
-#ifndef TOML_UTILS_H_
-#define TOML_UTILS_H_
+#pragma once
 
 #include "toml.h"
 
@@ -67,5 +66,3 @@ int toml_string_in(const toml_table_t* root, const char* key, char** retval);
  */
 int toml_sizestring_in(const toml_table_t* root, const char* key, uint64_t defaultval,
                        uint64_t* retval);
-
-#endif /* TOML_UTILS_H_ */

--- a/common/src/crypto/config.h
+++ b/common/src/crypto/config.h
@@ -5,8 +5,7 @@
 
 /* This mbedTLS config is for v2.26.0 and assumes Intel x86-64 CPU with AESNI and SSE2 support */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
+#pragma once
 
 #define MBEDTLS_AESNI_C
 #define MBEDTLS_AES_C
@@ -54,5 +53,3 @@ void free(void*);
 #define MBEDTLS_PLATFORM_STD_CALLOC   calloc
 #define MBEDTLS_PLATFORM_STD_FREE     free
 #define MBEDTLS_PLATFORM_STD_SNPRINTF snprintf
-
-#endif

--- a/common/src/protected_files/lru_cache.h
+++ b/common/src/protected_files/lru_cache.h
@@ -7,8 +7,7 @@
 /* Least-recently used cache, used by the protected file implementation for optimizing
    data and MHT node access */
 
-#ifndef LRU_CACHE_H_
-#define LRU_CACHE_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -30,5 +29,3 @@ void* lruc_get_last(lruc_context_t* context);
 void lruc_remove_last(lruc_context_t* context);
 
 void lruc_test(void);
-
-#endif /* LRU_CACHE_H_ */

--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -6,8 +6,7 @@
 
 /* See README.rst for protected files overview */
 
-#ifndef PROTECTED_FILES_H_
-#define PROTECTED_FILES_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -287,5 +286,3 @@ pf_status_t pf_get_handle(pf_context_t* pf, pf_handle_t* handle);
  * \return PF status
  */
 pf_status_t pf_flush(pf_context_t* pf);
-
-#endif /* PROTECTED_FILES_H_ */

--- a/common/src/protected_files/protected_files_format.h
+++ b/common/src/protected_files/protected_files_format.h
@@ -4,8 +4,7 @@
  * Copyright (C) 2020 Intel Corporation
  */
 
-#ifndef PROTECTED_FILES_FORMAT_H_
-#define PROTECTED_FILES_FORMAT_H_
+#pragma once
 
 #ifdef USE_STDLIB
 #include <assert.h>
@@ -139,6 +138,3 @@ typedef struct {
 } kdf_input_t;
 
 #pragma pack(pop)
-
-#endif /* PROTECTED_FILES_FORMAT_H_ */
-

--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -4,8 +4,7 @@
  * Copyright (C) 2019 Intel Corporation
  */
 
-#ifndef PROTECTED_FILES_INTERNAL_H_
-#define PROTECTED_FILES_INTERNAL_H_
+#pragma once
 
 #include <limits.h>
 
@@ -67,5 +66,3 @@ static size_t ipf_read(pf_context_t* pf, void* ptr, size_t size);
 static size_t ipf_write(pf_context_t* pf, const void* ptr, size_t size);
 static bool ipf_seek(pf_context_t* pf, uint64_t new_offset);
 static void ipf_try_clear_error(pf_context_t* pf);
-
-#endif /* PROTECTED_FILES_INTERNAL_H_ */

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-gramine.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-gramine.h
@@ -8,13 +8,10 @@
  * `mbedtls/config.h`.
  */
 
-#ifndef MBEDTLS_CONFIG_GRAMINE_H_
-#define MBEDTLS_CONFIG_GRAMINE_H_
+#pragma once
 
 #include "mbedtls/config.h"
 
 #define MBEDTLS_CMAC_C
 
 #include "mbedtls/check_config.h"
-
-#endif /* MBEDTLS_CONFIG_GRAMINE_H_ */

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
@@ -5,8 +5,7 @@
 
 /* This mbedTLS config is for v2.26.0 and assumes Intel x86-64 CPU with AESNI and SSE2 support */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
+#pragma once
 
 #define MBEDTLS_AESNI_C
 #define MBEDTLS_AES_C
@@ -56,5 +55,3 @@ void free(void*);
 #define MBEDTLS_PLATFORM_STD_CALLOC   calloc
 #define MBEDTLS_PLATFORM_STD_FREE     free
 #define MBEDTLS_PLATFORM_STD_SNPRINTF snprintf
-
-#endif


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Cons of `#pragma once`:
- not in C standard
- compiler-specific behavior in cases like including the same file through different {soft,hard}links, or multiple copies of the same header in the repo

Pros:
- less boilerplate
- works well in practice
- no need to update it when moving/renaming a header file
- handcrafted header guards are error prone (easy to have non-matching `#ifndef` and `#define`, easy to collide with other file header guards, and especially prone to copy-paste errors)

The cases with {soft,hard}links and using multiple copies of the same headers are rather exotic and we don't ever plan to have them in our codebase.

Overall: `#pragma once` works well in practice and it's much more likely that we'll introduce a bug with handcrafted include guards than with `#pragma once`.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/669)
<!-- Reviewable:end -->
