### PR TITLE
[LibOS/regression] Fix `test_212_shebang_test_script` to run with bash

### DIFF
--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -234,10 +234,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         'Test uses /bin/sh from the host which is usually built against glibc')
     def test_212_shebang_test_script(self):
         stdout, _ = self.run_binary(['shebang_test_script'])
-        self.assertIn('Printing Args: '
-            'scripts/baz.sh ECHO FOXTROT GOLF scripts/bar.sh '
-            'ALPHA BRAVO CHARLIE DELTA '
-            'scripts/foo.sh', stdout)
+        self.assertRegex(stdout, r'Printing Args: '
+            r'scripts/baz\.sh ECHO FOXTROT GOLF scripts/bar\.sh '
+            r'ALPHA BRAVO CHARLIE DELTA '
+            r'/?scripts/foo\.sh')
 
     def test_220_send_handle(self):
         path = 'tmp/send_handle_test'


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Bash first resolves the path to be absolute and then passes it as pathname (contrary to dash, which does not do it).

Dash is a default `/bin/sh` on Ubuntu, so the shebang test previously used a relative pathname. But on CentOS/RHEL/Fedora, Bash is the default `/bin/sh`, and thus the shebang test failed. With this PR, we introduce a Regex that works both for relative and absolute pathnames.

Fixes #807.

## How to test this PR? <!-- (if applicable) -->

@anjalirai-intel Could you test it on CentOS?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/809)
<!-- Reviewable:end -->
