### PR TITLE
[LibOS] Enhance logging of `bind` syscall

### DIFF
--- a/libos/src/libos_parser.c
+++ b/libos/src/libos_parser.c
@@ -158,7 +158,7 @@ struct parser_table {
     [__NR_shutdown] = {.slow = false, .name = "shutdown", .parser = {parse_long_arg,
                        parse_integer_arg, parse_integer_arg}},
     [__NR_bind] = {.slow = false, .name = "bind", .parser = {parse_long_arg, parse_integer_arg,
-                   parse_pointer_arg, parse_integer_arg}},
+                   parse_sockaddr, parse_integer_arg}},
     [__NR_listen] = {.slow = false, .name = "listen", .parser = {parse_long_arg, parse_integer_arg,
                      parse_integer_arg}},
     [__NR_getsockname] = {.slow = false, .name = "getsockname", .parser = {parse_long_arg,
@@ -1130,19 +1130,18 @@ static void parse_sockaddr(struct print_buf* buf, va_list* ap) {
         case AF_INET: {
             struct sockaddr_in* a = (void*)addr;
             unsigned char* ip     = (void*)&a->sin_addr.s_addr;
-            buf_printf(buf, "{family=INET,ip=%u.%u.%u.%u,port=htons(%u)}", ip[0], ip[1], ip[2], ip[3],
-                   __ntohs(a->sin_port));
+            buf_printf(buf, "{family=IPv4,ip=%u.%u.%u.%u,port=%u}", ip[0], ip[1], ip[2], ip[3],
+                       __ntohs(a->sin_port));
             break;
         }
 
         case AF_INET6: {
             struct sockaddr_in6* a = (void*)addr;
             unsigned short* ip     = (void*)&a->sin6_addr.s6_addr;
-            buf_printf(buf,
-                "{family=INET,ip=[%x:%x:%x:%x:%x:%x:%x:%x],"
-                "port=htons(%u)}",
-                __ntohs(ip[0]), __ntohs(ip[1]), __ntohs(ip[2]), __ntohs(ip[3]), __ntohs(ip[4]),
-                __ntohs(ip[5]), __ntohs(ip[6]), __ntohs(ip[7]), __ntohs(a->sin6_port));
+            buf_printf(buf, "{family=IPv6,ip=[%x:%x:%x:%x:%x:%x:%x:%x],port=%u}",
+                       __ntohs(ip[0]), __ntohs(ip[1]), __ntohs(ip[2]), __ntohs(ip[3]),
+                       __ntohs(ip[4]), __ntohs(ip[5]), __ntohs(ip[6]), __ntohs(ip[7]),
+                       __ntohs(a->sin6_port));
             break;
         }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Parse and print `sockaddr` in log of bind syscall. for example:
```
trace: ---- bind(6, {family=INET6,ip=[0:0:0:0:0:0:0:0],port=htons(29501)}, 28) = 0x0
```
Also change `family=INET` to `family=INET6` in log of `bind` and `connect` when it's `AF_INET6`.
## How to test this PR? <!-- (if applicable) -->
Straightforward change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/829)
<!-- Reviewable:end -->
