### PR TITLE
[RA-TLS] Terminate process upon secret provisioning failure

### DIFF
--- a/tools/sgx/ra-tls/secret_prov_attest.c
+++ b/tools/sgx/ra-tls/secret_prov_attest.c
@@ -309,8 +309,10 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
 
         int ret = secret_provision_start(/*in_servers=*/NULL, /*in_ca_chain_path=*/NULL,
                                          /*out_ctx=*/NULL);
-        if (ret < 0)
-            return;
+        if (ret < 0) {
+            ERROR("Secret provisioning failed, terminating the whole process\n");
+            exit(1);
+        }
 
         ret = secret_provision_get(&secret, &secret_size);
         if (ret < 0 || !secret || !secret_size || secret_size > PATH_MAX ||


### PR DESCRIPTION
The libsecret_prov_attest.so library provisions a secret upon successful attestation. However, there can be cases when applications would want Gramine to terminate upon an unsuccessful secret prov flow (due to unsuccessful attestation), as opposed to the application directly handling this part. In this PR,  Gramine exits in the event of an unsuccessful secret prov flow.