### PR TITLE
[Pal/Linux] Remove unused `file.map_start` from `PAL_HANDLE`

### DIFF
--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -47,7 +47,6 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
     init_handle_hdr(hdl, PAL_TYPE_FILE);
     hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     hdl->file.fd = ret;
-    hdl->file.map_start = NULL;
     char* path = (void*)hdl + HANDLE_SIZE(file);
     ret = get_norm_path(uri, path, &uri_size);
     if (ret < 0) {
@@ -134,16 +133,6 @@ static int file_map(PAL_HANDLE handle, void** addr, pal_prot_flags_t prot, uint6
                     uint64_t size) {
     int fd = handle->file.fd;
     void* mem = *addr;
-    /*
-     * work around for fork emulation
-     * the first exec image to be loaded has to be at same address
-     * as parent.
-     */
-    if (mem == NULL && handle->file.map_start != NULL) {
-        mem = handle->file.map_start;
-        /* this address is used. don't over-map it later */
-        handle->file.map_start = NULL;
-    }
     int flags = PAL_MEM_FLAGS_TO_LINUX(0, prot) | (mem ? MAP_FIXED : 0);
     int linux_prot = PAL_PROT_TO_LINUX(prot);
 

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -39,12 +39,6 @@ typedef struct {
         struct {
             PAL_IDX fd;
             const char* realpath;
-            /*
-             * map_start is to request this file should be mapped to this
-             * address. When fork is emulated, the address is already
-             * determined by parent process.
-             */
-            void* map_start;
             bool seekable; /* regular files are seekable, FIFO pipes are not */
         } file;
 


### PR DESCRIPTION
`handle.file.map_start` initially introduced for fork emulation in https://github.com/gramineproject/graphene/commit/b8031c4224021f3943a87093f40c91ce4e431f34 was removed by https://github.com/gramineproject/gramine/commit/a95c063436053b218904d9da7e3e4dcaf4177397. It's not used any more so that we can remove it.

Fixes https://github.com/gramineproject/gramine/issues/694

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/695)
<!-- Reviewable:end -->
