### PR TITLE
[meson,CI,Docs] Upgrade Meson to ">= 0.56"

### DIFF
--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -80,14 +80,14 @@ RUN git clone https://github.com/giltene/wrk2.git \
     && rm -rf wrk2
 
 
-# NOTE about meson version: we support "0.55 or newer", so in CI we pin to latest patch version of
+# NOTE about meson version: we support "0.56 or newer", so in CI we pin to latest patch version of
 # the earliest supported minor version (pip implicitly installs latest version satisfying the
 # specification)
 RUN python3 -m pip install -U \
     'Sphinx==1.8' \
     'sphinx_rtd_theme<1' \
     'toml>=0.10' \
-    'meson>=0.55,<0.56' \
+    'meson>=0.56,<0.57' \
     'docutils>=0.17,<0.18'
 
 # Add the user UID:1001, GID:1001, home at /leeroy

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -83,11 +83,11 @@ RUN git clone https://github.com/giltene/wrk2.git \
     && cd .. \
     && rm -rf wrk2
 
-# NOTE about meson version: we support "0.55 or newer", so in CI we pin to latest patch version of
+# NOTE about meson version: we support "0.56 or newer", so in CI we pin to latest patch version of
 # the earliest supported minor version (pip implicitly installs latest version satisfying the
 # specification)
 RUN python3 -m pip install -U \
-    'meson>=0.55,<0.56' \
+    'meson>=0.56,<0.57' \
     'docutils>=0.17,<0.18'
 
 # Add the user UID:1001, GID:1001, home at /leeroy

--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -38,10 +38,10 @@ Run the following command on Ubuntu LTS to install dependencies::
     sudo apt-get install -y build-essential \
         autoconf bison gawk nasm ninja-build python3 python3-click \
         python3-jinja2 python3-pyelftools wget
-    sudo python3 -m pip install 'meson>=0.55' 'toml>=0.10'
+    sudo python3 -m pip install 'meson>=0.56' 'toml>=0.10'
 
 You can also install Meson and python3-toml from apt instead of pip, but only if
-your distro is new enough to have Meson >= 0.55 and python3-toml >= 0.10 (Debian
+your distro is new enough to have Meson >= 0.56 and python3-toml >= 0.10 (Debian
 11, Ubuntu 20.10).
 
 For GDB support and to run all tests locally you also need to install::

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
     version: '1.2post-UNRELEASED',
     license: 'LGPLv3+',
 
-    meson_version: '>=0.55',
+    meson_version: '>=0.56',
 
     default_options: [
         'c_std=c11',


### PR DESCRIPTION
"meson >= 0.56" is required for properly linking static libraries with custom targets.

See https://github.com/gramineproject/gramine/pull/773#pullrequestreview-1051815308 for details.

Related gsc PR: https://github.com/gramineproject/gsc/pull/82.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/799)
<!-- Reviewable:end -->
