### PR TITLE
[PAL/Linux-SGX] Set pipe handle as nonblocking only after TLS handshake

### DIFF
--- a/pal/src/host/linux-sgx/pal_pipes.c
+++ b/pal/src/host/linux-sgx/pal_pipes.c
@@ -66,6 +66,14 @@ static noreturn int thread_handshake_func(void* param) {
         _PalProcessExit(1);
     }
 
+    if (handle->pipe.nonblocking) {
+        ret = ocall_fsetnonblock(handle->pipe.fd, /*nonblocking=*/1);
+        if (ret < 0) {
+            log_error("Failed to set handle as non-blocking: %d", ret);
+            _PalProcessExit(1);
+        }
+    }
+
     struct handshake_helper_thread* thread = malloc(sizeof(*thread));
     if (!thread) {
         log_error("Failed to allocate helper handshake thread list item");
@@ -167,9 +175,11 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     if (handle->pipe.fd == PAL_IDX_POISON)
         return -PAL_ERROR_DENIED;
 
-    static_assert(O_CLOEXEC == SOCK_CLOEXEC && O_NONBLOCK == SOCK_NONBLOCK, "assumed below");
-    int flags = PAL_OPTION_TO_LINUX_OPEN(options);
-    int ret = ocall_accept(handle->pipe.fd, /*addr=*/NULL, /*addrlen=*/NULL, flags);
+    assert(WITHIN_MASK(options, PAL_OPTION_NONBLOCK | PAL_OPTION_CLOEXEC));
+    bool nonblocking = options & PAL_OPTION_NONBLOCK;
+    /* We do not take `nonblocking` into account here - it will be set after the TLS handshake below
+     * if needed. */
+    int ret = ocall_accept(handle->pipe.fd, /*addr=*/NULL, /*addrlen=*/NULL, SOCK_CLOEXEC);
     if (ret < 0)
         return unix_to_pal_error(ret);
 
@@ -183,7 +193,7 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     clnt->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     clnt->pipe.fd          = ret;
     clnt->pipe.name        = handle->pipe.name;
-    clnt->pipe.nonblocking = !!(flags & SOCK_NONBLOCK);
+    clnt->pipe.nonblocking = nonblocking;
 
     /* create the SSL pre-shared key for this end of the pipe; note that SSL context is initialized
      * lazily on first read/write on this pipe */
@@ -193,22 +203,33 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
 
     ret = pipe_session_key(&clnt->pipe.name, &clnt->pipe.session_key);
     if (ret < 0) {
-        ocall_close(clnt->pipe.fd);
-        free(clnt);
-        return -PAL_ERROR_DENIED;
+        goto out_err;
     }
 
     ret = _PalStreamSecureInit(clnt, clnt->pipe.is_server, &clnt->pipe.session_key,
                                (LIB_SSL_CONTEXT**)&clnt->pipe.ssl_ctx, NULL, 0);
     if (ret < 0) {
-        ocall_close(clnt->pipe.fd);
-        free(clnt);
-        return ret;
+        goto out_err;
+    }
+    if (clnt->pipe.nonblocking) {
+        ret = ocall_fsetnonblock(clnt->pipe.fd, /*nonblocking=*/1);
+        if (ret < 0) {
+            ret = unix_to_pal_error(ret);
+            goto out_err;
+        }
     }
     __atomic_store_n(&clnt->pipe.handshake_done, true, __ATOMIC_RELEASE);
 
     *client = clnt;
     return 0;
+
+out_err:
+    ocall_close(clnt->pipe.fd);
+    if (clnt->pipe.ssl_ctx) {
+        _PalStreamSecureFree(clnt->pipe.ssl_ctx);
+    }
+    free(clnt);
+    return ret;
 }
 
 /*!
@@ -232,11 +253,13 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 
+    assert(WITHIN_MASK(options, PAL_OPTION_NONBLOCK | PAL_OPTION_CLOEXEC));
     unsigned int addrlen = sizeof(struct sockaddr_un);
-    int nonblock = options & PAL_OPTION_NONBLOCK ? SOCK_NONBLOCK : 0;
-
-    ret = ocall_connect(AF_UNIX, SOCK_STREAM | nonblock, 0, /*ipv6_v6only=*/0,
-                        (const struct sockaddr*)&addr, addrlen, NULL, NULL);
+    bool nonblocking = options & PAL_OPTION_NONBLOCK;
+    /* We do not take `nonblocking` into account here - it will be set by `thread_handshake_func`
+     * later if needed. */
+    ret = ocall_connect(AF_UNIX, SOCK_STREAM, 0, /*ipv6_v6only=*/0, (const struct sockaddr*)&addr,
+                        addrlen, NULL, NULL);
     if (ret < 0)
         return unix_to_pal_error(ret);
 
@@ -249,7 +272,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
     init_handle_hdr(hdl, PAL_TYPE_PIPE);
     hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     hdl->pipe.fd            = ret;
-    hdl->pipe.nonblocking   = !!(options & PAL_OPTION_NONBLOCK);
+    hdl->pipe.nonblocking   = nonblocking;
 
     /* padding with zeros is because the whole buffer is used in key derivation */
     memset(&hdl->pipe.name.str, 0, sizeof(hdl->pipe.name.str));


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Linux SGX PAL pipes are encrypted using TLS. This requires performing a handshake when they are created. If the pipe is to be nonblocking, we make it so only after the handshake, not to waste time on send/recv ocalls returning `EAGAIN` (no data on nonblocking fd).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/715)
<!-- Reviewable:end -->
