### PR TITLE
[tools,Docs] Build and link `libsgx_util` statically

### DIFF
--- a/.ci/lib/stage-build-nosgx.jenkinsfile
+++ b/.ci/lib/stage-build-nosgx.jenkinsfile
@@ -45,7 +45,7 @@ stage('build') {
     env.GRAMINE_PKGLIBDIR = libdir + '/gramine'
 
     // In CI we install to non-standard --prefix (see above). This makes sure the libraries are
-    // available anyway (e.g. gramine-sgx-pf-crypt needs libsgx_util.so).
+    // available anyway.
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
     // prevent cheating and testing from repo

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -83,7 +83,7 @@ stage('build') {
     env.GRAMINE_PKGLIBDIR = libdir + '/gramine'
 
     // In CI we install to non-standard --prefix (see above). This makes sure the libraries are
-    // available anyway (e.g. gramine-sgx-pf-crypt needs libsgx_util.so).
+    // available anyway.
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
     // prevent cheating and testing from repo

--- a/Documentation/tutorials/pytorch/index.rst
+++ b/Documentation/tutorials/pytorch/index.rst
@@ -405,11 +405,8 @@ the confidential wrap key::
 In real deployments, the user must replace this ``wrap-key`` with her own
 128-bit encryption key.
 
-We also re-use the ``pf_crypt`` utility (with its ``libsgx_util.so`` helper
-library and required mbedTLS libraries) that encrypts/decrypts the files::
+We also re-use the ``pf_crypt`` utility that encrypts/decrypts the files::
 
-   cp <gramine repository>/CI-Examples/ra-tls-secret-prov/libs/libsgx_util.so .
-   cp <gramine repository>/CI-Examples/ra-tls-secret-prov/libs/libmbed*.so* .
    cp <gramine repository>/CI-Examples/ra-tls-secret-prov/pf_crypt .
 
 Let's also make sure that ``alexnet-pretrained.pt`` network-model file exists

--- a/tools/sgx/common/meson.build
+++ b/tools/sgx/common/meson.build
@@ -1,4 +1,4 @@
-sgx_util = shared_library('sgx_util',
+sgx_util = static_library('sgx_util',
     'ias.c',
     'ias.h',
     'pf_util.c',
@@ -35,16 +35,3 @@ sgx_util_dep = declare_dependency(
         protected_files_inc,
     ],
 )
-
-pkgconfig.generate(
-    sgx_util,
-    libraries: [
-        '-Wl,-rpath,${libdir}',
-        sgx_util,
-    ],
-)
-
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libsgx_util.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))


### PR DESCRIPTION
Previously, we built `libsgx_util` as a shared library which is linked into RA-TLS, Secret Provisioning libraries and some other tools.

This patch builds `libsgx_util` into a static library and links all the related libs and tools with it statically to avoid pulling in a lot of dependencies.

See https://github.com/gramineproject/gramine/pull/740 and https://github.com/gramineproject/gramine/pull/730 for some previous discussions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/771)
<!-- Reviewable:end -->
