### PR TITLE
[common] Init new protected file when file size is zero

### DIFF
--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -951,11 +951,10 @@ static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create
     pf->real_file_size = real_size;
     pf->mode = mode;
 
-    if (!create) {
+    if (!create && real_size > 0) {
         // existing file
         if (!ipf_init_existing_file(pf, path))
             goto out;
-
     } else {
         // new file
         if (!ipf_init_new_file(pf, path))


### PR DESCRIPTION
Currently, Gramine does not close a file opened inside an encrypted mount but not explicitly closed by the application. No data is ever written to the host in this case. A subsequent opening of this file (e.g., on the application restart) will be broken since it's considered as operating on an existing file however the file size is actually zero and the encrypted file header is also missing.

This patch initializes a new protected file instead of an existing one when the file size is found out to be zero.
Fixes https://github.com/gramineproject/gramine/issues/824.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/826)
<!-- Reviewable:end -->
