### PR TITLE
[Doc] Correct `RA_TLS_ISV_SVN` description in attestation

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/README.md
+++ b/CI-Examples/ra-tls-mbedtls/README.md
@@ -47,8 +47,10 @@ verification.
 If client is run without additional command-line arguments, it uses default
 RA-TLS verification callback that compares `MRENCLAVE`, `MRSIGNER`,
 `ISV_PROD_ID` and `ISV_SVN` against the corresonding `RA_TLS_*` environment
-variables. To run the client with its own verification callback, execute it with
-four additional command-line arguments (see the source code for details).
+variables. `MRENCLAVE`, `MRSIGNER` and `ISV_PROD_ID` are expected to match
+`RA_TLS_*` ones. `ISV_SVN` is expected to be equal or greater than `RA_TLS_ISV_SVN`.
+To run the client with its own verification callback, execute it with four
+additional command-line arguments (see the source code for details).
 
 Also, because this example builds and uses debug SGX enclaves (`sgx.debug` is
 set to `true`), we use environment variable `RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1`.

--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -317,8 +317,8 @@ SGX measurements:
   ``MRENCLAVE``. This is a hex string.
 - ``RA_TLS_ISV_PROD_ID`` -- verify that the attesting enclave has this
   ``ISV_PROD_ID``. This is a decimal string.
-- ``RA_TLS_ISV_SVN`` -- verify that the attesting enclave has this ``ISV_SVN``.
-  This is a decimal string.
+- ``RA_TLS_ISV_SVN`` -- verify that the attesting enclave has this or higher
+  ``ISV_SVN``. This is a decimal string.
 
 For each of these settings, you may specify the special value ``any`` to skip
 verifying a particular measurement. This used to be the default, which would

--- a/Documentation/sgx-intro.rst
+++ b/Documentation/sgx-intro.rst
@@ -552,7 +552,11 @@ SGX terminology
    Security Version Number
    SVN
 
-      .. todo:: TBD
+      Each element of the SGX :term:`TCB` is assigned a Security Version Number
+      (SVN). For the hardware, these SVNs are referred to collectively as
+      CPU_SVN, and for software referred as ISV_SVN. A TCB is considered up to
+      date if all components of the TCB have SVNs greater than or equal to a
+      threshold published by the author of the component.
 
    Trusted Execution Environment
    TEE


### PR DESCRIPTION
## Description of the change

`RA_TLS_ISV_SVN` description in document is not aligned with implementation.
https://github.com/gramineproject/gramine/blob/64b004bb59a237ea2486ef791fd970519888c638/tools/sgx/common/quote.c#L191-L194

Also add `Security Version Number (SVN)` in glossary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/793)
<!-- Reviewable:end -->
