### PR TITLE
[LibOS] fix `ioctl(FIONCLEX/FIONCLEX)` syscall

### DIFF
--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -47,7 +47,7 @@ struct libos_handle* get_new_socket_handle(int family, int type, int protocol,
 
     handle->type = TYPE_SOCK;
     handle->fs = &socket_builtin_fs;
-    handle->flags = is_nonblocking ? O_NONBLOCK : 0;
+    handle->flags = O_RDWR | (is_nonblocking ? O_NONBLOCK : 0);
     handle->acc_mode = MAY_READ | MAY_WRITE;
 
     struct libos_sock_handle* sock = &handle->info.sock;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
`ioctl(FIONCLEX/FIONCLEX)` should update flags in `libos_fd_handle` instead of `libos_handle`. `O_CLOEXEC` flag is only handled in `libos_fd_handle`. 

Also add `O_RDWR` to flags of `libos_handle` for socket.

Now `ioctl(FIONCLEX/FIONCLEX)` and `fcntl(F_GETFD/F_SETFD/F_GETFL/F_SETFL)` have expected behavior and return value.

Fixes #819

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/842)
<!-- Reviewable:end -->
