### PR TITLE
[CI-Examples]Modify ra_tls_mbedtls' Makefile to enable it in Anolis OS

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -1,7 +1,16 @@
 GRAMINEDIR ?= ../..
-GRAMINE_PKGLIBDIR ?= /usr/lib/x86_64-linux-gnu/gramine # this is debian/ubuntu specific
-
+OS_TYPE ?= $(shell cat /etc/os-release | grep -w NAME)
+ifeq ($(findstring Ubuntu, $(OS_TYPE)),Ubuntu)
+GRAMINE_PKGLIBDIR ?= /usr/lib/x86_64-linux-gnu/gramine
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+else
+ifeq ($(findstring Anolis OS,$(OS_TYPE)),Anolis OS)
+GRAMINE_PKGLIBDIR ?= /usr/lib64/gramine
+ARCH_LIBDIR ?= /lib64
+else
+echo "Unsupported operation system!"
+endif
+endif
 
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug


### PR DESCRIPTION
Signed-off-by: Liang, Ma <liang3.ma@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

1. When we configure gramine in [Anolis OS](https://openanolis.cn/), The[ ra_tls_mbedtls](https://github.com/gramineproject/gramine/tree/master/CI-Examples/ra-tls-mbedtls) under CI-Example can't work correctly. This is caused by the [Makefile](https://github.com/gramineproject/gramine/blob/master/CI-Examples/ra-tls-mbedtls/Makefile) is debian/ubuntu specific, so I think we can modify it to fit different operating systems.
2. In ubuntu the `ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)`, while in Anolis OS it should be `/usr/lib64`

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/843)
<!-- Reviewable:end -->
