### PR TITLE
[tools/sgx,common,Doc] Enable configurable signing algo for RA-TLS certs

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -20,6 +20,7 @@ fs.mounts = [
 ]
 
 sgx.debug = true
+sgx.enclave_size = "512M"
 
 sgx.remote_attestation = "{{ ra_type }}"
 sgx.ra_client_spid = "{{ ra_client_spid }}"

--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -298,6 +298,10 @@ The library uses the following environment variables if available:
 - ``RA_TLS_CERT_TIMESTAMP_NOT_AFTER`` -- the generated RA-TLS certificate uses
   this timestamp-not-after value, in the format "20301231235959" (this is also
   the default value if environment variable is not available).
+- ``RA_TLS_CERT_SIGNATURE_ALGO`` -- the generated RA-TLS certificate uses the
+  key pair created by the specified algorithm. The currently available values
+  are ``RSA-3072``, ``RSA-4096``, ``ECDSA-384``, ``ECDSA-521``. The default
+  value is ``RSA-3072``.
 
 ``ra_tls_verify_epid.so``
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/common/include/pal_error.h
+++ b/common/include/pal_error.h
@@ -56,7 +56,8 @@ typedef enum _pal_error_t {
     PAL_ERROR_CRYPTO_VERIFY_FAILED,
     PAL_ERROR_CRYPTO_RNG_FAILED,
     PAL_ERROR_CRYPTO_INVALID_DH_STATE,
-#define PAL_ERROR_CRYPTO_END PAL_ERROR_CRYPTO_INVALID_DH_STATE
+    PAL_ERROR_CRYPTO_INVALID_ALGO,
+#define PAL_ERROR_CRYPTO_END PAL_ERROR_CRYPTO_INVALID_ALGO
 } pal_error_t;
 
 /* err - value of error code, either positive or negative */

--- a/common/src/crypto/adapters/mbedtls_adapter.c
+++ b/common/src/crypto/adapters/mbedtls_adapter.c
@@ -12,6 +12,7 @@
 #include "crypto.h"
 #include "mbedtls/aes.h"
 #include "mbedtls/cmac.h"
+#include "mbedtls/ecp.h"
 #include "mbedtls/gcm.h"
 #include "mbedtls/hkdf.h"
 #include "mbedtls/net_sockets.h"
@@ -36,6 +37,7 @@ static int mbedtls_to_pal_error(int error) {
 
         case MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE:
         case MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE:
+        case MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE:
             return -PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE;
 
         case MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA:
@@ -43,9 +45,11 @@ static int mbedtls_to_pal_error(int error) {
         case MBEDTLS_ERR_HKDF_BAD_INPUT_DATA:
         case MBEDTLS_ERR_MD_BAD_INPUT_DATA:
         case MBEDTLS_ERR_MPI_BAD_INPUT_DATA:
+        case MBEDTLS_ERR_PK_BAD_INPUT_DATA:
         case MBEDTLS_ERR_RSA_BAD_INPUT_DATA:
         case MBEDTLS_ERR_RSA_PUBLIC_FAILED:  // see mbedtls_rsa_public()
         case MBEDTLS_ERR_RSA_PRIVATE_FAILED: // see mbedtls_rsa_private()
+        case MBEDTLS_ERR_ECP_BAD_INPUT_DATA:
             return -PAL_ERROR_CRYPTO_BAD_INPUT_DATA;
 
         case MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE:
@@ -56,6 +60,8 @@ static int mbedtls_to_pal_error(int error) {
         case MBEDTLS_ERR_MD_ALLOC_FAILED:
         case MBEDTLS_ERR_SSL_ALLOC_FAILED:
         case MBEDTLS_ERR_PK_ALLOC_FAILED:
+        case MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL:
+        case MBEDTLS_ERR_ECP_ALLOC_FAILED:
             return -PAL_ERROR_NOMEM;
 
         case MBEDTLS_ERR_CIPHER_INVALID_PADDING:
@@ -85,19 +91,28 @@ static int mbedtls_to_pal_error(int error) {
         case MBEDTLS_ERR_RSA_KEY_GEN_FAILED:
             return -PAL_ERROR_CRYPTO_KEY_GEN_FAILED;
 
+        case MBEDTLS_ERR_ECP_INVALID_KEY:
         case MBEDTLS_ERR_RSA_KEY_CHECK_FAILED:
             return -PAL_ERROR_CRYPTO_INVALID_KEY;
 
         case MBEDTLS_ERR_RSA_VERIFY_FAILED:
+        case MBEDTLS_ERR_ECP_VERIFY_FAILED:
+        case MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH:
             return -PAL_ERROR_CRYPTO_VERIFY_FAILED;
 
         case MBEDTLS_ERR_RSA_RNG_FAILED:
+        case MBEDTLS_ERR_ECP_RANDOM_FAILED:
             return -PAL_ERROR_CRYPTO_RNG_FAILED;
+
+        case MBEDTLS_ERR_PK_INVALID_ALG:
+        case MBEDTLS_ERR_PK_UNKNOWN_PK_ALG:
+            return -PAL_ERROR_CRYPTO_INVALID_ALGO;
 
         case MBEDTLS_ERR_SSL_WANT_READ:
         case MBEDTLS_ERR_SSL_WANT_WRITE:
         case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
         case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS:
+        case MBEDTLS_ERR_ECP_IN_PROGRESS:
             return -PAL_ERROR_TRYAGAIN;
 
         case MBEDTLS_ERR_NET_CONN_RESET:

--- a/tools/sgx/ra-tls/ra_tls_verify_common.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_common.c
@@ -167,9 +167,9 @@ static int sha256_over_crt_pk(mbedtls_x509_crt* crt, uint8_t* sha) {
     uint8_t pk_der[PUB_KEY_SIZE_MAX] = {0};
 
     /* below function writes data at the end of the buffer */
-    int pk_der_size_byte = mbedtls_pk_write_pubkey_der(&crt->pk, pk_der, PUB_KEY_SIZE_MAX);
-    if (pk_der_size_byte != RSA_PUB_3072_KEY_DER_LEN)
-        return MBEDTLS_ERR_PK_INVALID_PUBKEY;
+    int pk_der_size_byte = mbedtls_pk_write_pubkey_der(&crt->pk, pk_der, sizeof(pk_der));
+    if (pk_der_size_byte < 0)
+        return pk_der_size_byte;
 
     /* move the data to the beginning of the buffer, to avoid pointer arithmetic later */
     memmove(pk_der, pk_der + PUB_KEY_SIZE_MAX - pk_der_size_byte, pk_der_size_byte);


### PR DESCRIPTION
Resolves https://github.com/gramineproject/gramine/issues/156 and an initial PR was created by @dimakuv at https://github.com/gramineproject/graphene/pull/2314. This PR augments it w/ the possible RSA key size selection and drops ECDSA_SECP256K1 and ECDSA_SECP256R1 support based on Intel crypto guidelines/recommandations.

Previously, RA-TLS generated only RSA-3072 keypairs (and signed self-signed RA-TLS X.509 certificates with these RSA keys). This commit adds the ability to specify the signing algo: RSA (RSA-3072, RSA-4096) or ECDSA (ECDSA-384, ECDSA-521) for RA-TLS via a new envvar `RA_TLS_CERT_SIGNATURE_ALGO`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/748)
<!-- Reviewable:end -->
