### PR TITLE
[tests] Log timestamps within Python

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -9,7 +9,6 @@ stage('test-direct') {
             // separately
             sh '''
                 cd libos/test/ltp
-                export GRAMINE_LTP_LIVE_OUTPUT=fcntl14,fdatasync01
                 python3 -m pytest -v -n4 --junit-xml=ltp.xml
             '''
         }

--- a/libos/test/ltp/test_ltp.py
+++ b/libos/test/ltp/test_ltp.py
@@ -183,7 +183,7 @@ def check_must_pass(passed, failed, must_pass):
         pytest.fail('All subtests skipped, replace must-pass with skip')
 
 
-def test_ltp(cmd, section, capsys):
+def test_ltp(cmd, section):
     must_pass = section.getintset('must-pass')
 
     loader = 'gramine-sgx' if HAS_SGX else 'gramine-direct'
@@ -193,12 +193,7 @@ def test_ltp(cmd, section, capsys):
     logging.info('command: %s', full_cmd)
     logging.info('must_pass: %s', list(must_pass) if must_pass else 'all')
 
-    live_output = os.getenv('GRAMINE_LTP_LIVE_OUTPUT') or ''
-    if section.name in live_output.split(','):
-        with capsys.disabled():
-            returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
-    else:
-        returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
+    returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
 
     # Parse output regardless of whether `must_pass` is specified: unfortunately some tests
     # do not exit with non-zero code when failing, because they rely on `MAP_SHARED` (which

--- a/python/graminelibos/regression.py
+++ b/python/graminelibos/regression.py
@@ -34,18 +34,33 @@ def run_command(cmd, *, timeout, can_fail=False, **kwds):
             def __init__(self, input_pipe, output_pipe):
                 self.logged_data = b''
                 self.closed = False
+                self.at_line_start = True
                 self.input_pipe = input_pipe
                 self.output_pipe = output_pipe
+                self.start_time = time.time()
 
             def pump_data(self, pending_reads):
                 if self.input_pipe in pending_reads:
                     data = self.input_pipe.read(1024)
-                    self.output_pipe.write(data)
-                    self.output_pipe.flush()
                     self.logged_data += data
 
                     if not data:
                         self.closed = True
+                        return
+
+                    timestamped = bytearray()
+                    for ch in data:
+                        if self.at_line_start:
+                            timestamped += b'[%.3f] ' % (time.time() - self.start_time)
+                            self.at_line_start = False
+
+                        timestamped.append(ch)
+
+                        if ch == 10:
+                            self.at_line_start = True
+
+                    self.output_pipe.write(timestamped)
+                    self.output_pipe.flush()
 
         stdout_splice = LoggingSplice(proc.stdout.raw, sys.stdout.buffer)
         stderr_splice = LoggingSplice(proc.stderr.raw, sys.stderr.buffer)


### PR DESCRIPTION
## Description of the changes

In #632, I attempted to add log timestamps to the intermittently-failing tests (`fcntl14` and `fdatasync01`, for example). As we've later discovered (see discussion on #642), the approach of live-piping the output and having CI timestamp it is not viable, as `pytest-xdist` doesn't support running tests with stdout capture disabled.

Therefore I change the strategy to logging timestamps within Python while the output is being pumped around. Then the output gets printed, with the timestamps, when a test fails. This has the additional benefit of not having to list the problematic tests anywhere.

Closes #642.

## How to test this PR?

Try running a test with `-s` (e.g. `python3 -m pytest -v -k fcntl14 -s`, cf. [the docs on running LTP tests](https://gramine.readthedocs.io/en/latest/devel/contributing.html#ltp)), observe the timestamps getting added to the output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/700)
<!-- Reviewable:end -->
