### PR TITLE
[tools/sgx] Fix `pf_crypt` to run within an enclave

### DIFF
--- a/tools/sgx/common/util.c
+++ b/tools/sgx/common/util.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 /*! Console stdout fd */
 int g_stdout_fd = 1;
@@ -55,12 +56,19 @@ endianness_t get_endianness(void) {
 
 /* return -1 on error */
 uint64_t get_file_size(int fd) {
-    struct stat64 st;
-
-    if (fstat64(fd, &st) != 0)
+    off_t cur_pos = lseek(fd, 0L, SEEK_CUR);
+    if (cur_pos < 0)
         return (uint64_t)-1;
 
-    return st.st_size;
+    off_t pos = lseek(fd, 0L, SEEK_END);
+    if (pos < 0)
+        return (uint64_t)-1;
+
+    off_t reset_pos = lseek(fd, cur_pos, SEEK_SET);
+    if (reset_pos < 0)
+        return (uint64_t)-1;
+
+    return (uint64_t)pos;
 }
 
 void* read_file(const char* path, size_t* size, void* buffer) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
The current implementation of the `pf_crypt` tool uses `fstat` to find the wrap_key length. But `fstat` implementation in Gramine sgx doesn't support reporting the size field. So, use `lseek` to determine the length of the file when running within the enclave.

## How to test this PR? <!-- (if applicable) -->
Please run LibOS, PAL, fs regression tests. Also, please try encrypting and decrpting using `gramine-sgx-pf-crypt`  tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/787)
<!-- Reviewable:end -->
