### PR TITLE
[Pal] Always allocate `file.realpath` and `dir.realpath` in separate memory locations

### DIFF
--- a/pal/regression/Directory.c
+++ b/pal/regression/Directory.c
@@ -94,5 +94,23 @@ int main(int argc, char** argv, char** envp) {
         PalObjectClose(dir7);
     }
 
+    PAL_HANDLE dir8 = NULL;
+    ret = PalStreamOpen("dir:dir_rename.tmp", PAL_ACCESS_RDWR,
+                        PAL_SHARE_OWNER_R | PAL_SHARE_OWNER_W | PAL_SHARE_OWNER_X,
+                        PAL_CREATE_TRY, /*options=*/0, &dir8);
+    if (ret >= 0 && dir8) {
+        ret = PalStreamChangeName(dir8, "dir:dir_rename_delete.tmp");
+        if (ret < 0) {
+            pal_printf("PalStreamChangeName failed: %d\n", ret);
+            return 1;
+        }
+        ret = PalStreamDelete(dir8, PAL_DELETE_ALL);
+        if (ret < 0) {
+            pal_printf("PalStreamDelete failed: %d\n", ret);
+            return 1;
+        }
+        PalObjectClose(dir8);
+    }
+
     return 0;
 }

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -288,7 +288,8 @@ class TC_20_SingleProcess(RegressionTestCase):
         self.assertFalse(pathlib.Path('file_delete.tmp').exists())
 
     def test_110_directory(self):
-        for path in ['dir_exist.tmp', 'dir_nonexist.tmp', 'dir_delete.tmp']:
+        for path in ['dir_exist.tmp', 'dir_nonexist.tmp', 'dir_delete.tmp',
+                     'dir_rename.tmp', 'dir_rename_delete.tmp']:
             try:
                 shutil.rmtree(path)
             except FileNotFoundError:
@@ -327,6 +328,8 @@ class TC_20_SingleProcess(RegressionTestCase):
 
         # Directory Deletion
         self.assertFalse(pathlib.Path('dir_delete.tmp').exists())
+        self.assertFalse(pathlib.Path('dir_rename.tmp').exists())
+        self.assertFalse(pathlib.Path('dir_rename_delete.tmp').exists())
 
     def test_200_event(self):
         _, stderr = self.run_binary(['Event'])

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -55,7 +55,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
-            const char* realpath;
+            char* realpath;
             size_t total;
             /* below fields are used only for trusted files */
             sgx_chunk_hash_t* chunk_hashes; /* array of hashes of file chunks */
@@ -87,7 +87,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
-            const char* realpath;
+            char* realpath;
             void* buf;
             void* ptr;
             void* end;

