### PR TITLE
Override `argv[0]` with file pathname for interpreter scripts

### DIFF
--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -579,7 +579,7 @@ static int read_file_fragment(struct libos_handle* file, void* buf, size_t size,
 
 /* Note that `**out_new_argv` is allocated as a single object -- a concatenation of all argv
  * strings; caller of this function should do a single free(**out_new_argv). */
-static int load_and_check_shebang(struct libos_handle* file, char** argv,
+static int load_and_check_shebang(struct libos_handle* file, const char* pathname, char** argv,
                                   char*** out_new_argv) {
     int ret;
 
@@ -633,11 +633,16 @@ static int load_and_check_shebang(struct libos_handle* file, char** argv,
         new_argv_bytes += strlen(*a) + 1;
         new_argv_cnt++;
     }
-    for (char** a = argv; *a; a++) {
-        new_argv_bytes += strlen(*a) + 1;
-        new_argv_cnt++;
-    }
 
+    /* if arg list is { NULL }, then must transform it to { pathname, NULL } */
+    new_argv_bytes += strlen(pathname) + 1;
+    new_argv_cnt++;
+    if (*argv) {
+        for (char** a = argv + 1; *a; a++) {
+            new_argv_bytes += strlen(*a) + 1;
+            new_argv_cnt++;
+        }
+    }
     log_debug("Assembling %zu execve arguments (total size is %zu bytes)", new_argv_cnt,
               new_argv_bytes);
 
@@ -661,12 +666,21 @@ static int load_and_check_shebang(struct libos_handle* file, char** argv,
         new_argv_idx++;
         new_argv_ptr += size;
     }
-    for (char** a = argv; *a; a++) {
-        size_t size = strlen(*a) + 1;
-        memcpy(new_argv_ptr, *a, size);
-        new_argv[new_argv_idx] = new_argv_ptr;
-        new_argv_idx++;
-        new_argv_ptr += size;
+
+    /* if arg list is { NULL }, then must transform it to { pathname, NULL } */
+    size_t size = strlen(pathname) + 1;
+    memcpy(new_argv_ptr, pathname, size);
+    new_argv[new_argv_idx] = new_argv_ptr;
+    new_argv_idx++;
+    new_argv_ptr += size;
+    if (*argv) {
+        for (char** a = argv + 1; *a; a++) {
+            size_t size = strlen(*a) + 1;
+            memcpy(new_argv_ptr, *a, size);
+            new_argv[new_argv_idx] = new_argv_ptr;
+            new_argv_idx++;
+            new_argv_ptr += size;
+        }
     }
     new_argv[new_argv_idx] = NULL;
 
@@ -753,7 +767,7 @@ int load_and_check_exec(const char* path, const char** argv, struct libos_handle
                   depth > 1 ? curr_argv[0] : path);
 
         char** new_argv = NULL;
-        ret = load_and_check_shebang(file, curr_argv, &new_argv);
+        ret = load_and_check_shebang(file, depth > 1 ? curr_argv[0] : path, curr_argv, &new_argv);
         if (ret < 0) {
             goto err;
         }

--- a/libos/test/regression/exec_script.c
+++ b/libos/test/regression/exec_script.c
@@ -3,7 +3,11 @@
 #include <unistd.h>
 
 int main(void) {
-    char* const argv[] = {(char*)"scripts/foo.sh", (char*)"STRING FROM EXECVE", NULL};
-    execv(argv[0], argv);
+    char* const argv[] = {(char*)"foo.sh", (char*)"STRING FROM EXECVE", NULL};
+
+    /* The pathname arg to `execv()` differs from `argv[0]` on purpose: we want to test the corner
+     * case where `argv[0]` is overridden by the file pathname for interpreter scripts in execve
+     * family of syscalls. */
+    execv("scripts/foo.sh", argv);
     err(EXIT_FAILURE, "execve failed");
 }


### PR DESCRIPTION
According to POSIX, if the pathname argument of `execve()` specifies
an interpreter script, then interpreter will be invoked with the following
arguments:

    interpreter [optional-arg] pathname arg...

where `pathname` is the pathname of the file specified as the first argument of
`execve()`, and `arg...` is the series of words pointed to by the `argv` argument
of `execve()`, starting at `argv[1]`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/754)
<!-- Reviewable:end -->
