### PR TITLE
[tools/sgx] Initialize `strtok_r()`'s saveptr to NULL

### DIFF
--- a/tools/sgx/ra-tls/secret_prov_attest.c
+++ b/tools/sgx/ra-tls/secret_prov_attest.c
@@ -120,8 +120,8 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
         goto out;
     }
 
-    char* saveptr1;
-    char* saveptr2;
+    char* saveptr1 = NULL;
+    char* saveptr2 = NULL;
     char* str1;
     for (str1 = servers; /*no condition*/; str1 = NULL) {
         ret = -ECONNREFUSED;


### PR DESCRIPTION
From the man page of `strtok_r()` (https://man7.org/linux/man-pages/man3/strtok.3.html#NOTES): on some implementations, `*saveptr` is required to be NULL on the first call to `strtok_r()` that is being used to parse str.

This patch thus initializes the saveptr of `strtok_r()` to NULL for better portability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/784)
<!-- Reviewable:end -->
