### PR TITLE
[Pal] Move shared functions to Linux-common header

### DIFF
--- a/common/include/api.h
+++ b/common/include/api.h
@@ -373,6 +373,8 @@ extern const char* const* sys_errlist_internal;
 int get_norm_path(const char* path, char* buf, size_t* inout_size);
 int get_base_name(const char* path, char* buf, size_t* inout_size);
 
+bool is_dot_or_dotdot(const char* name);
+
 /*!
  * \brief Parse a size (number with optional "G"/"M"/"K" suffix) into an uint64_t.
  *

--- a/common/src/path.c
+++ b/common/src/path.c
@@ -163,3 +163,7 @@ int get_base_name(const char* path, char* buf, size_t* inout_size) {
 
     return 0;
 }
+
+bool is_dot_or_dotdot(const char* name) {
+    return (name[0] == '.' && !name[1]) || (name[0] == '.' && name[1] == '.' && !name[2]);
+}

--- a/libos/src/fs/libos_fs.c
+++ b/libos/src/fs/libos_fs.c
@@ -247,7 +247,7 @@ static int mount_one_nonroot(toml_table_t* mount, const char* prefix) {
     if (mount_path[0] != '/') {
         /* FIXME: Relative paths are deprecated starting from Gramine v1.2, we can disallow them
          * completely two versions after it. */
-        if (!strcmp(mount_path, ".") || !strcmp(mount_path, "..")) {
+        if (is_dot_or_dotdot(mount_path)) {
             log_error("Mount points '.' and '..' are not allowed, use absolute paths instead.");
             ret = -EINVAL;
             goto out;

--- a/pal/include/host/linux-common/linux_utils.h
+++ b/pal/include/host/linux-common/linux_utils.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <asm/stat.h>
 #include <linux/time.h>
 #include <linux/un.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdnoreturn.h>
+
+#include "pal.h"
 
 char* get_main_exec_path(void);
 
@@ -44,3 +47,8 @@ int64_t time_ns_diff_from_now(struct timespec* ts);
 
 int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
                                  struct sockaddr_un* out_addr);
+
+int file_stat_type(struct stat* stat);
+
+/* copy attr content from POSIX stat struct to PAL_STREAM_ATTR */
+void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat);

--- a/pal/src/host/linux-common/file_info.c
+++ b/pal/src/host/linux-common/file_info.c
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation */
+
+#include <asm/stat.h>
+
+#include "linux_utils.h"
+#include "pal.h"
+#include "stat.h"
+
+int file_stat_type(struct stat* stat) {
+    if (S_ISREG(stat->st_mode))
+        return PAL_TYPE_FILE;
+    if (S_ISDIR(stat->st_mode))
+        return PAL_TYPE_DIR;
+    if (S_ISCHR(stat->st_mode))
+        return PAL_TYPE_DEV;
+    if (S_ISFIFO(stat->st_mode))
+        return PAL_TYPE_PIPE;
+    if (S_ISSOCK(stat->st_mode))
+        return PAL_TYPE_DEV;
+
+    return 0;
+}
+
+void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
+    attr->handle_type  = file_stat_type(stat);
+    attr->nonblocking  = false;
+    attr->share_flags  = stat->st_mode & PAL_SHARE_MASK;
+    attr->pending_size = stat->st_size;
+}

--- a/pal/src/host/linux-common/meson.build
+++ b/pal/src/host/linux-common/meson.build
@@ -1,6 +1,7 @@
 pal_linux_common_sources_enclave = files(
     'bogomips.c',
     'gramine_unix_socket_addr.c',
+    'file_info.c',
 )
 pal_linux_common_sources_host = files(
     'debug_map.c',

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -13,6 +13,7 @@
 #include "api.h"
 #include "asan.h"
 #include "enclave_tf.h"
+#include "linux_utils.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "pal_flags_conv.h"
@@ -379,29 +380,6 @@ static int file_flush(PAL_HANDLE handle) {
     return 0;
 }
 
-static inline int file_stat_type(struct stat* stat) {
-    if (S_ISREG(stat->st_mode))
-        return PAL_TYPE_FILE;
-    if (S_ISDIR(stat->st_mode))
-        return PAL_TYPE_DIR;
-    if (S_ISCHR(stat->st_mode))
-        return PAL_TYPE_DEV;
-    if (S_ISFIFO(stat->st_mode))
-        return PAL_TYPE_PIPE;
-    if (S_ISSOCK(stat->st_mode))
-        return PAL_TYPE_DEV;
-
-    return 0;
-}
-
-/* copy attr content from POSIX stat struct to PAL_STREAM_ATTR */
-static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
-    attr->handle_type  = file_stat_type(stat);
-    attr->nonblocking  = false;
-    attr->share_flags  = stat->st_mode & PAL_SHARE_MASK;
-    attr->pending_size = stat->st_size;
-}
-
 /* 'attrquery' operation for file streams */
 static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     if (strcmp(type, URI_TYPE_FILE) && strcmp(type, URI_TYPE_DIR))
@@ -574,9 +552,6 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
 }
 
 #define DIRBUF_SIZE 1024
-static inline bool is_dot_or_dotdot(const char* name) {
-    return (name[0] == '.' && !name[1]) || (name[0] == '.' && name[1] == '.' && !name[2]);
-}
 
 /* 'read' operation for directory stream. Directory stream will not
    need a 'write' operation. */


### PR DESCRIPTION
`file_stat_type`, `file_attrcopy` and `is_dot_or_dotdot` are shared between
pal/linux and pal/linux-sgx, hence can be moved to Linux-common header.

Fixes https://github.com/gramineproject/gramine/issues/696

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/697)
<!-- Reviewable:end -->
