### PR TITLE
[libos/pal] Update `accept` to correct `getsockname` on accepted socket

### DIFF
--- a/libos/test/regression/tcp_msg_peek.c
+++ b/libos/test/regression/tcp_msg_peek.c
@@ -41,6 +41,21 @@ static void server(int pipefd) {
 
     int client = CHECK(accept(s, NULL, NULL));
 
+    struct sockaddr_in local_addr = { 0 };
+    socklen_t len = sizeof(local_addr);
+    CHECK(getsockname(client, (struct sockaddr*)&local_addr, &len));
+    char local_ip[INET_ADDRSTRLEN];
+    if (inet_ntop(AF_INET, &local_addr.sin_addr, local_ip, sizeof(local_ip)) != local_ip) {
+        CHECK(-1);
+    }
+    if (strcmp(local_ip, SRV_IP)) {
+        errx(1, "incorrect local IP address of client: \"%s\"", local_ip);
+    }
+    uint16_t local_port = ntohs(local_addr.sin_port);
+    if (local_port != PORT) {
+        errx(1, "incorrect local port of client: %hu", local_port);
+    }
+
     CHECK(close(s));
 
     size_t written = 0;

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -539,13 +539,16 @@ int PalSocketListen(PAL_HANDLE handle, unsigned int backlog);
  * \param[out] out_client       On success contains a handle for the new connection.
  * \param[out] out_client_addr  On success contains the remote address of the new connection.
  *                              Can be NULL, to ignore the result.
+ * \param[out] out_local_addr   On success contains the local address of the new connection.
+ *                              Can be NULL, to ignore the result.
  *
  * \returns 0 on success, negative error code on failure.
  *
  * This function can be safely called concurrently.
  */
 int PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                    struct pal_socket_addr* out_client_addr);
+                    struct pal_socket_addr* out_client_addr,
+                    struct pal_socket_addr* out_local_addr);
 
 /*!
  * \brief Connect a socket to a remote address.

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -129,7 +129,7 @@ struct socket_ops {
     int (*bind)(PAL_HANDLE handle, struct pal_socket_addr* addr);
     int (*listen)(PAL_HANDLE handle, unsigned int backlog);
     int (*accept)(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                  struct pal_socket_addr* out_client_addr);
+                  struct pal_socket_addr* out_client_addr, struct pal_socket_addr* out_local_addr);
     int (*connect)(PAL_HANDLE handle, struct pal_socket_addr* addr,
                    struct pal_socket_addr* out_local_addr);
     int (*send)(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
@@ -206,7 +206,8 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
 int _PalSocketBind(PAL_HANDLE handle, struct pal_socket_addr* addr);
 int _PalSocketListen(PAL_HANDLE handle, unsigned int backlog);
 int _PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                     struct pal_socket_addr* out_client_addr);
+                     struct pal_socket_addr* out_client_addr,
+                     struct pal_socket_addr* out_local_addr);
 int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
                       struct pal_socket_addr* out_local_addr);
 int _PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -162,7 +162,8 @@ static void do_child(void) {
 
     /* TCP socket */
     CHECK(PalReceiveHandle(PalGetPalPublicState()->parent_process, &handle));
-    CHECK(PalSocketAccept(handle, /*options=*/0, &client_handle, /*out_client_addr=*/NULL));
+    CHECK(PalSocketAccept(handle, /*options=*/0, &client_handle, /*out_client_addr=*/NULL,
+                          /*out_local_addr=*/NULL));
     PalObjectClose(handle);
     write_msg(client_handle, PAL_TYPE_SOCKET);
     PalObjectClose(client_handle);

--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -1231,9 +1231,11 @@ int ocall_listen(int domain, int type, int protocol, int ipv6_v6only, struct soc
     return retval;
 }
 