--- a/pal/src/host/linux-sgx/pal_streams.c
+++ b/pal/src/host/linux-sgx/pal_streams.c
@@ -118,26 +118,38 @@ out:
 static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size, int host_fd) {
     int ret;
 
-    PAL_HANDLE hdl = malloc(size);
+    size_t hdl_size = handle_size((PAL_HANDLE)data);
+    PAL_HANDLE hdl = malloc(hdl_size);
     if (!hdl)
         return -PAL_ERROR_NOMEM;
 
-    memcpy(hdl, data, size);
-    size_t hdlsz = handle_size(hdl);
+    memcpy(hdl, data, hdl_size);
 
-    /* update handle fields to point to correct contents (located right after handle itself) */
+    /* update handle fields to point to correct contents */
     switch (hdl->hdr.type) {
-        case PAL_TYPE_FILE:
-            hdl->file.realpath = hdl->file.realpath ? (const char*)hdl + hdlsz : NULL;
+        case PAL_TYPE_FILE: {
+            assert(hdl_size < size);
+
+            size_t path_size = size - hdl_size;
+            char* path = malloc(path_size);
+            if (!path) {
+                free(hdl);
+                return -PAL_ERROR_NOMEM;
+            }
+
+            memcpy(path, (const char*)data + hdl_size, path_size);
+
+            hdl->file.realpath = path;
             hdl->file.chunk_hashes = NULL;
             break;
+        }
         case PAL_TYPE_PIPE:
         case PAL_TYPE_PIPECLI:
             /* session key is part of handle but need to deserialize SSL context */
             hdl->pipe.fd = host_fd; /* correct host FD must be passed to SSL context */
             ret = _PalStreamSecureInit(hdl, hdl->pipe.is_server, &hdl->pipe.session_key,
                                        (LIB_SSL_CONTEXT**)&hdl->pipe.ssl_ctx,
-                                       (const uint8_t*)hdl + hdlsz, size - hdlsz);
+                                       (const uint8_t*)data + hdl_size, size - hdl_size);
             if (ret < 0) {
                 free(hdl);
                 return -PAL_ERROR_DENIED;
@@ -147,9 +159,21 @@ static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size,
             break;
         case PAL_TYPE_DEV:
             break;
-        case PAL_TYPE_DIR:
-            hdl->dir.realpath = hdl->dir.realpath ? (const char*)hdl + hdlsz : NULL;
+        case PAL_TYPE_DIR: {
+            assert(hdl_size < size);
+
+            size_t path_size = size - hdl_size;
+            char* path = malloc(path_size);
+            if (!path) {
+                free(hdl);
+                return -PAL_ERROR_NOMEM;
+            }
+
+            memcpy(path, (const char*)data + hdl_size, path_size);
+
+            hdl->dir.realpath = path;
             break;
+        }
         case PAL_TYPE_SOCKET:
             fixup_socket_handle_after_deserialization(hdl);
             break;
@@ -158,7 +182,7 @@ static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size,
             hdl->process.stream = host_fd; /* correct host FD must be passed to SSL context */
             ret = _PalStreamSecureInit(hdl, hdl->process.is_server, &hdl->process.session_key,
                                        (LIB_SSL_CONTEXT**)&hdl->process.ssl_ctx,
-                                       (const uint8_t*)hdl + hdlsz, size - hdlsz);
+                                       (const uint8_t*)data + hdl_size, size - hdl_size);
             if (ret < 0) {
                 free(hdl);
                 return -PAL_ERROR_DENIED;

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -39,7 +39,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
 
     /* if try_create_path succeeded, prepare for the file handle */
     size_t uri_size = strlen(uri) + 1;
-    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(file) + uri_size);
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(file));
     if (!hdl) {
         DO_SYSCALL(close, ret);
         return -PAL_ERROR_NOMEM;
@@ -48,11 +48,19 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
     init_handle_hdr(hdl, PAL_TYPE_FILE);
     hdl->flags |= PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE;
     hdl->file.fd = ret;
-    char* path = (void*)hdl + HANDLE_SIZE(file);
+
+    char* path = malloc(uri_size);
+    if (!path) {
+        DO_SYSCALL(close, hdl->file.fd);
+        free(hdl);
+        return -PAL_ERROR_NOMEM;
+    }
+
     ret = get_norm_path(uri, path, &uri_size);
     if (ret < 0) {
         DO_SYSCALL(close, hdl->file.fd);
         free(hdl);
+        free(path);
         return ret;
     }
 
@@ -63,6 +71,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
     if (ret < 0) {
         DO_SYSCALL(close, hdl->file.fd);
         free(hdl);
+        free(path);
         return unix_to_pal_error(ret);
     }
 
@@ -112,10 +121,7 @@ static int file_close(PAL_HANDLE handle) {
 
     int ret = DO_SYSCALL(close, fd);
 
-    /* initial realpath is part of handle object and will be freed with it */
-    if (handle->file.realpath && handle->file.realpath != (void*)handle + HANDLE_SIZE(file)) {
-        free((void*)handle->file.realpath);
-    }
+    free(handle->file.realpath);
 
     return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
@@ -226,11 +232,7 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
         return unix_to_pal_error(ret);
     }
 
-    /* initial realpath is part of handle object and will be freed with it */
-    if (handle->file.realpath && handle->file.realpath != (void*)handle + HANDLE_SIZE(file)) {
-        free((void*)handle->file.realpath);
-    }
-
+    free(handle->file.realpath);
     handle->file.realpath = tmp;
     return 0;
 }
