### PR TITLE
[LibOS] Remove `migrated_envp`

### DIFF
--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -185,8 +185,6 @@ static inline bool memory_migrated(void* mem) {
 extern void* __load_address;
 extern void* __load_address_end;
 
-extern const char** migrated_envp;
-
 int init_brk_region(void* brk_region, size_t data_segment_size);
 void reset_brk(void);
 int init_rlimit(void);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This variable is wrong and shouldn't be used.

But also see https://github.com/gramineproject/graphene/issues/2081 and the TODOs in this PR.

## How to test this PR? <!-- (if applicable) -->

CI is enough. I modified `sigprocmask_pending` LibOS regression test, otherwise (if `envp = {NULL}`) it failed with:
```
sigprocmask_pending: error while loading shared libraries: libpthread.so.0: cannot open shared object file: No such file or directory
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/781)
<!-- Reviewable:end -->
