### PR TITLE
[LibOS] Print debug message in `load_and_check_shebang()`

### DIFF
--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -594,7 +594,7 @@ static int load_and_check_shebang(struct libos_handle* file, const char* pathnam
             /* this may fail, but we are already inside a more serious error handler */
             dentry_abs_path(file->dentry, &path, /*size=*/NULL);
         }
-        log_error("Failed to read shebang line from %s", path ? path : "(unknown)");
+        log_debug("Failed to read shebang line from %s", path ? path : "(unknown)");
         free(path);
         return -ENOEXEC;
     }


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Print debug message on `-ENOEXEC` error (failure to read the shebang line) instead of the error message. The error code is already propagated to the app that called `execve()`, and sometimes apps open "wrong" files (e.g., LTP does it), so it is not a Gramine error and must be silenced.

## How to test this PR? <!-- (if applicable) -->

Run LTP `execve` tests. There is at least one test that tries to `execve("dummy-file")` on purpose, and suddenly we saw that `log_error` message. Now the error message gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/782)
<!-- Reviewable:end -->