@@ -297,8 +299,7 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     if (fd < 0)
         return unix_to_pal_error(fd);
 
-    size_t len = strlen(uri);
-    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(dir) + len + 1);
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(dir));
     if (!hdl) {
         DO_SYSCALL(close, fd);
         return -PAL_ERROR_NOMEM;
@@ -309,8 +310,12 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     hdl->flags |= PAL_HANDLE_FD_READABLE;
     hdl->dir.fd = fd;
 
-    char* path = (void*)hdl + HANDLE_SIZE(dir);
-    memcpy(path, uri, len + 1);
+    char* path = strdup(uri);
+    if (!path) {
+        DO_SYSCALL(close, hdl->dir.fd);
+        free(hdl);
+        return -PAL_ERROR_NOMEM;
+    }
 
     hdl->dir.realpath    = path;
     hdl->dir.buf         = NULL;
@@ -410,10 +415,7 @@ static int dir_close(PAL_HANDLE handle) {
         handle->dir.buf = handle->dir.ptr = handle->dir.end = NULL;
     }
 
-    /* initial realpath is part of handle object and will be freed with it */
-    if (handle->dir.realpath && handle->dir.realpath != (void*)handle + HANDLE_SIZE(dir)) {
-        free((void*)handle->dir.realpath);
-    }
+    free(handle->dir.realpath);
 
     if (ret < 0)
         return -PAL_ERROR_BADHANDLE;
@@ -426,12 +428,7 @@ static int dir_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
     if (delete_mode != PAL_DELETE_ALL)
         return -PAL_ERROR_INVAL;
 
-    int ret = dir_close(handle);
-
-    if (ret < 0)
-        return ret;
-
-    ret = DO_SYSCALL(rmdir, handle->dir.realpath);
+    int ret = DO_SYSCALL(rmdir, handle->dir.realpath);
 
     return (ret < 0 && ret != -ENOENT) ? -PAL_ERROR_DENIED : 0;
 }
@@ -450,11 +447,7 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
         return unix_to_pal_error(ret);
     }
 
-    /* initial realpath is part of handle object and will be freed with it */
-    if (handle->dir.realpath && handle->dir.realpath != (void*)handle + HANDLE_SIZE(dir)) {
-        free((void*)handle->dir.realpath);
-    }
-
+    free(handle->dir.realpath);
     handle->dir.realpath = tmp;
     return 0;
 }

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -38,7 +38,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
-            const char* realpath;
+            char* realpath;
             bool seekable; /* regular files are seekable, FIFO pipes are not */
         } file;
 
@@ -61,7 +61,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
-            const char* realpath;
+            char* realpath;
             void* buf;
             void* ptr;
             void* end;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously in `file_open`, `file.realpath` is allocated [together with the handle](https://github.com/gramineproject/gramine/blob/85078de3222367da4d0aaa14793c218648a94659/pal/src/host/linux/pal_files.c#L42). But in `file_rename`, it is allocated to a [separate memory location](https://github.com/gramineproject/gramine/blob/85078de3222367da4d0aaa14793c218648a94659/pal/src/host/linux/pal_files.c#L219). After this change, `file.realpath` is also allocated separately in `file_open`, and there is no need to [check the address of the pointer](https://github.com/gramineproject/gramine/blob/85078de3222367da4d0aaa14793c218648a94659/pal/src/host/linux/pal_files.c#L116) when doing free inside `file_close`. Same for `dir.realpath`.

Remove calling `dir_close()` in [`dir_delete()`](https://github.com/gramineproject/gramine/blob/d0f64b5417cc86267a320e4b72646e48c4fedfa0/pal/src/host/linux/pal_files.c#L429).

Fixes #758 

## How to test this PR? <!-- (if applicable) -->
This PR add test cases in `pal/regression/Directory.c`. You can use this branch to rebuild Gramine and do regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/764)
<!-- Reviewable:end -->
