### PR TITLE
[tools] Remove mbedTLS-specific funcs from RA-TLS API

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/README.md
+++ b/CI-Examples/ra-tls-mbedtls/README.md
@@ -6,9 +6,9 @@ minimal server and client written against the mbedTLS library.
 The server and client are based on `ssl_server.c` and `ssl_client1.c` example
 programs shipped with mbedTLS. We modified them to allow using RA-TLS flows. In
 particular, the server uses a self-signed RA-TLS cert with the SGX quote
-embedded in it via `ra_tls_create_key_and_crt()`. The client uses an RA-TLS
+embedded in it via `ra_tls_create_key_and_crt_der()`. The client uses an RA-TLS
 verification callback to verify the server RA-TLS certificate via
-`ra_tls_verify_callback()`.
+`ra_tls_verify_callback_der()`.
 
 This example uses the RA-TLS libraries `ra_tls_attest.so` for server and
 `ra_tls_verify_epid.so`/ `ra_tls_verify_dcap.so` for client. These libraries are

--- a/CI-Examples/ra-tls-mbedtls/src/server.c
+++ b/CI-Examples/ra-tls-mbedtls/src/server.c
@@ -136,9 +136,6 @@ int main(int argc, char** argv) {
             return 1;
         }
 
-        /* NOTE: use ra_tls_create_key_and_crt_der() API instead of ra_tls_create_key_and_crt()
-         * simply to test it in our CI and have an example of how to use this API; we already test
-         * ra_tls_create_key_and_crt() API in the Secret Provisioning example */
         char* error;
         ra_tls_create_key_and_crt_der_f = dlsym(ra_tls_attest_lib, "ra_tls_create_key_and_crt_der");
         if ((error = dlerror()) != NULL) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, RA-TLS exposed two mbedTLS-specific APIs:
- `ra_tls_verify_callback(..,  mbedtls_x509_crt*, ..)`
- `ra_tls_create_key_and_crt(mbedtls_pk_context*, mbedtls_x509_crt*)`

Any app that wanted to use these APIs of RA-TLS should have been linked against `mbedtls_gramine` version of mbedTLS. Otherwise the internal formats of `mbedtls_x509_crt` and `mbedtls_pk_context` objects could diverge, leading to hard-to-diagnose bugs.

Apps should not rely on Gramine-internal mbedTLS version. So this PR removes these two mbedTLS-specific funcs from RA-TLS API. **This is a breaking change**, but better do it now, while RA-TLS is not widely used.

Consequently, this PR modifies the `ra-tls-mbedtls` example to use DER-format versions of these functions.

For the context, see also discussion in https://github.com/gramineproject/gramine/pull/730.

*Next steps after this PR*:
- `ra-tls-mbedtls` and `ra-tls-secret-prov` examples should use the mbedTLS package installed on the platform, not `mbedtls_gramine`.
- `ra-tls` and `secret-prov` libraries should link all dependencies (most importantly, libCurl) statically. Note that these libs already link mbedTLS statically.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/740)
<!-- Reviewable:end -->
