### PR TITLE
[LibOS,PAL] Add flexible device-specific IOCTL support

### DIFF
--- a/.ci/lib/stage-build-sgx-vm.jenkinsfile
+++ b/.ci/lib/stage-build-sgx-vm.jenkinsfile
@@ -9,14 +9,17 @@ stage('build') {
         cd initramfs_builder
         {
            echo '#!/bin/sh'
-           echo 'if test -n $SGX; then GRAMINE=gramine-sgx; else GRAMINE=gramine-direct; fi'
+           echo 'set -e'
            echo 'cd $PWD_FOR_VM'
            echo '( cd device-testing-tools/gramine-device-testing-module; insmod gramine-testing-dev.ko )'
 
            # only couple tests -- executing in a VM with virtio-9p-pci FS passthrough is very slow
            echo 'cd libos/test/regression'
-           echo 'gramine-test build helloworld; $GRAMINE helloworld'
-           echo 'gramine-test build device_ioctl; $GRAMINE device_ioctl'
+           echo 'gramine-test build'
+           echo 'gramine-test pytest -v -k test_001_helloworld'
+           echo 'gramine-test pytest -v -k test_003_device_ioctl'
+           echo 'gramine-test pytest -v -k test_004_device_ioctl_fail'
+           echo 'gramine-test pytest -v -k test_005_device_ioctl_parse_fail'
            echo 'echo "TESTS OK"'
            echo 'poweroff -n -f'
         } > new_init

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -801,6 +801,147 @@ they were listed as ``allowed_files``. (However, this policy still does not
 allow writing/creating files specified as trusted.) This policy is a convenient
 way to determine the set of files that the ported application uses.
 
+Allowed IOCTLs
+^^^^^^^^^^^^^^
+
+::
+
+    sgx.ioctl_structs.[identifier] = [memory-layout-format]
+
+    sgx.allowed_ioctls = [
+      { request_code = [NUM], struct = "[identifier-of-ioctl-struct]" },
+    ]
+
+By default, Gramine disables all device-backed IOCTLs. This syntax allows to
+explicitly allow a set of IOCTLs on devices (devices must be explicitly mounted
+via ``fs.mounts`` manifest syntax). Only IOCTLs with the ``request_code``
+argument found among the manifest-listed IOCTLs are allowed to pass-through to
+the host. Each IOCTL entry may also contain a reference to an IOCTL struct in
+the ``struct`` field, in case the third IOCTL argument is intended to be
+translated by Gramine.
+
+Available IOCTL structs are described via ``sgx.ioctl_structs``. Each IOCTL
+struct describes the memory layout of the third argument to the ``ioctl`` system
+call (typically a pointer to a complex nested object passed to the device).
+Description of the memory layout is required for a deep copy of the IOCTL
+struct. Here we use the term *memory region* to denote a separate contiguous
+region of memory and the term *sub-region of a memory region* to denote a part
+of the memory region that has properties different from other sub-regions in the
+same memory region (e.g., should it be copied in or out of the SGX enclave, is
+it a pointer to another memory region, etc.). For example, a C struct can be
+considered one memory region, and fields of this C struct can be considered
+sub-regions of this memory region.
+
+Memory layout of the IOCTL struct is described using the TOML syntax of inline
+arrays (for each new separate memory region) and inline tables (for each
+sub-region in one memory region). Each sub-region is described via the following
+keys:
+
+- ``name`` is an optional name for this sub-region; mainly used to find
+  length-specifying sub-regions and nested memory regions.
+- ``alignment`` is an optional alignment of the memory region; may be specified
+  only in the first sub-region of a memory region (all other sub-regions are
+  contiguous with the first sub-region, so specifying their alignment doesn't
+  make sense). The default value is ``1``.
+- ``size`` is the size of this sub-region. The ``size`` field may be a string
+  with the name of another sub-region that contains the size value or an integer
+  with the constant size measured in ``unit`` units (default unit is 1 byte;
+  also see below). For example, ``size = "strlen"`` denotes a size field that
+  will be calculated dynamically during IOCTL execution based on the sub-region
+  named ``strlen``, whereas ``size = 16`` denotes a sub-region of size 16B. Note
+  that ``ptr`` sub-regions must *not* specify the ``size`` field.
+- ``unit`` is an optional unit of measurement for ``size``. It is 1 byte by
+  default. Unit of measurement must be a constant integer. For example,
+  ``size = "strlen"`` and ``unit = 2`` denote a wide-char string (where each
+  character is 2B long) of a dynamically specified length.
+- ``adjustment`` is an optional integer adjustment for ``size`` (always
+  specified in bytes). It is 0 bytes by default. This field must be a constant
+  (possibly negative) integer. For example, ``size = 6``, ``unit = 2`` and
+  ``adjustment = -8`` results in a total size of 4B.
+- ``direction = "none" | "out" | "in" | "inout"`` is an optional direction of
+  copy for this sub-region (from the app point of view). For example,
+  ``direction = "out"`` denotes a sub-region to be copied out of the enclave to
+  untrusted memory, i.e., this sub-region is an input to the host device. The
+  default value is ``none`` which is useful for e.g. padding of structs. This
+  field must be ommitted if the ``ptr`` field is specified for this sub-region
+  (pointer sub-regions contain the pointer value which will be unconditionally
+  rewired to point to untrusted memory).
+- ``ptr = inlined-memory-region`` or ``ptr = "another-ioctl-struct"``
+  specifies a pointer to another, nested memory region. This field is required
+  when describing complex IOCTL structs. Such pointer memory region always has
+  the implicit size of 8B, and the pointer value is always rewired by Gramine to
+  the memory region in untrusted memory (containing a corresponding nested
+  memory region). If ``ptr`` is specified together with ``array_len``, it
+  describes an array of pointers to these memory regions. (In other words,
+  ``ptr`` is an array of pointers to memory regions with ``array_len = 1`` by
+  default.) This may be recursive with the ``NULL`` value being a guard, which
+  allows describing linked lists.
+- ``array_len`` is an optional number of items in the ``ptr`` array. This field
+  cannot be specified with non-``ptr`` sub-regions. The default value is ``1``.
+
+Consider this simple C snippet:
+
+.. code-block:: c
+
+   struct ioctl_read {
+       size_t buf_size;                /* copied from enclave to device */
+       char* buf;                      /* copied from device to enclave */
+   } __attribute__((aligned(0x1000))); /* alignment just for illustration */
+
+This translates into the following manifest syntax::
+
+    sgx.ioctl_structs.ioctl_read = [
+        {
+            name      = "buf_size",
+            size      = 8,
+            direction = "out",
+            alignment = 0x1000
+        },
+        {
+            ptr = [
+                {
+                    size      = "buf_size",
+                    direction = "in"
+                }
+            ]
+        }
+    ]
+
+The above example specifies a root struct (first memory region) that consists of
+two sub-regions: the first one contains an 8-byte size value, the second one is
+an 8-byte pointer value. This pointer points to another memory region in enclave
+memory that contains a single sub-region of size ``buf_size``. This nested
+sub-region is copied from the device into the enclave.
+
+IOCTLs that use the above struct in a third argument are defined like this::
+
+    sgx.allowed_ioctls = [
+      { request_code = 0x12345678, struct = "ioctl_read" },
+      { request_code = 0x87654321, struct = "ioctl_read" },
+    ]
+
+If the IOCTL's third argument should be passed directly as-is (or unused at
+all), then the ``struct`` key must be an empty string or not exist at all::
+
+    sgx.allowed_ioctls = [
+      { request_code = 0x43218765, struct = "" },
+      { request_code = 0x87654321 },
+    ]
+
+.. note ::
+   IOCTLs for device communication are pass-through and thus potentially
+   insecure by themselves in SGX environments:
+
+   - IOCTL arguments are passed as-is from the app to the untrusted host,
+     which may lead to leaks of enclave data.
+   - Untrusted host can change IOCTL arguments as it wishes when passing
+     them from Gramine to the device and back.
+
+   It is the responsibility of the app developer to correctly use IOCTLs, with
+   security implications in mind. In most cases, IOCTL arguments should be
+   encrypted or integrity-protected with a key pre-shared between Gramine and
+   the device.
+
 Attestation and quotes
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/libos/test/regression/device_ioctl.c
+++ b/libos/test/regression/device_ioctl.c
@@ -9,16 +9,132 @@
 #include "common.h"
 #include "rw_file.h"
 
-#include "gramine_test_dev_ioctl.h" /* currently unused */
+#include "gramine_test_dev_ioctl.h"
 
