### PR TITLE
[CI] Add bash bc tool to CI systems

### DIFF
--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:18.04
 # Add steps here to set up dependencies
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     autoconf \
+    bc \
     bison \
     build-essential \
     cargo \

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 # Add steps here to set up dependencies
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     autoconf \
+    bc \
     bison \
     build-essential \
     cargo \

--- a/CI-Examples/lighttpd/lighttpd-generic.conf
+++ b/CI-Examples/lighttpd/lighttpd-generic.conf
@@ -1,8 +1,8 @@
-server.event-handler          = "select"
-#server.event-handler          = "linux-sysepoll"
-
+server.event-handler = "select"
+#server.event-handler = "linux-sysepoll"
+server.max-connections = 1024
 # If keep-alive is undesired, uncomment the following line.
-# server.max-keep-alive-requests = 0
+#server.max-keep-alive-requests = 0
 
 index-file.names = ( "index.html", "index.php" )
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Additionally, this commit also increases max-connections value for `lighttpd` workload in CI-Examples. This was done to remove the following log messages:

```
server.c.980) [note] sockets disabled, connection limit reached
server.c.973) [note] sockets enabled again
```

## How to test this PR? <!-- (if applicable) -->
Please run `lighttpd` workload as part of the `CI-Examples`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/693)
<!-- Reviewable:end -->
