### PR TITLE
[LibOS,PAL,Docs] Add peak memory usage support in procfs

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -364,6 +364,9 @@ and to obtain an attestation report and quote.
 .. doxygenfunction:: PalMemoryAvailableQuota
    :project: pal
 
+.. doxygenfunction:: PalPeakMemoryUsage
+   :project: pal
+
 .. doxygenfunction:: PalCpuIdRetrieve
    :project: pal
 

--- a/libos/include/libos_fs_pseudo.h
+++ b/libos/include/libos_fs_pseudo.h
@@ -218,6 +218,7 @@ int proc_thread_cmdline_load(struct libos_dentry* dent, char** out_data, size_t*
 bool proc_thread_fd_name_exists(struct libos_dentry* parent, const char* name);
 int proc_thread_fd_list_names(struct libos_dentry* parent, readdir_callback_t callback, void* arg);
 int proc_thread_fd_follow_link(struct libos_dentry* dent, char** out_target);
+int proc_thread_status_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 bool proc_ipc_thread_pid_name_exists(struct libos_dentry* parent, const char* name);
 int proc_ipc_thread_follow_link(struct libos_dentry* dent, char** out_target);
 

--- a/libos/src/fs/proc/fs.c
+++ b/libos/src/fs/proc/fs.c
@@ -28,6 +28,7 @@ static void init_thread_dir(struct pseudo_node* ent) {
     pseudo_add_link(ent, "exe", &proc_thread_follow_link);
     pseudo_add_str(ent, "maps", &proc_thread_maps_load);
     pseudo_add_str(ent, "cmdline", &proc_thread_cmdline_load);
+    pseudo_add_str(ent, "status", &proc_thread_status_load);
 
     struct pseudo_node* fd = pseudo_add_dir(ent, "fd");
     struct pseudo_node* fd_link = pseudo_add_link(fd, /*name=*/NULL, &proc_thread_fd_follow_link);

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -840,6 +840,11 @@ int PalSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr);
 size_t PalMemoryAvailableQuota(void);
 
 /*!
+ * \brief Return the peak amount of memory for LibOS/application usage.
+ */
+size_t PalPeakMemoryUsage(void);
+
+/*!
  * \brief Obtain the attestation report (local) with `user_report_data` embedded into it.
  *
  * \param[in]     user_report_data       Report data with arbitrary contents (typically uniquely

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -176,6 +176,7 @@ void _PalGetAvailableUserAddressRange(void** out_start, void** out_end);
 bool _PalCheckMemoryMappable(const void* addr, size_t size);
 unsigned long _PalMemoryQuota(void);
 unsigned long _PalMemoryAvailableQuota(void);
+unsigned long _PalPeakMemoryUsage(void);
 // Returns 0 on success, negative PAL code on failure
 int _PalGetCPUInfo(struct pal_cpu_info* info);
 

--- a/pal/regression/Memory.c
+++ b/pal/regression/Memory.c
@@ -92,5 +92,10 @@ int main(int argc, char** argv, char** envp) {
     if (avail > 0 && avail < PalGetPalPublicState()->mem_total)
         pal_printf("Get Memory Available Quota OK\n");
 
+    /* Testing peak memory usage (must be within valid range) */
+    size_t peak_mem = PalPeakMemoryUsage();
+    if (peak_mem > 0 && peak_mem < PalGetPalPublicState()->mem_total)
+        pal_printf("Get Peak Memory Usage OK\n");
+
     return 0;
 }

--- a/pal/regression/Symbols.c
+++ b/pal/regression/Symbols.c
@@ -57,6 +57,7 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(PalSegmentBaseSet);
 #endif
     PRINT_SYMBOL(PalMemoryAvailableQuota);
+    PRINT_SYMBOL(PalPeakMemoryUsage);
 
     return 0;
 }

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -179,6 +179,7 @@ class TC_02_Symbols(RegressionTestCase):
         'PalSystemTimeQuery',
         'PalRandomBitsRead',
         'PalMemoryAvailableQuota',
+        'PalPeakMemoryUsage',
     ]
     if ON_X86:
         ALL_SYMBOLS.append('PalSegmentBaseGet')

--- a/pal/src/host/linux-sgx/pal_memory.c
+++ b/pal/src/host/linux-sgx/pal_memory.c
@@ -14,6 +14,7 @@
 #include "pal_linux.h"
 
 extern struct atomic_int g_allocated_pages;
+extern struct atomic_int g_peak_allocated_pages;
 
 bool _PalCheckMemoryMappable(const void* addr, size_t size) {
     if (addr < DATA_END && addr + size > TEXT_START) {
@@ -95,4 +96,12 @@ uint64_t _PalMemoryQuota(void) {
 uint64_t _PalMemoryAvailableQuota(void) {
     return (g_pal_linuxsgx_state.heap_max - g_pal_linuxsgx_state.heap_min) -
            __atomic_load_n(&g_allocated_pages.counter, __ATOMIC_SEQ_CST) * g_page_size;
+}
+
+uint64_t _PalPeakMemoryUsage(void) {
+    uint64_t min_quota = (g_pal_linuxsgx_state.heap_max - g_pal_linuxsgx_state.heap_min) -
+        __atomic_load_n(&g_peak_allocated_pages.counter, __ATOMIC_SEQ_CST) * g_page_size;
+
+    return (g_pal_public_state.mem_total - min_quota) / 1024;
+
 }

--- a/pal/src/pal_misc.c
+++ b/pal/src/pal_misc.c
@@ -30,6 +30,10 @@ size_t PalMemoryAvailableQuota(void) {
     return _PalMemoryAvailableQuota();
 }
 
+size_t PalPeakMemoryUsage(void) {
+    return _PalPeakMemoryUsage();
+}
+
 #if defined(__x86_64__)
 int PalCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) {
     return _PalCpuIdRetrieve(leaf, subleaf, values);

--- a/pal/src/pal_symbols
+++ b/pal/src/pal_symbols
@@ -45,6 +45,7 @@ PalSegmentBaseSet
 PalStreamChangeName
 PalStreamAttributesSetByHandle
 PalMemoryAvailableQuota
+PalPeakMemoryUsage
 PalDebugMapAdd
 PalDebugMapRemove
 PalDebugDescribeLocation


### PR DESCRIPTION
The initial requirement was from https://github.com/gramineproject/gramine/issues/614.

An application may want to adjust itself based on the the peak (enclave) memory
usage in some scenarios, e.g., to perform some garbage collection or flush its
caches. This patch adds `VmPeak` stats into the pseudo-file `/proc/<pid>/status`
to support the usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/714)
<!-- Reviewable:end -->
