### PR TITLE
[LibOS] Add seek/tell/truncate test

### DIFF
--- a/libos/test/fs/meson.build
+++ b/libos/test/fs/meson.build
@@ -43,6 +43,7 @@ tests = {
     'open_flags': {},
     'read_write': {},
     'seek_tell': {},
+    'seek_tell_truncate': {},
     'stat': {},
     'truncate': {},
 }

--- a/libos/test/fs/seek_tell_truncate.c
+++ b/libos/test/fs/seek_tell_truncate.c
@@ -1,0 +1,67 @@
+#include "common.h"
+
+#define CHUNK_SIZE 512
+
+static void setup_file(const char* path, size_t size) {
+    int fd = open_output_fd(path, /*rdwr=*/false);
+
+    void* buf = alloc_buffer(size);
+    fill_random(buf, size);
+    write_fd(path, fd, buf, size);
+    free(buf);
+
+    close_fd(path, fd);
+}
+
+static void seek_truncate(const char* path, size_t file_pos, size_t file_truncate) {
+    int fd = open_output_fd(path, /*rdwr=*/false);
+
+    seek_fd(path, fd, file_pos, SEEK_SET);
+
+    off_t pos = tell_fd(path, fd);
+    if ((size_t)pos != file_pos) {
+        fatal_error("first tell failed (expected: %zu, got: %zd)", file_pos, pos);
+    }
+    printf("First tell(%s) returned position: %zd\n", path, pos);
+
+    if (ftruncate(fd, file_truncate) != 0) {
+        fatal_error("Failed to truncate file %s to %zu: %m\n", path, file_truncate);
+    }
+
+    pos = tell_fd(path, fd);
+    if ((size_t)pos != file_pos) {
+        fatal_error("second tell failed (expected: %zu, got: %zd)", file_pos, pos);
+    }
+    printf("Second tell(%s) returned position: %zd\n", path, pos);
+
+    void* buf = alloc_buffer(CHUNK_SIZE);
+    fill_random(buf, CHUNK_SIZE);
+    write_fd(path, fd, buf, CHUNK_SIZE);
+    free(buf);
+
+    size_t next_file_pos = file_pos + CHUNK_SIZE;
+    pos = tell_fd(path, fd);
+    if ((size_t)pos != next_file_pos) {
+        fatal_error("third tell failed (expected: %zu, got: %zd)", next_file_pos, pos);
+    }
+    printf("Third tell(%s) returned position: %zd\n", path, pos);
+
+    close_fd(path, fd);
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 5)
+        fatal_error("Usage: %s <output> <size> <position> <truncate>\n", argv[0]);
+
+    setup();
+    size_t file_size     = strtoul(argv[2], NULL, 10);
+    size_t file_pos      = strtoul(argv[3], NULL, 10);
+    size_t file_truncate = strtoul(argv[4], NULL, 10);
+
+    setup_file(argv[1], file_size);
+    seek_truncate(argv[1], file_pos, file_truncate);
+
+    printf("Test passed\n");
+
+    return 0;
+}

--- a/libos/test/fs/test_fs.py
+++ b/libos/test/fs/test_fs.py
@@ -240,6 +240,27 @@ class TC_00_FileSystem(RegressionTestCase):
         self.do_truncate_test(65537, 65535)
         self.do_truncate_test(65537, 65536)
 
+    def verify_seek_tell_truncate(self, file_out, file_size, file_pos, file_truncate):
+        stdout, _ = self.run_binary([
+            'seek_tell_truncate',
+            file_out,
+            str(file_size),
+            str(file_pos),
+            str(file_truncate)
+        ])
+
+        self.assertIn('Test passed', stdout)
+
+    def test_141_file_seek_tell_truncate(self):
+        file_path = os.path.join(self.OUTPUT_DIR, 'test_141')
+
+        self.verify_seek_tell_truncate(f"{file_path}a", 0, 0, 100)
+        self.verify_seek_tell_truncate(f"{file_path}b", 512, 512, 65536)
+        self.verify_seek_tell_truncate(f"{file_path}c", 512, 64, 65536)
+        self.verify_seek_tell_truncate(f"{file_path}d", 512, 512, 0)
+        self.verify_seek_tell_truncate(f"{file_path}e", 512, 256, 0)
+        # XXX: we do not support shrinking files to arbitrary sizes in protected files
+
     def verify_copy_content(self, input_path, output_path):
         self.assertTrue(filecmp.cmp(input_path, output_path, shallow=False))
 

--- a/libos/test/fs/tests.toml
+++ b/libos/test/fs/tests.toml
@@ -14,6 +14,7 @@ manifests = [
   "open_flags",
   "read_write",
   "seek_tell",
+  "seek_tell_truncate",
   "stat",
   "truncate",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The goal of this test is to verify that Gramine doesn't change file offset after truncation.

## How to test this PR? <!-- (if applicable) -->

This is a test.
```
gramine-test -C libos/test/fs pytest
gramine-test --sgx -C libos/test/fs pytest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/718)
<!-- Reviewable:end -->
