### PR TITLE
[common] Remove static function declarations from protected_files_internal.h

### DIFF
--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -29,36 +29,3 @@ struct pf_context {
     char* debug_buffer; // buffer for debug output
 #endif
 };
-
-/* ipf prefix means "Intel protected files", these are functions from the SGX SDK implementation */
-static bool ipf_init_fields(pf_context_t* pf);
-static bool ipf_init_existing_file(pf_context_t* pf, const char* path);
-static bool ipf_init_new_file(pf_context_t* pf, const char* path);
-
-static bool ipf_read_node(pf_context_t* pf, pf_handle_t handle, uint64_t node_number, void* buffer,
-                          uint32_t node_size);
-static bool ipf_write_node(pf_context_t* pf, pf_handle_t handle, uint64_t node_number, void* buffer,
-                           uint32_t node_size);
-
-static bool ipf_import_metadata_key(pf_context_t* pf, bool restore, pf_key_t* output);
-static bool ipf_generate_random_key(pf_context_t* pf, pf_key_t* output);
-static bool ipf_restore_current_metadata_key(pf_context_t* pf, pf_key_t* output);
-
-static file_node_t* ipf_get_data_node(pf_context_t* pf, uint64_t offset);
-static file_node_t* ipf_read_data_node(pf_context_t* pf, uint64_t offset);
-static file_node_t* ipf_append_data_node(pf_context_t* pf, uint64_t offset);
-static file_node_t* ipf_get_mht_node(pf_context_t* pf, uint64_t offset);
-static file_node_t* ipf_read_mht_node(pf_context_t* pf, uint64_t mht_node_number);
-static file_node_t* ipf_append_mht_node(pf_context_t* pf, uint64_t mht_node_number);
-
-static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf);
-static bool ipf_update_metadata_node(pf_context_t* pf);
-static bool ipf_write_all_changes_to_disk(pf_context_t* pf);
-static bool ipf_internal_flush(pf_context_t* pf);
-
-static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create, pf_handle_t file,
-                              size_t real_size, const pf_key_t* kdk_key, pf_status_t* status);
-static bool ipf_close(pf_context_t* pf);
-static size_t ipf_read(pf_context_t* pf, void* ptr, uint64_t offset, size_t size);
-static size_t ipf_write(pf_context_t* pf, const void* ptr, uint64_t offset, size_t size);
-static void ipf_try_clear_error(pf_context_t* pf);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As suggested in review https://reviewable.io/reviews/gramineproject/gramine/719 we don't want to have a file header with static definitions used in a single file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/766)
<!-- Reviewable:end -->
