### PR TITLE
[CI-Examples] Add SSL cert creation for `make dcap` target

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -35,7 +35,7 @@ app: \
 epid: secret_prov_server_epid
 
 .PHONY: dcap
-dcap: secret_prov_server_dcap
+dcap: ssl/server.crt secret_prov_server_dcap
 
 ############################# SSL DATA DEPENDENCY #############################
 


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Sometimes, we have a requirement of creating the dcap server binary along with ssl certificates on a non-sgx system. This change helps user to get the dcap server binary along with certificates using `make dcap` command only. 
## How to test this PR? <!-- (if applicable) -->
Step 1: `make app dcap ` should work as before 
Step 2: `make distclean`
Step 3: `make dcap` should generate `secret_prov_server_dcap` binary with ssl ceritificates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/727)
<!-- Reviewable:end -->
