### PR TITLE
[LibOS,PAL,Docs] Remove `loader.argv0_override` manifest option

### DIFF
--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -79,7 +79,7 @@ endif
 
 .PHONY: check
 check: all
-	$(GRAMINE) ./busybox echo "Hello" > OUTPUT
+	$(GRAMINE) busybox echo "Hello" > OUTPUT
 	@grep -q "Hello" OUTPUT && echo "[ Success 1/1 ]"
 	@rm OUTPUT
 

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -1,7 +1,7 @@
 # Busybox manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "busybox"
+libos.entrypoint = "/busybox"
 
 loader.log_level = "{{ log_level }}"
 
@@ -18,6 +18,7 @@ fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
+  { path = "/busybox", uri = "file:busybox" },
 ]
 
 sgx.debug = true

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -1,14 +1,14 @@
 # Hello World manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "helloworld"
+libos.entrypoint = "/helloworld"
 loader.log_level = "{{ log_level }}"
-loader.argv0_override = "helloworld"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/helloworld", uri = "file:helloworld" },
 ]
 
 sgx.debug = true

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -1,7 +1,7 @@
 # Memcached manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "memcached"
+libos.entrypoint = "/memcached"
 
 loader.log_level = "{{ log_level }}"
 
@@ -16,6 +16,7 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
+  { path = "/memcached", uri = "file:memcached" },
 ]
 
 sgx.debug = true

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -1,7 +1,7 @@
 # Client manifest file
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "client"
+libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
 
@@ -19,6 +19,7 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
+  { path = "/client", uri = "file:client" },
 ]
 
 sgx.debug = true

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -1,7 +1,7 @@
 # RA-TLS manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "server"
+libos.entrypoint = "/server"
 
 loader.log_level = "{{ log_level }}"
 
@@ -16,6 +16,7 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
+  { path = "/server", uri = "file:server" },
 ]
 
 sgx.debug = true

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -153,9 +153,9 @@ secret_prov_pf_client.token: secret_prov_pf_client.sig
 check_epid: app epid files/input.txt
 	./secret_prov_server_epid >/dev/null & SERVER_ID=$$!; \
 	sleep 3; \
-	gramine-sgx ./secret_prov_min_client > OUTPUT; \
-	gramine-sgx ./secret_prov_client >> OUTPUT; \
-	gramine-sgx ./secret_prov_pf_client >> OUTPUT; \
+	gramine-sgx secret_prov_min_client > OUTPUT; \
+	gramine-sgx secret_prov_client >> OUTPUT; \
+	gramine-sgx secret_prov_pf_client >> OUTPUT; \
 	kill -9 $$SERVER_ID;
 	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/4 ]"
 	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
@@ -167,9 +167,9 @@ check_epid: app epid files/input.txt
 check_dcap: app dcap files/input.txt
 	./secret_prov_server_dcap >/dev/null & SERVER_ID=$$!; \
 	sleep 3; \
-	gramine-sgx ./secret_prov_min_client > OUTPUT; \
-	gramine-sgx ./secret_prov_client >> OUTPUT; \
-	gramine-sgx ./secret_prov_pf_client >> OUTPUT; \
+	gramine-sgx secret_prov_min_client > OUTPUT; \
+	gramine-sgx secret_prov_client >> OUTPUT; \
+	gramine-sgx secret_prov_pf_client >> OUTPUT; \
 	kill -9 $$SERVER_ID;
 	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/4 ]"
 	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -1,7 +1,7 @@
 # Secret Provisioning manifest file example (client)
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "secret_prov_client"
+libos.entrypoint = "/secret_prov_client"
 
 loader.log_level = "{{ log_level }}"
 
@@ -14,6 +14,7 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
+  { path = "/secret_prov_client", uri = "file:secret_prov_client" },
 ]
 
 sgx.enclave_size = "512M"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -1,7 +1,7 @@
 # Secret Provisioning manifest file example (minimal client)
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "secret_prov_min_client"
+libos.entrypoint = "/secret_prov_min_client"
 
 loader.log_level = "{{ log_level }}"
 
