### PR TITLE
[PAL] Simplify `file_getname`,same for `dir_getname`

### DIFF
--- a/common/include/api.h
+++ b/common/include/api.h
@@ -401,6 +401,7 @@ int parse_size_str(const char* str, uint64_t* out_val);
 #define URI_PREFIX_FILE     URI_TYPE_FILE URI_PREFIX_SEPARATOR
 
 #define URI_PREFIX_FILE_LEN (static_strlen(URI_PREFIX_FILE))
+#define URI_PREFIX_DIR_LEN  (static_strlen(URI_PREFIX_DIR))
 
 #define TIME_US_IN_S 1000000ul
 #define TIME_US_IN_MS 1000ul

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -262,15 +262,16 @@ static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
         return 0;
 
     size_t realpath_len = strlen(handle->file.realpath);
-
     char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->file.realpath,realpath_len);
     if(!tmp)
         return -ENOMEM;
 
-    if(strlen(tmp)+1>count)
+    size_t tmp_len=strlen(tmp);
+    if(tmp_len+1>count)
         return -PAL_ERROR_TOOLONG;
     
-    memcpy(buffer,tmp,strlen(tmp)+1);
+    memcpy(buffer,tmp,tmp_len+1);
+    free(tmp);
 
     return strlen(tmp);
 }
@@ -490,20 +491,22 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
 }
 
 static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    if (!handle->file.realpath)
+    if (!handle->dir.realpath)
         return 0;
 
-    size_t realpath_len = strlen(handle->file.realpath);
-    char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->file.realpath,realpath_len);
+    size_t realpath_len = strlen(handle->dir.realpath);
+    char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->dir.realpath,realpath_len);
     if(!tmp)
         return -ENOMEM;
 
-    if(strlen(tmp)+1>count)
+    size_t tmp_len=strlen(tmp);
+    if(tmp_len+1>count)
         return -PAL_ERROR_TOOLONG;
     
-    memcpy(buffer,tmp,strlen(tmp)+1);
-
-    return strlen(tmp);
+    memcpy(buffer,tmp,tmp_len+1);
+    free(tmp);
+    
+    return tmp_len;
 }
 
 static const char* dir_getrealpath(PAL_HANDLE handle) {

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -259,21 +259,15 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
 
 static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     if (!handle->file.realpath)
-        return 0;
+    return 0;
 
-    size_t realpath_len = strlen(handle->file.realpath);
-    char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->file.realpath,realpath_len);
-    if(!tmp)
-        return -ENOMEM;
-
-    size_t tmp_len=strlen(tmp);
-    if(tmp_len+1>count)
+    size_t realpath_size = strlen(handle->file.realpath) + 1;
+    if (count < URI_PREFIX_FILE_LEN + realpath_size)
         return -PAL_ERROR_TOOLONG;
-    
-    memcpy(buffer,tmp,tmp_len+1);
-    free(tmp);
 
