### PR TITLE
[CI-Examples] Change the default retries number in `downloads` script

### DIFF
--- a/CI-Examples/common_tools/download
+++ b/CI-Examples/common_tools/download
@@ -58,7 +58,7 @@ trap cleanup EXIT
 
 for url in "${urls[@]}"; do
     echo "download: Trying to fetch $url"
-    wget --timeout=10 -O "$tmpd/unverified" "$url" || true
+    wget --timeout=10 --tries=3 -O "$tmpd/unverified" "$url" || true
     sha256_received="$(sha256sum "$tmpd/unverified" | cut -d ' ' -f 1)"
     if [ "$sha256" != "$sha256_received" ]; then
         echo "download: WARNING: Hash mismatch: Expected $sha256 but received $sha256_received"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
The default number is `20` which combined with 10s per try timeout could result in a pipeline timeout in our CI, if the host (from which we download) was down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/710)
<!-- Reviewable:end -->
