### PR TITLE
Support running scripts as the entrypoint

### DIFF
--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -277,7 +277,8 @@ int walk_handle_map(int (*callback)(struct libos_fd_handle*, struct libos_handle
                     struct libos_handle_map* map);
 
 int init_handle(void);
-int init_important_handles(void);
+int init_std_handles(void);
+int init_exec_handle(const char* const* argv, char*** out_new_argv);
 
 int open_executable(struct libos_handle* hdl, const char* path);
 

--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -17,7 +17,7 @@
 #include "pal.h"
 #include "pal_error.h"
 
-noreturn void libos_init(int argc, const char* const* argv, const char* const* envp);
+noreturn void libos_init(const char* const* argv, const char* const* envp);
 
 /* important macros and static inline functions */
 

--- a/libos/include/libos_process.h
+++ b/libos/include/libos_process.h
@@ -69,7 +69,8 @@ struct libos_process {
 
 extern struct libos_process g_process;
 
-int init_process(int argc, const char* const* argv);
+int init_process(void);
+int init_process_cmdline(const char* const* argv);
 
 /* Allocates a new child process structure, initializing all fields. */
 struct libos_child_process* create_child_process(void);

--- a/libos/src/arch/x86_64/start.S
+++ b/libos/src/arch/x86_64/start.S
@@ -13,9 +13,9 @@ libos_start:
     xorq %rbp, %rbp
 
     # Arguments for libos_init:
-    movq 0(%rsp), %rdi         # argc
-    leaq 8(%rsp), %rsi         # argv
-    leaq 8(%rsi,%rdi,8), %rdx  # envp, after all args (including argv[argc] = NULL)
+    movq 0(%rsp), %r8          # argc, unused by libos_init, used to calculate location of envp
+    leaq 8(%rsp), %rdi         # argv
+    leaq 8(%rdi,%r8,8), %rsi   # envp, after all args (including argv[argc] = NULL)
 
     # Required by System V AMD64 ABI.
     andq  $~0xF, %rsp

--- a/libos/src/bookkeep/libos_process.c
+++ b/libos/src/bookkeep/libos_process.c
@@ -17,7 +17,7 @@ typedef bool (*child_cmp_t)(const struct libos_child_process*, unsigned long);
 
 struct libos_process g_process = { .pid = 0 };
 
-int init_process(int argc, const char* const* argv) {
+int init_process(void) {
     if (g_process.pid) {
         /* `g_process` is already initialized, e.g. via checkpointing code. */
         return 0;
@@ -56,24 +56,26 @@ int init_process(int argc, const char* const* argv) {
     /* `g_process.exec` will be initialized later on (in `init_important_handles`). */
     g_process.exec = NULL;
 
+    return 0;
+}
+
+int init_process_cmdline(const char* const* argv) {
     /* The command line arguments passed are stored in /proc/self/cmdline as part of the proc fs.
      * They are not separated by space, but by NUL instead. So, it is essential to maintain the
      * cmdline_size also as a member here. */
-
     g_process.cmdline_size = 0;
     memset(g_process.cmdline, '\0', ARRAY_SIZE(g_process.cmdline));
     size_t tmp_size = 0;
 
-    for (int i = 0; i < argc; i++) {
-        if (tmp_size + strlen(argv[i]) + 1 > ARRAY_SIZE(g_process.cmdline))
+    for (const char* const* a = argv; *a; a++) {
+        if (tmp_size + strlen(*a) + 1 > ARRAY_SIZE(g_process.cmdline))
             return -ENOMEM;
 
-        memcpy(g_process.cmdline + tmp_size, argv[i], strlen(argv[i]));
-        tmp_size += strlen(argv[i]) + 1;
+        memcpy(g_process.cmdline + tmp_size, *a, strlen(*a));
+        tmp_size += strlen(*a) + 1;
     }
 
     g_process.cmdline_size = tmp_size;
-
     return 0;
 }
 

--- a/libos/src/sys/libos_exec.c
+++ b/libos/src/sys/libos_exec.c
@@ -123,6 +123,10 @@ static int libos_syscall_execve_rtld(struct libos_handle* hdl, char** argv,
     char** new_argp;
     elf_auxv_t* new_auxv;
 
+    ret = init_process_cmdline((const char* const*)argv);
+    if (ret < 0)
+        return ret;
+
     /* note the typecast of argv here: the C standard disallows implicit conversion of `char**` ->
      * `const char* const*`, but in reality it is safe to do */
     ret = init_stack((const char* const*)argv, envp, &new_argp, &new_auxv);

--- a/libos/test/regression/shebang_test_script.manifest.template
+++ b/libos/test/regression/shebang_test_script.manifest.template
@@ -1,0 +1,24 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "shebang_test_script.sh"
+loader.argv0_override = "shebang_test_script.sh"
+
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/bin", uri = "file:/bin" },
+]
+
+sgx.thread_num = 16
+sgx.nonpie_binary = true
+sgx.debug = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:/bin/sh",
+  "file:shebang_test_script.sh",
+  "file:scripts/",
+]

--- a/libos/test/regression/shebang_test_script.sh
+++ b/libos/test/regression/shebang_test_script.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec scripts/foo.sh

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -221,13 +221,23 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('execve(invalid-argv) correctly returned error', stdout)
         self.assertIn('execve(invalid-envp) correctly returned error', stdout)
 
-    @unittest.skipIf(USES_MUSL, 'Test uses /bin/sh from the host which is built against Glibc')
+    @unittest.skipIf(USES_MUSL,
+        'Test uses /bin/sh from the host which is usually built against glibc')
     def test_211_exec_script(self):
         stdout, _ = self.run_binary(['exec_script'])
         self.assertIn('Printing Args: '
             'scripts/baz.sh ECHO FOXTROT GOLF scripts/bar.sh '
             'ALPHA BRAVO CHARLIE DELTA '
             'scripts/foo.sh STRING FROM EXECVE', stdout)
+
+    @unittest.skipIf(USES_MUSL,
+        'Test uses /bin/sh from the host which is usually built against glibc')
+    def test_212_shebang_test_script(self):
+        stdout, _ = self.run_binary(['shebang_test_script'])
+        self.assertIn('Printing Args: '
+            'scripts/baz.sh ECHO FOXTROT GOLF scripts/bar.sh '
+            'ALPHA BRAVO CHARLIE DELTA '
+            'scripts/foo.sh', stdout)
 
     def test_220_send_handle(self):
         path = 'tmp/send_handle_test'

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -90,6 +90,7 @@ manifests = [
   "select",
   "send_handle",
   "shared_object",
+  "shebang_test_script",
   "sigaction_per_process",
   "sigaltstack",
   "sighandler_reset",


### PR DESCRIPTION
This will enable users to run scripts in Gramine (as opposed to manually providing a ELF entrypoint - this can be quite an inconvenience to users). This will also minimize the need to create wrapper docker files for entrypoint manipulation while using GSC.

Fixes https://github.com/gramineproject/gramine/issues/320

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/722)
<!-- Reviewable:end -->