-int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, int options) {
+int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, struct sockaddr* local_addr,
+                 size_t* local_addrlen, int options) {
     int retval = 0;
     size_t len = addrlen ? *addrlen : 0;
+    size_t local_len = local_addrlen ? *local_addrlen : 0;
     ms_ocall_accept_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
@@ -1245,12 +1247,20 @@ int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, int options
 
     WRITE_ONCE(ms->ms_sockfd, sockfd);
     WRITE_ONCE(ms->ms_addrlen, len);
+    WRITE_ONCE(ms->ms_local_addrlen, local_len);
     void* untrusted_addr = (addr && len) ? sgx_copy_to_ustack(addr, len) : NULL;
     if (addr && len && !untrusted_addr) {
         sgx_reset_ustack(old_ustack);
         return -EPERM;
     }
+    void* untrusted_local_addr = (local_addr && local_len) ?
+                                 sgx_copy_to_ustack(local_addr, local_len) : NULL;
+    if (local_addr && local_len && !untrusted_local_addr) {
+        sgx_reset_ustack(old_ustack);
+        return -EPERM;
+    }
     WRITE_ONCE(ms->ms_addr, untrusted_addr);
+    WRITE_ONCE(ms->ms_local_addr, untrusted_local_addr);
     WRITE_ONCE(ms->options, options);
 
     retval = sgx_exitless_ocall(OCALL_ACCEPT, ms);
@@ -1270,6 +1280,15 @@ int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, int options
                 return -EPERM;
             }
             *addrlen = untrusted_addrlen;
+        }
+        if (local_addr && local_len) {
+            size_t untrusted_local_addrlen = READ_ONCE(ms->ms_local_addrlen);
+            if (!sgx_copy_to_enclave(local_addr, local_len,
+                                     READ_ONCE(ms->ms_local_addr), untrusted_local_addrlen)) {
+                sgx_reset_ustack(old_ustack);
+                return -EPERM;
+            }
+            *local_addrlen = untrusted_local_addrlen;
         }
     }
 

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -57,7 +57,8 @@ int ocall_listen_simple(int fd, unsigned int backlog);
 int ocall_listen(int domain, int type, int protocol, int ipv6_v6only, struct sockaddr* addr,
                  size_t* addrlen);
 
-int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, int options);
+int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, struct sockaddr* local_addr,
+                 size_t* local_addrlen, int options);
 
 int ocall_connect(int domain, int type, int protocol, int ipv6_v6only, const struct sockaddr* addr,
                   size_t addrlen, struct sockaddr* bind_addr, size_t* bind_addrlen);

--- a/pal/src/host/linux-sgx/pal_ocall_types.h
+++ b/pal/src/host/linux-sgx/pal_ocall_types.h
@@ -228,6 +228,8 @@ typedef struct {
     int options;
     struct sockaddr* ms_addr;
     size_t ms_addrlen;
+    struct sockaddr* ms_local_addr;
+    size_t ms_local_addrlen;
 } ms_ocall_accept_t;
 
 typedef struct {

--- a/pal/src/host/linux-sgx/pal_pipes.c
+++ b/pal/src/host/linux-sgx/pal_pipes.c
@@ -181,7 +181,8 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     bool nonblocking = options & PAL_OPTION_NONBLOCK;
     /* We do not take `nonblocking` into account here - it will be set after the TLS handshake below
      * if needed. */
-    int ret = ocall_accept(handle->pipe.fd, /*addr=*/NULL, /*addrlen=*/NULL, SOCK_CLOEXEC);
+    int ret = ocall_accept(handle->pipe.fd, /*addr=*/NULL, /*addrlen=*/NULL, /*local_addr=*/NULL,
+                           /*local_addrlen=*/NULL, SOCK_CLOEXEC);
     if (ret < 0)
         return unix_to_pal_error(ret);
 

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -194,15 +194,19 @@ static int tcp_listen(PAL_HANDLE handle, unsigned int backlog) {
 }
 
 static int tcp_accept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                      struct pal_socket_addr* out_client_addr) {
+                      struct pal_socket_addr* out_client_addr,
+                      struct pal_socket_addr* out_local_addr) {
     assert(PAL_GET_TYPE(handle) == PAL_TYPE_SOCKET);
 
-    struct sockaddr_storage sa_storage = { 0 };
-    size_t linux_addrlen = sizeof(sa_storage);
+    struct sockaddr_storage client_addr = { 0 };
+    size_t client_addrlen = sizeof(client_addr);
+    struct sockaddr_storage local_addr = { 0 };
+    size_t local_addrlen = sizeof(local_addr);
     int flags = options & PAL_OPTION_NONBLOCK ? SOCK_NONBLOCK : 0;
     flags |= SOCK_CLOEXEC;
 
-    int fd = ocall_accept(handle->sock.fd, (void*)&sa_storage, &linux_addrlen, flags);
+    int fd = ocall_accept(handle->sock.fd, (void*)&client_addr, &client_addrlen,
+                          (void*)&local_addr, &local_addrlen, flags);
     if (fd < 0) {
         return unix_to_pal_error(fd);
     }
@@ -218,15 +222,24 @@ static int tcp_accept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDL
         return -PAL_ERROR_NOMEM;
     }
 
