### PR TITLE
[PAL/Linux-SGX] Bump the max number of enclave threads to 4096

### DIFF
--- a/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.h
+++ b/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.h
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 
-#define MAX_DBG_THREADS 1024
+#define MAX_DBG_THREADS 4096
 
 /*
  * Pre-defined address at which Gramine-SGX writes the `enclave_dbginfo` object, and periodically

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -208,6 +208,8 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     char* token_path = NULL;
     int sigfile_fd = -1, token_fd = -1;
     int enclave_mem = -1;
+    size_t areas_size = 0;
+    struct mem_area* areas = NULL;
 
     /* this array may overflow the stack, so we allocate it in BSS */
     static void* tcs_addrs[MAX_DBG_THREADS];
@@ -334,8 +336,16 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
      * + enclave->thread_num for normal stack
      * + enclave->thread_num for signal stack
      */
-    int max_area_cnt = 10 + enclave->thread_num * 2;
-    struct mem_area* areas = __alloca(sizeof(areas[0]) * max_area_cnt);
+    areas_size = ALIGN_UP_POW2(sizeof(*areas) * (10 + enclave->thread_num * 2), PRESET_PAGESIZE);
+    areas = (struct mem_area*)DO_SYSCALL(mmap, NULL, areas_size, PROT_READ | PROT_WRITE,
+                                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (IS_PTR_ERR(areas)) {
+        log_error("Allocating memory failed (%ld)", PTR_TO_ERR(areas));
+        areas = NULL;
+        ret = -ENOMEM;
+        goto out;
+    }
+
     int area_num = 0;
 
     /* The manifest needs to be allocated at the upper end of the enclave
@@ -608,6 +618,8 @@ out:
         DO_SYSCALL(close, sigfile_fd);
     if (token_fd >= 0)
         DO_SYSCALL(close, token_fd);
+    if (areas)
+        DO_SYSCALL(munmap, areas, areas_size);
     free(sig_path);
     free(token_path);
     return ret;
@@ -661,13 +673,7 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
         goto out;
     }
 
-    enclave_info->thread_num = thread_num_int64;
-
-    if (!enclave_info->thread_num) {
-        log_warning("Number of enclave threads ('sgx.thread_num') is not specified; assumed "
-                    "to be 1");
-        enclave_info->thread_num = 1;
-    }
+    enclave_info->thread_num = thread_num_int64 ?: 1;
 
     if (enclave_info->thread_num > MAX_DBG_THREADS) {
         log_error("Too large 'sgx.thread_num', maximum allowed is %d", MAX_DBG_THREADS);


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Modern Intel CPUs have a large number of cores, and modern workloads (such as PyTorch) allocate a large number of threads (e.g., 4 threads per each CPU core). This exceeds the previous limit on the number of threads (1024) and leads to boostrap errors like this:

    error: There are no available TCS pages left for a new thread!
    Please try to increase sgx.thread_num in the manifest.

This PR bumps the limit to 4096 and fixes several potential stack-overflow issues along the way.

## How to test this PR? <!-- (if applicable) -->

CI. Plus I tested several large workloads manually (testing with different `sgx.enclave_thread` settings).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/812)
<!-- Reviewable:end -->