@@ -18,6 +18,7 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
+  { path = "/secret_prov_min_client", uri = "file:secret_prov_min_client" },
 ]
 
 sgx.enclave_size = "512M"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -1,7 +1,7 @@
 # Secret Provisioning manifest file example (Protected Files client)
 
 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "secret_prov_pf_client"
+libos.entrypoint = "/secret_prov_pf_client"
 
 loader.log_level = "{{ log_level }}"
 
@@ -20,6 +20,7 @@ fs.mounts = [
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
   { path = "/files/input.txt", uri = "file:files/input.txt", type = "encrypted" },
+  { path = "/secret_prov_pf_client", uri = "file:secret_prov_pf_client" },
 ]
 
 sgx.enclave_size = "512M"

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -7,7 +7,7 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 
 # Entrypoint binary which Gramine invokes.
-libos.entrypoint = "redis-server"
+libos.entrypoint = "/redis-server"
 
 # Verbosity of Gramine debug log (none/error/warning/debug/trace/all). Note
 # that GRAMINE_LOG_LEVEL macro is expanded in the Makefile as part of the
@@ -59,6 +59,10 @@ fs.mounts = [
   # Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
   # into in-Gramine visible directory /etc (in 'path').
   { path = "/etc", uri = "file:/etc" },
+
+  # Mount redis-server executable (located in the current directory) under the
+  # in-Gramine visible root directory.
+  { path = "/redis-server", uri = "file:redis-server" },
 ]
 
 ############################### SGX: GENERAL ##################################

--- a/CI-Examples/rust/README.md
+++ b/CI-Examples/rust/README.md
@@ -15,7 +15,7 @@ make SGX=1
 
 # run the server in Gramine-SGX against an HTTP benchmark
 make SGX=1 start-gramine-server &
