### PR TITLE
[CI-Examples] Modify secret_prov_server to not require a key

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -151,30 +151,30 @@ secret_prov_pf_client.token: secret_prov_pf_client.sig
 
 .PHONY: check_epid
 check_epid: app epid files/input.txt
-	./secret_prov_server_epid >/dev/null & SERVER_ID=$$!; \
+	./secret_prov_server_epid files/wrap-key >/dev/null & SERVER_ID=$$!; \
 	sleep 3; \
 	gramine-sgx secret_prov_min_client > OUTPUT; \
 	gramine-sgx secret_prov_client >> OUTPUT; \
 	gramine-sgx secret_prov_pf_client >> OUTPUT; \
 	kill -9 $$SERVER_ID;
-	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/4 ]"
-	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
-	@grep "\[parent\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/4 ]"
-	@grep "\[child\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 4/4 ]"
+	@grep -E "Received secret = '[[:xdigit:]]{32}'" OUTPUT && echo "[ Success 1/4 ]"
+	@grep -E "Received secret1 = '[[:xdigit:]]{32}', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
+	@grep -E "\[parent\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/4 ]"
+	@grep -E "\[child\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 4/4 ]"
 	@rm OUTPUT
 
 .PHONY: check_dcap
 check_dcap: app dcap files/input.txt
-	./secret_prov_server_dcap >/dev/null & SERVER_ID=$$!; \
+	./secret_prov_server_dcap files/wrap-key >/dev/null & SERVER_ID=$$!; \
 	sleep 3; \
 	gramine-sgx secret_prov_min_client > OUTPUT; \
 	gramine-sgx secret_prov_client >> OUTPUT; \
 	gramine-sgx secret_prov_pf_client >> OUTPUT; \
 	kill -9 $$SERVER_ID;
-	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/4 ]"
-	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
-	@grep "\[parent\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/4 ]"
-	@grep "\[child\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 4/4 ]"
+	@grep -E "Received secret = '[[:xdigit:]]{32}'" OUTPUT && echo "[ Success 1/4 ]"
+	@grep -E "Received secret1 = '[[:xdigit:]]{32}', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
+	@grep -E "\[parent\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/4 ]"
+	@grep -E "\[child\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 4/4 ]"
 	@rm OUTPUT
 
 ################################## CLEANUP ####################################

--- a/CI-Examples/ra-tls-secret-prov/README.md
+++ b/CI-Examples/ra-tls-secret-prov/README.md
@@ -20,8 +20,10 @@ The server is supposed to run on a trusted machine (not in the SGX enclave). The
 server listens for client connections. For each connected client, the server
 verifies the client's RA-TLS certificate and the embedded SGX quote and, if
 verification succeeds, sends the first secret back to the client (the master key
-for encrypted files, read from `files/wrap-key`). If the client requests a
-second secret, the server sends the dummy string `42` as the second secret.
+for encrypted files, read from `files/wrap-key` that is passed as a command-line
+argument while running the server, or a 16B random key if no command-line argument
+is provided). If the client requests a second secret, the server sends the dummy
+string `42` as the second secret.
 
 There are two versions of the server: the EPID one and the DCAP one. Each of
 them links against the corresponding EPID/DCAP secret-provisioning library at
@@ -75,7 +77,7 @@ make app epid files/input.txt RA_TYPE=epid RA_CLIENT_SPID=<your SPID> \
 RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
 RA_TLS_EPID_API_KEY=<your EPID API key> \
-./secret_prov_server_epid &
+./secret_prov_server_epid files/wrap-key &
 
 # test minimal client
 gramine-sgx ./secret_prov_min_client
@@ -96,7 +98,7 @@ make app dcap files/input.txt RA_TYPE=dcap
 
 RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
-./secret_prov_server_dcap &
+./secret_prov_server_dcap files/wrap-key &
 
 # test minimal client
 gramine-sgx ./secret_prov_min_client


### PR DESCRIPTION
The `libsecret_prov_attest.so` library provisions a secret upon successful attestation. However, there can be cases when applications would want Gramine to terminate upon an unsuccessful attestation, as opposed to the application directly handling this part. In this PR,  `libsecret_prov_attest.so`  exits when attestation is unsuccessful, also handles a case where there aren't any keys to provision, under which case a `REMOTE_ATTESTATION_SUCCESSFUL` string is set at the host enclave (by the server), that client applications are free to customize and use if they want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/721)
<!-- Reviewable:end -->
