### PR TITLE
[common] Don't extend files while reading data from protected files

### DIFF
--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -20,7 +20,6 @@ struct pf_context {
     file_node_t root_mht; // the root of the mht is always needed (for files bigger than 3KB)
     pf_handle_t file;
     pf_file_mode_t mode;
-    bool end_of_file;
     uint64_t real_file_size;
     bool need_writing;
     pf_status_t file_status;
@@ -62,5 +61,4 @@ static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create
 static bool ipf_close(pf_context_t* pf);
 static size_t ipf_read(pf_context_t* pf, void* ptr, uint64_t offset, size_t size);
 static size_t ipf_write(pf_context_t* pf, const void* ptr, uint64_t offset, size_t size);
-static bool ipf_update_after_seek(pf_context_t* pf, uint64_t new_offset);
 static void ipf_try_clear_error(pf_context_t* pf);

--- a/libos/test/fs/seek_tell.c
+++ b/libos/test/fs/seek_tell.c
@@ -63,6 +63,16 @@ static void seek_output_fd(const char* path) {
     }
     pos = tell_fd(path, f);
     printf("tell(%s) output end 2 OK: %zd\n", path, pos);
+    seek_fd(path, f, pos * 2, SEEK_SET);
+    printf("seek(%s) output beyond end OK\n", path);
+    pos = tell_fd(path, f);
+    printf("tell(%s) output beyond end OK: %zd\n", path, pos);
+    ssize_t ret = read(f, &buf, 1);
+    printf("read(%s) output OK: %zd\n", path, ret);
+    seek_fd(path, f, 0, SEEK_END);
+    printf("seek(%s) output end 4 OK\n", path);
+    pos = tell_fd(path, f);
+    printf("tell(%s) output end 3 OK: %zd\n", path, pos);
     close_fd(path, f);
     printf("close(%s) output OK\n", path);
 }
@@ -94,6 +104,16 @@ static void seek_output_stdio(const char* path) {
     }
     pos = tell_stdio(path, f);
     printf("ftell(%s) output end 2 OK: %zd\n", path, pos);
+    seek_stdio(path, f, pos * 2, SEEK_SET);
+    printf("fseek(%s) output beyond end OK\n", path);
+    pos = tell_stdio(path, f);
+    printf("ftell(%s) output beyond end OK: %zd\n", path, pos);
+    ssize_t ret = fread(&buf, 1, 1, f);
+    printf("fread(%s) output OK: %zd\n", path, ret);
+    seek_stdio(path, f, 0, SEEK_END);
+    printf("fseek(%s) output end 4 OK\n", path);
+    pos = tell_stdio(path, f);
+    printf("ftell(%s) output end 3 OK: %zd\n", path, pos);
     close_stdio(path, f);
     printf("fclose(%s) output OK\n", path);
 }

--- a/libos/test/fs/test_fs.py
+++ b/libos/test/fs/test_fs.py
@@ -99,6 +99,8 @@ class TC_00_FileSystem(RegressionTestCase):
     # pylint: disable=too-many-arguments
     def verify_seek_tell(self, stdout, stderr, input_path, output_path_1, output_path_2, size):
         self.assertNotIn('ERROR: ', stderr)
+
+        # seek_input_fd:
         self.assertIn('open(' + input_path + ') input OK', stdout)
         self.assertIn('seek(' + input_path + ') input start OK', stdout)
         self.assertIn('seek(' + input_path + ') input end OK', stdout)
@@ -106,6 +108,8 @@ class TC_00_FileSystem(RegressionTestCase):
         self.assertIn('seek(' + input_path + ') input rewind OK', stdout)
         self.assertIn('tell(' + input_path + ') input start OK: 0', stdout)
         self.assertIn('close(' + input_path + ') input OK', stdout)
+
+        # seek_input_stdio:
         self.assertIn('fopen(' + input_path + ') input OK', stdout)
         self.assertIn('fseek(' + input_path + ') input start OK', stdout)
         self.assertIn('fseek(' + input_path + ') input end OK', stdout)
@@ -114,6 +118,7 @@ class TC_00_FileSystem(RegressionTestCase):
         self.assertIn('ftell(' + input_path + ') input start OK: 0', stdout)
         self.assertIn('fclose(' + input_path + ') input OK', stdout)
 
+        # seek_output_fd:
         self.assertIn('open(' + output_path_1 + ') output OK', stdout)
         self.assertIn('seek(' + output_path_1 + ') output start OK', stdout)
         self.assertIn('seek(' + output_path_1 + ') output end OK', stdout)
@@ -121,7 +126,17 @@ class TC_00_FileSystem(RegressionTestCase):
         self.assertIn('seek(' + output_path_1 + ') output end 2 OK', stdout)
         self.assertIn('seek(' + output_path_1 + ') output end 3 OK', stdout)
         self.assertIn('tell(' + output_path_1 + ') output end 2 OK: ' + str(size + 4098), stdout)
+        self.assertIn('seek(' + output_path_1 + ') output beyond end OK', stdout)
+        self.assertIn(
+            'tell(' + output_path_1 + ') output beyond end OK: ' + str((size + 4098) * 2),
+            stdout
+        )
+        self.assertIn('read(' + output_path_1 + ') output OK: 0', stdout)
+        self.assertIn('seek(' + output_path_1 + ') output end 4 OK', stdout)
+        self.assertIn('tell(' + output_path_1 + ') output end 3 OK: ' + str(size + 4098), stdout)
         self.assertIn('close(' + output_path_1 + ') output OK', stdout)
+
+        # seek_output_stdio:
         self.assertIn('fopen(' + output_path_2 + ') output OK', stdout)
         self.assertIn('fseek(' + output_path_2 + ') output start OK', stdout)
         self.assertIn('fseek(' + output_path_2 + ') output end OK', stdout)
@@ -129,6 +144,14 @@ class TC_00_FileSystem(RegressionTestCase):
         self.assertIn('fseek(' + output_path_2 + ') output end 2 OK', stdout)
         self.assertIn('fseek(' + output_path_2 + ') output end 3 OK', stdout)
         self.assertIn('ftell(' + output_path_2 + ') output end 2 OK: ' + str(size + 4098), stdout)
+        self.assertIn('fseek(' + output_path_2 + ') output beyond end OK', stdout)
+        self.assertIn(
+            'ftell(' + output_path_2 + ') output beyond end OK: ' + str((size + 4098) * 2),
+            stdout
+        )
+        self.assertIn('fread(' + output_path_2 + ') output OK: 0', stdout)
+        self.assertIn('fseek(' + output_path_2 + ') output end 4 OK', stdout)
+        self.assertIn('ftell(' + output_path_2 + ') output end 3 OK: ' + str(size + 4098), stdout)
         self.assertIn('fclose(' + output_path_2 + ') output OK', stdout)
 
         expected_size = size + 4098


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The file should grow only during write and truncation. The protected file was extended when the application opened it for reading and writing and read from an offset larger than the current size. Previous logic, in the `ipf_update_after_seek` function, assumed that if the file is writable, the file should be extended. This function was called in the read and write routine of protected files.

New tests verify that the file is not extended after seek/tell routine, and they are not extended after the read syscall.

## How to test this PR? <!-- (if applicable) -->

```
gramine-test -C libos/test/fs pytest
gramine-test --sgx -C libos/test/fs pytest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/738)
<!-- Reviewable:end -->
