### PR TITLE
[LibOS] Remove `shim_` prefix from syscalls trace log

### DIFF
--- a/Documentation/devel/onboarding.rst
+++ b/Documentation/devel/onboarding.rst
@@ -560,7 +560,7 @@ system call that is not implemented in Gramine (recall that ``-38`` is the
 ``-ENOSYS`` error code, which means "syscall not implemented")::
 
     $ gramine-sgx ./myapp
-    .. [P1:T1:app] trace: ---- shim_some_syscall(...) = -38 ..
+    .. [P1:T1:app] trace: ---- some_syscall(...) = -38 ..
     <unexpected output, terminates abnormally>
 
 #. Make sure this system call is required:
@@ -569,7 +569,7 @@ system call that is not implemented in Gramine (recall that ``-38`` is the
      In this case, the application detects ``-ENOSYS`` and either falls back to
      another implementation (e.g., app first tries ``flock()`` and then falls
      back to ``fcntl()``) or simply ignores the result of this syscall (e.g.,
-     ``shim_ioctl(1, TCGETS, ..)`` can be safely ignored).
+     ``ioctl(1, TCGETS, ..)`` can be safely ignored).
 
      Make sure that ``some_syscall`` returning ``-ENOSYS`` in the log is
      actually the root cause of the application failure. Sometimes such syscalls

--- a/libos/src/shim_parser.c
+++ b/libos/src/shim_parser.c
@@ -1573,7 +1573,6 @@ static void parse_pointer_ret(struct print_buf* buf, va_list* ap) {
 }
 
 static void print_syscall_name(struct print_buf* buf, const char* name, unsigned long sysno) {
-    buf_puts(buf, "shim_");
     if (name) {
         buf_printf(buf, "%s", name);
     } else {

--- a/libos/src/sys/shim_exit.c
+++ b/libos/src/sys/shim_exit.c
@@ -169,7 +169,7 @@ long libos_syscall_exit_group(int error_code) {
 
     error_code &= 0xFF;
 
-    log_debug("---- shim_exit_group (returning %d)", error_code);
+    log_debug("---- exit_group (returning %d)", error_code);
 
     process_exit(error_code, 0);
 }
@@ -179,7 +179,7 @@ long libos_syscall_exit(int error_code) {
 
     error_code &= 0xFF;
 
-    log_debug("---- shim_exit (returning %d)", error_code);
+    log_debug("---- exit (returning %d)", error_code);
 
     thread_exit(error_code, 0);
 }

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -370,7 +370,7 @@ class TC_01_Bootstrap(RegressionTestCase):
     def _verify_debug_log(self, log: str):
         self.assertIn('Host:', log)
         self.assertIn('LibOS initialized', log)
-        self.assertIn('--- shim_exit_group', log)
+        self.assertIn('--- exit_group', log)
 
 
 class TC_02_OpenMP(RegressionTestCase):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Syscall name should be enough to have in the trace log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/682)
<!-- Reviewable:end -->
