### PR TITLE
[tools/sgx] Improve public API of Secret Prov lib

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/src/secret_prov_client.c
+++ b/CI-Examples/ra-tls-secret-prov/src/secret_prov_client.c
@@ -17,31 +17,20 @@
 
 int main(int argc, char** argv) {
     int ret;
-    int bytes;
 
-    struct ra_tls_ctx ctx = {0};
-
-    uint8_t* secret1   = NULL;
+    uint8_t* secret1 = NULL;
     size_t secret1_size = 0;
-
     uint8_t secret2[3] = {0}; /* we expect second secret to be 2-char string */
 
-    bool is_constructor = false;
-    char* str = getenv(SECRET_PROVISION_CONSTRUCTOR);
-    if (str && (!strcmp(str, "1") || !strcmp(str, "true") || !strcmp(str, "TRUE")))
-        is_constructor = true;
-
-    if (!is_constructor) {
-        /* secret provisioning was not run as part of initialization, run it now */
-        ret = secret_provision_start("dummyserver:80;localhost:4433;anotherdummy:4433",
-                                     CA_CRT_PATH, &ctx);
-        if (ret < 0) {
-            fprintf(stderr, "[error] secret_provision_start() returned %d\n", ret);
-            goto out;
-        }
+    struct ra_tls_ctx* ctx = NULL;
+    ret = secret_provision_start("dummyserver:80;localhost:4433;anotherdummy:4433",
+                                 CA_CRT_PATH, &ctx);
+    if (ret < 0) {
+        fprintf(stderr, "[error] secret_provision_start() returned %d\n", ret);
+        goto out;
     }
 
-    ret = secret_provision_get(&secret1, &secret1_size);
+    ret = secret_provision_get(ctx, &secret1, &secret1_size);
     if (ret < 0) {
         fprintf(stderr, "[error] secret_provision_get() returned %d\n", ret);
         goto out;
@@ -50,36 +39,27 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[error] secret_provision_get() returned secret with size 0\n");
         goto out;
     }
-
     secret1[secret1_size - 1] = '\0';
 
-    if (!is_constructor) {
-        /* let's ask for another secret (just to show communication with secret-prov server) */
-        bytes = secret_provision_write(&ctx, (uint8_t*)SEND_STRING, sizeof(SEND_STRING));
-        if (bytes < 0) {
-            fprintf(stderr, "[error] secret_provision_write() returned %d\n", bytes);
-            goto out;
-        }
-
-        /* the secret we expect in return is a 2-char string */
-        bytes = secret_provision_read(&ctx, secret2, sizeof(secret2));
-        if (bytes < 0) {
-            fprintf(stderr, "[error] secret_provision_read() returned %d\n", bytes);
-            goto out;
-        }
-        if (bytes != sizeof(secret2)) {
-            fprintf(stderr, "[error] secret_provision_read() returned secret with size %d"
-                    " (expected %lu)\n", bytes, sizeof(secret2));
-            goto out;
-        }
-
-        secret2[bytes - 1] = '\0';
+    /* let's ask for another secret (just to show communication with secret-prov server) */
+    ret = secret_provision_write(ctx, (uint8_t*)SEND_STRING, sizeof(SEND_STRING));
+    if (ret < 0) {
+        fprintf(stderr, "[error] secret_provision_write() returned %d\n", ret);
+        goto out;
     }
+
+    /* the secret we expect in return is a 2-char string */
+    ret = secret_provision_read(ctx, secret2, sizeof(secret2));
+    if (ret < 0) {
+        fprintf(stderr, "[error] secret_provision_read() returned %d\n", ret);
+        goto out;
+    }
+    secret2[sizeof(secret2) - 1] = '\0';
 
     printf("--- Received secret1 = '%s', secret2 = '%s' ---\n", secret1, secret2);
     ret = 0;
 out:
-    secret_provision_destroy();
-    secret_provision_close(&ctx);
-    return ret;
+    free(secret1);
+    secret_provision_close(ctx);
+    return ret == 0 ? 0 : 1;
 }

--- a/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c
+++ b/CI-Examples/ra-tls-secret-prov/src/secret_prov_server.c
@@ -60,41 +60,32 @@ static int communicate_with_client_callback(struct ra_tls_ctx* ctx) {
     printf("--- Sent secret1 = '%s' ---\n", g_secret_string);
 
     /* let's send another secret (just to show communication with secret-awaiting client) */
-    int bytes;
-    uint8_t buf[128] = {0};
+    uint8_t buf[sizeof(EXPECTED_STRING)] = {0};
 
-    bytes = secret_provision_read(ctx, buf, sizeof(EXPECTED_STRING));
-    if (bytes < 0) {
-        if (bytes == -ECONNRESET) {
+    ret = secret_provision_read(ctx, buf, sizeof(buf));
+    if (ret < 0) {
+        if (ret == -ECONNRESET) {
             /* client doesn't want another secret, shutdown communication gracefully */
-            ret = 0;
-            goto out;
+            return 0;
         }
 
-        fprintf(stderr, "[error] secret_provision_read() returned %d\n", bytes);
-        ret = -EINVAL;
-        goto out;
+        fprintf(stderr, "[error] secret_provision_read() returned %d\n", ret);
+        return -EINVAL;
     }
 
-    assert(bytes == sizeof(EXPECTED_STRING));
-    if (memcmp(buf, EXPECTED_STRING, bytes)) {
+    if (memcmp(buf, EXPECTED_STRING, sizeof(EXPECTED_STRING))) {
         fprintf(stderr, "[error] client sent '%s' but expected '%s'\n", buf, EXPECTED_STRING);
-        ret = -EINVAL;
-        goto out;
+        return -EINVAL;
     }
 
-    bytes = secret_provision_write(ctx, (uint8_t*)SECRET_STRING, sizeof(SECRET_STRING));
-    if (bytes < 0) {
-        fprintf(stderr, "[error] secret_provision_write() returned %d\n", bytes);
-        ret = -EINVAL;
-        goto out;
+    ret = secret_provision_write(ctx, (uint8_t*)SECRET_STRING, sizeof(SECRET_STRING));
+    if (ret < 0) {
+        fprintf(stderr, "[error] secret_provision_write() returned %d\n", ret);
+        return -EINVAL;
     }
 
     printf("--- Sent secret2 = '%s' ---\n", SECRET_STRING);
-    ret = 0;
-out:
-    secret_provision_close(ctx);
-    return ret;
+    return 0;
 }
 
 int main(int argc, char** argv) {

--- a/tools/sgx/ra-tls/secret_prov.h
+++ b/tools/sgx/ra-tls/secret_prov.h
@@ -22,9 +22,7 @@
 
 #define DEFAULT_SERVERS "localhost:4433"
 
-struct ra_tls_ctx {
-    void* ssl;
-};
+struct ra_tls_ctx;
 
 typedef int (*verify_measurements_cb_t)(const char* mrenclave, const char* mrsigner,
                                         const char* isv_prod_id, const char* isv_svn);
@@ -43,6 +41,8 @@ typedef int (*secret_provision_cb_t)(struct ra_tls_ctx* ctx);
  *
  * This function can be called after an RA-TLS session is established via client-side call to
  * secret_provision_start() or in the server-side callback secret_provision_cb_t().
+ *
+ * This function always writes all \p size bytes on success (partial writes are not possible).
  */
 __attribute__ ((visibility("default")))
 int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t size);
@@ -59,29 +59,36 @@ int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t si
  *
  * This function can be called after an RA-TLS session is established via client-side call to
  * secret_provision_start() or in the server-side callback secret_provision_cb_t().
+ *
+ * This function always reads all \p size bytes on success (partial reads are not possible).
  */
 __attribute__ ((visibility("default")))
 int secret_provision_read(struct ra_tls_ctx* ctx, uint8_t* buf, size_t size);
 
 /*!
- * \brief Close an established RA-TLS session.
+ * \brief Close an established RA-TLS session and its associated secret.
  *
  * \param ctx  Established RA-TLS session.
  *
  * \returns 0 on success, specific error code (negative int) otherwise.
  *
  * This function can be called after an RA-TLS session is established via client-side call to
- * secret_provision_start() or in the server-side callback secret_provision_cb_t(). Typically,
- * application-specific protocol to provision secrets is implemented via secret_provision_read()
- * and secret_provision_write(), and this function is called to finish secret provisioning.
+ * secret_provision_start(). Typically, application-specific protocol to provision secrets is
+ * implemented via secret_provision_read() and secret_provision_write(), and this function is called
+ * to finish secret provisioning.
+ *
+ * This function zeroes out the memory where provisioned secret is stored and frees it.
+ *
+ * This function must not be called again even if it returned an error. \p ctx is always freed.
  */
 __attribute__ ((visibility("default")))
 int secret_provision_close(struct ra_tls_ctx* ctx);
 
 /*!
- * \brief Get a provisioned secret.
+ * \brief Get a copy of the provisioned secret.
  *
- * \param[out] out_secret       Pointer to buffer with secret (allocated by the library).
+ * \param      ctx              Established RA-TLS session.
+ * \param[out] out_secret       Pointer to newly allocated buffer with secret.
  * \param[out] out_secret_size  Size of allocated buffer.
  *
  * \returns 0 on success, specific error code (negative int) otherwise.
@@ -89,18 +96,11 @@ int secret_provision_close(struct ra_tls_ctx* ctx);
  * This function is relevant only for clients. Typically, the client would ask for secret
  * provisioning via secret_provision_start() which will obtain the secret from the server and
  * save it in enclave memory. After that, the client can call this function to retrieve the
- * secret from memory.
+ * copy of the secret from memory. Content of \p out_secret is dynamically allocated and should be
+ * released using `free(*out_secret)`.
  */
 __attribute__ ((visibility("default")))
-int secret_provision_get(uint8_t** out_secret, size_t* out_secret_size);
-
-/*!
- * \brief Destroy a provisioned secret.
- *
- * This function zeroes out the memory where provisioned secret is stored and frees it.
- */
-__attribute__ ((visibility("default")))
-void secret_provision_destroy(void);
+int secret_provision_get(struct ra_tls_ctx* ctx, uint8_t** out_secret, size_t* out_secret_size);
 
 /*!
  * \brief Establish an RA-TLS session and retrieve first secret (client-side).
@@ -113,23 +113,22 @@ void secret_provision_destroy(void);
  *                              environment variable `SECRET_PROVISION_CA_CHAIN_PATH` is used. If
  *                              the environment variable is also not specified, function returns
  *                              with error code EINVAL.
- * \param[out] out_ctx          Pointer to an established RA-TLS session. If user supplies NULL,
- *                              then only the first secret is retrieved from the server and the
- *                              RA-TLS session is closed.
+ * \param[out] out_ctx          Pointer to an established RA-TLS session. Cannot be NULL.
  *
  * \returns 0 on success, specific error code (negative int) otherwise.
  *
  * This function must be called before other functions. It establishes a secure RA-TLS session
  * with the first available server from the \p in_servers list and retrieves the first secret.
- * If \p out_ssl pointer is supplied by the user, the session is not closed and the user can
- * continue this secure session with the server via secret_provision_read(),
- * secret_provision_write(), and the final secret_provision_close(). The first secret can be
- * retrieved via secret_provision_get() and later destroyed via secret_provision_destroy().
- * Not thread-safe.
+ *
+ * The user can continue this secure session with the server via secret_provision_read() and
+ * secret_provision_write(). The user must finish the session by calling secret_provision_close().
+ *
+ * The first secret can be retrieved via secret_provision_get(). The secret is destroyed together
+ * with the session during secret_provision_close().
  */
 __attribute__ ((visibility("default")))
 int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
-                           struct ra_tls_ctx* out_ctx);
+                           struct ra_tls_ctx** out_ctx);
 
 /*!
  * \brief Start a secret provisioning service (server-side).
@@ -156,7 +155,9 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
  * m_cb() for user-specific verification of measurements in client's SGX quote (if user supplied
  * it). After successfuly establishing the RA-TLS session and sending the first secret \p secret,
  * the server invokes a user-supplied callback f_cb() for user-specific communication with the
- * client (if user supplied it). This function is thread-safe and requires pthread library.
+ * client (if user supplied it).
+ *
+ * This function is thread-safe and requires pthread library.
  */
 __attribute__ ((visibility("default")))
 int secret_provision_start_server(uint8_t* secret, size_t secret_size, const char* port,

--- a/tools/sgx/ra-tls/secret_prov_attest.c
+++ b/tools/sgx/ra-tls/secret_prov_attest.c
@@ -31,45 +31,71 @@
 
 #include "ra_tls.h"
 #include "secret_prov.h"
+#include "secret_prov_common.h"
 #include "util.h"
 
-/* these are globals because the user may continue using the SSL session even after invoking
- * secret_provision_start() (in the user-supplied callback) */
-static mbedtls_ctr_drbg_context g_ctr_drbg;
-static mbedtls_entropy_context g_entropy;
-static mbedtls_ssl_config g_conf;
-static mbedtls_x509_crt g_verifier_ca_chain;
-static mbedtls_net_context g_verifier_fd;
-static mbedtls_ssl_context g_ssl;
-static mbedtls_pk_context g_my_ratls_key;
-static mbedtls_x509_crt g_my_ratls_cert;
+struct ra_tls_ctx {
+    mbedtls_ssl_context* ssl;
+    mbedtls_net_context* net;
+    mbedtls_ssl_config* conf;
+    uint8_t* secret;
+    size_t   secret_size;
+};
 
-static uint8_t* provisioned_secret = NULL;
-static size_t provisioned_secret_size = 0;
-
-int secret_provision_get(uint8_t** out_secret, size_t* out_secret_size) {
-    if (!out_secret || !out_secret_size)
+int secret_provision_get(struct ra_tls_ctx* ctx, uint8_t** out_secret, size_t* out_secret_size) {
+    if (!ctx || !out_secret || !out_secret_size)
         return -EINVAL;
 
-    *out_secret      = provisioned_secret;
-    *out_secret_size = provisioned_secret_size;
+    uint8_t* secret_copy = malloc(ctx->secret_size);
+    if (!secret_copy)
+        return -ENOMEM;
+
+    memcpy(secret_copy, ctx->secret, ctx->secret_size);
+    *out_secret      = secret_copy;
+    *out_secret_size = ctx->secret_size;
     return 0;
 }
 
-void secret_provision_destroy(void) {
-    if (provisioned_secret && provisioned_secret_size)
+int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t size) {
+    if (!ctx || (size && !buf))
+        return -EINVAL;
+    return secret_provision_common_write(ctx->ssl, buf, size);
+}
+
+int secret_provision_read(struct ra_tls_ctx* ctx, uint8_t* buf, size_t size) {
+    if (!ctx || (size && !buf))
+        return -EINVAL;
+    return secret_provision_common_read(ctx->ssl, buf, size);
+}
+
+int secret_provision_close(struct ra_tls_ctx* ctx) {
+    if (!ctx)
+        return -EINVAL;
+
+    if (ctx->secret && ctx->secret_size) {
 #ifdef __STDC_LIB_EXT1__
-        memset_s(provisioned_secret, 0, provisioned_secret_size);
+        memset_s(ctx->secret, 0, ctx->secret_size);
 #else
-        memset(provisioned_secret, 0, provisioned_secret_size);
+        memset(ctx->secret, 0, ctx->secret_size);
 #endif
-    free(provisioned_secret);
-    provisioned_secret      = NULL;
-    provisioned_secret_size = 0;
+    }
+
+    int ret = secret_provision_common_close(ctx->ssl);
+
+    mbedtls_ssl_free(ctx->ssl);
+    mbedtls_ssl_config_free(ctx->conf);
+    mbedtls_net_free(ctx->net);
+    free(ctx->ssl);
+    free(ctx->conf);
+    free(ctx->net);
+
+    free(ctx->secret);
+    free(ctx);
+    return ret;
 }
 
 int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
-                           struct ra_tls_ctx* out_ctx) {
+                           struct ra_tls_ctx** out_ctx) {
     int ret;
 
     char* servers       = NULL;
@@ -78,28 +104,62 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
     char* connected_addr = NULL;
     char* connected_port = NULL;
 
-    mbedtls_ctr_drbg_init(&g_ctr_drbg);
-    mbedtls_entropy_init(&g_entropy);
-    mbedtls_x509_crt_init(&g_verifier_ca_chain);
+    uint8_t* secret = NULL;
 
-    mbedtls_pk_init(&g_my_ratls_key);
-    mbedtls_x509_crt_init(&g_my_ratls_cert);
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_context entropy;
+    mbedtls_x509_crt verifier_ca_chain;
+    mbedtls_pk_context my_ratls_key;
+    mbedtls_x509_crt my_ratls_cert;
 
-    mbedtls_net_init(&g_verifier_fd);
-    mbedtls_ssl_config_init(&g_conf);
-    mbedtls_ssl_init(&g_ssl);
+    if (!out_ctx)
+        return -EINVAL;
+
+    mbedtls_net_context* net  = malloc(sizeof(*net));
+    mbedtls_ssl_config*  conf = malloc(sizeof(*conf));
+    mbedtls_ssl_context* ssl  = malloc(sizeof(*ssl));
+    struct ra_tls_ctx*   ctx  = malloc(sizeof(*ctx));
+
+    if (!net || !conf || !ssl || !ctx) {
+        free(net);
+        free(conf);
+        free(ssl);
+        free(ctx);
+        return -ENOMEM;
+    }
+
+    ctx->ssl         = ssl;
+    ctx->conf        = conf;
+    ctx->net         = net;
+    ctx->secret      = NULL;
+    ctx->secret_size = 0;
+
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_entropy_init(&entropy);
+    mbedtls_x509_crt_init(&verifier_ca_chain);
+    mbedtls_pk_init(&my_ratls_key);
+    mbedtls_x509_crt_init(&my_ratls_cert);
+
+    mbedtls_net_init(net);
+    mbedtls_ssl_config_init(conf);
+    mbedtls_ssl_init(ssl);
 
     const char* pers = "secret-provisioning";
-    ret = mbedtls_ctr_drbg_seed(&g_ctr_drbg, mbedtls_entropy_func, &g_entropy,
+    ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                 (const uint8_t*)pers, strlen(pers));
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ctr_drbg_seed with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     if (!in_ca_chain_path) {
         in_ca_chain_path = getenv(SECRET_PROVISION_CA_CHAIN_PATH);
-        if (!in_ca_chain_path)
-            return -EINVAL;
+        if (!in_ca_chain_path) {
+            ERROR("Secret Provisioning could not find envvar " SECRET_PROVISION_CA_CHAIN_PATH "\n");
+            ret = -EINVAL;
+            goto out;
+        }
     }
 
     ca_chain_path = strdup(in_ca_chain_path);
@@ -124,7 +184,7 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
     char* saveptr2 = NULL;
     char* str1;
     for (str1 = servers; /*no condition*/; str1 = NULL) {
-        ret = -ECONNREFUSED;
+        ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
         char* token = strtok_r(str1, ",; ", &saveptr1);
         if (!token)
             break;
@@ -137,78 +197,92 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
         if (!connected_port)
             continue;
 
-        ret = mbedtls_net_connect(&g_verifier_fd, connected_addr, connected_port,
-                                  MBEDTLS_NET_PROTO_TCP);
+        ret = mbedtls_net_connect(net, connected_addr, connected_port, MBEDTLS_NET_PROTO_TCP);
         if (!ret)
             break;
     }
 
     if (ret < 0) {
+        ERROR("Secret Provisioning could not connect to any of the servers specified in "
+              SECRET_PROVISION_SERVERS "; last mbedTLS error was %d\n", ret);
         goto out;
     }
 
-    ret = mbedtls_ssl_config_defaults(&g_conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+    ret = mbedtls_ssl_config_defaults(conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
                                       MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_config_defaults with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
-    ret = mbedtls_x509_crt_parse_file(&g_verifier_ca_chain, ca_chain_path);
+    ret = mbedtls_x509_crt_parse_file(&verifier_ca_chain, ca_chain_path);
     if (ret != 0) {
+        ERROR("Secret Provisioning failed during mbedtls_x509_crt_parse_file with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     char crt_issuer[256];
-    ret = mbedtls_x509_dn_gets(crt_issuer, sizeof(crt_issuer), &g_verifier_ca_chain.issuer);
+    ret = mbedtls_x509_dn_gets(crt_issuer, sizeof(crt_issuer), &verifier_ca_chain.issuer);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_x509_dn_gets with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
-    mbedtls_ssl_conf_authmode(&g_conf, MBEDTLS_SSL_VERIFY_REQUIRED);
-    mbedtls_ssl_conf_ca_chain(&g_conf, &g_verifier_ca_chain, NULL);
+    mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+    mbedtls_ssl_conf_ca_chain(conf, &verifier_ca_chain, NULL);
 
-    ret = ra_tls_create_key_and_crt(&g_my_ratls_key, &g_my_ratls_cert);
+    ret = ra_tls_create_key_and_crt(&my_ratls_key, &my_ratls_cert);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during ra_tls_create_key_and_crt with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
-    mbedtls_ssl_conf_rng(&g_conf, mbedtls_ctr_drbg_random, &g_ctr_drbg);
+    mbedtls_ssl_conf_rng(conf, mbedtls_ctr_drbg_random, &ctr_drbg);
 
-    ret = mbedtls_ssl_conf_own_cert(&g_conf, &g_my_ratls_cert, &g_my_ratls_key);
+    ret = mbedtls_ssl_conf_own_cert(conf, &my_ratls_cert, &my_ratls_key);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_conf_own_cert with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
-    ret = mbedtls_ssl_setup(&g_ssl, &g_conf);
+    ret = mbedtls_ssl_setup(ssl, conf);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_setup with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
-    ret = mbedtls_ssl_set_hostname(&g_ssl, connected_addr);
+    ret = mbedtls_ssl_set_hostname(ssl, connected_addr);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_set_hostname with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
-    mbedtls_ssl_set_bio(&g_ssl, &g_verifier_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
+    mbedtls_ssl_set_bio(ssl, net, mbedtls_net_send, mbedtls_net_recv, NULL);
 
-    ret = -1;
-    while (ret < 0) {
-        ret = mbedtls_ssl_handshake(&g_ssl);
-        if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
-            continue;
-        }
-        if (ret < 0) {
-            goto out;
-        }
+    do {
+        ret = mbedtls_ssl_handshake(ssl);
+    } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+    if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_handshake with error %d\n", ret);
+        ret = -EPERM;
+        goto out;
     }
 
-    uint32_t flags = mbedtls_ssl_get_verify_result(&g_ssl);
+    uint32_t flags = mbedtls_ssl_get_verify_result(ssl);
     if (flags != 0) {
-        ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
+        ERROR("Secret Provisioning failed during mbedtls_ssl_get_verify_result (flags = %u)\n",
+              flags);
+        ret = -EPERM;
         goto out;
     }
 
-    struct ra_tls_ctx ctx = {.ssl = &g_ssl};
     uint8_t buf[128] = {0};
     size_t size;
 
@@ -217,75 +291,69 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
     size = sprintf((char*)buf, SECRET_PROVISION_REQUEST);
     size += 1; /* include null byte */
 
-    ret = secret_provision_write(&ctx, buf, size);
+    ret = secret_provision_common_write(ssl, buf, size);
     if (ret < 0) {
         goto out;
     }
 
     /* remote verifier sends 32-bit integer over network; we need to ntoh it */
-    uint32_t received_secret_size;
-    static_assert(sizeof(buf) >= sizeof(SECRET_PROVISION_RESPONSE) + sizeof(received_secret_size),
+    uint32_t secret_size;
+    static_assert(sizeof(buf) >= sizeof(SECRET_PROVISION_RESPONSE) + sizeof(secret_size),
                   "buffer must be sufficiently large to hold SECRET_PROVISION_RESPONSE + int32");
 
     memset(buf, 0, sizeof(buf));
-    ret = secret_provision_read(&ctx, buf,
-                                sizeof(SECRET_PROVISION_RESPONSE) + sizeof(received_secret_size));
+    ret = secret_provision_common_read(ssl, buf,
+                                       sizeof(SECRET_PROVISION_RESPONSE) + sizeof(secret_size));
     if (ret < 0) {
         goto out;
     }
 
     if (memcmp(buf, SECRET_PROVISION_RESPONSE, sizeof(SECRET_PROVISION_RESPONSE))) {
+        ERROR("Secret Provisioning read a response that doesn't match the expected "
+              SECRET_PROVISION_RESPONSE "\n");
         ret = -EINVAL;
         goto out;
     }
 
-    memcpy(&received_secret_size, buf + sizeof(SECRET_PROVISION_RESPONSE),
-           sizeof(received_secret_size));
+    memcpy(&secret_size, buf + sizeof(SECRET_PROVISION_RESPONSE), sizeof(secret_size));
 
-    received_secret_size = ntohl(received_secret_size);
-    if (received_secret_size > INT_MAX) {
+    secret_size = ntohl(secret_size);
+    if (secret_size > INT_MAX) {
         ret = -EINVAL;
         goto out;
     }
 
-    provisioned_secret_size = received_secret_size;
-    provisioned_secret = malloc(provisioned_secret_size);
-    if (!provisioned_secret) {
+    secret = malloc(secret_size);
+    if (!secret) {
         ret = -ENOMEM;
         goto out;
     }
 
-    ret = secret_provision_read(&ctx, provisioned_secret, provisioned_secret_size);
+    ret = secret_provision_common_read(ssl, secret, secret_size);
     if (ret < 0) {
         goto out;
     }
 
-    if (out_ctx) {
-        out_ctx->ssl = ctx.ssl;
-    } else {
-        secret_provision_close(&ctx);
-    }
-
+    ctx->secret      = secret;
+    ctx->secret_size = secret_size;
+    *out_ctx = ctx;
     ret = 0;
 out:
     if (ret < 0) {
-        secret_provision_destroy();
+        free(secret);
+        int close_ret = secret_provision_close(ctx);
+        if (close_ret < 0)
+            INFO("WARNING: Closing the secret-prov context failed with error %d.\n", close_ret);
     }
 
-    if (ret < 0 || !out_ctx) {
-        mbedtls_x509_crt_free(&g_my_ratls_cert);
-        mbedtls_pk_free(&g_my_ratls_key);
-        mbedtls_net_free(&g_verifier_fd);
-        mbedtls_ssl_free(&g_ssl);
-        mbedtls_ssl_config_free(&g_conf);
-        mbedtls_x509_crt_free(&g_verifier_ca_chain);
-        mbedtls_ctr_drbg_free(&g_ctr_drbg);
-        mbedtls_entropy_free(&g_entropy);
-    }
+    mbedtls_x509_crt_free(&my_ratls_cert);
+    mbedtls_pk_free(&my_ratls_key);
+    mbedtls_x509_crt_free(&verifier_ca_chain);
+    mbedtls_entropy_free(&entropy);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
 
     free(servers);
     free(ca_chain_path);
-
     return ret;
 }
 
@@ -307,14 +375,15 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
 
         unsetenv(SECRET_PROVISION_SECRET_STRING);
 
+        struct ra_tls_ctx* ctx;
         int ret = secret_provision_start(/*in_servers=*/NULL, /*in_ca_chain_path=*/NULL,
-                                         /*out_ctx=*/NULL);
+                                         &ctx);
         if (ret < 0) {
             ERROR("Secret provisioning failed, terminating the whole process\n");
             exit(1);
         }
 
-        ret = secret_provision_get(&secret, &secret_size);
+        ret = secret_provision_get(ctx, &secret, &secret_size);
         if (ret < 0 || !secret || !secret_size || secret_size > PATH_MAX ||
                 secret[secret_size - 1] != '\0') {
             ERROR("Secret is not a null-terminated string, cannot do anything about such secret\n");
@@ -354,7 +423,8 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
 
             size_t total_written = 0;
             while (total_written < sizeof(keydata)) {
-                ssize_t written = write(fd, keydata + total_written, sizeof(keydata) - total_written);
+                ssize_t written = write(fd, keydata + total_written,
+                                        sizeof(keydata) - total_written);
                 if (written > 0) {
                     total_written += written;
                 } else if (written == 0) {
@@ -375,6 +445,6 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
         /* put the secret into an environment variable */
         setenv(SECRET_PROVISION_SECRET_STRING, (const char*)secret, /*overwrite=*/1);
 
-        secret_provision_destroy();
+        secret_provision_close(ctx);
     }
 }

--- a/tools/sgx/ra-tls/secret_prov_common.c
+++ b/tools/sgx/ra-tls/secret_prov_common.c
@@ -7,80 +7,80 @@
  * This file contains common utilities for secret provisioning library.
  */
 
+#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 
-#include "mbedtls/ssl.h"
-
 #include "secret_prov.h"
+#include "secret_prov_common.h"
+#include "util.h"
 
-int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t size) {
+int secret_provision_common_write(mbedtls_ssl_context* ssl, const uint8_t* buf, size_t size) {
     int ret;
 
-    if (!ctx || !ctx->ssl || size > INT_MAX)
+    if (!ssl || size > INT_MAX)
         return -EINVAL;
-
-    mbedtls_ssl_context* _ssl = (mbedtls_ssl_context*)ctx->ssl;
 
     size_t written = 0;
     while (written < size) {
-        ret = mbedtls_ssl_write(_ssl, buf + written, size - written);
+        ret = mbedtls_ssl_write(ssl, buf + written, size - written);
         if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE)
             continue;
         if (ret < 0) {
             /* use well-known error code for a typical case when remote party closes connection */
-            return ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY ? -ECONNRESET : ret;
+            if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+                return -ECONNRESET;
+            ERROR("Secret Provisioning failed during write with mbedTLS error %d\n", ret);
+            return -EPERM;
         }
         written += (size_t)ret;
     }
     assert(written == size);
-    return (int)written;
+    return 0;
 }
 
-int secret_provision_read(struct ra_tls_ctx* ctx, uint8_t* buf, size_t size) {
+int secret_provision_common_read(mbedtls_ssl_context* ssl, uint8_t* buf, size_t size) {
     int ret;
 
-    if (!ctx || !ctx->ssl || size > INT_MAX)
+    if (!ssl || size > INT_MAX)
         return -EINVAL;
-
-    mbedtls_ssl_context* _ssl = (mbedtls_ssl_context*)ctx->ssl;
 
     size_t read = 0;
     while (read < size) {
-        ret = mbedtls_ssl_read(_ssl, buf + read, size - read);
+        ret = mbedtls_ssl_read(ssl, buf + read, size - read);
         if (!ret)
             return -ECONNRESET;
         if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE)
             continue;
         if (ret < 0) {
             /* use well-known error code for a typical case when remote party closes connection */
-            return ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY ? -ECONNRESET : ret;
+            if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+                return -ECONNRESET;
+            ERROR("Secret Provisioning failed during read with mbedTLS error %d\n", ret);
+            return -EPERM;
         }
         read += (size_t)ret;
     }
-
     assert(read == size);
-    return (int)read;
+    return 0;
 }
 
-int secret_provision_close(struct ra_tls_ctx* ctx) {
-    if (!ctx || !ctx->ssl)
+int secret_provision_common_close(mbedtls_ssl_context* ssl) {
+    if (!ssl)
         return 0;
 
-    mbedtls_ssl_context* _ssl = (mbedtls_ssl_context*)ctx->ssl;
-
-    int ret = -1;
-    while (ret < 0) {
-        ret = mbedtls_ssl_close_notify(_ssl);
-        if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
-            continue;
-        }
-        if (ret < 0) {
-            /* use well-known error code for a typical case when remote party closes connection */
-            return ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY ? -ECONNRESET : ret;
-        }
+    int ret;
+    do {
+        ret = mbedtls_ssl_close_notify(ssl);
+    } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+    if (ret < 0) {
+        /* use well-known error code for a typical case when remote party closes connection */
+        if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+            return -ECONNRESET;
+        ERROR("Secret Provisioning failed during connection close with mbedTLS error %d\n", ret);
+        return -EPERM;
     }
     return 0;
 }

--- a/tools/sgx/ra-tls/secret_prov_common.h
+++ b/tools/sgx/ra-tls/secret_prov_common.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Labs */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "mbedtls/ssl.h"
+
+int secret_provision_common_write(mbedtls_ssl_context* ssl, const uint8_t* buf, size_t size);
+int secret_provision_common_read(mbedtls_ssl_context* ssl, uint8_t* buf, size_t size);
+int secret_provision_common_close(mbedtls_ssl_context* ssl);

--- a/tools/sgx/ra-tls/secret_prov_verify.c
+++ b/tools/sgx/ra-tls/secret_prov_verify.c
@@ -13,6 +13,7 @@
  * into the secret provisioning server. This library is *not* thread-safe.
  */
 
+#define _XOPEN_SOURCE 700
 #include <arpa/inet.h>
 #include <errno.h>
 #include <limits.h>
@@ -31,6 +32,12 @@
 
 #include "ra_tls.h"
 #include "secret_prov.h"
+#include "secret_prov_common.h"
+#include "util.h"
+
+struct ra_tls_ctx {
+    mbedtls_ssl_context* ssl;
+};
 
 struct thread_info {
     mbedtls_net_context client_fd;
@@ -43,6 +50,25 @@ struct thread_info {
 /* SSL/TLS + RA-TLS handshake is not thread-safe, use coarse-grained lock */
 static pthread_mutex_t g_handshake_lock;
 
+int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t size) {
+    if (!ctx || (size && !buf))
+        return -EINVAL;
+    return secret_provision_common_write(ctx->ssl, buf, size);
+}
+
+int secret_provision_read(struct ra_tls_ctx* ctx, uint8_t* buf, size_t size) {
+    if (!ctx || (size && !buf))
+        return -EINVAL;
+    return secret_provision_common_read(ctx->ssl, buf, size);
+}
+
+int secret_provision_close(struct ra_tls_ctx* ctx) {
+    if (!ctx)
+        return -EINVAL;
+    /* no need to free the ctx resources, this will be done in client_connection() */
+    return secret_provision_common_close(ctx->ssl);
+}
+
 static void* client_connection(void* data) {
     int ret;
     struct thread_info* ti = (struct thread_info*)data;
@@ -52,49 +78,48 @@ static void* client_connection(void* data) {
 
     ret = mbedtls_ssl_setup(&ssl, ti->conf);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_setup with error %d\n", ret);
         goto out;
     }
 
     mbedtls_ssl_set_bio(&ssl, &ti->client_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
 
-    ret = -1;
-    while (ret < 0) {
+    do {
         /* FIXME: this coarse-grained locking is less than optimal; need to switch to thread-safe
          *        mbedTLS configuration and thread-safe RA-TLS in the future */
         pthread_mutex_lock(&g_handshake_lock);
         ret = mbedtls_ssl_handshake(&ssl);
         pthread_mutex_unlock(&g_handshake_lock);
-        if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
-            continue;
-        }
-        if (ret < 0) {
-            goto out;
-        }
+    } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+    if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_handshake with error %d\n", ret);
+        goto out;
     }
 
     uint32_t flags = mbedtls_ssl_get_verify_result(&ssl);
     if (flags != 0) {
-        ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
+        ERROR("Secret Provisioning failed during mbedtls_ssl_get_verify_result (flags = %u)\n",
+              flags);
         goto out;
     }
 
-    struct ra_tls_ctx ctx = {.ssl = &ssl};
     uint8_t buf[128] = {0};
     static_assert(sizeof(buf) >= sizeof(SECRET_PROVISION_REQUEST),
                   "buffer must be sufficiently large to hold SECRET_PROVISION_REQUEST");
 
-    ret = secret_provision_read(&ctx, buf, sizeof(SECRET_PROVISION_REQUEST));
+    ret = secret_provision_common_read(&ssl, buf, sizeof(SECRET_PROVISION_REQUEST));
     if (ret < 0) {
         goto out;
     }
 
     if (memcmp(buf, SECRET_PROVISION_REQUEST, sizeof(SECRET_PROVISION_REQUEST))) {
+        ERROR("Secret Provisioning read a request that doesn't match the expected "
+              SECRET_PROVISION_REQUEST "\n");
         goto out;
     }
 
     /* remote attester receives 32-bit integer over network; we need to hton it */
     if (ti->secret_size > INT_MAX) {
-        ret = -EINVAL;
         goto out;
     }
 
@@ -106,24 +131,22 @@ static void* client_connection(void* data) {
     memcpy(buf, SECRET_PROVISION_RESPONSE, sizeof(SECRET_PROVISION_RESPONSE));
     memcpy(buf + sizeof(SECRET_PROVISION_RESPONSE), &send_secret_size, sizeof(send_secret_size));
 
-    ret = secret_provision_write(&ctx, buf,
-                                 sizeof(SECRET_PROVISION_RESPONSE) + sizeof(send_secret_size));
+    ret = secret_provision_common_write(&ssl, buf, sizeof(SECRET_PROVISION_RESPONSE)
+                                                   + sizeof(send_secret_size));
     if (ret < 0) {
         goto out;
     }
 
-    ret = secret_provision_write(&ctx, ti->secret, ti->secret_size);
+    ret = secret_provision_common_write(&ssl, ti->secret, ti->secret_size);
     if (ret < 0) {
         goto out;
     }
 
     if (ti->f_cb) {
-        /* pass ownership of SSL session with client to the caller; it is caller's responsibility
-         * to gracefuly terminate the session using secret_provision_close() */
+        struct ra_tls_ctx ctx = { .ssl = &ssl };
         ti->f_cb(&ctx);
-    } else {
-        secret_provision_close(&ctx);
     }
+    secret_provision_common_close(&ssl);
 
 out:
     mbedtls_ssl_free(&ssl);
@@ -164,34 +187,46 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
     ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                 (const uint8_t*)pers, strlen(pers));
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ctr_drbg_seed with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     ret = mbedtls_x509_crt_parse_file(&srvcert, cert_path);
     if (ret != 0) {
+        ERROR("Secret Provisioning failed during mbedtls_x509_crt_parse_file with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     char crt_issuer[256];
     ret = mbedtls_x509_dn_gets(crt_issuer, sizeof(crt_issuer), &srvcert.issuer);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_x509_dn_gets with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     ret = mbedtls_pk_parse_keyfile(&srvkey, key_path, /*password=*/NULL, mbedtls_ctr_drbg_random,
                                    &ctr_drbg);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_pk_parse_keyfile with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     ret = mbedtls_net_bind(&listen_fd, NULL, port ?: "4433", MBEDTLS_NET_PROTO_TCP);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_net_bind with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
     ret = mbedtls_ssl_config_defaults(&conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_STREAM,
                                       MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_config_defaults with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
@@ -207,6 +242,8 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
 
     ret = mbedtls_ssl_conf_own_cert(&conf, &srvcert, &srvkey);
     if (ret < 0) {
+        ERROR("Secret Provisioning failed during mbedtls_ssl_conf_own_cert with error %d\n", ret);
+        ret = -EPERM;
         goto out;
     }
 
@@ -257,6 +294,7 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
         pthread_attr_destroy(&tattr);
     }
 
+    ret = 0;
 out:
     mbedtls_x509_crt_free(&srvcert);
     mbedtls_pk_free(&srvkey);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a breaking change that modifies the API of the Secret Prov lib as follows:

- `secret_provision_start()` allocates a context that should be supplied to all other Secret Prov APIs and must be closed afterwards.

- `secret_provision_get()` requires a context as the first argument, and extracts the secret that is associated with this context. Thus, it allows for several secrets being delivered in parallel from different remote parties (previously, the secret was a global variable).

- `secret_provision_destroy()` is removed. Instead, users should call `secret_provision_close()` that will both close the session and destroy the secret.

With these changes, the context ceases to be global, and the library becomes thread-safe. Also, leaks of mbedTLS resources are prevented.

As a small side fix, the library always returns normal POSIX error codes (previously, the library could return mbedTLS error codes).

Fixes #646. Supersedes #647.

## How to test this PR? <!-- (if applicable) -->

CI should be enough. But also see manual way in #647 to test resource/memory leaks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/813)
<!-- Reviewable:end -->
