### PR TITLE
[LibOS] Define `locked` function only in debug builds

### DIFF
--- a/libos/include/libos_lock.h
+++ b/libos/include/libos_lock.h
@@ -47,9 +47,11 @@ static inline void unlock(struct libos_lock* l) {
     PalEventSet(l->lock);
 }
 
+#ifdef DEBUG
 static inline bool locked(struct libos_lock* l) {
     if (!l->lock) {
         return false;
     }
     return get_cur_tid() == l->owner;
 }
+#endif // DEBUG


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This function is meant to be used only in `assert`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/834)
<!-- Reviewable:end -->
