### PR TITLE
[LibOS] Support `/sys/devices/system/node/nodeX/meminfo` files

### DIFF
--- a/libos/include/libos_fs_pseudo.h
+++ b/libos/include/libos_fs_pseudo.h
@@ -235,6 +235,7 @@ bool sys_resource_name_exists(struct libos_dentry* parent, const char* name);
 int sys_resource_list_names(struct libos_dentry* parent, readdir_callback_t callback, void* arg);
 int sys_node_general_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int sys_node_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
+int sys_node_meminfo_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int sys_cpu_general_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int sys_cpu_load_online(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int sys_cpu_load_topology(struct libos_dentry* dent, char** out_data, size_t* out_size);

--- a/libos/src/fs/sys/fs.c
+++ b/libos/src/fs/sys/fs.c
@@ -251,6 +251,7 @@ static void init_node_dir(struct pseudo_node* node) {
 
     pseudo_add_str(nodeX, "cpumap", &sys_node_load);
     pseudo_add_str(nodeX, "distance", &sys_node_load);
+    pseudo_add_str(nodeX, "meminfo", &sys_node_meminfo_load);
 
     // TODO(mkow): Does this show up for offline nodes? I never succeeded in shutting down one, even
     // after shutting down all CPUs inside the node it shows up as online on `node/online` list.


### PR DESCRIPTION
Gramine currently doesn't emulate `/sys/devices/system/node/nodeX/meminfo` files. This will lead to some workload failures due to these missing NUMA node meminfo files.

This patch adds basic support for the above usage by simply "mimicking" a typical environment where each NUMA node returns:
- NodeMemTotal = PalMemTotal / numa_nodes_cnt
- NodeMemFree = PalMemAvailable / numa_nodes_cnt

Resolves https://github.com/gramineproject/gramine/issues/364.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/847)
<!-- Reviewable:end -->
