### PR TITLE
[LibOS] Release POSIX file locks on fds with `CLOEXEC` flag on `execve`

### DIFF
--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -269,6 +269,7 @@ struct libos_handle* __detach_fd_handle(struct libos_fd_handle* fd, int* flags,
                                         struct libos_handle_map* map);
 struct libos_handle* detach_fd_handle(uint32_t fd, int* flags, struct libos_handle_map* map);
 void detach_all_fds(void);
+void close_cloexec_handles(struct libos_handle_map* map);
 
 /* manage handle mapping */
 int dup_handle_map(struct libos_handle_map** new_map, struct libos_handle_map* old_map);

--- a/libos/src/sys/libos_exec.c
+++ b/libos/src/sys/libos_exec.c
@@ -15,18 +15,6 @@
 #include "libos_vma.h"
 #include "pal.h"
 
-static int close_on_exec(struct libos_fd_handle* fd_hdl, struct libos_handle_map* map) {
-    if (fd_hdl->flags & FD_CLOEXEC) {
-        struct libos_handle* hdl = __detach_fd_handle(fd_hdl, NULL, map);
-        put_handle(hdl);
-    }
-    return 0;
-}
-
-static int close_cloexec_handle(struct libos_handle_map* map) {
-    return walk_handle_map(&close_on_exec, map);
-}
-
 /* new_argp: pointer to beginning of first stack frame (argc, argv[0], ...)
  * new_auxv: pointer inside first stack frame (auxv[0], auxv[1], ...) */
 noreturn static void __libos_syscall_execve_rtld(void* new_argp, elf_auxv_t* new_auxv) {
@@ -102,8 +90,7 @@ static int libos_syscall_execve_rtld(struct libos_handle* hdl, char** argv,
     struct libos_thread* cur_thread = get_cur_thread();
     int ret;
 
-    if ((ret = close_cloexec_handle(cur_thread->handle_map)) < 0)
-        return ret;
+    close_cloexec_handles(cur_thread->handle_map);
 
     lock(&g_process.fs_lock);
     put_handle(g_process.exec);

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -40,6 +40,7 @@ sgx.trusted_files = [
   "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:{{ binary_dir }}/exec_victim",
   "file:/bin/sh",
+  "file:/bin/sleep",
 ]
 
 sgx.insecure__protected_files_key = "ffeeddccbbaa99887766554433221100"


### PR DESCRIPTION
Quickly adapted from a previous PR.

Resolves https://github.com/gramineproject/gramine/issues/836.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/837)
<!-- Reviewable:end -->
