### PR TITLE
[LibOS,PAL,common] Add `flags` line to `/proc/cpuinfo`

### DIFF
--- a/libos/include/arch/x86_64/libos_cpuid.h
+++ b/libos/include/arch/x86_64/libos_cpuid.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ */
+
+/*!
+ * \brief Get CPU feature flags.
+ *
+ * \param[out] out_cpu_flags  On success, set to CPU feature flags.
+ *
+ * \returns 0 on success, negative on failure.
+ *
+ * This function returns a new buffer with CPU feature flags, the caller is responsible to free it
+ * afterwards.
+ */
+int libos_get_cpu_flags(char** out_cpu_flags);

--- a/libos/src/arch/x86_64/fs_proc/info.c
+++ b/libos/src/arch/x86_64/fs_proc/info.c
@@ -4,6 +4,7 @@
  */
 
 #include "api.h"
+#include "libos_cpuid.h"
 #include "libos_fs_proc.h"
 #include "pal.h"
 
@@ -41,6 +42,15 @@ int proc_cpuinfo_display_cpu(char** str, size_t* size, size_t* max,
             cores_in_socket++;
     }
     ADD_INFO("cpu cores\t: %zu\n", cores_in_socket);
+
+    char* cpu_flags = NULL;
+    int ret = libos_get_cpu_flags(&cpu_flags);
+    if (ret < 0) {
+        return ret;
+    }
+    ADD_INFO("flags\t\t: %s\n", cpu_flags);
+    free(cpu_flags);
+
     double bogomips = cpu->cpu_bogomips;
     // Apparently Gramine snprintf cannot into floats.
     ADD_INFO("bogomips\t: %lu.%02lu\n", (unsigned long)bogomips,

--- a/libos/src/arch/x86_64/libos_cpuid.c
+++ b/libos/src/arch/x86_64/libos_cpuid.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ */
+
+#include "cpu.h"
+#include "libos_cpuid.h"
+#include "libos_internal.h"
+#include "libos_utils.h"
+
+static const char* const g_cpu_flags[] = {
+    "fpu",    // "x87 FPU on chip"
+    "vme",    // "virtual-8086 mode enhancement"
+    "de",     // "debugging extensions"
+    "pse",    // "page size extensions"
+    "tsc",    // "time stamp counter"
+    "msr",    // "RDMSR and WRMSR support"
+    "pae",    // "physical address extensions"
+    "mce",    // "machine check exception"
+    "cx8",    // "CMPXCHG8B inst."
+    "apic",   // "APIC on chip"
+    NULL,
+    "sep",    // "SYSENTER and SYSEXIT"
+    "mtrr",   // "memory type range registers"
+    "pge",    // "PTE global bit"
+    "mca",    // "machine check architecture"
+    "cmov",   // "conditional move/compare instruction"
+    "pat",    // "page attribute table"
+    "pse36",  // "page size extension"
+    "pn",     // "processor serial number"
+    "clflush",    // "CLFLUSH instruction"
+    NULL,
+    "dts",    // "debug store"
+    "acpi",   // "Onboard thermal control"
+    "mmx",    // "MMX Technology"
+    "fxsr",   // "FXSAVE/FXRSTOR"
+    "sse",    // "SSE extensions"
+    "sse2",   // "SSE2 extensions"
+    "ss",     // "self snoop"
+    "ht",     // "hyper-threading / multi-core supported"
+    "tm",     // "therm. monitor"
+    "ia64",   // "IA64"
+    "pbe",    // "pending break event"
+};
+
+int libos_get_cpu_flags(char** out_cpu_flags) {
+    unsigned int words[CPUID_WORD_NUM];
+    int ret;
+
+    ret = PalCpuIdRetrieve(1, 0, words);
+    if (ret < 0) {
+        return pal_to_unix_errno(ret);
+    }
+
+    size_t flen = 0;
+    size_t fmax = 80;
+    char* flags = malloc(fmax);
+    if (!flags) {
+        ret = -ENOMEM;
+        goto out_err;
+    }
+
+    for (size_t i = 0; i < 32; i++) {
+        if (!g_cpu_flags[i])
+            continue;
+
+        if ((words[CPUID_WORD_EDX] >> i) & 1) {
+            size_t len = strlen(g_cpu_flags[i]);
+            if (flen + len + 1 > fmax) {
+                /* TODO: use `realloc()` once it's available. */
+                char* new_flags = malloc(fmax * 2);
+                if (!new_flags) {
+                    ret = -ENOMEM;
+                    goto out_err;
+                }
+                memcpy(new_flags, flags, flen);
+                free(flags);
+                fmax *= 2;
+                flags = new_flags;
+            }
+            memcpy(flags + flen, g_cpu_flags[i], len);
+            flen += len;
+            flags[flen++] = ' ';
+        }
+    }
+
+    flags[flen ? flen - 1 : 0] = 0;
+    *out_cpu_flags = flags;
+
+    return 0;
+
+out_err:
+    free(flags);
+    return ret;
+}

--- a/libos/src/arch/x86_64/meson.build
+++ b/libos/src/arch/x86_64/meson.build
@@ -2,6 +2,7 @@ libos_sources_arch_list = {
     'fs_proc/info.c': {},
     'libos_arch_prctl.c': {},
     'libos_context.c': {},
+    'libos_cpuid.c': {},
     'libos_elf_entry.nasm': { 'type': 'nasm' },
     'libos_table.c': {},
     'start.S': {},

--- a/pal/include/arch/x86_64/pal_arch.h
+++ b/pal/include/arch/x86_64/pal_arch.h
@@ -69,7 +69,6 @@ struct pal_cpu_info {
     uint64_t cpu_model;
     uint64_t cpu_stepping;
     double cpu_bogomips;
-    const char* cpu_flags;
 };
 
 union pal_csgsfs {

--- a/pal/regression/Bootstrap.c
+++ b/pal/regression/Bootstrap.c
@@ -42,7 +42,6 @@ int main(int argc, char** argv, char** envp) {
     pal_printf("CPU family: %ld\n",   ci->cpu_family);
     pal_printf("CPU model: %ld\n",    ci->cpu_model);
     pal_printf("CPU stepping: %ld\n", ci->cpu_stepping);
-    pal_printf("CPU flags: %s\n",     ci->cpu_flags);
 
     return 0;
 }

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -15,12 +15,6 @@ from graminelibos.regression import (
     expectedFailureIf,
 )
 
-CPUINFO_FLAGS_WHITELIST = [
-    'fpu', 'vme', 'de', 'pse', 'tsc', 'msr', 'pae', 'mce', 'cx8', 'apic', 'sep',
-    'mtrr', 'pge', 'mca', 'cmov', 'pat', 'pse36', 'pn', 'clflush', 'dts',
-    'acpi', 'mmx', 'fxsr', 'sse', 'sse2', 'ss', 'ht', 'tm', 'ia64', 'pbe',
-]
-
 
 class TC_00_Basic(RegressionTestCase):
     def test_001_path_normalization(self):
@@ -105,9 +99,6 @@ class TC_01_Bootstrap(RegressionTestCase):
             cpuinfo = file_.read().strip().split('\n\n')[-1]
         cpuinfo = dict(map(str.strip, line.split(':'))
             for line in cpuinfo.split('\n'))
-        if 'flags' in cpuinfo:
-            cpuinfo['flags'] = ' '.join(flag for flag in cpuinfo['flags']
-                if flag in CPUINFO_FLAGS_WHITELIST)
 
         _, stderr = self.run_binary(['Bootstrap'])
 
@@ -118,7 +109,6 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('CPU family: {[cpu family]}'.format(cpuinfo), stderr)
         self.assertIn('CPU model: {[model]}'.format(cpuinfo), stderr)
         self.assertIn('CPU stepping: {[stepping]}'.format(cpuinfo), stderr)
-        self.assertIn('CPU flags: {[flags]}'.format(cpuinfo), stderr)
 
     def test_103_dotdot(self):
         _, stderr = self.run_binary(['..Bootstrap'])


### PR DESCRIPTION
Some workloads may require to parse the flags line in the pseudo-file
`/proc/cpuinfo`.

This patch
- removes `cpu_flags` from `pal_cpu_info` to keep the generality of PAL (i.e., to avoid emulating part of Linux-specific stuff in PAL, which should be done in LibOS instead)
- builds the `flags` line via performing `PalCpuIdRetrieve()` call when printing `/proc/cpuinfo`

Partially resolves <!----> https://github.com/gramineproject/gramine/issues/592.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/768)
<!-- Reviewable:end -->
