### PR TITLE
[PAL/Linux-SGX] Add `ECONNRESET` to errors allowed from `ocall_recv`

### DIFF
--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -1448,8 +1448,9 @@ ssize_t ocall_recv(int sockfd, struct iovec* iov, size_t iov_len, void* addr, si
 
     if (retval < 0) {
         if (retval != -EAGAIN && retval != -EWOULDBLOCK && retval != -EBADF
-                && retval != -ECONNREFUSED && retval != -EINTR && retval != -EINVAL
-                && retval != -ENOMEM && retval != -ENOTCONN && retval != -ENOTSOCK) {
+                && retval != -ECONNREFUSED && retval != -ECONNRESET && retval != -EINTR
+                && retval != -EINVAL && retval != -ENOMEM && retval != -ENOTCONN
+                && retval != -ENOTSOCK) {
             retval = -EPERM;
         }
         goto out;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This cause `ECONNRESET` to be translated to `EPERM` and confused the app. For example `lighttpd` printed error messaged, but continued to work.

## How to test this PR? <!-- (if applicable) -->
Try running `lighttpd` example as we do in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/709)
<!-- Reviewable:end -->