-    return tmp_len;
+    memcpy(buffer, URI_PREFIX_FILE, count);
+    memcpy(buffer + URI_PREFIX_FILE_LEN, handle->file.realpath, realpath_size);
+    return URI_PREFIX_FILE_LEN + realpath_size - 1; /* return string length, not size */
 }
 
 static const char* file_getrealpath(PAL_HANDLE handle) {
@@ -494,19 +488,13 @@ static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     if (!handle->dir.realpath)
         return 0;
 
-    size_t realpath_len = strlen(handle->dir.realpath);
-    char* tmp = alloc_concat(URI_PREFIX_DIR,URI_PREFIX_DIR_LEN,handle->dir.realpath,realpath_len);
-    if(!tmp)
-        return -ENOMEM;
-
-    size_t tmp_len=strlen(tmp);
-    if(tmp_len+1>count)
+    size_t realpath_size = strlen(handle->dir.realpath) + 1;
+    if (count < URI_PREFIX_DIR_LEN + realpath_size)
         return -PAL_ERROR_TOOLONG;
-    
-    memcpy(buffer,tmp,tmp_len+1);
-    free(tmp);
-    
-    return tmp_len;
+
+    memcpy(buffer, URI_PREFIX_DIR, count);
+    memcpy(buffer + URI_PREFIX_DIR_LEN, handle->dir.realpath, realpath_size);
+    return URI_PREFIX_DIR_LEN + realpath_size - 1; /* return string length, not size */
 }
 
 static const char* dir_getrealpath(PAL_HANDLE handle) {

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -273,7 +273,7 @@ static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     memcpy(buffer,tmp,tmp_len+1);
     free(tmp);
 
-    return strlen(tmp);
+    return tmp_len;
 }
 
 static const char* file_getrealpath(PAL_HANDLE handle) {

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -495,8 +495,7 @@ static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
         return 0;
 
     size_t realpath_len = strlen(handle->dir.realpath);
-    size_t prefix_len=static_strlen(URI_PREFIX_DIR);
-    char* tmp = alloc_concat(URI_PREFIX_DIR,prefix_len,handle->dir.realpath,realpath_len);
+    char* tmp = alloc_concat(URI_PREFIX_DIR,URI_PREFIX_DIR_LEN,handle->dir.realpath,realpath_len);
     if(!tmp)
         return -ENOMEM;
 

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -261,14 +261,18 @@ static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     if (!handle->file.realpath)
         return 0;
 
-    size_t len = strlen(handle->file.realpath);
-    char* tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
+    size_t realpath_len = strlen(handle->file.realpath);
 
-    if (!tmp || buffer + count < tmp + len + 1)
+    char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->file.realpath,realpath_len);
+    if(!tmp)
+        return -ENOMEM;
+
+    if(strlen(tmp)+1>count)
         return -PAL_ERROR_TOOLONG;
+    
+    memcpy(buffer,tmp,strlen(tmp)+1);
 
-    memcpy(tmp, handle->file.realpath, len + 1);
-    return tmp + len - buffer;
+    return strlen(tmp);
 }
 
 static const char* file_getrealpath(PAL_HANDLE handle) {
@@ -486,17 +490,20 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
 }
 
 static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    if (!handle->dir.realpath)
+    if (!handle->file.realpath)
         return 0;
 
-    size_t len = strlen(handle->dir.realpath);
-    char* tmp = strcpy_static(buffer, URI_PREFIX_DIR, count);
+    size_t realpath_len = strlen(handle->file.realpath);
+    char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->file.realpath,realpath_len);
+    if(!tmp)
+        return -ENOMEM;
 
-    if (!tmp || buffer + count < tmp + len + 1)
+    if(strlen(tmp)+1>count)
         return -PAL_ERROR_TOOLONG;
+    
+    memcpy(buffer,tmp,strlen(tmp)+1);
 
-    memcpy(tmp, handle->dir.realpath, len + 1);
-    return tmp + len - buffer;
+    return strlen(tmp);
 }
 
 static const char* dir_getrealpath(PAL_HANDLE handle) {

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -495,7 +495,8 @@ static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
         return 0;
 
     size_t realpath_len = strlen(handle->dir.realpath);
-    char* tmp = alloc_concat(URI_PREFIX_FILE,URI_PREFIX_FILE_LEN,handle->dir.realpath,realpath_len);
+    size_t prefix_len=static_strlen(URI_PREFIX_DIR);
+    char* tmp = alloc_concat(URI_PREFIX_DIR,prefix_len,handle->dir.realpath,realpath_len);
     if(!tmp)
         return -ENOMEM;
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
The function `file_getname` defined [here](https://github.com/gramineproject/gramine/blob/839ba4eef309350c41005e670562193a5f6d0767/pal/src/host/linux/pal_files.c#L260) and 'dir_getname' defined [here](https://github.com/gramineproject/gramine/blob/839ba4eef309350c41005e670562193a5f6d0767/pal/src/host/linux/pal_files.c#L488).
you’ll see that there are two actions:
1. First copy **URI_PREFIX_FILE** into buffer and return the end-of-string in the variable `tmp`
2. Then copy `handle->file.realpath` into buffer (after **URI_PREFIX_FILE** string)

The problem with this code is that it is very obscure. Mostly because of this weird : 
[function](https://github.com/gramineproject/gramine/blob/5a39aee217955701b412d4ff807c32da8e53ab94/common/include/api.h#L277)
In reality, we can just use the `alloc_concat()` [function](https://github.com/gramineproject/gramine/blob/839ba4eef309350c41005e670562193a5f6d0767/common/src/string/utils.c#L19) instead of all that code.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/724)
<!-- Reviewable:end -->