-#define STRING_READWRITE "Hello world via read/write\n"
+#define STRING_READWRITE      "Hello world via read/write\n"
+#define STRING_IOCTL          "Hello world via ioctls\n"
+#define STRING_IOCTL_REPLACED "He$$0 w0r$d via i0ct$s\n"
 
 int main(void) {
+    ssize_t bytes;
+    char buf[64];
+
     int devfd = CHECK(open("/dev/gramine_test_dev", O_RDWR));
 
-    ssize_t bytes = posix_fd_write(devfd, STRING_READWRITE, sizeof(STRING_READWRITE));
+    /* test 1 -- use write() and read() syscalls */
+    bytes = posix_fd_write(devfd, STRING_READWRITE, sizeof(STRING_READWRITE));
     if (bytes != sizeof(STRING_READWRITE))
         CHECK(-1);
+
+    /* lseek() doesn't work in Gramine because it is fully emulated in LibOS and therefore lseek()
+     * is not aware of device-specific semantics; instead we use a device-specific ioctl() */
+    off_t offset = CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_REWIND));
+    if (offset != 0)
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_REWIND) didn't return 0 "
+                "(returned: %ld)", offset);
+
+    memset(&buf, 0, sizeof(buf));
+    bytes = posix_fd_read(devfd, buf, sizeof(buf) - 1);
+    if (bytes != sizeof(STRING_READWRITE))
+        CHECK(-1);
+
+    if (strcmp(buf, STRING_READWRITE))
+        errx(1, "read `%s` from /dev/gramine_test_dev but expected `%s`", buf, STRING_READWRITE);
+
+    ssize_t devfd_size = CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_GETSIZE));
+    if (devfd_size != sizeof(STRING_READWRITE))
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_GETSIZE) didn't return %lu "
+                "(returned: %ld)", sizeof(STRING_READWRITE), devfd_size);
+
+    /* test 2 -- use ioctl(GRAMINE_TEST_DEV_IOCTL_WRITE) and ioctl(GRAMINE_TEST_DEV_IOCTL_READ)
+     *           syscalls */
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_CLEAR));
+
+    devfd_size = CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_GETSIZE));
+    if (devfd_size != 0)
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_GETSIZE) didn't return 0 "
+                "(returned: %ld)", devfd_size);
+
+    struct gramine_test_dev_ioctl_write write_arg = {
+        .buf_size = sizeof(STRING_IOCTL),
+        .buf      = STRING_IOCTL,
+        .off      = 0
+    };
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_WRITE, &write_arg));
+    if (write_arg.off != sizeof(STRING_IOCTL))
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_WRITE) didn't update offset "
+                "to %lu (returned: %ld)", sizeof(STRING_IOCTL), write_arg.off);
+    if (write_arg.copied != sizeof(STRING_IOCTL))
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_WRITE) didn't copy %lu bytes "
+                "(returned: %ld)", sizeof(STRING_IOCTL), write_arg.copied);
+
+    memset(buf, 0, sizeof(buf));
+    struct gramine_test_dev_ioctl_read read_arg = {
+        .buf_size = sizeof(buf) - 1,
+        .buf      = buf,
+        .off      = 0
+    };
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_READ, &read_arg));
+    if (read_arg.off != sizeof(STRING_IOCTL))
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_READ) didn't update offset "
+                "to %lu (returned: %ld)", sizeof(STRING_IOCTL), read_arg.off);
+    if (read_arg.copied != sizeof(STRING_IOCTL))
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_READ) didn't copy %lu bytes "
+                "(returned: %ld)", sizeof(STRING_IOCTL), read_arg.copied);
+
+    if (strcmp(buf, STRING_IOCTL))
+        errx(1, "read `%s` from /dev/gramine_test_dev but expected `%s`", buf, STRING_IOCTL);
+
+    devfd_size = CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_GETSIZE));
+    if (devfd_size != sizeof(STRING_IOCTL))
+        errx(1, "/dev/gramine_test_dev ioctl(GRAMINE_TEST_DEV_IOCTL_GETSIZE) didn't return %lu "
+                "(returned: %ld)", sizeof(STRING_IOCTL), devfd_size);
+
+    /* test 3 -- use ioctl(GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR) syscall with a complex struct as an
+     *           argument */
+    struct gramine_test_dev_ioctl_replace_char replace_chars[] = {
+        { .src = 'l', .dst = '$' },
+        { .src = 'o', .dst = '0' }
+    };
+    struct gramine_test_dev_ioctl_replace_arr replace_arr = {
+        .replacements_cnt = ARRAY_LEN(replace_chars),
+        .replacements_arr = replace_chars
+    };
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR, &replace_arr));
+
+    memset(buf, 0, sizeof(buf));
+    read_arg = (struct gramine_test_dev_ioctl_read){
+        .buf_size = sizeof(buf) - 1,
+        .buf      = buf,
+        .off      = 0
+    };
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_READ, &read_arg));
+    if (strcmp(buf, STRING_IOCTL_REPLACED))
+        errx(1, "read `%s` from /dev/gramine_test_dev but expected `%s`", buf,
+             STRING_IOCTL_REPLACED);
+
+    /* test 4 -- use ioctl(GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST) syscall with a complex struct as an
+     *           argument */
+    struct gramine_test_dev_ioctl_replace_list replace_list_2 = {
+        .replacement = { .src = '0', .dst = 'o' },
+        .next = NULL
+    };
+    struct gramine_test_dev_ioctl_replace_list replace_list = {
+        .replacement = { .src = '$', .dst = 'l' },
+        .next = &replace_list_2
+    };
+
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST, &replace_list));
+
+    memset(buf, 0, sizeof(buf));
+    read_arg = (struct gramine_test_dev_ioctl_read){
+        .buf_size = sizeof(buf) - 1,
+        .buf      = buf,
+        .off      = 0
+    };
+    CHECK(ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_READ, &read_arg));
+    if (strcmp(buf, STRING_IOCTL))
+        errx(1, "read `%s` from /dev/gramine_test_dev but expected `%s`", buf, STRING_IOCTL);
 
     CHECK(close(devfd));
     puts("TEST OK");

--- a/libos/test/regression/device_ioctl.manifest.template
+++ b/libos/test/regression/device_ioctl.manifest.template
@@ -16,3 +16,43 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
+
+sgx.ioctl_structs.gramine_test_dev_ioctl_write = [
+    { size = 8, direction = "out", name = "buf_size" },    # buf_size
+    { ptr = [ {size = "buf_size", direction = "out"} ] },  # buf
+    { size = 8, direction = "inout" },                     # off
+    { size = 8, direction = "in" },                        # copied
+]
+
+sgx.ioctl_structs.gramine_test_dev_ioctl_read = [
+    { size = 8, direction = "out", name = "buf_size" },   # buf_size
+    { ptr = [ {size = "buf_size", direction = "in"} ] },  # buf
+    { size = 8, direction = "inout" },                    # off
+    { size = 8, direction = "in" },                       # copied
+]
+
+sgx.ioctl_structs.gramine_test_dev_ioctl_replace_arr = [
+    { size = 8, direction = "out", name = "replacements_cnt" },            # replacements_cnt
+    { array_len = "replacements_cnt", ptr = [                              # replacements_arr
+                                        { size = 2, direction = "out" },   # src, dst
+                                        { size = 6, direction = "none" },  # padding
+                                      ] },
+]
+
+sgx.ioctl_structs.gramine_test_dev_ioctl_replace_list = [
+    { size = 1, unit = 2, direction = "out" },        # src, dst; `unit` is just for testing
+    { size = 3, adjustment = 3, direction = "none" }, # 6B padding; `adjustment` is just for testing
+    { ptr = "gramine_test_dev_ioctl_replace_list" },  # next
+]
+
+sgx.allowed_ioctls = [
+  # three IOCTLs below test different "no struct needed" syntaxes of the `struct` key
+  { request_code = 0x8100, struct = "" },  # REWIND
+  { request_code = 0x8103 },               # GETSIZE
+  { request_code = 0x8104 },               # CLEAR
+
+  { request_code = 0xc0208101, struct = "gramine_test_dev_ioctl_write" },        # WRITE
+  { request_code = 0xc0208102, struct = "gramine_test_dev_ioctl_read" },         # READ
+  { request_code = 0x40108105, struct = "gramine_test_dev_ioctl_replace_arr" },  # REPLACE_ARR
+  { request_code = 0x40108106, struct = "gramine_test_dev_ioctl_replace_list" }, # REPLACE_LIST
+]

--- a/libos/test/regression/device_ioctl_fail.manifest.template
+++ b/libos/test/regression/device_ioctl_fail.manifest.template
@@ -1,0 +1,24 @@
+{% set entrypoint = "device_ioctl" -%}
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "/dev/gramine_test_dev", uri = "dev:/dev/gramine_test_dev" },
+]
+
+sgx.debug = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]
+
+sgx.allowed_ioctls = [
+  # no allowed IOCTLs to force test failure (on SGX)
+]

