### PR TITLE
[nasm] Make stack nonexecutable

### DIFF
--- a/common/src/arch/x86_64/no_exec_stack.nasm
+++ b/common/src/arch/x86_64/no_exec_stack.nasm
@@ -1,0 +1,1 @@
+section .note.GNU-stack noalloc noexec write

--- a/libos/src/arch/x86_64/libos_elf_entry.nasm
+++ b/libos/src/arch/x86_64/libos_elf_entry.nasm
@@ -9,7 +9,8 @@
 ; - RSP: the initial stack, contains program arguments and environment
 ; - FLAGS: should be zeroed out
 
-global    call_elf_entry
+global call_elf_entry
+section .text
 
 ; noreturn void call_elf_entry(elf_addr_t entry, void* argp)
 call_elf_entry:

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,7 @@ if host_machine.cpu_family() == 'x86_64'
         depfile: '@BASENAME@.dep',
         arguments: [
             '-f', 'elf64',
+            '-p', '@SOURCE_DIR@/common/src/arch/x86_64/no_exec_stack.nasm',
             '-I', '@0@/'.format(meson.current_build_dir()),
             '-MQ', '@OUTPUT@', '-MF', '@DEPFILE@',
             '@EXTRA_ARGS@',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
On x64 stack is executable by default, unless we specify a special GNU-stack section.

## How to test this PR? <!-- (if applicable) -->
Check `GNU_STACK` section (e.g. using `readelf`) of e.g. `libsysdb.so` before and after this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/736)
<!-- Reviewable:end -->
