### PR TITLE
[LibOS] Add peak memory usage support in procfs

### DIFF
--- a/libos/include/libos_fs_pseudo.h
+++ b/libos/include/libos_fs_pseudo.h
@@ -215,6 +215,7 @@ int proc_thread_tid_list_names(struct libos_dentry* parent, readdir_callback_t c
 int proc_thread_follow_link(struct libos_dentry* dent, char** out_target);
 int proc_thread_maps_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int proc_thread_cmdline_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
+int proc_thread_status_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 bool proc_thread_fd_name_exists(struct libos_dentry* parent, const char* name);
 int proc_thread_fd_list_names(struct libos_dentry* parent, readdir_callback_t callback, void* arg);
 int proc_thread_fd_follow_link(struct libos_dentry* dent, char** out_target);

--- a/libos/include/libos_vma.h
+++ b/libos/include/libos_vma.h
@@ -130,3 +130,6 @@ int msync_range(uintptr_t begin, uintptr_t end);
 int msync_handle(struct libos_handle* hdl);
 
 void debug_print_all_vmas(void);
+
+/* Returns the peak amount of memory usage */
+size_t get_peak_memory_usage(void);

--- a/libos/src/fs/proc/fs.c
+++ b/libos/src/fs/proc/fs.c
@@ -28,6 +28,7 @@ static void init_thread_dir(struct pseudo_node* ent) {
     pseudo_add_link(ent, "exe", &proc_thread_follow_link);
     pseudo_add_str(ent, "maps", &proc_thread_maps_load);
     pseudo_add_str(ent, "cmdline", &proc_thread_cmdline_load);
+    pseudo_add_str(ent, "status", &proc_thread_status_load);
 
     struct pseudo_node* fd = pseudo_add_dir(ent, "fd");
     struct pseudo_node* fd_link = pseudo_add_link(fd, /*name=*/NULL, &proc_thread_fd_follow_link);

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -905,6 +905,8 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/proc/2/exe: link: /proc_common', lines)
         self.assertIn('/proc/2/root: link: /', lines)
         self.assertIn('/proc/2/maps: file', lines)
+        self.assertIn('/proc/2/cmdline: file', lines)
+        self.assertIn('/proc/2/status: file', lines)
 
         # /proc/[pid]/fd
         self.assertIn('/proc/2/fd/0: link: /dev/tty', lines)


### PR DESCRIPTION
Resolves https://github.com/gramineproject/gramine/issues/614. Use the VMA subsystem instead of adding a PAL API.

An application may want to adjust itself based on the peak memory usage in some scenarios. This patch adds VmPeak stats into the pseudo-file `/proc/<pid>/status` to support the usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/742)
<!-- Reviewable:end -->