--- a/libos/test/regression/device_ioctl_parse_fail.c
+++ b/libos/test/regression/device_ioctl_parse_fail.c
@@ -1,0 +1,71 @@
+#define _GNU_SOURCE /* for loff_t */
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#include "gramine_test_dev_ioctl.h"
+
+int main(void) {
+    int ret;
+
+    int devfd = CHECK(open("/dev/gramine_test_dev", O_RDWR));
+
+    /* test 1: no corresponding struct found */
+    errno = 0;
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_REWIND);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_REWIND) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    /* test 2: sub-region is not a TOML table */
+    errno = 0;
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_GETSIZE);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_GETSIZE) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    /* test 3: negative size specified */
+    errno = 0;
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_CLEAR);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_CLEAR) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    /* test 4: buffer detected before the size of this buffer was detected */
+    errno = 0;
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_WRITE);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_WRITE) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    /* test 5: pointer of size not 8 (which is mandated on x86-64) */
+    errno = 0;
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_READ);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_READ) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    /* test 6: `alignment` keyword specified not in the first sub-region; note that we need the
+     * struct arg because the parser tries to collect the first sub-region */
+    errno = 0;
+    struct gramine_test_dev_ioctl_replace_arr replace_arr = { 0 };
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR, &replace_arr);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    /* test 7: unrecognized string in `direction` keyword */
+    errno = 0;
+    ret = ioctl(devfd, GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST);
+    if (ret != -1 || errno != EINVAL)
+        errx(1, "ioctl(GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST) didn't fail on parsing "
+                "(returned: %d, errno: %d)", ret, errno);
+
+    CHECK(close(devfd));
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/device_ioctl_parse_fail.manifest.template
+++ b/libos/test/regression/device_ioctl_parse_fail.manifest.template
@@ -1,0 +1,63 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { path = "/dev/gramine_test_dev", uri = "dev:/dev/gramine_test_dev" },
+]
+
+sgx.debug = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]
+
+# Below IOCTL structs are intentionally modified to test IOCTL parsing (i.e. they don't really make
+# sense). Each IOCTL struct has a single error/limitation that should fail Gramine's IOCTL parser.
+
+# Sub-regions must be TOML tables and not e.g. strings
+sgx.ioctl_structs.subregion_is_not_a_table = [
+    "some dummy string",
+]
+
+# Negative size makes no sense
+sgx.ioctl_structs.negative_size = [
+    { size = -16 },
+]
+
+# Buffer is defined before its size is defined (parser doesn't "know" where buffer ends and fails)
+sgx.ioctl_structs.size_after_buffer_fail = [
+    { size = "buf_size", direction = "out" },
+    { size = 8, direction = "out", name = "buf_size" },
+]
+
+# Pointers can only be of size 8 (pointer size on x86-64 machines)
+sgx.ioctl_structs.pointer_of_wrong_size = [
+    { ptr = [ {size = 256 } ], size = 5 },
+]
+
+# Alignment can be specified only on the first sub-region
+sgx.ioctl_structs.alignment_specified_in_second_subregion = [
+    { size = 1, direction = "none" },
+    { size = 1, alignment = 16 },
+]
+
+# Direction field can only be one of "out", "in", "inout" and "none"
+sgx.ioctl_structs.wrong_direction_string = [
+    { size = 1, direction = "dummy" },
+]
+
+sgx.allowed_ioctls = [
+  { request_code = 0x8100,     struct = "not_real_struct" },                          # REWIND
+  { request_code = 0x8103,     struct = "subregion_is_not_a_table" },                 # GETSIZE
+  { request_code = 0x8104,     struct = "negative_size" },                            # CLEAR
+  { request_code = 0xc0208101, struct = "size_after_buffer_fail" },                   # WRITE
+  { request_code = 0xc0208102, struct = "pointer_of_wrong_size" },                    # READ
+  { request_code = 0x40108105, struct = "alignment_specified_in_second_subregion" },  # REPLACE_ARR
+  { request_code = 0x40108106, struct = "wrong_direction_string" },                   # REPLACE_LIST
+]

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -158,7 +158,10 @@ endif
 
 # device_ioctl test may only be executed in a VM environment that prepares the below header file
 if fs.exists('gramine_test_dev_ioctl.h')
-    tests += { 'device_ioctl': {} }
+    tests += {
+      'device_ioctl': {},
+      'device_ioctl_parse_fail': {},
+    }
 endif
 
 tests_musl = tests

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1048,6 +1048,29 @@ class TC_40_FileSystem(RegressionTestCase):
         stdout, _ = self.run_binary(['device_ioctl'])
         self.assertIn('TEST OK', stdout)
 
+    @unittest.skipUnless(IS_VM and HAS_SGX, 'Requires /dev/gramine_test_dev and SGX')
+    def test_004_device_ioctl_fail(self):
+        try:
+            self.run_binary(['device_ioctl_fail'])
+            self.fail('device_ioctl_fail unexpectedly succeeded')
+        except subprocess.CalledProcessError as e:
+            stdout = e.stdout.decode()
+            self.assertRegex(stdout, r'ioctl\(devfd, GRAMINE_TEST_DEV_IOCTL_REWIND\).*'
+                                     r'Function not implemented')
+
+    @unittest.skipUnless(IS_VM and HAS_SGX, 'Requires /dev/gramine_test_dev and SGX')
+    def test_005_device_ioctl_parse_fail(self):
+        stdout, stderr = self.run_binary(['device_ioctl_parse_fail'])
+        self.assertRegex(stderr, r'error: Invalid struct value of allowed IOCTL .* in manifest')
+        self.assertIn('error: IOCTL: each memory sub-region must be a TOML table', stderr)
+        self.assertIn('error: IOCTL: parsing of \'size\' field failed', stderr)
+        self.assertIn('error: IOCTL: cannot find \'buf_size\'', stderr)
+        self.assertIn('error: IOCTL: \'ptr\' cannot specify \'size\'', stderr)
+        self.assertIn('error: IOCTL: \'alignment\' may be specified only at beginning of mem '
+                      'region', stderr)
+        self.assertIn('error: IOCTL: parsing of \'direction\' field failed', stderr)
+        self.assertIn('TEST OK', stdout)
+
     def test_010_path(self):
         stdout, _ = self.run_binary(['proc_path'])
         self.assertIn('proc path test success', stdout)

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -145,4 +145,6 @@ manifests = [
 
 manifests = [
   "device_ioctl",
+  "device_ioctl_fail",
+  "device_ioctl_parse_fail",
 ]

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -137,4 +137,6 @@ manifests = [
 
 manifests = [
   "device_ioctl",
+  "device_ioctl_fail",
+  "device_ioctl_parse_fail",
 ]

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -884,6 +884,29 @@ int PalSegmentBaseGet(enum pal_segment_reg reg, uintptr_t* addr);
 int PalSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr);
 
 /*!
+ * \brief Perform a device-specific operation `cmd`.
+ *
+ * \param         handle   Handle of the device.
+ * \param         cmd      Device-dependent request/control code.
+ * \param[in,out] arg      Arbitrary argument to `cmd`. May be unused or used as a 64-bit integer
+ *                         or used as a pointer to a buffer that contains the data required to
+ *                         perform the operation as well as the data returned by the operation. For
+ *                         some PALs (e.g. Linux-SGX), the manifest must describe the layout of
+ *                         this buffer in order to correctly copy the data to/from the host.
+ * \param[out]    out_ret  Typically zero, but some device-specific operations return a
+ *                         device-specific value (in addition to or instead of \p arg).
+ *
+ * \returns 0 on success, negative error value on failure.
+ *
+ * Note that this function returns a negative error value only for PAL-internal errors (like errors
+ * during finding/parsing of the corresponding IOCTL data struct in the manifest). The host's error
+ * value, if any, is always passed in `out_ret`.
+ *
+ * This function corresponds to ioctl() in UNIX systems and DeviceIoControl() in Windows.
+ */
+int PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int* out_ret);
+
+/*!
  * \brief Obtain the attestation report (local) with `user_report_data` embedded into it.
  *
  * \param         user_report_data       Report data with arbitrary contents (typically uniquely

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -156,6 +156,7 @@ noreturn void pal_main(uint64_t instance_id, PAL_HANDLE parent_process, PAL_HAND
 /* For initialization */
 
 unsigned long _PalMemoryQuota(void);
+int _PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int* out_ret);
 // Returns 0 on success, negative PAL code on failure
 int _PalGetCPUInfo(struct pal_cpu_info* info);
 

--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -2067,6 +2067,30 @@ int ocall_eventfd(int flags) {
     return retval;
 }
 
