### PR TITLE
[common,PAL] Introduce constant-time memcmp and use it for MAC check

### DIFF
--- a/common/include/api.h
+++ b/common/include/api.h
@@ -248,6 +248,21 @@ void* memmove(void* dest, const void* src, size_t count);
 void* memset(void* dest, int ch, size_t count);
 int memcmp(const void* lhs, const void* rhs, size_t count);
 
+/*!
+ * \brief Constant-time buffer comparison.
+ *
+ * \param lhs    Pointer to the first buffer.
+ * \param rhs    Pointer to the second buffer.
+ * \param count  The number of bytes to compare in the buffer.
+ *
+ * \returns true if the content of the two buffers is the same, otherwise false.
+ *
+ * The time taken by this function depends on `count`, but not on the data at `lhs` or `rhs`.
+ * Hence, it can be used for comparing cryptographic secrets, hashes, message authentication codes
+ * etc. without timing side-channel leaks.
+ */
+bool ct_memequal(const void* lhs, const void* rhs, size_t count);
+
 /* Used by _FORTIFY_SOURCE */
 void* __memcpy_chk(void* restrict dest, const void* restrict src, size_t count, size_t dest_count);
 void* __memmove_chk(void* dest, const void* src, size_t count, size_t dest_count);

--- a/common/src/arch/meson.build
+++ b/common/src/arch/meson.build
@@ -1,0 +1,1 @@
+subdir(host_machine.cpu_family())

--- a/common/src/arch/x86_64/ct_memequal.nasm
+++ b/common/src/arch/x86_64/ct_memequal.nasm
@@ -1,0 +1,33 @@
+; SPDX-License-Identifier: LGPL-3.0-or-later
+; Copyright (C) 2022 Intel Corporation
+
+; Constant-time buffer comparison
+
+global ct_memequal
+
+section .text
+
+; bool ct_memequal(const void* lhs, const void* rhs, size_t count)
+; Arguments:
+; - RDI: Pointer to the first buffer (lhs)
+; - RSI: Pointer to the second buffer (rhs)
+; - RDX: The number of bytes to compare in the buffer (count)
+ct_memequal:
+    mov     ecx, 0
+    test    rdx, rdx
+    jz      .return
+    add     rdx, rdi
+.loop:
+    movzx   eax, byte [rdi]
+    movzx   r8d, byte [rsi]
+    add     rdi, 1
+    add     rsi, 1
+    xor     eax, r8d        ; using bitwise operation rather than a branch
+    or      ecx, eax
+    cmp     rdi, rdx
+    jnz     .loop
+.return:
+    mov     eax, ecx
+    test    al, al
+    sete    al
+    ret

--- a/common/src/arch/x86_64/meson.build
+++ b/common/src/arch/x86_64/meson.build
@@ -1,0 +1,10 @@
+common_src_arch_nasm = nasm_gen.process(
+    'ct_memequal.nasm',
+)
+
+common_src_arch_c = files()
+
+common_src_arch = [
+    common_src_arch_nasm,
+    common_src_arch_c,
+]

--- a/common/src/meson.build
+++ b/common/src/meson.build
@@ -21,6 +21,12 @@ common_src = files(
     'string/toml_utils.c',
     'string/utils.c',
 )
+
+# Arch-specific meson.build must define the following Meson variables:
+#   - `common_src_arch` - a list of arch-specific sources.
+subdir('arch')
+common_src += common_src_arch
+
 if asan
     common_src += files('asan.c')
 endif

--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -230,7 +230,7 @@ int sgx_verify_report(sgx_report_t* report) {
     log_debug("Verify report:");
     print_report(report);
 
-    if (memcmp(&check_mac, &report->mac, sizeof(check_mac))) {
+    if (!ct_memequal(&check_mac, &report->mac, sizeof(check_mac))) {
         log_error("Report verification failed");
         return -PAL_ERROR_DENIED;
     }


### PR DESCRIPTION
The MAC check in `sgx_verify_report()` should be done in a constant-time manner
to avoid side-channel leaks via timing attacks which could potentially allow an
attacker to guess a valid value and thereby bypass security controls. Similar
hardening is also applied in SGX SDK.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/704)
<!-- Reviewable:end -->
