### PR TITLE
[LibOS,PAL/Linux-SGX] Add shared untrusted memory support

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -427,6 +427,9 @@ Gramine currently supports the following types of mount points:
 * ``encrypted``: Host-backed encrypted files. See :ref:`encrypted-files` for
   more information.
 
+* ``untrusted_shm``: Untrusted shared memory files. See
+  :ref:`untrusted-shared-memory` for more information.
+
 * ``tmpfs``: Temporary in-memory-only files. These files are *not* backed by
   host-level files. The tmpfs files are created under ``[PATH]`` (this path is
   empty on Gramine instance startup) and are destroyed when a Gramine instance
@@ -1009,6 +1012,56 @@ Gramine:
    and using the same key obtained via ``/dev/attestation/keys/_sgx_mrenclave``
    in the application is insecure. If you need to derive encryption keys from
    such a "doubly-used" key, you must apply a KDF.
+
+.. _untrusted-shared-memory:
+
+Untrusted shared memory
+^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    fs.mounts = [
+      { type = "untrusted_shm", path = "[PATH]", uri = "[URI]" },
+    ]
+
+This syntax allows mounting shared memory objects that are accessible by both
+the application running inside Gramine and by other host software/hardware (host
+OS, other host processes, devices connected to the host). In Gramine, untrusted
+shared memory applies to files which must be mapped into application address
+space with the ``MAP_SHARED`` flag.
+
+URI can be a file or a directory (with a ``dev:`` prefix). If a directory is
+mounted, all files under this directory are treated as shared memory objects
+(but sub-directories are inaccessible for security reasons). New files created
+in a shared memory mount are also automatically treated as shared memory
+objects. Creating sub-directories in a shared memory mount is not allowed, for
+security reasons. Files in a shared memory mount (or the mounted directory
+itself) need to be explicitly listed as ``allowed_files`` to be accessed. See
+:ref:`allowed_files` for more information.
+
+Typically, you should mount the directory ``/dev/shm/`` (it is used for sharing
+data between processes and devices) and allow specific files in it. When this
+directory is mounted, the Gramine application may create the files -- called
+"shared memory objects" in POSIX -- under this directory (for example, this is
+how ``shm_open()`` Glibc function works). It is not recommended to allow a
+directory unless the application creates shared memory objects with
+unpredictable names. Allowing a directory creates a risk of exposing unexpected
+data to the host.
+
+.. note ::
+   Adding shared memory mounts is insecure by itself in SGX environments:
+
+       - All data put in shared memory reside outside of the SGX enclave.
+       - Typically applications do not encrypt the data put in shared memory,
+         which may lead to leaks of enclave data.
+       - Untrusted host can modify data in shared memory as it wishes, so
+         applications could see or operate on maliciously modified data.
+
+   It is the responsibility of the app developer to correctly use shared memory,
+   with security implications in mind. In most cases, data in shared memory
+   should be preliminarily encrypted or integrity-protected by the user app
+   with a key pre-shared between all participating processes (and possibly
+   devices that use this shared memory).
 
 File check policy
 ^^^^^^^^^^^^^^^^^

--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -926,6 +926,7 @@ extern struct libos_fs epoll_builtin_fs;
 extern struct libos_fs eventfd_builtin_fs;
 extern struct libos_fs synthetic_builtin_fs;
 extern struct libos_fs path_builtin_fs;
