### PR TITLE
[CI] Verify that .gitignore rules aren't violated

### DIFF
--- a/.ci/lib/stage-lint.jenkinsfile
+++ b/.ci/lib/stage-lint.jenkinsfile
@@ -1,5 +1,6 @@
 stage('lint') {
     sh '''
+        ./scripts/gitignore-check-files
         if .ci/isdistro bionic
         then
             ./.ci/run-pylint -f text

--- a/scripts/gitignore-check-files
+++ b/scripts/gitignore-check-files
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Intended to be run before a build. Returns 1 (i.e. failure) if there's at
+# least one file that should be ignored.
+
+files="$(git ls-files -i --exclude-standard)"
+if [ -z "${files}" ]; then
+    exit 0
+fi
+
+echo "================================================================================"
+echo "              ERROR: Files ignored by git exist in the repository:              "
+echo "--------------------------------------------------------------------------------"
+echo "${files}"
+echo "================================================================================"
+exit 1


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

After the https://github.com/gramineproject/gramine/pull/606, we don't have any files listed as ignored (in `.gitignore` files) and which are in the repo. This PR introduces a Jenkins check that verifies that this assumption hasn't been violated.

## How to test this PR? <!-- (if applicable) -->

```
$ ./scripts/gitignore-check-files
.gitignore rules aren't violated
$ echo $?
0
$ touch libos/test/fs/build.ninja
$ git add -f libos/test/fs/build.ninja
$ ./scripts/gitignore-check-files
================================================================================
              ERROR: Files ignored by git exists in the repository:             
--------------------------------------------------------------------------------
libos/test/fs/build.ninja
================================================================================
$ echo $?
1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/729)
<!-- Reviewable:end -->