-    if (out_client_addr) {
-        int ret = verify_ip_addr(client->sock.domain, &sa_storage, linux_addrlen);
-        if (ret < 0) {
-            _PalObjectClose(client);
-            return ret;
-        }
+    int ret = verify_ip_addr(client->sock.domain, &client_addr, client_addrlen);
+    if (ret < 0) {
+        _PalObjectClose(client);
+        return ret;
+    }
+    ret = verify_ip_addr(client->sock.domain, &local_addr, local_addrlen);
+    if (ret < 0) {
+        _PalObjectClose(client);
+        return ret;
+    }
 
-        linux_to_pal_sockaddr(&sa_storage, out_client_addr);
+    if (out_client_addr) {
+        linux_to_pal_sockaddr(&client_addr, out_client_addr);
         assert(out_client_addr->domain == client->sock.domain);
+    }
+    if (out_local_addr) {
+        linux_to_pal_sockaddr(&local_addr, out_local_addr);
+        assert(out_local_addr->domain == client->sock.domain);
     }
 
     *out_client = client;
@@ -604,11 +617,12 @@ int _PalSocketListen(PAL_HANDLE handle, unsigned int backlog) {
 }
 
 int _PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                     struct pal_socket_addr* out_client_addr) {
+                     struct pal_socket_addr* out_client_addr,
+                     struct pal_socket_addr* out_local_addr) {
     if (!handle->sock.ops->accept) {
         return -PAL_ERROR_NOTSUPPORT;
     }
-    return handle->sock.ops->accept(handle, options, out_client, out_client_addr);
+    return handle->sock.ops->accept(handle, options, out_client, out_client_addr, out_local_addr);
 }
 
 int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,

--- a/pal/src/host/skeleton/pal_sockets.c
+++ b/pal/src/host/skeleton/pal_sockets.c
@@ -19,7 +19,8 @@ int _PalSocketListen(PAL_HANDLE handle, unsigned int backlog) {
 }
 
 int _PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                     struct pal_socket_addr* out_client_addr) {
+                     struct pal_socket_addr* out_client_addr,
+                     struct pal_socket_addr* out_local_addr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/pal/src/pal_sockets.c
+++ b/pal/src/pal_sockets.c
@@ -22,9 +22,10 @@ int PalSocketListen(PAL_HANDLE handle, unsigned int backlog) {
 }
 
 int PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,
-                    struct pal_socket_addr* out_client_addr) {
+                    struct pal_socket_addr* out_client_addr,
+                    struct pal_socket_addr* out_local_addr) {
     assert(PAL_GET_TYPE(handle) == PAL_TYPE_SOCKET);
-    return _PalSocketAccept(handle, options, out_client, out_client_addr);
+    return _PalSocketAccept(handle, options, out_client, out_client_addr, out_local_addr);
 }
 
 int PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,


### PR DESCRIPTION
## Description of the changes 
When server listening on IP of a interface, local address of socket returned by `accept` is the same as listening address.
When server listening on any IP, "0.0.0.0" for IPv4 and "0:0:0:0:0:0:0:0" for IPv6, IP of socket returned by `accept` is the actual IP of interface.
`getsockname` in LibOS returns cached local and remote addresses. So `accept` in LibOS needs to retrieve and validate the local address.
`PalSocketAccept` interface and related functions are updated.

fixes #725

## How to test this PR? 
Updated `tcp_msg_peek` regression test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/734)
<!-- Reviewable:end -->
