### PR TITLE
[LibOS] Move "Allocated stack" log message to after `allocate_stack()`

### DIFF
--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -99,8 +99,6 @@ void* allocate_stack(size_t size, size_t protect_size, bool user) {
     size = ALLOC_ALIGN_UP(size);
     protect_size = ALLOC_ALIGN_UP(protect_size);
 
-    log_debug("Allocating stack at %p (size = %ld)", stack, size);
-
     if (!user) {
         stack = system_malloc(size + protect_size);
         if (!stack) {
@@ -301,6 +299,8 @@ int init_stack(const char** argv, const char** envp, const char*** out_argp,
     void* stack = allocate_stack(stack_size, ALLOC_ALIGNMENT, /*user=*/true);
     if (!stack)
         return -ENOMEM;
+
+    log_debug("Allocated stack at %p (size = %#lx)", stack, stack_size);
 
     /* if there is envp inherited from parent, use it */
     envp = migrated_envp ?: envp;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
At the start, Gramine often outputs allocating stack at 0
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Now the log work correctly!

```
debug: Gramine was built from commit: 1.2post-UNRELEASED
debug: Host: Linux
debug: LibOS xsave_enabled 1, xsave_size 0x440(1088), xsave_features 0x1f
debug: Initial VMA region 0x7ffff3efd000-0x7ffff3fd1000 (LibOS) bookkeeped
debug: Initial VMA region 0x7ffff3fd2000-0x7ffff7fd2000 (pal_init_pool) bookkeeped
debug: Initial VMA region 0x7ffff7fd6000-0x7ffff7fd8000 (vdso) bookkeeped
debug: Initial VMA region 0x7ffff7fd2000-0x7ffff7fd6000 (vvar) bookkeeped
debug: Initial VMA region 0x7ffff3fd1000-0x7ffff3fd2000 (pal_internal_me) bookkeeped
debug: ASLR top address adjusted to 0x42ef1b19e000
debug: Shim loaded at 0x7ffff3efd000, ready to initialize
debug: mounting "file:." (chroot) under /
debug: mounting "proc" (pseudo) under /proc
debug: mounting "dev" (pseudo) under /dev
debug: mounting "dev:tty" (chroot) under /dev/tty
debug: mounting "sys" (pseudo) under /sys
debug: Creating pipe: pipe.srv:62816d9b5911aa3bca1594124e44c1b5f3a4b4c9d0193259f485c3fc72868321
[P1:T1:] debug: mounting "file:/usr/local/lib/x86_64-linux-gnu/gramine/runtime/glibc" (chroot) under /lib
[P1:T1:helloworld] debug: Creating pipe: pipe.srv:daf39d5d89be1d966e8a2ccd5c1b3e4def8083bbd12531bcb1ce1e275e922f07
**[P1:T1:helloworld] debug: Allocating stack at 0x42ef1b15e000 (size = 262144)**
[P1:T1:helloworld] debug: loading "file:./helloworld"
[P1:T1:helloworld] debug: append_r_debug: adding file:./helloworld at 0x42ef1b158000
[P1:T1:helloworld] debug: find_interp: searching for interpreter: /lib/ld-linux-x86-64.so.2
[P1:T1:helloworld] debug: loading "file:/usr/local/lib/x86_64-linux-gnu/gramine/runtime/glibc/ld-linux-x86-64.so.2"
[P1:T1:helloworld] debug: append_r_debug: adding file:/usr/local/lib/x86_64-linux-gnu/gramine/runtime/glibc/ld-linux-x86-64.so.2 at 0x42ef1b11f000
[P1:T1:helloworld] debug: Creating pipe: pipe.srv:1
[P1:T1:helloworld] debug: Creating pipe: pipe.srv:78dfd182bac10f1da10e6cc7616b1ecf5e8abdeb0f3aec65671b02c35bd0e3f9
[P1:T1:helloworld] debug: LibOS initialized
[P1:T1:helloworld] debug: append_r_debug: adding file:[vdso_libos] at 0x42ef1b11e000
[P1:shim] debug: IPC worker started
[P1:T1:helloworld] warning: Not supported flag (0x3001) passed to arch_prctl
[P1:T1:helloworld] debug: glibc register library /lib/libc.so.6 loaded at 0x42ef1af22000
[P1:T1:helloworld] debug: append_r_debug: adding file:/usr/local/lib/x86_64-linux-gnu/gramine/runtime/glibc/libc.so.6 at 0x42ef1af22000
[P1:T1:helloworld] warning: Unsupported system call rseq
Hello, world
[P1:T1:helloworld] debug: ---- shim_exit_group (returning 0)
[P1:T1:helloworld] debug: clearing POSIX locks for pid 1
[P1:T1:helloworld] debug: sync client shutdown: closing handles
[P1:T1:helloworld] debug: sync client shutdown: waiting for confirmation
[P1:T1:helloworld] debug: sync client shutdown: finished
[P1:shim] debug: IPC worker: exiting worker thread
[P1:T1:helloworld] debug: process 1 exited with status 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/707)
<!-- Reviewable:end -->
