### PR TITLE
[PAL] Disable attestation flows in child enclaves

### DIFF
--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -10,9 +10,11 @@ initial state.
 There are two types of attestation: :term:`Local Attestation` and
 :term:`Remote Attestation`. Local attestation is used when two TEEs run on the
 same physical machine and remote attestation is used when a user attests a TEE
-running on a remote physical machine. In the following, even though Gramine
-attestation flows are designed to be TEE-agnostic, we discuss only :term:`SGX`
-attestation flows (the SGX flows are currently the only ones implemented).
+running on a remote physical machine. Only initial process in Gramine can 
+attest remotely; child processes have no access to attestation flows. In the 
+following, even though Gramine attestation flows are designed to be 
+TEE-agnostic, we discuss only :term:`SGX` attestation flows (the SGX flows are 
+currently the only ones implemented).
 
 By itself, remote attestation only provides the assurance to the user that the
 remotely executing TEE is trusted, that the correct code is executed and that

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -953,7 +953,7 @@ static int load_enclave(struct pal_enclave* enclave, char* args, size_t args_siz
         return ret;
 
     sgx_target_info_t qe_targetinfo = {0};
-    if (enclave->attestation_type != SGX_ATTESTATION_NONE) {
+    if (enclave->attestation_type != SGX_ATTESTATION_NONE && parent_stream_fd < 0) {
         /* initialize communication with Quoting Enclave only if app requests attestation */
         log_debug("Using SGX attestation type \"%s\"",
                   attestation_type_to_str(enclave->attestation_type));

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -628,11 +628,13 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
-    enum sgx_attestation_type attestation_type;
-    ret = parse_attestation_type(g_pal_public_state.manifest_root, &attestation_type);
-    if (ret < 0) {
-        log_error("Failed to parse attestation type: %d", unix_to_pal_error(ret));
-        ocall_exit(1, /*is_exitgroup=*/true);
+    enum sgx_attestation_type attestation_type=SGX_ATTESTATION_NONE;
+    if(parent_stream_fd < 0){
+        ret = parse_attestation_type(g_pal_public_state.manifest_root, &attestation_type);
+        if (ret < 0) {
+            log_error("Failed to parse attestation type: %d", unix_to_pal_error(ret));
+            ocall_exit(1, /*is_exitgroup=*/true);
+        }
     }
     g_pal_public_state.attestation_type = attestation_type_to_str(attestation_type);
 


### PR DESCRIPTION
Signed-off-by: Liang Ma <liang3.ma@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Only the initial process should be possible to attest remotely (otherwise various security properties break) - we need to disable doing this in children.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/774)
<!-- Reviewable:end -->
