### PR TITLE
[tools/sgx,curl,Docs] Link all dependencies of `tools/sgx` statically

### DIFF
--- a/.ci/lib/stage-build-nosgx.jenkinsfile
+++ b/.ci/lib/stage-build-nosgx.jenkinsfile
@@ -45,7 +45,7 @@ stage('build') {
     env.GRAMINE_PKGLIBDIR = libdir + '/gramine'
 
     // In CI we install to non-standard --prefix (see above). This makes sure the libraries are
-    // available anyway (e.g. gramine-sgx-pf-crypt needs libsgx_util.so).
+    // available anyway.
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
     // prevent cheating and testing from repo

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -57,7 +57,7 @@ stage('build') {
     env.GRAMINE_PKGLIBDIR = libdir + '/gramine'
 
     // In CI we install to non-standard --prefix (see above). This makes sure the libraries are
-    // available anyway (e.g. gramine-sgx-pf-crypt needs libsgx_util.so).
+    // available anyway.
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
     // prevent cheating and testing from repo

--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     jq \
     libapr1-dev \
     libaprutil1-dev \
-    libcurl4-openssl-dev \
     libelf-dev \
     libevent-dev \
     libexpat1 \

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libapr1-dev \
     libaprutil1-dev \
     libcjson-dev \
-    libcurl4-openssl-dev \
     libelf-dev \
     libevent-dev \
     libexpat1 \

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -49,12 +49,12 @@ ssl/server.crt: ssl/ca_config.conf
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
 # Use hard-coded GRAMINEDIR because we currently fail to provide secret prov headers in Gramine
-# installation. We also use `sgx_util` pkg-config because we don't have a secret prov one.
+# installation. We also use `mbedtls_gramine` pkg-config because we don't have a secret prov one.
 # TODO: Create a pkg-config file for secretprov_gramine libs, and use it in below
 #       CFLAGS/LDFLAGS lines (via `pkg-config {--cflags|--libs} secretprov_gramine`).
 GRAMINEDIR ?= ../..
 CFLAGS += -Wall -std=c11 -I$(GRAMINEDIR)/tools/sgx/ra-tls
-LDFLAGS += -Wl,--enable-new-dtags $(shell pkg-config --libs sgx_util)
+LDFLAGS += -Wl,--enable-new-dtags $(shell pkg-config --libs mbedtls_gramine)
 
 %/server_epid: %/server.c
 	$(CC) $< $(CFLAGS) $(LDFLAGS) -lsecret_prov_verify_epid -pthread -o $@

--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -71,9 +71,8 @@ running, and Intel SGX SDK/PSW/DCAP must be installed.
 """"""""""""""""""""
 Run the following commands on Ubuntu to install SGX-related dependencies::
 
-    sudo apt-get install -y libcurl4-openssl-dev \
-        libprotobuf-c-dev protobuf-c-compiler protobuf-compiler \
-        python3-cryptography python3-pip python3-protobuf
+    sudo apt-get install -y libprotobuf-c-dev protobuf-c-compiler \
+        protobuf-compiler python3-cryptography python3-pip python3-protobuf
 
 2. Install Linux kernel with patched FSGSBASE
 """""""""""""""""""""""""""""""""""""""""""""

--- a/meson.build
+++ b/meson.build
@@ -247,7 +247,8 @@ if sgx
 
     threads_dep = dependency('threads')
 
-    libcurl_dep = dependency('libcurl', version: '>=7.58.0')
+    curl_proj = subproject('curl-7.84.0')
+    libcurl_dep = curl_proj.get_variable('curl_minimal_dep')
 
     cjson_dep = dependency('cjson', required: false)
     if not cjson_dep.found()

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,6 +1,7 @@
 /packagecache
 
 /cJSON-*/
+/curl-*/
 /gcc-*/
 /glibc-*/
 /mbedtls-*/

--- a/subprojects/curl-7.84.0.wrap
+++ b/subprojects/curl-7.84.0.wrap
@@ -1,0 +1,7 @@
+[wrap-file]
+directory = curl-7.84.0
+source_url = https://github.com/curl/curl/releases/download/curl-7_84_0/curl-7.84.0.tar.gz
+source_fallback_url = https://packages.gramineproject.io/distfiles/curl-7.84.0.tar.gz
+source_filename = curl-7.84.0.tar.gz
+source_hash = 3c6893d38d054d4e378267166858698899e9d87258e8ff1419d020c395384535
+patch_directory = curl-7.84.0

--- a/subprojects/packagefiles/curl-7.84.0/compile.sh
+++ b/subprojects/packagefiles/curl-7.84.0/compile.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+set -e
+
+log() {
+    echo "curl: $*"
+}
+
+CURRENT_SOURCE_DIR="$1"
+CURRENT_BUILD_DIR="$2"
+PRIVATE_DIR="$3"
+SUBPROJ_ROOT="$4"
+shift 4
+
+BUILD_LOG=$(realpath "$CURRENT_BUILD_DIR/curl-build.log")
+rm -f "$BUILD_LOG"
+
+log "see $BUILD_LOG for full build log"
+
+log "preparing sources..."
+
+rm -rf "$PRIVATE_DIR"
+cp -ar "$CURRENT_SOURCE_DIR" "$PRIVATE_DIR"
+
+(
+    cd "$PRIVATE_DIR"
+
+    log "running configure..."
+    # The list of configure options is selected based on:
+    # https://github.com/curl/curl/blob/curl-7_84_0/docs/INSTALL.md#reducing-size
+    ./configure                                     \
+        --disable-alt-svc                           \
+        --disable-ares                              \
+        --disable-cookies                           \
+        --disable-crypto-auth                       \
+        --disable-dateparse                         \
+        --disable-dict                              \
+        --disable-dnsshuffle                        \
+        --disable-doh                               \
+        --disable-file                              \
+        --disable-ftp                               \
+        --disable-get-easy-options                  \
+        --disable-gopher                            \
+        --disable-hsts                              \
+        --disable-http-auth                         \
+        --disable-imap                              \
+        --disable-ldap                              \
+        --disable-ldaps                             \
+        --disable-libcurl-option                    \
+        --disable-manual                            \
+        --disable-mqtt                              \
+        --disable-netrc                             \
+        --disable-ntlm-wb                           \
+        --disable-pop3                              \
+        --disable-progress-meter                    \
+        --disable-proxy                             \
+        --disable-pthreads                          \
+        --disable-rtsp                              \
+        --disable-shared                            \
+        --disable-smb                               \
+        --disable-smtp                              \
+        --disable-socketpair                        \
+        --disable-telnet                            \
+        --disable-tftp                              \
+        --disable-threaded-resolver                 \
+        --disable-tls-srp                           \
+        --disable-unix-sockets                      \
+        --disable-verbose                           \
+        --disable-versioned-symbols                 \
+        --with-mbedtls="$SUBPROJ_ROOT"/mbedtls-curl \
+        --without-brotli                            \
+        --without-libidn2                           \
+        --without-libpsl                            \
+        --without-librtmp                           \
+        --without-nghttp2                           \
+        --without-ngtcp2                            \
+        --without-zlib                              \
+        --without-zstd                              \
+        >>"$BUILD_LOG" 2>&1
+
+    log "running make..."
+
+    # The curl executable is not needed so we only build libcurl here.
+    cd lib; make -j"$(nproc)" >>"$BUILD_LOG" 2>&1
+)
+
+cp -r "$PRIVATE_DIR"/lib/.libs/* "$CURRENT_BUILD_DIR"/
+
+log "done"

--- a/subprojects/packagefiles/curl-7.84.0/meson.build
+++ b/subprojects/packagefiles/curl-7.84.0/meson.build
@@ -1,0 +1,23 @@
+project('curl', 'c', version: '7.84.0')
+
+curl_libs_output = [
+    'libcurl.a',
+]
+
+curl = custom_target('curl',
+    command: [
+        find_program('compile.sh'),
+        '@CURRENT_SOURCE_DIR@',
+        meson.current_build_dir(),
+        '@PRIVATE_DIR@',
+        join_paths(meson.build_root(), 'subprojects'),
+    ],
+
+    depends: subproject('mbedtls-mbedtls-3.2.1').get_variable('mbedtls_curl_libs'),
+    output: curl_libs_output,
+)
+
+curl_minimal_dep = declare_dependency(
+    link_with: curl,
+    include_directories: 'include',
+)

--- a/subprojects/packagefiles/mbedtls/compile-curl.sh
+++ b/subprojects/packagefiles/mbedtls/compile-curl.sh
@@ -6,18 +6,8 @@ CURRENT_SOURCE_DIR="$1"
 VENDOR_SOURCE_DIR="$2"
 CURRENT_BUILD_DIR="$3"
 PRIVATE_DIR="$4"
-shift 4
-
-OUTPUTS=""
-while test "$#" -gt 0 && ! test "$1" = --
-do
-    OUTPUTS="$OUTPUTS $1"
-    shift
-done
-if test "$1" = --
-then
-    shift
-fi
+SUBPROJ_ROOT="$5"
+shift 5
 
 rm -rf "$PRIVATE_DIR"
 
@@ -26,9 +16,9 @@ cp "$CURRENT_SOURCE_DIR"/include/mbedtls/*.h "$PRIVATE_DIR"/include/mbedtls/
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/gramine.patch
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/fcntl.patch
 
-make -C "$PRIVATE_DIR" lib "$@"
+make -C "$PRIVATE_DIR" lib SUFFIX="''" install DESTDIR="$SUBPROJ_ROOT"/mbedtls-curl
 
-for output in $OUTPUTS
+for output in $@
 do
     cp -a "$PRIVATE_DIR"/library/"$(basename "$output")" "$output"
 done

--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -84,6 +84,28 @@ mbedtls_pal_libs = custom_target('mbedtls_pal',
     build_by_default: true,
 )
 
+mbedtls_curl_libs = custom_target('mbedtls_curl',
+    command: [
+        find_program('compile-curl.sh'),
+        '@CURRENT_SOURCE_DIR@',
+        '@CURRENT_SOURCE_DIR@/mbedtls-mbedtls-3.2.1',
+        meson.current_build_dir(),
+        '@PRIVATE_DIR@',
+        join_paths(meson.build_root(), 'subprojects'),
+        '@OUTPUT@',
+    ],
+
+    input: ['mbedtls-mbedtls-3.2.1/Makefile', 'gramine.patch'],
+
+    output: [
+        'libmbedcrypto.a',
+        'libmbedtls.a',
+        'libmbedx509.a',
+    ],
+
+    build_by_default: true,
+)
+
 mbedtls_inc = include_directories('include', 'mbedtls-mbedtls-3.2.1/include')
 
 mbedtls_static_dep = declare_dependency(
@@ -95,6 +117,13 @@ mbedtls_pal_dep = declare_dependency(
     # HACK: Apparently Meson considers the `mbedtls_pal_libs` to be "not linkable", because it has
     # multiple outputs; however, it allows picking the outputs one by one.
     link_with: [mbedtls_pal_libs[0], mbedtls_pal_libs[1], mbedtls_pal_libs[2]],
+    include_directories: mbedtls_inc,
+    compile_args: '-DMBEDTLS_CONFIG_FILE="mbedtls/config-pal.h"',
+)
+mbedtls_curl_dep = declare_dependency(
+    # HACK: Apparently Meson considers the `mbedtls_curl_libs` to be "not linkable", because it has
+    # multiple outputs; however, it allows picking the outputs one by one.
+    link_with: [mbedtls_curl_libs[0], mbedtls_curl_libs[1], mbedtls_curl_libs[2]],
     include_directories: mbedtls_inc,
     compile_args: '-DMBEDTLS_CONFIG_FILE="mbedtls/config-pal.h"',
 )

--- a/tools/sgx/common/meson.build
+++ b/tools/sgx/common/meson.build
@@ -1,4 +1,4 @@
-sgx_util = shared_library('sgx_util',
+sgx_util = static_library('sgx_util',
     'ias.c',
     'ias.h',
     'pf_util.c',
@@ -36,16 +36,3 @@ sgx_util_dep = declare_dependency(
         protected_files_inc,
     ],
 )
-
-pkgconfig.generate(
-    sgx_util,
-    libraries: [
-        '-Wl,-rpath,${libdir}',
-        sgx_util,
-    ],
-)
-
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libsgx_util.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))


### PR DESCRIPTION
Previously, we built `libsgx_util` as a shared library which is linked into RA-TLS, Secret Provisioning libraries and some other tools.

This patch
- builds `libsgx_util` into a static library
- builds and minimizes `curl` into a static library (leveraging `mbedtls` as the TLS backend)
- links all dependencies of `tools/sgx` statically to avoid pulling in a lot of dependencies.

See https://github.com/gramineproject/gramine/pull/740 and https://github.com/gramineproject/gramine/pull/730 for some previous discussions.

**BEFORE**
```
kailun@kailun-NUC:~/workspace/intel/upstream/gramine/build/tools/sgx/ias-request$ ldd gramine-sgx-ias-request
        linux-vdso.so.1 (0x00007ffd21e84000)
        libsgx_util.so => /home/kailun/workspace/intel/upstream/gramine/build/tools/sgx/ias-request/./../common/libsgx_util.so (0x00007ff62a17d000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ff629f77000)
        libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4 (0x00007ff629ee5000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ff62a1f8000)
        libnghttp2.so.14 => /lib/x86_64-linux-gnu/libnghttp2.so.14 (0x00007ff629ebc000)
        libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x00007ff629e9b000)
        librtmp.so.1 => /lib/x86_64-linux-gnu/librtmp.so.1 (0x00007ff629e79000)
        libssh.so.4 => /lib/x86_64-linux-gnu/libssh.so.4 (0x00007ff629e0b000)
        libpsl.so.5 => /lib/x86_64-linux-gnu/libpsl.so.5 (0x00007ff629df8000)
        libssl.so.1.1 => /lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007ff629d65000)
        libcrypto.so.1.1 => /lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007ff629a8f000)
        libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x00007ff629a42000)
        libldap_r-2.4.so.2 => /lib/x86_64-linux-gnu/libldap_r-2.4.so.2 (0x00007ff6299ea000)
        liblber-2.4.so.2 => /lib/x86_64-linux-gnu/liblber-2.4.so.2 (0x00007ff6299d9000)
        libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007ff6299cb000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007ff6299af000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ff62998c000)
        libunistring.so.2 => /lib/x86_64-linux-gnu/libunistring.so.2 (0x00007ff62980a000)
        libgnutls.so.30 => /lib/x86_64-linux-gnu/libgnutls.so.30 (0x00007ff629632000)
        libhogweed.so.5 => /lib/x86_64-linux-gnu/libhogweed.so.5 (0x00007ff6295fb000)
        libnettle.so.7 => /lib/x86_64-linux-gnu/libnettle.so.7 (0x00007ff6295c1000)
        libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x00007ff62953d000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007ff629537000)
        libkrb5.so.3 => /lib/x86_64-linux-gnu/libkrb5.so.3 (0x00007ff629458000)
        libk5crypto.so.3 => /lib/x86_64-linux-gnu/libk5crypto.so.3 (0x00007ff629427000)
        libcom_err.so.2 => /lib/x86_64-linux-gnu/libcom_err.so.2 (0x00007ff629420000)
        libkrb5support.so.0 => /lib/x86_64-linux-gnu/libkrb5support.so.0 (0x00007ff629411000)
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007ff6293f5000)
        libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x00007ff6293d8000)
        libgssapi.so.3 => /lib/x86_64-linux-gnu/libgssapi.so.3 (0x00007ff629393000)
        libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007ff62936e000)
        libp11-kit.so.0 => /lib/x86_64-linux-gnu/libp11-kit.so.0 (0x00007ff629238000)
        libtasn1.so.6 => /lib/x86_64-linux-gnu/libtasn1.so.6 (0x00007ff629222000)
        libkeyutils.so.1 => /lib/x86_64-linux-gnu/libkeyutils.so.1 (0x00007ff62921b000)
        libheimntlm.so.0 => /lib/x86_64-linux-gnu/libheimntlm.so.0 (0x00007ff62920f000)
        libkrb5.so.26 => /lib/x86_64-linux-gnu/libkrb5.so.26 (0x00007ff62917a000)
        libasn1.so.8 => /lib/x86_64-linux-gnu/libasn1.so.8 (0x00007ff6290d3000)
        libhcrypto.so.4 => /lib/x86_64-linux-gnu/libhcrypto.so.4 (0x00007ff62909b000)
        libroken.so.18 => /lib/x86_64-linux-gnu/libroken.so.18 (0x00007ff629082000)
        libffi.so.7 => /lib/x86_64-linux-gnu/libffi.so.7 (0x00007ff629076000)
        libwind.so.0 => /lib/x86_64-linux-gnu/libwind.so.0 (0x00007ff62904c000)
        libheimbase.so.1 => /lib/x86_64-linux-gnu/libheimbase.so.1 (0x00007ff629038000)
        libhx509.so.5 => /lib/x86_64-linux-gnu/libhx509.so.5 (0x00007ff628fea000)
        libsqlite3.so.0 => /lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007ff628ec1000)
        libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007ff628e86000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ff628d37000)
```

**AFTER**
```
kailun@kailun-dev:~/workspace/clean/gramine/build/tools/sgx/ias-request$ ldd gramine-sgx-ias-request
        linux-vdso.so.1 (0x00007ffebf3d7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4b282ac000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f4b28556000)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/773)
<!-- Reviewable:end -->