+int ocall_ioctl(int fd, unsigned int cmd, unsigned long arg) {
+    int retval;
+    struct ocall_ioctl* ocall_ioctl_args;
+
+    void* old_ustack = sgx_prepare_ustack();
+    ocall_ioctl_args = sgx_alloc_on_ustack_aligned(sizeof(*ocall_ioctl_args),
+                                                   alignof(*ocall_ioctl_args));
+    if (!ocall_ioctl_args) {
+        sgx_reset_ustack(old_ustack);
+        return -EPERM;
+    }
+
+    COPY_VALUE_TO_UNTRUSTED(&ocall_ioctl_args->fd, fd);
+    COPY_VALUE_TO_UNTRUSTED(&ocall_ioctl_args->cmd, cmd);
+    COPY_VALUE_TO_UNTRUSTED(&ocall_ioctl_args->arg, arg);
+
+    retval = sgx_exitless_ocall(OCALL_IOCTL, ocall_ioctl_args);
+    /* in general case, IOCTL may return any error code (the list of possible error codes is not
+     * standardized and is up to the Linux driver/kernel module), so no check of `retval` here */
+
+    sgx_reset_ustack(old_ustack);
+    return retval;
+}
+
 int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
                     const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len) {
     int retval;

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -106,6 +106,8 @@ int ocall_debug_describe_location(uintptr_t addr, char* buf, size_t buf_size);
 
 int ocall_eventfd(int flags);
 
+int ocall_ioctl(int fd, unsigned int cmd, unsigned long arg);
+
 /*!
  * \brief Execute untrusted code in PAL to obtain a quote from the Quoting Enclave.
  *

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -729,6 +729,11 @@ static long sgx_ocall_debug_describe_location(void* args) {
 #endif
 }
 
+static long sgx_ocall_ioctl(void* args) {
+    struct ocall_ioctl* ocall_ioctl_args = args;
+    return DO_SYSCALL(ioctl, ocall_ioctl_args->fd, ocall_ioctl_args->cmd, ocall_ioctl_args->arg);
+}
+
 static long sgx_ocall_get_quote(void* args) {
     struct ocall_get_quote* ocall_quote_args = args;
     return retrieve_quote(ocall_quote_args->is_epid ? &ocall_quote_args->spid : NULL,
@@ -797,6 +802,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_DEBUG_MAP_REMOVE]         = sgx_ocall_debug_map_remove,
     [OCALL_DEBUG_DESCRIBE_LOCATION]  = sgx_ocall_debug_describe_location,
     [OCALL_EVENTFD]                  = sgx_ocall_eventfd,
+    [OCALL_IOCTL]                    = sgx_ocall_ioctl,
     [OCALL_GET_QUOTE]                = sgx_ocall_get_quote,
     [OCALL_EDMM_MODIFY_PAGES_TYPE]   = sgx_ocall_edmm_modify_pages_type,
     [OCALL_EDMM_REMOVE_PAGES]        = sgx_ocall_edmm_remove_pages,

--- a/pal/src/host/linux-sgx/pal_devices.c
+++ b/pal/src/host/linux-sgx/pal_devices.c
@@ -18,6 +18,8 @@
 #include "pal_linux.h"
 #include "pal_linux_error.h"
 #include "perm.h"
+#include "toml.h"
+#include "toml_utils.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum pal_access access,
                     pal_share_flags_t share, enum pal_create_mode create,
@@ -219,3 +221,839 @@ struct handle_ops g_dev_ops = {
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,
 };
+
+/*
+ * Code below describes the TOML syntax of the manifest entries used for deep-copying complex nested
+ * objects out and inside the SGX enclave. This syntax is currently used for IOCTL emulation and is
+ * generic enough to describe the most common memory layouts for deep copy of IOCTL structs.
+ *
+ * The high-level description can be found in the "manifest syntax" documentation page.
+ *
+ * The following example describes the main implementation details:
+ *
+ *   struct pascal_str { uint8_t len; char str[]; };
+ *   struct c_str { char str[]; };
+ *   struct root { struct pascal_str* s1;
+ *                 struct c_str* s2; uint64_t s2_buf_size;
+ *                 int8_t x; int8_t y; };
+ *
+ *   alignas(128) struct root obj;
+ *   ioctl(devfd, DEV_IOCTL_NUMBER, &obj);
+ *
+ * The example IOCTL takes as a third argument a pointer to an object of type `struct root` that
+ * contains two pointers to other objects (pascal-style string and a C-style string) and embeds two
+ * integers `x` and `y`. The two strings reside in separate memory regions in enclave memory. Note
+ * that the size of the allocated buffer for the C-style string is stored in the `s2_buf_size` field
+ * of the root object. The `pascal_str` string is an input to the IOCTL, the `c_str` string and its
+ * actual size `s2_buf_size` are the outputs of the IOCTL, and the integers `x` and `y` are also
+ * outputs of the IOCTL. Also note that the root object is 128B-aligned (for illustration purposes).
+ * This IOCTL could for example be used to convert a Pascal string into a C string (C string will be
+ * truncated to user-specified `s2_buf_size` if greater than this limit), and find the indices of
+ * the first occurrences of chars "x" and "y" in the Pascal string.
+ *
+ * The corresponding manifest entries describing these structs look like this:
+ *
+ *   sgx.ioctl_structs.root = [
+ *     { alignment = 128, ptr = [
+ *                            { name = "pascal-str-len", size = 1, direction = "out" },
+ *                            { name = "pascal-str", size = "pascal-str-len", direction = "out"}
+ *                        ] },
+ *     { ptr = [
+ *           { name = "c-str", size = "c-buf-size", direction = "in" }
+ *       ] },
+ *     { name = "c-buf-size", size = 8, direction = "inout" },
+ *     { size = 2, direction = "in" }  # x and y fields
+ *   ]
+ *
+ *   sgx.allowed_ioctls = [
+ *     { request_code = <DEV_IOCTL_NUMER>, struct = "root" }
+ *   ]
+ *
+ * The current TOML syntax has the following rules/limitations:
+ *
+ *  1. Each separate memory region is represented as a TOML array (`[]`).
+ *  2. Each sub-region of one memory region is represented as a TOML table (`{}`).
+ *  3. Each sub-region may be a pointer (`ptr`) to another memory region. In this case, the value of
+ *     `ptr` is a TOML-array representation of that other memory region or a TOML string with the
+ *     name of another memory region. The `ptr` sub-region always has size of 8B (assuming x86-64)
+ *     and doesn't have an in/out direction. The `array_len` field specifies the number of adjacent
+ *     memory regions that this pointer points to (i.e. the length of the array).
+ *  4. Sub-regions can be fixed-size (like the last sub-region containing two bytes `x` and `y`) or
+ *     can be flexible-size (like the two strings). In the latter case, the `size` field contains a
+ *     name of a sub-region where the actual size is stored. Note that this referenced sub-region
+ *     must come *before* (in the Breadth-First-Search sense) the sub-region with such flexible-size
+ *     `size` -- TOML representations of typical IOCTL structs always have the size specifier in a
+ *     sub-region found before the buffer sub-region, either in the same memory region (e.g. as in
+ *     flexible array members in C) or in the "outer" memory region (e.g. the size specifier is
+ *     located in the root memory region and the buffer is located in the nested memory region).
+ *     This is a limitation of the current parser and could be removed in the future, if need
+ *     arises.
+ *  5. Sub-regions that store the size of another sub-region must be less than or equal to 8 bytes
+ *     in size.
+ *  6. Sub-regions may have a name for ease of identification; this is required for "size" /
+ *     "array_len" sub-regions but may be omitted for all other kinds of sub-regions.
+ *  7. Sub-regions may have one of the four directions: "out" to copy contents of the sub-region out
+ *     of the enclave to untrusted memory, "in" to copy from untrusted memory into the enclave,
+ *     "inout" to copy in both directions, "none" to not copy at all (useful for e.g. padding).
+ *     Note that pointer sub-regions do not have a direction (their values are unconditionally
+ *     rewired so as to point to the corresponding region in untrusted memory).
+ *  8. The first sub-region (and only the first!) may specify the alignment of the memory region.
+ *  9. The total size of a sub-region is calculated as `size * unit + adjustment`. By default `unit`
+ *     is 1 byte and `adjustment` is 0. Note that `adjustment` may be a negative number.
+ *
+ * The diagram below shows how this complex object is copied from enclave memory (left side) to
+ * untrusted memory (right side). MR stands for "memory region", SR stands for "sub-region". Note
+ * how enclave pointers are copied and rewired to point to untrusted memory regions.
+ *
+ *      struct root (MR1)                    |       deep-copied struct (aligned at 128B)
+ *      +-----------------------+            |       +------------------------------+
+ *  +----+ pascal_str* s1       |     SR1    |    +----+ pascal_str* s1       (MR1) |
+ *  |   |                       |            |    |  |                              |
+ *  |   |  c_str* s2 +------------+   SR2    |    |  |   c_str* s2 +-------------------+
+ *  |   |                       | |          |    |  |                              |  |
+ *  |   |  uint64_t s2_buf_size | |   SR3    |    |  |   uint64_t s2_buf_size       |  |
+ *  |   |                       | |          |    |  |                              |  |
+ *  |   |  int8_t x, y          | |   SR4    |    |  |   int8_t x, y                |  |
+ *  |   +-----------------------+ |          |    |  +------------------------------+  |
+ *  |                             |          |    +->|   uint8_t len          (MR2) |  |
+ *  v (MR2)                       |          |       |                              |  |
+ * +-------------+                |          |       |   char str[len]              |  |
+ * | uint8_t len |                |   SR5    |       +------------------------------+  |
+ * |             |                |          |       |  char str[s2_buf_size] (MR3) |<-+
+ * | char str[]  |                |   SR6    |       +------------------------------+
+ * +-------------+                |          |
+ *                       (MR3)    v          |
+ *                     +----------+-+        |
+ *                     | char str[] | SR7    |
+ *                     +------------+        |
+ */
+
+/* for simplicity, we limit the number of memory and sub-regions; these limits should be enough for
+ * any reasonable IOCTL struct object */
+#define MAX_MEM_REGIONS 1024
+#define MAX_SUB_REGIONS (10 * 1024)
+
+/* direction of copy: none (used for padding), out of enclave, inside enclave or both;
+ * default is DIRECTION_NONE */
+enum mem_copy_direction {
+    DIRECTION_NONE,
+    DIRECTION_OUT,
+    DIRECTION_IN,
+    DIRECTION_INOUT
+};
+
+struct mem_region {
+    toml_array_t* toml_mem_region; /* describes contiguous sub-regions in this mem-region */
+    void* enclave_addr;            /* base address of this memory region in enclave memory */
+    bool adjacent;                 /* memory region adjacent to previous one? (used for arrays) */
+};
+
+struct dynamic_value {
+    bool is_determined;
+    union {
+        /* actual value, use only if `is_determined == true` */
+        uint64_t value;
+        /* sub-region name that determines the value, use only if `is_determined == false`;
+         * FIXME: memorize name hash for quicker string comparison? */
+        char* sub_region_name;
+    };
+};
+
+/* total size in bytes of a sub-region is calculated as `size * unit + adjustment` */
+struct sub_region {
+    enum mem_copy_direction direction; /* direction of copy during OCALL */
+    char* name;                     /* may be NULL for unnamed regions */
+    struct dynamic_value array_len; /* array length of the sub-region (only for `ptr` regions) */
+    size_t size;                    /* size of this sub-region */
+    size_t unit;                    /* unit of measurement, used in total size calculation */
+    int64_t adjustment;             /* may be negative; used to adjust total size */
+    size_t alignment;               /* alignment of this sub-region */
+    void* enclave_addr;             /* base address of this sub region in enclave mem */
+    void* untrusted_addr;           /* base address of corresponding sub region in untrusted mem */
+    toml_array_t* toml_mem_region;  /* for pointers/arrays, specifies pointed-to mem region */
+};
+
+static bool strings_equal(const char* s1, const char* s2) {
+    if (!s1 || !s2)
+        return false;
+    return !strcmp(s1, s2);
+}
+
+static int copy_value(void* addr, size_t size, uint64_t* out_value) {
+    if (!addr || size > sizeof(*out_value))
+        return -PAL_ERROR_INVAL;
+
+    /* the copy below assumes little-endian machines (which x86 is) */
+    *out_value = 0;
+    memcpy(out_value, addr, size);
+    return 0;
+}
+
+/* finds a sub region with name `sub_region_name` among `all_sub_regions` and returns its index */
+static int get_sub_region_idx(struct sub_region* all_sub_regions, size_t all_sub_regions_cnt,
+                              const char* sub_region_name, size_t* out_idx) {
+    /* it is important to iterate in reverse order because there may be an array of mem regions
+     * with same-named sub regions, and we want to find the latest sub region */
+    for (size_t i = all_sub_regions_cnt; i > 0; i--) {
+        size_t idx = i - 1;
+        if (strings_equal(all_sub_regions[idx].name, sub_region_name)) {
+            *out_idx = idx;
+            return 0;
+        }
+    }
+    log_error("IOCTL: cannot find '%s'", sub_region_name);
+    return -PAL_ERROR_INVAL;
+}
+
+/* allocates a name string, it is responsibility of the caller to free it after use */
+static int get_sub_region_name(const toml_table_t* toml_sub_region, char** out_name) {
+    return toml_string_in(toml_sub_region, "name", out_name) < 0 ? -PAL_ERROR_INVAL : 0;
+}
+
+static int get_sub_region_direction(const toml_table_t* toml_sub_region,
+                                    enum mem_copy_direction* out_direction) {
+    char* direction_str;
+    int ret = toml_string_in(toml_sub_region, "direction", &direction_str);
+    if (ret < 0)
+        return -PAL_ERROR_INVAL;
+
+    if (!direction_str) {
+        *out_direction = DIRECTION_NONE;
+        return 0;
+    }
+
+    ret = 0;
+    if (!strcmp(direction_str, "out")) {
+        *out_direction = DIRECTION_OUT;
+    } else if (!strcmp(direction_str, "in")) {
+        *out_direction = DIRECTION_IN;
+    } else if (!strcmp(direction_str, "inout")) {
+        *out_direction = DIRECTION_INOUT;
+    } else if (!strcmp(direction_str, "none")) {
+        *out_direction = DIRECTION_NONE;
+    } else {
+        ret = -PAL_ERROR_INVAL;
+    }
+    free(direction_str);
+    return ret;
+}
+
+static int get_sub_region_alignment(const toml_table_t* toml_sub_region, size_t* out_alignment) {
+    int64_t alignment;
+    int ret = toml_int_in(toml_sub_region, "alignment", /*defaultval=*/1, &alignment);
+    if (ret < 0 || alignment <= 0)
+        return -PAL_ERROR_INVAL;
+
+    *out_alignment = (size_t)alignment;
+    return 0;
+}
+
+static int get_sub_region_unit(const toml_table_t* toml_sub_region, size_t* out_unit) {
+    int64_t unit;
+    int ret = toml_int_in(toml_sub_region, "unit", /*defaultval=*/1, &unit);
+    if (ret < 0 || unit <= 0)
+        return -PAL_ERROR_INVAL;
+
+    *out_unit = (size_t)unit;
+    return 0;
+}
+
+static int get_sub_region_adjustment(const toml_table_t* toml_sub_region, int64_t* out_adjustment) {
+    int ret = toml_int_in(toml_sub_region, "adjustment", /*defaultval=*/0, out_adjustment);
+    return ret < 0 ? -PAL_ERROR_INVAL : 0;
+}
+
+static int get_toml_nested_mem_region(toml_table_t* toml_sub_region,
+                                      toml_array_t** out_toml_mem_region) {
+    toml_array_t* toml_mem_region = toml_array_in(toml_sub_region, "ptr");
+    if (toml_mem_region) {
+        *out_toml_mem_region = toml_mem_region;
+        return 0;
+    }
+
+    char* ioctl_struct_str;
+    int ret = toml_string_in(toml_sub_region, "ptr", &ioctl_struct_str);
+    if (ret < 0)
+        return -PAL_ERROR_INVAL;
+
+    if (!ioctl_struct_str) {
+        /* if we're here, then we didn't find `ptr` field at all */
+        *out_toml_mem_region = NULL;
+        return 0;
+    }
+
+    /* since we're in this function, we are parsing sgx.ioctl_structs list, so we know it exists */
+    toml_table_t* manifest_sgx = toml_table_in(g_pal_public_state.manifest_root, "sgx");
+    assert(manifest_sgx);
+    toml_table_t* toml_ioctl_structs = toml_table_in(manifest_sgx, "ioctl_structs");
+    assert(toml_ioctl_structs);
+
+    toml_mem_region = toml_array_in(toml_ioctl_structs, ioctl_struct_str);
+    if (!toml_mem_region || toml_array_nelem(toml_mem_region) <= 0) {
+        ret = -PAL_ERROR_INVAL;
+        goto out;
+    }
+
+    *out_toml_mem_region = toml_mem_region;
+    ret = 0;
+out:
+    free(ioctl_struct_str);
+    return ret;
+}
+
+static int get_sub_region_size(struct sub_region* all_sub_regions, size_t all_sub_regions_cnt,
+                               const toml_table_t* toml_sub_region, size_t* out_size) {
+    toml_raw_t sub_region_size_raw = toml_raw_in(toml_sub_region, "size");
+    if (!sub_region_size_raw) {
+        *out_size = 0;
+        return 0;
+    }
+
+    int64_t size;
+    int ret = toml_rtoi(sub_region_size_raw, &size);
+    if (ret == 0) {
+        /* size is specified as constant */
+        if (size <= 0)
+            return -PAL_ERROR_INVAL;
+
+        *out_size = (size_t)size;
+        return 0;
+    }
+
+    /* size must have been specified as string (another sub-region's name) */
+    char* sub_region_name = NULL;
+    ret = toml_rtos(sub_region_size_raw, &sub_region_name);
+    if (ret < 0)
+        return -PAL_ERROR_INVAL;
+
+    size_t found_idx;
+    ret = get_sub_region_idx(all_sub_regions, all_sub_regions_cnt, sub_region_name, &found_idx);
+    free(sub_region_name);
+    if (ret < 0)
+        return ret;
+
+    void* addr_of_size_field  = all_sub_regions[found_idx].enclave_addr;
+    size_t size_of_size_field = all_sub_regions[found_idx].size;
+    uint64_t read_size;
+
+    ret = copy_value(addr_of_size_field, size_of_size_field, &read_size);
+    if (ret < 0)
+        return ret;
+
+    static_assert(sizeof(read_size) == sizeof(*out_size), "wrong types");
+    *out_size = (size_t)read_size;
+    return 0;
+}
+
+/* may allocate an array-len-name string, it is responsibility of the caller to free it after use */
+static int get_sub_region_array_len(const toml_table_t* toml_sub_region,
+                                    struct dynamic_value* out_array_len) {
+    toml_raw_t sub_region_array_len_raw = toml_raw_in(toml_sub_region, "array_len");
+    if (!sub_region_array_len_raw) {
+        *out_array_len = (struct dynamic_value){
+            .is_determined = true,
+            .value = 1  /* 1 array item by default */
+        };
+        return 0;
+    }
+
+    int64_t array_len;
+    int ret = toml_rtoi(sub_region_array_len_raw, &array_len);
+    if (ret == 0) {
+        /* array_len is specified as constant */
+        if (array_len <= 0)
+            return -PAL_ERROR_INVAL;
+
+        *out_array_len = (struct dynamic_value){
+            .is_determined = true,
+            .value = (uint64_t)array_len
+        };
+        return 0;
+    }
+
+    /* array_len must be specified as string (another sub-region's name) */
+    char* sub_region_name = NULL;
+    ret = toml_rtos(sub_region_array_len_raw, &sub_region_name);
+    if (ret < 0)
+        return -PAL_ERROR_INVAL;
+
+    *out_array_len = (struct dynamic_value){
+        .is_determined = false,
+        .sub_region_name = sub_region_name
+    };
+    return 0;
+}
+
+/* Caller sets `mem_regions_cnt_ptr` to the length of `mem_regions` array; this variable is updated
+ * to return the number of actually used `mem_regions`. Similarly with `sub_regions`. */
+static int collect_sub_regions(toml_array_t* root_toml_mem_region, void* root_enclave_addr,
+                               struct mem_region* mem_regions, size_t* mem_regions_cnt_ptr,
+                               struct sub_region* sub_regions, size_t* sub_regions_cnt_ptr) {
+    int ret;
+
+    assert(root_toml_mem_region && toml_array_nelem(root_toml_mem_region) > 0);
+
+    size_t max_sub_regions = *sub_regions_cnt_ptr;
+    size_t sub_regions_cnt = 0;
+
+    size_t max_mem_regions = *mem_regions_cnt_ptr;
+    size_t mem_regions_cnt = 0;
+
+    if (!max_sub_regions || !max_mem_regions)
+        return -PAL_ERROR_NOMEM;
+
+    mem_regions[0].toml_mem_region = root_toml_mem_region;
+    mem_regions[0].enclave_addr    = root_enclave_addr;
+    mem_regions[0].adjacent        = false;
+    mem_regions_cnt++;
+
+    /*
+     * Collecting memory regions and their sub-regions must use top-to-bottom breadth-first search
+     * to dynamically calculate sizes of sub-regions when they are specified via another
+     * sub-region's "name". Consider this example (unnecessary fields not shown for simplicity):
+     *
+     *   ioctl_read = [ { ptr = [ { size = "buf_size" } ] }, { name = "buf_size" } ]
+     *
+     * Here the field that contains size of the buffer (pointed to by the first sub-region) is
+     * located in the second sub-region. Note that the buffer itself is located in the nested memory
+     * region. Now, if the search would be depth-first, then the parser would arrive at the buffer
+     * before learning its size.
+     *
+     */
+    char* cur_enclave_addr = NULL;
+    size_t mem_region_idx = 0;
+    while (mem_region_idx < mem_regions_cnt) {
+        struct mem_region* cur_mem_region = &mem_regions[mem_region_idx];
+        mem_region_idx++;
+
+        if (!cur_mem_region->adjacent)
+            cur_enclave_addr = cur_mem_region->enclave_addr;
+
+        size_t cur_mem_region_first_sub_region_idx = sub_regions_cnt;
+
+        assert(toml_array_nelem(cur_mem_region->toml_mem_region) >= 0);
+        for (size_t i = 0; i < (size_t)toml_array_nelem(cur_mem_region->toml_mem_region); i++) {
+            toml_table_t* toml_sub_region = toml_table_at(cur_mem_region->toml_mem_region, i);
+            if (!toml_sub_region) {
+                log_error("IOCTL: each memory sub-region must be a TOML table");
+                ret = -PAL_ERROR_INVAL;
+                goto out;
+            }
+
+            if (sub_regions_cnt == max_sub_regions) {
+                log_error("IOCTL: too many memory sub-regions (max is %zu)", max_sub_regions);
+                ret = -PAL_ERROR_NOMEM;
+                goto out;
+            }
+
+            struct sub_region* cur_sub_region = &sub_regions[sub_regions_cnt];
+            sub_regions_cnt++;
+
+            memset(cur_sub_region, 0, sizeof(*cur_sub_region));
+
+            cur_sub_region->enclave_addr = cur_enclave_addr;
+            if (!cur_enclave_addr) {
+                /* FIXME: use `is_user_memory_readable()` to check invalid enclave addresses */
+                ret = -PAL_ERROR_INVAL;
+                goto out;
+            }
+
+            if (toml_raw_in(toml_sub_region, "alignment") && i != 0) {
+                log_error("IOCTL: 'alignment' may be specified only at beginning of mem region");
+                ret = -PAL_ERROR_INVAL;
+                goto out;
+            }
+
+            if (toml_array_in(toml_sub_region, "ptr") || toml_raw_in(toml_sub_region, "ptr")) {
+                if (toml_raw_in(toml_sub_region, "direction")) {
+                    log_error("IOCTL: 'ptr' cannot specify 'direction'");
+                    ret = -PAL_ERROR_INVAL;
+                    goto out;
+                }
+                if (toml_raw_in(toml_sub_region, "size")) {
+                    log_error("IOCTL: 'ptr' cannot specify 'size' (did you mean 'array_len'?)");
+                    ret = -PAL_ERROR_INVAL;
+                    goto out;
+                }
+            } else if (toml_raw_in(toml_sub_region, "array_len")) {
+                    log_error("IOCTL: non-'ptr' field cannot specify 'array_len' (did you mean"
+                              " 'size'?)");
+                    ret = -PAL_ERROR_INVAL;
+                    goto out;
+            }
+
+            ret = get_sub_region_name(toml_sub_region, &cur_sub_region->name);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'name' field failed");
+                goto out;
+            }
+
+            ret = get_sub_region_direction(toml_sub_region, &cur_sub_region->direction);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'direction' field failed");
+                goto out;
+            }
+
+            ret = get_sub_region_alignment(toml_sub_region, &cur_sub_region->alignment);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'alignment' field failed");
+                goto out;
+            }
+
+            ret = get_sub_region_unit(toml_sub_region, &cur_sub_region->unit);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'unit' field failed");
+                goto out;
+            }
+
+            ret = get_sub_region_adjustment(toml_sub_region, &cur_sub_region->adjustment);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'adjustment' field failed");
+                goto out;
+            }
+
+            ret = get_sub_region_size(sub_regions, sub_regions_cnt, toml_sub_region,
+                                      &cur_sub_region->size);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'size' field failed");
+                goto out;
+            }
+
+            /* for simplicity, we try to get `array_len` field even for non-ptr sub regions; this
+             * will always return success (as we have a check on `array_len` existence above) and a
+             * dummy default `array_len = 1`, but it will be unused */
+            ret = get_sub_region_array_len(toml_sub_region, &cur_sub_region->array_len);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'array_len' field failed");
+                goto out;
+            }
+
+            ret = get_toml_nested_mem_region(toml_sub_region, &cur_sub_region->toml_mem_region);
+            if (ret < 0) {
+                log_error("IOCTL: parsing of 'ptr' field failed");
+                goto out;
+            }
+
+            if (cur_sub_region->toml_mem_region) {
+                /* only set size for now, we postpone pointer/array handling for later */
+                cur_sub_region->size = sizeof(void*);
+            } else {
+                if (__builtin_mul_overflow(cur_sub_region->size, cur_sub_region->unit,
+                                           &cur_sub_region->size)) {
+                    log_error("IOCTL: integer overflow while applying 'unit'");
+                    ret = -PAL_ERROR_OVERFLOW;
+                    goto out;
+                }
+                if (__builtin_add_overflow(cur_sub_region->size, cur_sub_region->adjustment,
+                                           &cur_sub_region->size)) {
+                    log_error("IOCTL: integer overflow while applying 'adjustment'");
+                    ret = -PAL_ERROR_OVERFLOW;
+                    goto out;
+                }
+            }
+
+            if (!access_ok(cur_enclave_addr, cur_sub_region->size)) {
+                log_error("IOCTL: enclave address overflows");
+                ret = -PAL_ERROR_OVERFLOW;
+                goto out;
+            }
+            cur_enclave_addr += cur_sub_region->size;
+        }
+
+        /* iterate through collected pointer/array sub regions and add corresponding mem regions */
+        for (size_t i = cur_mem_region_first_sub_region_idx; i < sub_regions_cnt; i++) {
+            if (!sub_regions[i].toml_mem_region)
+                continue;
+
+            if (!sub_regions[i].array_len.is_determined) {
+                /* array len was not hard-coded in struct definition, dynamically determine it */
+                assert(sub_regions[i].array_len.sub_region_name);
+
+                size_t found_idx;
+                ret = get_sub_region_idx(sub_regions, sub_regions_cnt,
+                                         sub_regions[i].array_len.sub_region_name, &found_idx);
+                if (ret < 0) {
+                    log_error("IOCTL: cannot find '%s'", sub_regions[i].array_len.sub_region_name);
+                    goto out;
+                }
+
+                void* addr_of_array_len_field  = sub_regions[found_idx].enclave_addr;
+                size_t size_of_array_len_field = sub_regions[found_idx].size;
+                uint64_t array_len;
+                ret = copy_value(addr_of_array_len_field, size_of_array_len_field, &array_len);
+                if (ret < 0) {
+                    log_error("IOCTL: cannot get array len from '%s'",
+                              sub_regions[i].array_len.sub_region_name);
+                    goto out;
+                }
+
+                free(sub_regions[i].array_len.sub_region_name);
+                sub_regions[i].array_len = (struct dynamic_value){
+                    .is_determined = true,
+                    .value = array_len
+                };
+            }
+
+            /* add nested mem regions only if this pointer/array sub region value is not NULL */
+            void* mem_region_addr = *((void**)sub_regions[i].enclave_addr);
+            if (mem_region_addr) {
+                for (size_t k = 0; k < sub_regions[i].array_len.value; k++) {
+                    if (mem_regions_cnt == max_mem_regions) {
+                        log_error("IOCTL: too many memory regions (max is %zu)", max_mem_regions);
+                        ret = -PAL_ERROR_NOMEM;
+                        goto out;
+                    }
+
+                    mem_regions[mem_regions_cnt].toml_mem_region = sub_regions[i].toml_mem_region;
+                    mem_regions[mem_regions_cnt].enclave_addr    = mem_region_addr;
+                    mem_regions[mem_regions_cnt].adjacent        = k > 0;
+                    mem_regions_cnt++;
+                }
+            }
+        }
+    }
+
+    *mem_regions_cnt_ptr = mem_regions_cnt;
+    *sub_regions_cnt_ptr = sub_regions_cnt;
+    ret = 0;
+out:
+    for (size_t i = 0; i < sub_regions_cnt; i++) {
+        /* "name" fields are not needed after we collected all sub_regions */
+        free(sub_regions[i].name);
+        sub_regions[i].name = NULL;
+        if (!sub_regions[i].array_len.is_determined) {
+            free(sub_regions[i].array_len.sub_region_name);
+            sub_regions[i].array_len.sub_region_name = NULL;
+        }
+    }
+    return ret;
+}
+
+static int copy_sub_regions_to_untrusted(struct sub_region* sub_regions, size_t sub_regions_cnt,
+                                         void* untrusted_addr) {
+    /* we rely on the fact that the untrusted memory region was zeroed out: we can simply "jump
+     * over" untrusted memory when doing alignment and when direction of copy is `in` or `none` */
+    char* cur_untrusted_addr = untrusted_addr;
+    for (size_t i = 0; i < sub_regions_cnt; i++) {
+        if (!sub_regions[i].size)
+            continue;
+
+        assert(sub_regions[i].alignment);
+        cur_untrusted_addr = ALIGN_UP_PTR(cur_untrusted_addr, sub_regions[i].alignment);
+
+        if (!sgx_is_completely_within_enclave(sub_regions[i].enclave_addr, sub_regions[i].size)
+                || !sgx_is_valid_untrusted_ptr(cur_untrusted_addr, sub_regions[i].size, 1)) {
+            return -PAL_ERROR_DENIED;
+        }
+
+        if (sub_regions[i].direction == DIRECTION_OUT
+                || sub_regions[i].direction == DIRECTION_INOUT) {
+            bool ret = sgx_copy_from_enclave(cur_untrusted_addr, sub_regions[i].enclave_addr,
+                                             sub_regions[i].size);
+            if (!ret)
+                return -PAL_ERROR_DENIED;
+        }
+
+        sub_regions[i].untrusted_addr = cur_untrusted_addr;
+        cur_untrusted_addr += sub_regions[i].size;
+    }
+
+    for (size_t i = 0; i < sub_regions_cnt; i++) {
+        if (!sub_regions[i].size)
+            continue;
+
+        if (sub_regions[i].toml_mem_region) {
+            void* enclave_ptr_value = *((void**)sub_regions[i].enclave_addr);
+            /* rewire pointer value in untrusted memory to a corresponding untrusted sub-region */
+            for (size_t j = 0; j < sub_regions_cnt; j++) {
+                if (sub_regions[j].enclave_addr == enclave_ptr_value) {
+                    bool ret = sgx_copy_from_enclave(sub_regions[i].untrusted_addr,
+                                                     &sub_regions[j].untrusted_addr,
+                                                     sizeof(void*));
+                    if (!ret)
+                        return -PAL_ERROR_DENIED;
+                    break;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int copy_sub_regions_to_enclave(struct sub_region* sub_regions, size_t sub_regions_cnt) {
+    for (size_t i = 0; i < sub_regions_cnt; i++) {
+        if (!sub_regions[i].size)
+            continue;
+
+        if (sub_regions[i].direction == DIRECTION_IN
+                || sub_regions[i].direction == DIRECTION_INOUT) {
+            bool ret = sgx_copy_to_enclave(sub_regions[i].enclave_addr, sub_regions[i].size,
+                                           sub_regions[i].untrusted_addr, sub_regions[i].size);
+            if (!ret)
+                return -PAL_ERROR_DENIED;
+        }
+    }
+    return 0;
+}
+
+/* may return `*out_toml_ioctl_struct = NULL` which means "no struct needed for this IOCTL" */
+static int get_ioctl_struct(toml_table_t* manifest_sgx, toml_table_t* toml_ioctl_table,
+                            toml_array_t** out_toml_ioctl_struct) {
+    toml_raw_t toml_ioctl_struct_raw = toml_raw_in(toml_ioctl_table, "struct");
+    if (!toml_ioctl_struct_raw) {
+        /* no corresponding struct -> base-type or ignored IOCTL argument */
+        *out_toml_ioctl_struct = NULL;
+        return 0;
+    }
+
+    char* ioctl_struct_str = NULL;
+    int ret = toml_rtos(toml_ioctl_struct_raw, &ioctl_struct_str);
+    if (ret < 0)
+        return -PAL_ERROR_INVAL;
+
+    if (strcmp(ioctl_struct_str, "") == 0) {
+        /* empty string instead of struct name -> base-type or ignored IOCTL argument */
+        *out_toml_ioctl_struct = NULL;
+        ret = 0;
+        goto out;
+    }
+
+    toml_table_t* toml_ioctl_structs = toml_table_in(manifest_sgx, "ioctl_structs");
+    if (!toml_ioctl_structs) {
+        log_error("There are no IOCTL structs found in manifest");
+        ret = -PAL_ERROR_INVAL;
+        goto out;
+    }
+
+    toml_array_t* toml_ioctl_struct = toml_array_in(toml_ioctl_structs, ioctl_struct_str);
+    if (!toml_ioctl_struct || toml_array_nelem(toml_ioctl_struct) <= 0) {
+        ret = -PAL_ERROR_INVAL;
+        goto out;
+    }
+
+    *out_toml_ioctl_struct = toml_ioctl_struct;
+    ret = 0;
+out:
+    free(ioctl_struct_str);
+    return ret;
+}
+
+/* may return `*out_toml_ioctl_struct = NULL` which means "no struct needed for this IOCTL" */
+static int get_allowed_ioctl_struct(uint32_t cmd, toml_array_t** out_toml_ioctl_struct) {
+    int ret;
+
+    /* find this IOCTL request in the manifest */
+    toml_table_t* manifest_sgx = toml_table_in(g_pal_public_state.manifest_root, "sgx");
+    if (!manifest_sgx)
+        return -PAL_ERROR_NOTIMPLEMENTED;
+
+    toml_array_t* toml_allowed_ioctls = toml_array_in(manifest_sgx, "allowed_ioctls");
+    if (!toml_allowed_ioctls)
+        return -PAL_ERROR_NOTIMPLEMENTED;
+
+    ssize_t toml_allowed_ioctls_cnt = toml_array_nelem(toml_allowed_ioctls);
+    if (toml_allowed_ioctls_cnt <= 0)
+        return -PAL_ERROR_NOTIMPLEMENTED;
+
+    for (size_t idx = 0; idx < (size_t)toml_allowed_ioctls_cnt; idx++) {
+        toml_table_t* toml_ioctl_table = toml_table_at(toml_allowed_ioctls, idx);
+        if (!toml_ioctl_table) {
+            log_error("Invalid allowed IOCTL #%zu in manifest (not a TOML table)", idx + 1);
+            return -PAL_ERROR_INVAL;
+        }
+
+        int64_t request_code;
+        ret = toml_int_in(toml_ioctl_table, "request_code", /*default_val=*/-1, &request_code);
+        if (ret < 0 || request_code < 0) {
+            log_error("Invalid request code of allowed IOCTL #%zu in manifest", idx + 1);
+            return -PAL_ERROR_INVAL;
+        }
+
+        if (request_code == (int64_t)cmd) {
+            /* found this IOCTL request in the manifest, now must find the corresponding struct */
+            ret = get_ioctl_struct(manifest_sgx, toml_ioctl_table, out_toml_ioctl_struct);
+            if (ret < 0) {
+                log_error("Invalid struct value of allowed IOCTL #%zu in manifest", idx + 1);
+            }
+            return ret;
+        }
+    }
+
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+int _PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int* out_ret) {
+    int ret;
+
+    if (handle->hdr.type != PAL_TYPE_DEV)
+        return -PAL_ERROR_INVAL;
+
+    if (handle->dev.fd == PAL_IDX_POISON)
+        return -PAL_ERROR_DENIED;
+
+    toml_array_t* toml_ioctl_struct = NULL;
+    ret = get_allowed_ioctl_struct(cmd, &toml_ioctl_struct);
+    if (ret < 0)
+        return ret;
+
+    if (!toml_ioctl_struct) {
+        /* special case of "no struct needed for IOCTL" -> base-type or ignored IOCTL argument */
+        *out_ret = ocall_ioctl(handle->dev.fd, cmd, arg);
+        return 0;
+    }
+
+    void* untrusted_addr = NULL;
+    size_t untrusted_size = 0;
+
+    size_t mem_regions_cnt = MAX_MEM_REGIONS;
+    size_t sub_regions_cnt = MAX_SUB_REGIONS;
+    struct mem_region* mem_regions = calloc(mem_regions_cnt, sizeof(*mem_regions));
+    struct sub_region* sub_regions = calloc(sub_regions_cnt, sizeof(*sub_regions));
+    if (!mem_regions || !sub_regions) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
+    /* deep-copy the IOCTL argument's input data outside of enclave, execute the IOCTL OCALL, and
+     * deep-copy the IOCTL argument's output data back into enclave */
+    ret = collect_sub_regions(toml_ioctl_struct, (void*)arg, mem_regions, &mem_regions_cnt,
+                              sub_regions, &sub_regions_cnt);
+    if (ret < 0) {
+        log_error("IOCTL: failed to parse ioctl struct (request code = 0x%x)", cmd);
+        goto out;
+    }
+
+    for (size_t i = 0; i < sub_regions_cnt; i++) {
+        /* overapproximation since alignment doesn't necessarily increase sub-region's size */
+        untrusted_size += sub_regions[i].size + sub_regions[i].alignment - 1;
+    }
+
+    ret = ocall_mmap_untrusted(&untrusted_addr, ALLOC_ALIGN_UP(untrusted_size),
+                               PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, /*fd=*/-1,
+                               /*offset=*/0);
+    if (ret < 0) {
+        ret = unix_to_pal_error(ret);
+        goto out;
+    }
+
+    assert(untrusted_addr);
+    ret = copy_sub_regions_to_untrusted(sub_regions, sub_regions_cnt, untrusted_addr);
+    if (ret < 0)
+        goto out;
+
+    int ioctl_ret = ocall_ioctl(handle->dev.fd, cmd, (unsigned long)untrusted_addr);
+
+    ret = copy_sub_regions_to_enclave(sub_regions, sub_regions_cnt);
+    if (ret < 0)
+        goto out;
+
+    *out_ret = ioctl_ret;
+    ret = 0;
+out:
+    if (untrusted_addr)
+        ocall_munmap_untrusted(untrusted_addr, ALLOC_ALIGN_UP(untrusted_size));
+    free(mem_regions);
+    free(sub_regions);
+    return ret;
+}

--- a/pal/src/host/linux-sgx/pal_ocall_types.h
+++ b/pal/src/host/linux-sgx/pal_ocall_types.h
@@ -68,6 +68,7 @@ enum {
     OCALL_DEBUG_MAP_REMOVE,
     OCALL_DEBUG_DESCRIBE_LOCATION,
     OCALL_EVENTFD,
+    OCALL_IOCTL,
     OCALL_GET_QUOTE,
     OCALL_EDMM_RESTRICT_PAGES_PERM,
     OCALL_EDMM_MODIFY_PAGES_TYPE,
@@ -326,6 +327,12 @@ struct ocall_debug_describe_location {
 
 struct ocall_eventfd {
     int          flags;
+};
+
+struct ocall_ioctl {
+    int           fd;
+    unsigned int  cmd;
+    unsigned long arg;
 };
 
 struct ocall_get_quote {

--- a/pal/src/host/linux/pal_devices.c
+++ b/pal/src/host/linux/pal_devices.c
@@ -209,3 +209,17 @@ struct handle_ops g_dev_ops = {
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,
 };
+
+int _PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int* out_ret) {
+    if (handle->hdr.type != PAL_TYPE_DEV)
+        return -PAL_ERROR_INVAL;
+
+    if (handle->dev.fd == PAL_IDX_POISON)
+        return -PAL_ERROR_DENIED;
+
+    /* note that if the host returned a negative value (typically means an error, but not always
+     * since this is completely device-specific), then we still return success and forward the value
+     * as-is to the LibOS and ultimately to the app */
+    *out_ret = DO_SYSCALL(ioctl, handle->dev.fd, cmd, arg);
+    return 0;
+}

--- a/pal/src/host/skeleton/pal_devices.c
+++ b/pal/src/host/skeleton/pal_devices.c
@@ -55,3 +55,7 @@ struct handle_ops g_dev_ops = {
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,
 };
+
+int _PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int* out_ret) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}

--- a/pal/src/pal_misc.c
+++ b/pal/src/pal_misc.c
@@ -26,6 +26,10 @@ int PalSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
 }
 #endif
 
+int PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int* out_ret) {
+    return _PalDeviceIoControl(handle, cmd, arg, out_ret);
+}
+
 #if defined(__x86_64__)
 int PalCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) {
     return _PalCpuIdRetrieve(leaf, subleaf, values);

--- a/pal/src/pal_symbols
+++ b/pal/src/pal_symbols
@@ -43,6 +43,7 @@ PalSegmentBaseGet
 PalSegmentBaseSet
 PalStreamChangeName
 PalStreamAttributesSetByHandle
+PalDeviceIoControl
 PalDebugMapAdd
 PalDebugMapRemove
 PalDebugDescribeLocation


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The newly added `ioctl()` syscall emulation on device-backed file descriptors is pass-through. It is insecure by itself since the emulation only passes the arguments to and from the untrusted memory. It is the responsibility of the app developer to correctly use ioctls, with security implications in mind.

On the Linux-SGX PAL, a set of IOCTL requests must be explicitly allowed in the manifest via the new option `sgx.allowed_ioctls.[id].request`. Also, the allowed IOCTLs' arguments (typically pointers to complex nested objects) must be explicitly described in the manifest via the new options `sgx.ioctl_structs.[id]` and a corresponding reference `sgx.allowed_ioctls.[id].struct`; see docs for explanation of the IOCTL struct format.

Companion PR: https://github.com/gramineproject/device-testing-tools/pull/4 (MERGED)

Next steps in future PRs: 
- [ ] Add caching of memory for regions and sub-regions (to avoid `malloc`/`free` all the time) -- probably useless.
- [ ] Add string hashes, for quicker comparisons.
- [ ] Add `onlyif` syntax.
- [ ] Add caching of sub-regions.
- [ ] Add caching of IOCTL TOML definitions.

**If reviewers think this is still too much functionality for the first commit**, then I can strip off:
- Pointer-arrays with `size > 1` (but I already have a test for it!).

## How to test this PR? <!-- (if applicable) -->

This PR adds a new LibOS test `device_ioctl` that tests the flexible IOCTL logic against Gramine dummy device `/dev/gramine_test_dev`. This device is found in companion repo `gramineproject/device-testing-tools` (https://github.com/gramineproject/device-testing-tools/tree/master/gramine-device-testing-module).

**TODO**: 
- [x] Add a 22.04 bare-metal CI pipeline:
    - [x] https://github.com/gramineproject/device-testing-tools/pull/8
    - [x] https://github.com/gramineproject/gramine/pull/1032

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/671)
<!-- Reviewable:end -->
