### PR TITLE
[Pal/Linux-SGX] Allow `CPUID(EAX=0x7, ECX=<any value>)`

### DIFF
--- a/libos/test/regression/cpuid.c
+++ b/libos/test/regression/cpuid.c
@@ -107,6 +107,16 @@ static void test_cpuid_leaf_reserved(void) {
     struct regs r;
     set_dummy_regs(&r);
 
+    cpuid(0x7, 0x2, &r); /* leaf 0x7 returns all-zeros on sub-leaves > 1 */
+    if (r.eax || r.ebx || r.ecx || r.edx)
+        abort();
+    set_dummy_regs(&r);
+
+    cpuid(0x7, 0xFFFF, &r); /* leaf 0x7 returns all-zeros on sub-leaves > 1 */
+    if (r.eax || r.ebx || r.ecx || r.edx)
+        abort();
+    set_dummy_regs(&r);
+
     cpuid(0x8, 0x0, &r); /* subleaf value doesn't matter */
     if (r.eax || r.ebx || r.ecx || r.edx)
         abort();

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -107,6 +107,8 @@ bool is_tsc_usable(void);
 uint64_t get_tsc_hz(void);
 void init_tsc(void);
 
+int init_cpuid(void);
+
 int init_enclave(void);
 void init_untrusted_slab_mgr(void);
 

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -511,6 +511,12 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     init_tsc();
     (void)get_tsc(); /* must be after `ready_for_exceptions=1` since it may generate SIGILL */
 
+    ret = init_cpuid();
+    if (ret < 0) {
+        log_error("init_cpuid failed: %d", ret);
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+
     /* initialize master key (used for pipes' encryption for all enclaves of an application); it
      * will be overwritten below in init_child_process() with inherited-from-parent master key if
      * this enclave is child */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `_DkCpuIdRetrieve()` was too restrictive on the leaf 0x7 (Structured Extended Feature Flags) -- it only allowed sub-leaves 0 and 1. In reality, Intel SDM states the following:

    If ECX contains an invalid sub-leaf index, EAX/EBX/ECX/EDX return 0.
    Sub-leaf index n is invalid if n exceeds the value that sub-leaf 0
    returns in EAX.

This could lead to Gramine erroneously failing with `Unrecognized leaf/subleaf in CPUID`.

Fixes #668.

## How to test this PR? <!-- (if applicable) -->

Added a test case in the `cpuid` LibOS test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/670)
<!-- Reviewable:end -->
