### PR TITLE
[LibOS] Append `handle::uri` to GDB link map only when it's set

### DIFF
--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -1034,7 +1034,8 @@ int register_library(const char* name, unsigned long load_address) {
         return err;
     }
 
-    append_r_debug(hdl->uri, (void*)load_address);
+    if (hdl->uri)
+        append_r_debug(hdl->uri, (void*)load_address);
     put_handle(hdl);
     return 0;
 }


### PR DESCRIPTION
LibOS codebase doesn't require `handle::uri` to be set. Appending NULL URI directly to GDB link map will lead to an unexpected memory fault occurred inside PAL.

This patch appends `handle::uri` to GDB link map only when it's set.

Fixes #840.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/845)
<!-- Reviewable:end -->