-../common_tools/benchmark-http.sh 127.0.0.1:3000
+../common_tools/benchmark-http.sh http://127.0.0.1:3000
 kill -SIGINT %%
 ```
 

--- a/CI-Examples/rust/rust-hyper-http-server.manifest.template
+++ b/CI-Examples/rust/rust-hyper-http-server.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ self_exe }}"
 loader.log_level = "{{ log_level }}"
-loader.argv0_override = "{{ self_exe }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}"
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -110,17 +110,6 @@ Command-line arguments
 
 ::
 
-   loader.argv0_override = "[STRING]"
-
-This syntax specifies an arbitrary string (typically the executable name) that
-will be passed as the first argument (``argv[0]``) to the executable.
-
-If the string is not specified in the manifest, the application will get
-``argv[0]`` from :program:`gramine-direct` or :program:`gramine-sgx`
-invocation.
-
-::
-
    loader.insecure__use_cmdline_argv = true
 
 or
@@ -143,6 +132,9 @@ arguments to be provided at runtime from an external (trusted) source.
    Pointing to an encrypted file is currently not supported, due to the fact
    that encryption key provisioning currently happens after setting up
    arguments.
+
+If none of the above arguments-handling manifest options is specified in the
+manifest, the application will get ``argv = [ <libos.entrypoint value> ]``.
 
 Environment variables
 ^^^^^^^^^^^^^^^^^^^^^

--- a/libos/test/abi/x86_64/stack_arg.manifest.template
+++ b/libos/test/abi/x86_64/stack_arg.manifest.template
@@ -1,6 +1,11 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
+# The argv source file must set argv[0] as the basename of the entrypoint. This is crucial for
+# stack tests because if argv[0] contains an absolute path to the binary, then tests become
+# unreliable.
+loader.argv_src_file = "file:stack_arg_argv_input"
+
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
@@ -14,4 +19,8 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
+]
+
+sgx.allowed_files = [
+  "file:stack_arg_argv_input",
 ]

--- a/libos/test/abi/x86_64/test_entrypoint.py
+++ b/libos/test/abi/x86_64/test_entrypoint.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import os
+import subprocess
+
 from graminelibos.regression import RegressionTestCase
 
 class TC_00_Entrypoint(RegressionTestCase):
@@ -19,7 +22,14 @@ class TC_00_Entrypoint(RegressionTestCase):
         self.run_binary(['stack'])
 
     def test_060_arg(self):
-        self.run_binary(['stack_arg', 'foo', 'bar'])
+        args = ['stack_arg', 'foo', 'bar']
+        result = subprocess.check_output(['gramine-argv-serializer'] + args)
+        with open('stack_arg_argv_input', 'wb') as f:
+            f.write(result)
+        try:
+            self.run_binary(['stack_arg'])
+        finally:
+            os.remove('stack_arg_argv_input')
 
     def test_070_env(self):
         self.run_binary(['stack_env'])

--- a/libos/test/regression/argv_from_file.manifest.template
+++ b/libos/test/regression/argv_from_file.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.argv_src_file = "file:argv_test_input"
 

--- a/libos/test/regression/attestation.manifest.template
+++ b/libos/test/regression/attestation.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 

--- a/libos/test/regression/attestation_deprecated_syntax.manifest.template
+++ b/libos/test/regression/attestation_deprecated_syntax.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 

--- a/libos/test/regression/bootstrap_cpp.manifest.template
+++ b/libos/test/regression/bootstrap_cpp.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
 # Preload libunwind so that it has precedence over libstdc++ when resolving stack-unwinding routines

--- a/libos/test/regression/debug_log_file.manifest.template
+++ b/libos/test/regression/debug_log_file.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 loader.log_level = "debug"

--- a/libos/test/regression/debug_log_inline.manifest.template
+++ b/libos/test/regression/debug_log_inline.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 loader.log_level = "debug"

--- a/libos/test/regression/device_passthrough.manifest.template
+++ b/libos/test/regression/device_passthrough.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 # the manifest option below has no significance for this specific test, it's added only so that this

--- a/libos/test/regression/env_from_file.manifest.template
+++ b/libos/test/regression/env_from_file.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.env_src_file = "file:env_test_input"
 

--- a/libos/test/regression/env_from_host.manifest.template
+++ b/libos/test/regression/env_from_host.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_host_env = true
 

--- a/libos/test/regression/env_passthrough.manifest.template
+++ b/libos/test/regression/env_passthrough.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 loader.env.A = { passthrough = true }

--- a/libos/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/libos/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 

--- a/libos/test/regression/file_check_policy_strict.manifest.template
+++ b/libos/test/regression/file_check_policy_strict.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_cmdline_argv = true
 

--- a/libos/test/regression/host_root_fs.manifest.template
+++ b/libos/test/regression/host_root_fs.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ binary_dir }}/{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.root.uri = "file:/"

--- a/libos/test/regression/init_fail.manifest.template
+++ b/libos/test/regression/init_fail.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [

--- a/libos/test/regression/init_fail2.manifest.template
+++ b/libos/test/regression/init_fail2.manifest.template
@@ -3,7 +3,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [

--- a/libos/test/regression/large_mmap.manifest.template
+++ b/libos/test/regression/large_mmap.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 # application allocates 2GB and 4GB memory regions which may occasionally fail

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -1,6 +1,5 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
-loader.argv0_override = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.insecure__use_cmdline_argv = true

--- a/libos/test/regression/multi_pthread.manifest.template
+++ b/libos/test/regression/multi_pthread.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [

--- a/libos/test/regression/multi_pthread_exitless.manifest.template
+++ b/libos/test/regression/multi_pthread_exitless.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "multi_pthread"
 
-loader.argv0_override = "multi_pthread"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [

--- a/libos/test/regression/openmp.manifest.template
+++ b/libos/test/regression/openmp.manifest.template
@@ -1,8 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
-
 # Gramine optionally provides patched OpenMP runtime library that runs faster inside SGX enclaves
 # (add `-Dlibgomp=enabled` when configuring the build). This library will replace the native one
 # because Gramine's Runtime path has priority in LD_LIBRARY_PATH.

--- a/libos/test/regression/shebang_test_script.manifest.template
+++ b/libos/test/regression/shebang_test_script.manifest.template
@@ -1,6 +1,5 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "shebang_test_script.sh"
-loader.argv0_override = "shebang_test_script.sh"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 

--- a/libos/test/regression/sysfs_common.manifest.template
+++ b/libos/test/regression/sysfs_common.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 
 fs.mounts = [

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -389,6 +389,18 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('LibOS initialized', log)
         self.assertIn('--- exit_group', log)
 
+    def test_702_debug_log_inline_unexpected_arg(self):
+        try:
+            # `debug_log_inline` program logic is irrelevant here, we only want to test Gramine's
+            # handling of unexpected args when the manifest has no explicit argv handling options
+            self.run_binary(['debug_log_inline', 'unexpected arg'])
+            self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            self.assertEqual(e.returncode, 1)
+            stderr = e.stderr.decode()
+            self.assertIn('argv handling wasn\'t configured in the manifest, but cmdline arguments '
+                          'were specified', stderr)
+
 
 class TC_02_OpenMP(RegressionTestCase):
     @unittest.skipIf(USES_MUSL, 'OpenMP is not supported with musl')

--- a/libos/test/regression/uid_gid.manifest.template
+++ b/libos/test/regression/uid_gid.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.argv0_override = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
 loader.uid = 1338

--- a/pal/regression/Bootstrap6.manifest.template
+++ b/pal/regression/Bootstrap6.manifest.template
@@ -2,7 +2,6 @@
 
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
-loader.argv0_override = "{{ entrypoint }}"
 
 sgx.enclave_size = "8192M"
 sgx.nonpie_binary = true

--- a/pal/regression/Bootstrap7.manifest.template
+++ b/pal/regression/Bootstrap7.manifest.template
@@ -1,5 +1,4 @@
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
-loader.argv0_override = "{{ entrypoint }}"
 
 sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]
 sgx.nonpie_binary = true

--- a/pal/regression/File.manifest.template
+++ b/pal/regression/File.manifest.template
@@ -1,5 +1,4 @@
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
-loader.argv0_override = "{{ entrypoint }}"
 loader.log_level = "debug"
 
 sgx.nonpie_binary = true

--- a/pal/regression/Thread2.manifest.template
+++ b/pal/regression/Thread2.manifest.template
@@ -1,5 +1,4 @@
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
-loader.argv0_override = "{{ entrypoint }}"
 
 sgx.thread_num = 2
 sgx.enable_stats = true

--- a/pal/regression/Thread2_exitless.manifest.template
+++ b/pal/regression/Thread2_exitless.manifest.template
@@ -1,7 +1,6 @@
 {% set entrypoint = "Thread2" -%}
 
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
-loader.argv0_override = "{{ entrypoint }}"
 
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -56,7 +56,7 @@ class TC_00_BasicSet2(RegressionTestCase):
     @unittest.skipIf(HAS_SGX, "Pipes must be created in two parallel threads under SGX")
     def test_Process4(self):
         _, stderr = self.run_binary(['Process4'], timeout=5)
-        self.assertIn('In process: Process4', stderr)
+        self.assertRegex(stderr, r'In process: .*Process4')
         self.assertIn('wall time = ', stderr)
         for i in range(100):
             self.assertIn('In process: Process4 %d ' % i, stderr)
@@ -76,7 +76,7 @@ class TC_01_Bootstrap(RegressionTestCase):
 
         # One Argument Given
         self.assertIn('# of Arguments: 1', stderr)
-        self.assertIn('argv[0] = Bootstrap', stderr)
+        self.assertRegex(stderr, r'argv\[0\] = .*Bootstrap')
 
         # Control Block: Debug Stream (Inline)
         self.assertIn('Written to Debug Stream', stderr)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This manifest option was always set to `libos.entrypoint` anyway (or abused in one of the LibOS ABI stack tests).

Instead, when there is no argv-handling manifest option specified, Gramine sets `argv = [ libos.entrypoint ]` (or `argv = [ loader.entrypoint ]` if there is no LibOS, as happens in PAL tests).

Note that this only happens in the first process; child processes get argv from the parent as-is.

Fixes #795.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/801)
<!-- Reviewable:end -->
