### PR TITLE
[LibOS] Use proper const qualifiers for `argv` and `envp`

### DIFF
--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -17,7 +17,7 @@
 #include "pal.h"
 #include "pal_error.h"
 
-noreturn void* libos_init(int argc, const char** argv, const char** envp);
+noreturn void libos_init(int argc, const char* const* argv, const char* const* envp);
 
 /* important macros and static inline functions */
 
@@ -185,7 +185,7 @@ static inline bool memory_migrated(void* mem) {
 extern void* __load_address;
 extern void* __load_address_end;
 
-extern const char** migrated_envp;
+extern const char* const* migrated_envp; /* TODO: needs to be removed */
 
 int init_brk_region(void* brk_region, size_t data_segment_size);
 void reset_brk(void);
@@ -250,7 +250,8 @@ void delete_epoll_items_for_fd(int fd, struct libos_handle* handle);
 void maybe_epoll_et_trigger(struct libos_handle* handle, int ret, bool in, bool was_partial);
 
 void* allocate_stack(size_t size, size_t protect_size, bool user);
-int init_stack(const char** argv, const char** envp, const char*** out_argp, elf_auxv_t** out_auxv);
+int init_stack(const char* const* argv, const char* const* envp, char*** out_argp,
+               elf_auxv_t** out_auxv);
 
 /*!
  * \brief Jump to the defined entry point.

--- a/libos/include/libos_process.h
+++ b/libos/include/libos_process.h
@@ -69,7 +69,7 @@ struct libos_process {
 
 extern struct libos_process g_process;
 
-int init_process(int argc, const char** argv);
+int init_process(int argc, const char* const* argv);
 
 /* Allocates a new child process structure, initializing all fields. */
 struct libos_child_process* create_child_process(void);

--- a/libos/include/libos_table.h
+++ b/libos/include/libos_table.h
@@ -83,7 +83,7 @@ long libos_syscall_clone(unsigned long flags, unsigned long user_stack_addr, int
                          int* child_tidptr, unsigned long tls);
 long libos_syscall_fork(void);
 long libos_syscall_vfork(void);
-long libos_syscall_execve(const char* file, const char** argv, const char** envp);
+long libos_syscall_execve(const char* file, const char* const* argv, const char* const* envp);
 long libos_syscall_exit(int error_code);
 long libos_syscall_waitid(int which, pid_t id, siginfo_t* infop, int options,
                           struct __kernel_rusage* ru);

--- a/libos/include/libos_utils.h
+++ b/libos/include/libos_utils.h
@@ -36,7 +36,7 @@ int init_elf_objects(void);
 int check_elf_object(struct libos_handle* file);
 int load_elf_object(struct libos_handle* file, struct link_map** out_map);
 int load_elf_interp(struct link_map* exec_map);
-int load_and_check_exec(const char* path, const char** argv, struct libos_handle** out_exec,
+int load_and_check_exec(const char* path, const char* const* argv, struct libos_handle** out_exec,
                         char*** out_new_argv);
 noreturn void execute_elf_object(struct link_map* exec_map, void* argp, elf_auxv_t* auxp);
 void remove_loaded_elf_objects(void);

--- a/libos/src/bookkeep/libos_process.c
+++ b/libos/src/bookkeep/libos_process.c
@@ -17,7 +17,7 @@ typedef bool (*child_cmp_t)(const struct libos_child_process*, unsigned long);
 
 struct libos_process g_process = { .pid = 0 };
 
-int init_process(int argc, const char** argv) {
+int init_process(int argc, const char* const* argv) {
     if (g_process.pid) {
         /* `g_process` is already initialized, e.g. via checkpointing code. */
         return 0;

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -86,7 +86,7 @@ long pal_to_unix_errno(long err) {
 void* migrated_memory_start;
 void* migrated_memory_end;
 
-const char** migrated_envp __attribute_migratable;
+const char* const* migrated_envp __attribute_migratable;
 
 /* `g_library_paths` is populated with LD_PRELOAD entries once during LibOS initialization and is
  * used in `__load_interp_object()` to search for ELF program interpreter in specific paths. Once
@@ -155,8 +155,8 @@ out_fail:;
 /* populate already-allocated stack with copied argv and envp and space for auxv;
  * returns a pointer to first stack frame (starting with argc, then argv pointers, and so on)
  * and a pointer inside first stack frame (with auxv[0], auxv[1], and so on) */
-static int populate_stack(void* stack, size_t stack_size, const char** argv, const char** envp,
-                          const char*** out_argp, elf_auxv_t** out_auxv) {
+static int populate_stack(void* stack, size_t stack_size, const char* const* argv,
+                          const char* const* envp, char*** out_argp, elf_auxv_t** out_auxv) {
     void* stack_low_addr  = stack;
     void* stack_high_addr = stack + stack_size;
 
@@ -197,7 +197,7 @@ static int populate_stack(void* stack, size_t stack_size, const char** argv, con
      */
     size_t argc      = 0;
     size_t argv_size = 0;
-    for (const char** a = argv; *a; a++) {
+    for (const char* const* a = argv; *a; a++) {
         argv_size += strlen(*a) + 1;
         argc++;
     }
@@ -214,32 +214,32 @@ static int populate_stack(void* stack, size_t stack_size, const char** argv, con
     /* Even though the SysV ABI does not specify the order of argv strings, some applications
      * (notably Node.js's libuv) assume the compact encoding of argv where (1) all strings are
      * located adjacently and (2) in increasing order. */
-    const char** new_argv = stack_low_addr;
-    for (const char** a = argv; *a; a++) {
+    char** new_argv = stack_low_addr;
+    for (const char* const* a = argv; *a; a++) {
         size_t size = strlen(*a) + 1;
-        const char** argv_ptr = ALLOCATE_FROM_LOW_ADDR(sizeof(const char*));  /* ptr to argv[i] */
-        memcpy(argv_str, *a, size);                                           /* argv[i] string */
+        char** argv_ptr = ALLOCATE_FROM_LOW_ADDR(sizeof(char*)); /* ptr to argv[i] */
+        memcpy(argv_str, *a, size);                              /* argv[i] string */
         *argv_ptr = argv_str;
         argv_str += size;
     }
-    *((const char**)ALLOCATE_FROM_LOW_ADDR(sizeof(const char*))) = NULL;
+    *((char**)ALLOCATE_FROM_LOW_ADDR(sizeof(char*))) = NULL;
 
     /* populate envp on stack similarly to argv */
     size_t envp_size = 0;
-    for (const char** e = envp; *e; e++) {
+    for (const char* const* e = envp; *e; e++) {
         envp_size += strlen(*e) + 1;
     }
     char* envp_str = ALLOCATE_FROM_HIGH_ADDR(envp_size);
 
-    const char** new_envp = stack_low_addr;
-    for (const char** e = envp; *e; e++) {
+    char** new_envp = stack_low_addr;
+    for (const char* const* e = envp; *e; e++) {
         size_t size = strlen(*e) + 1;
-        const char** envp_ptr = ALLOCATE_FROM_LOW_ADDR(sizeof(const char*)); /* ptr to envp[i] */
-        memcpy(envp_str, *e, size);                                          /* envp[i] string */
+        char** envp_ptr = ALLOCATE_FROM_LOW_ADDR(sizeof(char*)); /* ptr to envp[i] */
+        memcpy(envp_str, *e, size);                              /* envp[i] string */
         *envp_ptr = envp_str;
         envp_str += size;
     }
-    *((const char**)ALLOCATE_FROM_LOW_ADDR(sizeof(const char*))) = NULL;
+    *((char**)ALLOCATE_FROM_LOW_ADDR(sizeof(char*))) = NULL;
 
     /* reserve space for ELF aux vectors, populated later in execute_elf_object() */
     elf_auxv_t* new_auxv = ALLOCATE_FROM_LOW_ADDR(REQUIRED_ELF_AUXV * sizeof(elf_auxv_t) +
@@ -269,14 +269,14 @@ static int populate_stack(void* stack, size_t stack_size, const char** argv, con
     /* set global envp pointer for future checkpoint/migration: this is required for fork/clone
      * case (so that migrated envp points to envvars on the migrated stack) and redundant for
      * execve case (because execve passes an explicit list of envvars to child process) */
-    migrated_envp = new_envp;
+    migrated_envp = (const char* const*)new_envp;
 
     *out_argp = new_stack_low_addr;
     *out_auxv = new_auxv;
     return 0;
 }
 
-int init_stack(const char** argv, const char** envp, const char*** out_argp,
+int init_stack(const char* const* argv, const char* const* envp, char*** out_argp,
                elf_auxv_t** out_auxv) {
     int ret;
 
@@ -315,8 +315,8 @@ int init_stack(const char** argv, const char** envp, const char*** out_argp,
     return 0;
 }
 
-static int read_environs(const char** envp) {
-    for (const char** e = envp; *e; e++) {
+static int read_environs(const char* const* envp) {
+    for (const char* const* e = envp; *e; e++) {
         if (strstartswith(*e, "LD_LIBRARY_PATH=")) {
             /* populate `g_library_paths` with entries from LD_LIBRARY_PATH envvar */
             const char* s = *e + static_strlen("LD_LIBRARY_PATH=");
@@ -366,7 +366,7 @@ static int read_environs(const char** envp) {
         }                                                                   \
     } while (0)
 
-noreturn void* libos_init(int argc, const char** argv, const char** envp) {
+noreturn void libos_init(int argc, const char* const* argv, const char* const* envp) {
     g_pal_public_state = PalGetPalPublicState();
     assert(g_pal_public_state);
 
@@ -430,7 +430,7 @@ noreturn void* libos_init(int argc, const char** argv, const char** envp) {
 
     RUN_INIT(init_async_worker);
 
-    const char** new_argp;
+    char** new_argp;
     elf_auxv_t* new_auxv;
     RUN_INIT(init_stack, argv, envp, &new_argp, &new_auxv);
 

--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -698,7 +698,7 @@ err:
 
 /* Note that `**out_new_argv` is allocated as a single object -- a concatenation of all argv
  * strings; caller of this function should do a single free(**out_new_argv). */
-int load_and_check_exec(const char* path, const char** argv, struct libos_handle** out_exec,
+int load_and_check_exec(const char* path, const char* const* argv, struct libos_handle** out_exec,
                         char*** out_new_argv) {
     int ret;
 
@@ -707,7 +707,7 @@ int load_and_check_exec(const char* path, const char** argv, struct libos_handle
     /* immediately copy `argv` into `curr_argv`; this simplifies ownership tracking because this way
      * `*out_new_argv` must be always freed by caller */
     size_t curr_argv_bytes = 0, curr_argv_cnt = 0;
-    for (const char** a = argv; *a; a++) {
+    for (const char* const* a = argv; *a; a++) {
         curr_argv_bytes += strlen(*a) + 1;
         curr_argv_cnt++;
     }
@@ -725,7 +725,7 @@ int load_and_check_exec(const char* path, const char** argv, struct libos_handle
     }
 
     size_t curr_argv_idx = 0;
-    for (const char** a = argv; *a; a++) {
+    for (const char* const* a = argv; *a; a++) {
         size_t size = strlen(*a) + 1;
         memcpy(curr_argv_ptr, *a, size);
         curr_argv[curr_argv_idx] = curr_argv_ptr;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, LibOS codebase used incorrect types:
- `const char** argv`
- `const char** envp`

In reality, the types must be "arrays of constant pointers". So the correct types should be:
- `char* const* argv` (array of constant ptrs to data)
- `const char* const* envp` (array of constant ptrs to constant data)

Notice that argv items point to non-constant data: this is because argv list is modified in LibOS -- both the pointers and the strings. On the other hand, envvars are not modified so they have const qualifiers in both places.

Good references:
- https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html -- read RATIONALE
- https://github.com/gramineproject/gramine/pull/459 -- for some initial discussions
- https://c-faq.com/ansi/constmismatch.html
- https://stackoverflow.com/a/40090931/6325371
- https://stackoverflow.com/questions/18950010/why-does-memcpy-need-a-const-void-pointer

Split from #722.

## How to test this PR? <!-- (if applicable) -->

Compiler in our CI is enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/777)
<!-- Reviewable:end -->
