### PR TITLE
[CI-Examples] Add SGX measurements verification code to ra-tls-secret…

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/README.md
+++ b/CI-Examples/ra-tls-secret-prov/README.md
@@ -75,6 +75,10 @@ make app epid files/input.txt RA_TYPE=epid RA_CLIENT_SPID=<your SPID> \
 RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
 RA_TLS_EPID_API_KEY=<your EPID API key> \
+RA_TLS_MRENCLAVE=<MRENCLAVE of the client enclave> \
+RA_TLS_MRSIGNER=<MRSIGNER of the client enclave> \
+RA_TLS_ISV_PROD_ID=<ISV_PROD_ID of the client enclave> \
+RA_TLS_ISV_SVN=<ISV_SVN of the client enclave> \
 ./secret_prov_server_epid &
 
 # test minimal client
@@ -94,9 +98,12 @@ kill %%
 ```sh
 make app dcap files/input.txt RA_TYPE=dcap
 
-RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
-RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
-./secret_prov_server_dcap &
+RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
+    ./secret_prov_server_dcap \
+    <MRENCLAVE of the client enclave> \
+    <MRSIGNER of the client enclave> \
+    <ISV_PROD_ID of the client enclave> \
+    <ISV_SVN of the client enclave> &
 
 # test minimal client
 gramine-sgx ./secret_prov_min_client

--- a/CI-Examples/ra-tls-secret-prov/README.md
+++ b/CI-Examples/ra-tls-secret-prov/README.md
@@ -27,6 +27,12 @@ There are two versions of the server: the EPID one and the DCAP one. Each of
 them links against the corresponding EPID/DCAP secret-provisioning library at
 build time.
 
+If the server is run without additional command-line arguments, it uses the
+default RA-TLS verification logic that compares `MRENCLAVE`, `MRSIGNER`,
+`ISV_PROD_ID` and `ISV_SVN` against the corresponding `RA_TLS_*` environment
+variables. To run the server with its own verification logic, execute it with
+four additional command-line arguments (see the examples below).
+
 Because this example builds and uses debug SGX enclaves (`sgx.debug` is set
 to `true`), we use environment variable `RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1`.
 Note that in production environments, you must *not* use this option!

--- a/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c
+++ b/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c
@@ -98,9 +98,9 @@ static int verify_measurements_callback(const char* mrenclave, const char* mrsig
     pthread_mutex_unlock(&g_print_lock);
     return 0;
 
-    fail:
-         pthread_mutex_unlock(&g_print_lock);
-         return -1;
+fail:
+    pthread_mutex_unlock(&g_print_lock);
+    return -1;
 }
 
 /* this callback is called in a new thread associated with a client; be careful to make this code
@@ -151,6 +151,7 @@ out:
 
 int main(int argc, char** argv) {
     int ret;
+
     if (argc > 1) {
         if (argc != 5) {
             printf("USAGE: %s <expected mrenclave> <expected mrsigner>"

--- a/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c
+++ b/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c
@@ -262,7 +262,7 @@ int main(int argc, char** argv) {
     puts("--- Starting the Secret Provisioning server on port 4433 ---");
     ret = secret_provision_start_server((uint8_t*)g_secret_pf_key_hex, sizeof(g_secret_pf_key_hex),
                                         "4433", SRV_CRT_PATH, SRV_KEY_PATH,
-                                        verify_measurements_callback,
+                                        argc > 1 ? verify_measurements_callback : NULL,
                                         communicate_with_client_callback);
     if (ret < 0) {
         fprintf(stderr, "[error] secret_provision_start_server() returned %d\n", ret);


### PR DESCRIPTION
…-prov server

Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Currently the [CI-Examples/ra-tls-secret-prov/](https://github.com/gramineproject/gramine/tree/master/CI-Examples/ra-tls-secret-prov) server code just [prints](https://github.com/gramineproject/gramine/blob/master/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c#L43-L48) the SGX measurements received by the client. This PR incorporates SGX measurements verification code with ra-tls-secret-prov server code (just the way it done for [ra-tls-mbedtls](https://github.com/gramineproject/gramine/blob/master/CI-Examples/ra-tls-mbedtls/src/client.c#L99-L113) code.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
**Step 1:** `$ cd gramine/CI-Examples/ra-tls-secret-prov`
**Step 2:** `$ make app dcap files/input.txt RA_TYPE=dcap`

### Flow 1
**Step 1.1:** ` $ RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 \
             RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
             ./secret_prov_server_dcap 0 0 0 0 & `
**Step 1.2:** `$ gramine-sgx ./secret_prov_min_client`  // client should receive a secret (this test should pass for other clients too)
**Step 1.3:** Kill the server 

### Flow 2
**Step 2.1:** `$ RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
    ./secret_prov_server_dcap &`
**Step 2.2:** `$ gramine-sgx ./secret_prov_client`  // client should receive a secret (this test should pass for other clients too)
**Step 2.3:** Kill the server
### Flow 3
**Step 3.1** `RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
    ./secret_prov_server_dcap \
    <MRENCLAVE of the min client enclave> \
    <MRSIGNER of the min client enclave> \
    <ISV_PROD_ID of the min client enclave> \
    <ISV_SVN of the min client enclave> &
`
**Step 3.2** `$ gramine-sgx ./secret_prov_min_client`  // client should receive a secret (as the server is expecting min client's measurements)
**Step 3.3** `$ gramine-sgx ./secret_prov_client`  // client should **not** receive a secret and also at the server side one error message will be printed
**Step 3.4** `$ gramine-sgx ./secret_prov_pf_client`  // client should **not** receive a secret and also at the server side one error message will be printed

### Flow 4
Similar to DCAP , EPID flow can also be tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/802)
<!-- Reviewable:end -->
