### PR TITLE
[LibOS] Fix memory leaks detected by Klocwork

### DIFF
--- a/libos/src/bookkeep/libos_thread.c
+++ b/libos/src/bookkeep/libos_thread.c
@@ -223,6 +223,7 @@ static int init_main_thread(void) {
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
         log_error("Failed to get thread CPU affinity mask: %d", ret);
+        put_thread(cur_thread);
         return ret;
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Klocwork detected memory leaks due to non-freeing of memory resources in the event of `PalThreadGetCpuAffinity` failure. This commit fixes the three leaks reported by Klocwork.

## How to test this PR? <!-- (if applicable) -->
Regular CI test suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/810)
<!-- Reviewable:end -->