+extern struct libos_fs shm_builtin_fs;
 
 struct libos_fs* find_fs(const char* name);
 

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -37,6 +37,7 @@ enum libos_handle_type {
     TYPE_TMPFS,      /* string-based files (with data inside dentry), used by `tmpfs` filesystem */
     TYPE_SYNTHETIC,  /* synthetic files, used by `synthetic` filesystem */
     TYPE_PATH,       /* path to a file (the file is not actually opened) */
+    TYPE_SHM,        /* shared files, used by `shm` filesystem */
 
     /* Pipes and sockets: */
     TYPE_PIPE,       /* pipes, used by `pipe` filesystem */

--- a/libos/src/bookkeep/libos_vma.c
+++ b/libos/src/bookkeep/libos_vma.c
@@ -999,8 +999,10 @@ int bkeep_mmap_any_in_range(void* _bottom_addr, void* _top_addr, size_t length, 
                             struct libos_handle* file, uint64_t offset, const char* comment,
                             void** ret_val_ptr) {
     assert(_bottom_addr < _top_addr);
-    assert(g_pal_public_state->memory_address_start <= _bottom_addr
-           && _top_addr <= g_pal_public_state->memory_address_end);
+    assert((g_pal_public_state->memory_address_start <= _bottom_addr
+               && _top_addr <= g_pal_public_state->memory_address_end)
+           || (g_pal_public_state->shared_address_start <= _bottom_addr
+               && _top_addr <= g_pal_public_state->shared_address_end));
 
     if (!length || !IS_ALLOC_ALIGNED(length)) {
         return -EINVAL;

--- a/libos/src/fs/libos_fs.c
+++ b/libos/src/fs/libos_fs.c
@@ -32,6 +32,7 @@ static struct libos_fs* g_builtin_fs[] = {
     &pseudo_builtin_fs,
     &synthetic_builtin_fs,
     &path_builtin_fs,
+    &shm_builtin_fs,
 };
 
 static struct libos_lock g_mount_mgr_lock;

--- a/libos/src/fs/proc/thread.c
+++ b/libos/src/fs/proc/thread.c
@@ -286,6 +286,7 @@ static char* describe_handle(struct libos_handle* hdl) {
         case TYPE_SOCK:    str = "sock:[?]";    break;
         case TYPE_EPOLL:   str = "epoll:[?]";   break;
         case TYPE_EVENTFD: str = "eventfd:[?]"; break;
+        case TYPE_SHM:     str = "shm:[?]";     break;
         default:           str = "unknown:[?]"; break;
     }
     return strdup(str);

--- a/libos/src/fs/shm/fs.c
+++ b/libos/src/fs/shm/fs.c
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Li Xun <xun.li@intel.com>
+ */
+
+/*
+ * This file contains code for implementation of 'shm' filesystem.
+ * If mounted in manifest, files of this type are shared with the host OS when mapped.
+ */
+
+#include "libos_flags_conv.h"
+#include "libos_fs.h"
+#include "libos_handle.h"
+#include "libos_lock.h"
+#include "linux_abi/errors.h"
+#include "perm.h"
+#include "stat.h"
+
+#define HOST_PERM(perm) ((perm) | PERM_r________)
+
+static int shm_mount(struct libos_mount_params* params, void** mount_data) {
+    __UNUSED(mount_data);
+
+    if (!params->uri) {
+        log_error("Missing shared memory URI");
+        return -EINVAL;
+    }
+    if (!strstartswith(params->uri, URI_PREFIX_DEV)) {
+        log_error("'%s' is invalid shared memory URI (expected prefix %s)", params->uri,
+                  URI_PREFIX_DEV);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int shm_mmap(struct libos_handle* hdl, void* addr, size_t size, int prot, int flags,
+                    uint64_t offset) {
+    assert(hdl->type == TYPE_SHM);
+    assert(addr);
+
+    pal_prot_flags_t pal_prot = LINUX_PROT_TO_PAL(prot, flags);
+
+    if (flags & MAP_ANONYMOUS)
+        return -EINVAL;
+
+    int ret = PalStreamMap(hdl->pal_handle, addr, pal_prot, offset, size);
+    if (ret < 0)
+        return pal_to_unix_errno(ret);
+
+    return 0;
+}
+
+/* Open a PAL handle, and associate it with a LibOS handle. */
+static int shm_do_open(struct libos_handle* hdl, struct libos_dentry* dent, mode_t type,
+                       int flags, mode_t perm) {
+    assert(locked(&g_dcache_lock));
+
+    char* uri;
+    int ret = chroot_dentry_uri(dent, type, &uri);
+    if (ret < 0)
+        return ret;
+
+    PAL_HANDLE palhdl;
+    enum pal_access access = LINUX_OPEN_FLAGS_TO_PAL_ACCESS(flags);
+    enum pal_create_mode create = LINUX_OPEN_FLAGS_TO_PAL_CREATE(flags);
+    pal_stream_options_t options = LINUX_OPEN_FLAGS_TO_PAL_OPTIONS(flags);
+    mode_t host_perm = HOST_PERM(perm);
+    ret = PalStreamOpen(uri, access, host_perm, create, options, &palhdl);
+    if (ret < 0) {
+        ret = pal_to_unix_errno(ret);
+        goto out;
+    }
+
+    hdl->uri = uri;
+    uri = NULL;
+
+    hdl->type = TYPE_SHM;
+    hdl->pal_handle = palhdl;
+    ret = 0;
+
+out:
+    free(uri);
+    return ret;
+}
+
+static int shm_setup_dentry(struct libos_dentry* dent, mode_t type, mode_t perm,
+                            file_off_t size) {
+    assert(locked(&g_dcache_lock));
+    assert(!dent->inode);
+
+    struct libos_inode* inode = get_new_inode(dent->mount, type, perm);
+    if (!inode)
+        return -ENOMEM;
+    inode->size = size;
+    dent->inode = inode;
+    return 0;
+}
+
+static int shm_lookup(struct libos_dentry* dent) {
+    assert(locked(&g_dcache_lock));
+
+    char* uri = NULL;
+    /*
+     * We don't know the file type yet, so we can't construct a PAL URI with the right prefix.
+     * However, "file:" prefix is good enough here: `PalStreamAttributesQuery` will access the file
+     * and report the right file type.
+     */
+    int ret = chroot_dentry_uri(dent, S_IFREG, &uri);
+    if (ret < 0)
+        goto out;
+
+    PAL_STREAM_ATTR pal_attr;
+    ret = PalStreamAttributesQuery(uri, &pal_attr);
+    if (ret < 0) {
+        ret = pal_to_unix_errno(ret);
+        goto out;
+    }
+
+    mode_t type;
+    switch (pal_attr.handle_type) {
+        case PAL_TYPE_FILE: /* Regular files in shm file system are device files. */
+        case PAL_TYPE_DEV:
+            type = S_IFCHR;
+            break;
+        case PAL_TYPE_DIR:
+            /* Subdirectories (e.g. /dev/shm/subdir/) are not allowed in shm file system. */
+            if (dent != dent->mount->root) {
+                log_warning("trying to access '%s' which is a subdirectory of shared memory mount",
+                            uri);
+                ret = -EACCES;
+                goto out;
+            }
+            type = S_IFDIR;
+            break;
+        default:
+            log_error("unexpected handle type returned by PAL: %d", pal_attr.handle_type);
+            BUG();
+    }
+
+    file_off_t size = (type == S_IFCHR ? pal_attr.pending_size : 0);
+
+    ret = shm_setup_dentry(dent, type, pal_attr.share_flags, size);
+out:
+    free(uri);
+    return ret;
+}
+
+static int shm_open(struct libos_handle* hdl, struct libos_dentry* dent, int flags) {
+    assert(locked(&g_dcache_lock));
+    assert(dent->inode);
+
+    return shm_do_open(hdl, dent, dent->inode->type, flags, /*perm=*/0);
+}
+
+static int shm_creat(struct libos_handle* hdl, struct libos_dentry* dent, int flags, mode_t perm) {
+    assert(locked(&g_dcache_lock));
+    assert(!dent->inode);
+
+    mode_t type = S_IFCHR;
+    int ret = shm_do_open(hdl, dent, type, flags | O_CREAT | O_EXCL, perm);
+    if (ret < 0)
+        return ret;
+
+    return shm_setup_dentry(dent, type, perm, /*size=*/0);
+}
+
+struct libos_fs_ops shm_fs_ops = {
+    .mount      = shm_mount,
+    /* .read and .write are intentionally not supported according to POSIX shared memory API. */
+    .mmap       = shm_mmap,
+    .hstat      = generic_inode_hstat,
+    .truncate   = generic_truncate,
+};
+
+struct libos_d_ops shm_d_ops = {
+    .open    = shm_open,
+    .lookup  = shm_lookup,
+    .creat   = shm_creat,
+    .stat    = generic_inode_stat,
+    .unlink  = chroot_unlink,
+};
+
+struct libos_fs shm_builtin_fs = {
+    .name   = "untrusted_shm",
+    .fs_ops = &shm_fs_ops,
+    .d_ops  = &shm_d_ops,
+};

--- a/libos/src/meson.build
+++ b/libos/src/meson.build
@@ -37,6 +37,7 @@ libos_sources = files(
     'fs/proc/info.c',
     'fs/proc/ipc_thread.c',
     'fs/proc/thread.c',
+    'fs/shm/fs.c',
     'fs/socket/fs.c',
     'fs/sys/cache_info.c',
     'fs/sys/cpu_info.c',

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -117,6 +117,9 @@ tests = {
     'shared_object': {
         'pie': true,
     },
+    'shm': {
+        'link_args': '-lrt',
+    },
     'sid': {},
     'sigaction_per_process': {},
     'sigaltstack': {},

--- a/libos/test/regression/shm.c
+++ b/libos/test/regression/shm.c
@@ -1,0 +1,67 @@
+#define _XOPEN_SOURCE 700
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#define SHMNAME "/shm_test"
+#define CREATE_MODE 0666
+#define FILE_SIZE (4096 * 4)
+
+static const char g_shared_text[] = "test_text";
+
+static void write_shm(void) {
+    int fd = CHECK(shm_open(SHMNAME, O_RDWR | O_CREAT | O_EXCL, CREATE_MODE));
+    CHECK(ftruncate(fd, FILE_SIZE));
+
+    void* addr = mmap(NULL, FILE_SIZE, PROT_WRITE, MAP_SHARED, fd, 0);
+    if (addr == MAP_FAILED) {
+        err(1, "mmap failed");
+    }
+    memcpy(addr, g_shared_text, sizeof(g_shared_text));
+
+    CHECK(munmap(addr, FILE_SIZE));
+    CHECK(close(fd));
+}
+
+static void read_shm(void) {
+    int fd = CHECK(shm_open(SHMNAME, O_RDONLY, 0));
+
+    void* addr = mmap(NULL, FILE_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+    if (addr == MAP_FAILED) {
+        err(1, "mmap failed");
+    }
+
+    if (memcmp(addr, g_shared_text, sizeof(g_shared_text))) {
+        errx(1, "memcmp failed");
+    }
+    CHECK(munmap(addr, FILE_SIZE));
+    CHECK(close(fd));
+    CHECK(shm_unlink(SHMNAME));
+}
+
+int main(void) {
+    pid_t p = CHECK(fork());
+    if (p == 0) {
+        write_shm();
+        return 0;
+    }
+
+    /* parent waits for child termination */
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+        errx(1, "child wait status: %#x", status);
+    }
+    read_shm();
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/shm.manifest.template
+++ b/libos/test/regression/shm.manifest.template
@@ -1,0 +1,23 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+  { type = "untrusted_shm", path = "/dev/shm", uri = "dev:/dev/shm" },
+]
+
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.allowed_files = [
+  "dev:/dev/shm/shm_test",
+]
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1247,6 +1247,11 @@ class TC_40_FileSystem(RegressionTestCase):
         stdout, _ = self.run_binary(['synthetic'])
         self.assertIn("TEST OK", stdout)
 
+    def test_070_shm(self):
+        if os.path.exists('/dev/shm/shm_test'):
+            os.remove('/dev/shm/shm_test')
+        stdout, _ = self.run_binary(['shm'])
+        self.assertIn("TEST OK", stdout)
 
 class TC_50_GDB(RegressionTestCase):
     def setUp(self):

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -102,6 +102,7 @@ manifests = [
   "shared_object",
   "shadow_pseudo_fs",
   "shebang_test_script",
+  "shm",
   "sid",
   "sigaction_per_process",
   "sigaltstack",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -103,6 +103,7 @@ manifests = [
   "send_handle",
   "shadow_pseudo_fs",
   "shared_object",
+  "shm",
   "sid",
   "sigaction_per_process",
   "sigaltstack",

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -149,6 +149,8 @@ struct pal_public_state {
     void* memory_address_end;               /*!< usable memory end address */
     uintptr_t early_libos_mem_range_start;  /*!< start of memory usable before checkpoint restore */
     uintptr_t early_libos_mem_range_end;    /*!< end of memory usable before checkpoint restore */
+    void* shared_address_start;             /*!< usable shared memory start address */
+    void* shared_address_end;               /*!< usable shared memory end address */
 
     struct pal_initial_mem_range* initial_mem_ranges; /*!< array of initial memory ranges, see
                                                            `pal_memory.c` for more details */

--- a/pal/src/host/linux-sgx/pal_linux_defs.h
+++ b/pal/src/host/linux-sgx/pal_linux_defs.h
@@ -40,3 +40,10 @@ static_assert(SSA_XSAVE_SIZE_MAX + /* GPRs size in SSA */176 <= SSA_FRAME_SIZE -
 
 #define MAX_ARGS_SIZE 10000000
 #define MAX_ENV_SIZE  10000000
+
+/*
+ * The address should be in untrusted memory (outside of enclave), and should not overlap with the
+ * ASan shadow memory area (see `asan.h`) or DBGINFO_ADDR (see `sgx_gdb.h`).
+ */
+#define SHARED_ADDR_MIN 0x400000000000ULL /* 64TB */
+#define SHARED_MEM_SIZE 0x10000000000ULL  /* 1TB */

--- a/pal/src/host/linux/pal_memory.c
+++ b/pal/src/host/linux/pal_memory.c
@@ -211,6 +211,9 @@ int init_memory_bookkeeping(void) {
     g_pal_public_state.memory_address_start = (void*)start_addr;
     g_pal_public_state.memory_address_end = (void*)end_addr;
 
+    g_pal_public_state.shared_address_start = g_pal_public_state.memory_address_start;
+    g_pal_public_state.shared_address_end = g_pal_public_state.memory_address_end;
+
     g_vdso_start = proc_maps_info.vdso_start;
     g_vdso_end = proc_maps_info.vdso_end;
     return 0;

--- a/pal/src/host/skeleton/pal_devices.c
+++ b/pal/src/host/skeleton/pal_devices.c
@@ -48,12 +48,18 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
+static int dev_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,
+                   uint64_t size) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
 struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .destroy        = &dev_destroy,
     .delete         = &dev_delete,
+    .map            = &dev_map,
     .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,


### PR DESCRIPTION
## Description of the changes
As description in [RFC](https://github.com/gramineproject/gramine/issues/757), I aim to add new manifest syntax item `sys.insecure__shared_memory = "[none|passthrough]"`. to support Libc call `shm_open` and `shm_unlink` , which are required in communication with devices.
When `passthrough` is specified, Gramine mounts `/dev/shm/` on host to `/dev/shm/`, which is folder contains shared memory file. Since `/dev/shm/` on host is tmpfs, when a file is created in the folder, shared memory is created in untrusted memory, and accessible by its child, another Gramine or native process. Files under ``/dev/shm/`` support read-write pass-through mmap. 

 A new memory address range `shared_address_start/end` is introduced. The range default starts at `128TB` in Linux-SGX Pal to avoid overlapping and its size is `1TB`. The range is also managed by vma bookkeep.

Fixes #757 
Fixes #353 

## How to test this PR? <!-- (if applicable) -->
New LibOS regression tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/827)
<!-- Reviewable:end -->
