### PR TITLE
[PAL] Remove redundant PAL APIs

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -203,9 +203,6 @@ applications.
 .. doxygenfunction:: PalStreamAttributesSetByHandle
    :project: pal
 
-.. doxygenfunction:: PalStreamGetName
-   :project: pal
-
 .. doxygenfunction:: PalStreamChangeName
    :project: pal
 

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -290,7 +290,7 @@ static ssize_t chroot_read(struct libos_handle* hdl, void* buf, size_t count, fi
     assert(hdl->type == TYPE_CHROOT);
 
     size_t actual_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, *pos, &actual_count, buf, /*source=*/NULL, /*size=*/0);
+    int ret = PalStreamRead(hdl->pal_handle, *pos, &actual_count, buf);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -306,7 +306,7 @@ static ssize_t chroot_write(struct libos_handle* hdl, const void* buf, size_t co
     assert(hdl->type == TYPE_CHROOT);
 
     size_t actual_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, *pos, &actual_count, (void*)buf, /*dest=*/NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, *pos, &actual_count, (void*)buf);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -375,7 +375,7 @@ int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void*
 
     while (true) {
         size_t read_size = buf_size;
-        ret = PalStreamRead(palhdl, /*offset=*/0, &read_size, buf, /*source=*/NULL, /*size=*/0);
+        ret = PalStreamRead(palhdl, /*offset=*/0, &read_size, buf);
         if (ret < 0) {
             ret = pal_to_unix_errno(ret);
             goto out;

--- a/libos/src/fs/eventfd/fs.c
+++ b/libos/src/fs/eventfd/fs.c
@@ -20,7 +20,7 @@ static ssize_t eventfd_read(struct libos_handle* hdl, void* buf, size_t count, f
         return -EINVAL;
 
     size_t orig_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, NULL, 0);
+    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/true, ret == 0 ? count < orig_count : false);
     if (ret < 0) {
@@ -38,7 +38,7 @@ static ssize_t eventfd_write(struct libos_handle* hdl, const void* buf, size_t c
         return -EINVAL;
 
     size_t orig_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/false, ret == 0 ? count < orig_count : false);
     if (ret < 0) {

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -27,8 +27,7 @@ static pf_status_t cb_read(pf_handle_t handle, void* buffer, uint64_t offset, si
 
     while (remaining > 0) {
         size_t count = remaining;
-        int ret = PalStreamRead(pal_handle, offset + buffer_offset, &count, buffer + buffer_offset,
-                                /*source=*/NULL, /*size=*/0);
+        int ret = PalStreamRead(pal_handle, offset + buffer_offset, &count, buffer + buffer_offset);
         if (ret == -PAL_ERROR_INTERRUPTED)
             continue;
 
@@ -58,7 +57,7 @@ static pf_status_t cb_write(pf_handle_t handle, const void* buffer, uint64_t off
     while (remaining > 0) {
         size_t count = remaining;
         int ret = PalStreamWrite(pal_handle, offset + buffer_offset, &count,
-                                 (void*)(buffer + buffer_offset), /*dest=*/NULL);
+                                 (void*)(buffer + buffer_offset));
         if (ret == -PAL_ERROR_INTERRUPTED)
             continue;
 

--- a/libos/src/fs/pipe/fs.c
+++ b/libos/src/fs/pipe/fs.c
@@ -92,7 +92,7 @@ static ssize_t pipe_read(struct libos_handle* hdl, void* buf, size_t count, file
         return -EACCES;
 
     size_t orig_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, NULL, 0);
+    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/true, ret == 0 ? count < orig_count : false);
     if (ret < 0) {
@@ -111,7 +111,7 @@ static ssize_t pipe_write(struct libos_handle* hdl, const void* buf, size_t coun
         return -EACCES;
 
     size_t orig_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/false, ret == 0 ? count < orig_count : false);
     if (ret < 0) {

--- a/libos/src/ipc/libos_ipc_worker.c
+++ b/libos/src/ipc/libos_ipc_worker.c
@@ -136,7 +136,7 @@ static int receive_ipc_messages(struct libos_ipc_connection* conn) {
         /* Receive at least the message header. */
         while (size < sizeof(buf.msg_header)) {
             size_t tmp_size = sizeof(buf) - size;
-            int ret = PalStreamRead(conn->handle, /*offset=*/0, &tmp_size, buf.buf + size, NULL, 0);
+            int ret = PalStreamRead(conn->handle, /*offset=*/0, &tmp_size, buf.buf + size);
             if (ret < 0) {
                 if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                     continue;

--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -74,7 +74,7 @@ int set_pollable_event(struct libos_pollable_event* event) {
     do {
         char c = 0;
         size_t size = sizeof(c);
-        ret = PalStreamWrite(event->write_handle, /*offset=*/0, &size, &c, /*dest=*/NULL);
+        ret = PalStreamWrite(event->write_handle, /*offset=*/0, &size, &c);
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;
@@ -97,7 +97,7 @@ int clear_pollable_event(struct libos_pollable_event* event) {
     do {
         char buf[0x100];
         size_t size = sizeof(buf);
-        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf, NULL, 0);
+        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf);
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;

--- a/libos/src/libos_utils.c
+++ b/libos/src/libos_utils.c
@@ -11,7 +11,7 @@ int read_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t read = 0;
     while (read < size) {
         size_t tmp_read = size - read;
-        int ret = PalStreamRead(handle, /*offset=*/0, &tmp_read, (char*)buf + read, NULL, 0);
+        int ret = PalStreamRead(handle, /*offset=*/0, &tmp_read, (char*)buf + read);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 continue;
@@ -29,7 +29,7 @@ int write_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t written = 0;
     while (written < size) {
         size_t tmp_written = size - written;
-        int ret = PalStreamWrite(handle, /*offset=*/0, &tmp_written, (char*)buf + written, NULL);
+        int ret = PalStreamWrite(handle, /*offset=*/0, &tmp_written, (char*)buf + written);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 continue;

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -360,7 +360,7 @@ static int send(struct libos_handle* handle, struct iovec* iov, size_t iov_len, 
         /* `size` is already correct. */
     }
 
-    int ret = PalStreamWrite(pal_handle, /*offset=*/0, &size, buf, NULL);
+    int ret = PalStreamWrite(pal_handle, /*offset=*/0, &size, buf);
     free(backing_buf);
     if (ret < 0) {
         return (ret == -PAL_ERROR_TOOLONG) ? -EMSGSIZE : pal_to_unix_errno(ret);
@@ -415,7 +415,7 @@ static int recv(struct libos_handle* handle, struct iovec* iov, size_t iov_len, 
         /* `size` is already correct. */
     }
 
-    int ret = PalStreamRead(pal_handle, /*offset=*/0, &size, buf, NULL, 0);
+    int ret = PalStreamRead(pal_handle, /*offset=*/0, &size, buf);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
     } else {

--- a/libos/src/sys/libos_eventfd.c
+++ b/libos/src/sys/libos_eventfd.c
@@ -57,7 +57,7 @@ static int create_eventfd(PAL_HANDLE* efd, uint64_t initial_count, int flags) {
 
     /* set the initial count */
     size_t write_size = sizeof(initial_count);
-    ret = PalStreamWrite(hdl, /*offset=*/0, &write_size, &initial_count, /*dest=*/NULL);
+    ret = PalStreamWrite(hdl, /*offset=*/0, &write_size, &initial_count);
     if (ret < 0) {
         log_error("eventfd: failed to set initial count");
         return pal_to_unix_errno(ret);

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -28,9 +28,6 @@ typedef struct toml_table_t toml_table_t;
 
 typedef uint32_t    PAL_IDX; /*!< an index */
 
-/* maximum length of pipe/FIFO name (should be less than Linux sockaddr_un.sun_path = 108) */
-#define PIPE_NAME_MAX 96
-
 /* maximum length of URIs */
 #define URI_MAX 4096
 
@@ -312,17 +309,13 @@ int PalStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_opt
  * \param[in,out] count   Contains size of \p buffer. On success, will be set to the number of bytes
  *                        read.
  * \param         buffer  Pointer to the buffer to read into.
- * \param[out]    source  If \p handle is a UDP socket, \p size is not zero and \p source is not
- *                        NULL, the remote socket address is returned in it.
- * \param         size    Size of the \p source buffer.
  *
  * \returns 0 on success, negative error code on failure.
  *
  * If \p handle is a directory, PalStreamRead fills the buffer with the null-terminated names of the
  * directory entries.
  */
-int PalStreamRead(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer, char* source,
-                  size_t size);
+int PalStreamRead(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer);
 
 /*!
  * \brief Write data to an open stream.
@@ -333,12 +326,10 @@ int PalStreamRead(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffe
  * \param[in,out] count   Contains size of \p buffer. On success, will be set to the number of bytes
  *                        written.
  * \param         buffer  Pointer to the buffer to write from.
- * \param         dest    If the handle is a UDP socket, specifies the remote socket address.
  *
  * \returns 0 on success, negative error code on failure.
  */
-int PalStreamWrite(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer,
-                   const char* dest);
+int PalStreamWrite(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer);
 
 enum pal_delete_mode {
     PAL_DELETE_ALL,  /*!< delete the whole resource / shut down both directions */
@@ -455,11 +446,6 @@ int PalStreamAttributesQueryByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr);
  * mutual exclusion).
  */
 int PalStreamAttributesSetByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr);
-
-/*!
- * \brief Query the name of an open stream. On success `buffer` contains a null-terminated string.
- */
-int PalStreamGetName(PAL_HANDLE handle, char* buffer, size_t size);
 
 /*!
  * \brief This API changes the name of an open stream.

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -35,16 +35,9 @@ struct pal_common_state {
 extern struct pal_common_state g_pal_common_state;
 extern struct pal_public_state g_pal_public_state;
 
-// TODO: clean unused stuff
 /* handle_ops is the operators provided for each handler type. They are mostly used by
  * stream-related PAL calls, but can also be used by some others in special ways. */
 struct handle_ops {
-    /* 'getrealpath' return the real path that represent the handle */
-    const char* (*getrealpath)(PAL_HANDLE handle);
-
-    /* 'getname' is used by PalStreamGetName. It's different from 'getrealpath' */
-    int (*getname)(PAL_HANDLE handle, char* buffer, size_t count);
-
     /* 'open' is used by PalStreamOpen. 'handle' is a preallocated handle, 'type' will be a
      * normalized prefix, 'uri' is the remaining string of uri. access, share, create, and options
      * follow the same flags defined for PalStreamOpen in pal.h. */
@@ -55,13 +48,6 @@ struct handle_ops {
      * prototype as them. */
     int64_t (*read)(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
     int64_t (*write)(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
-
-    /* 'readbyaddr' and 'writebyaddr' are the same as read and write, but with extra field to
-     * specify address */
-    int64_t (*readbyaddr)(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer,
-                          char* addr, size_t addrlen);
-    int64_t (*writebyaddr)(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer,
-                           const char* addr, size_t addrlen);
 
     /* 'close' and 'delete' is used by PalObjectClose and PalStreamDelete, 'close' will close the
      * stream, while 'delete' actually destroy the stream, such as deleting a file or shutting
@@ -184,10 +170,8 @@ int _PalStreamOpen(PAL_HANDLE* handle, const char* uri, enum pal_access access,
                    pal_share_flags_t share, enum pal_create_mode create,
                    pal_stream_options_t options);
 int _PalStreamDelete(PAL_HANDLE handle, enum pal_delete_mode delete_mode);
-int64_t _PalStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buf, char* addr,
-                       int addrlen);
-int64_t _PalStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buf,
-                        const char* addr, int addrlen);
+int64_t _PalStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buf);
+int64_t _PalStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buf);
 int _PalStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr);
 int _PalStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
 int _PalStreamMap(PAL_HANDLE handle, void** addr_ptr, pal_prot_flags_t prot, uint64_t offset,
@@ -195,8 +179,6 @@ int _PalStreamMap(PAL_HANDLE handle, void** addr_ptr, pal_prot_flags_t prot, uin
 int _PalStreamUnmap(void* addr, uint64_t size);
 int64_t _PalStreamSetLength(PAL_HANDLE handle, uint64_t length);
 int _PalStreamFlush(PAL_HANDLE handle);
-int _PalStreamGetName(PAL_HANDLE handle, char* buf, size_t size);
-const char* _PalStreamRealpath(PAL_HANDLE hdl);
 int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo);
 int _PalReceiveHandle(PAL_HANDLE source_process, PAL_HANDLE* out_cargo);
 

--- a/pal/regression/Directory.c
+++ b/pal/regression/Directory.c
@@ -20,7 +20,7 @@ int main(int argc, char** argv, char** envp) {
         }
 
         size_t bytes = sizeof(buffer);
-        ret = PalStreamRead(dir1, 0, &bytes, buffer, NULL, 0);
+        ret = PalStreamRead(dir1, 0, &bytes, buffer);
         if (ret >= 0 && bytes) {
             for (char* c = buffer; c < buffer + bytes; c += strlen(c) + 1)
                 if (strlen(c))

--- a/pal/regression/File.c
+++ b/pal/regression/File.c
@@ -32,19 +32,19 @@ int main(int argc, char** argv, char** envp) {
 
         /* test file read */
         size_t size = sizeof(buffer1);
-        ret = PalStreamRead(file1, 0, &size, buffer1, NULL, 0);
+        ret = PalStreamRead(file1, 0, &size, buffer1);
         if (ret == 0 && size == sizeof(buffer1)) {
             print_hex("Read Test 1 (0th - 40th): %s\n", buffer1, size);
         }
 
         size = sizeof(buffer1);
-        ret = PalStreamRead(file1, 0, &size, buffer1, NULL, 0);
+        ret = PalStreamRead(file1, 0, &size, buffer1);
         if (ret == 0 && size == sizeof(buffer1)) {
             print_hex("Read Test 2 (0th - 40th): %s\n", buffer1, size);
         }
 
         size = sizeof(buffer2);
-        ret = PalStreamRead(file1, 200, &size, buffer2, NULL, 0);
+        ret = PalStreamRead(file1, 200, &size, buffer2);
         if (ret == 0 && size == sizeof(buffer2)) {
             print_hex("Read Test 3 (200th - 240th): %s\n", buffer2, size);
         }
@@ -135,17 +135,17 @@ int main(int argc, char** argv, char** envp) {
         /* test file writing */
 
         size_t size = sizeof(buffer1);
-        ret = PalStreamWrite(file4, 0, &size, buffer1, NULL);
+        ret = PalStreamWrite(file4, 0, &size, buffer1);
         if (ret < 0)
             goto fail_writing;
 
         size = sizeof(buffer2);
-        ret = PalStreamWrite(file4, 0, &size, buffer2, NULL);
+        ret = PalStreamWrite(file4, 0, &size, buffer2);
         if (ret < 0)
             goto fail_writing;
 
         size = sizeof(buffer1);
-        ret = PalStreamWrite(file4, 200, &size, buffer1, NULL);
+        ret = PalStreamWrite(file4, 200, &size, buffer1);
         if (ret < 0)
             goto fail_writing;
 

--- a/pal/regression/File2.c
+++ b/pal/regression/File2.c
@@ -18,7 +18,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     size_t bytes = sizeof(str) - 1;
-    ret = PalStreamWrite(out, 0, &bytes, str, NULL);
+    ret = PalStreamWrite(out, 0, &bytes, str);
     if (ret < 0 || bytes != sizeof(str) - 1) {
         pal_printf("second PalStreamWrite failed\n");
         return 1;
@@ -36,7 +36,7 @@ int main(int argc, char** argv, char** envp) {
 
     bytes = sizeof(str);
     memset(str, 0, bytes);
-    ret = PalStreamRead(in, 0, &bytes, str, NULL, 0);
+    ret = PalStreamRead(in, 0, &bytes, str);
     if (ret < 0) {
         pal_printf("PalStreamRead failed\n");
         return 1;

--- a/pal/regression/HelloWorld.c
+++ b/pal/regression/HelloWorld.c
@@ -16,7 +16,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     size_t bytes = sizeof(str) - 1;
-    ret = PalStreamWrite(out, 0, &bytes, str, NULL);
+    ret = PalStreamWrite(out, 0, &bytes, str);
 
     if (ret < 0 || bytes != sizeof(str) - 1) {
         pal_printf("PalStreamWrite failed\n");

--- a/pal/regression/Pie.c
+++ b/pal/regression/Pie.c
@@ -16,7 +16,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     size_t bytes = sizeof(str) - 1;
-    ret = PalStreamWrite(out, 0, &bytes, str, NULL);
+    ret = PalStreamWrite(out, 0, &bytes, str);
 
     if (ret < 0 || bytes != sizeof(str) - 1) {
         pal_printf("PalStreamWrite failed\n");

--- a/pal/regression/Pipe.c
+++ b/pal/regression/Pipe.c
@@ -40,22 +40,22 @@ int main(int argc, char** argv, char** envp) {
                 pal_printf("Pipe Connection 1 OK\n");
 
                 size_t size = sizeof(buffer1);
-                ret = PalStreamWrite(pipe3, 0, &size, buffer1, NULL);
+                ret = PalStreamWrite(pipe3, 0, &size, buffer1);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Write 1 OK\n");
 
                 size = sizeof(buffer3);
-                ret = PalStreamRead(pipe2, 0, &size, buffer3, NULL, 0);
+                ret = PalStreamRead(pipe2, 0, &size, buffer3);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Read 1: %s\n", buffer3);
 
                 size = sizeof(buffer2);
-                ret = PalStreamWrite(pipe2, 0, &size, buffer2, NULL);
+                ret = PalStreamWrite(pipe2, 0, &size, buffer2);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Write 2 OK\n");
 
                 size = sizeof(buffer4);
-                ret = PalStreamRead(pipe3, 0, &size, buffer4, NULL, 0);
+                ret = PalStreamRead(pipe3, 0, &size, buffer4);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Read 2: %s\n", buffer4);
             }

--- a/pal/regression/Process.c
+++ b/pal/regression/Process.c
@@ -18,15 +18,15 @@ int main(int argc, char** argv, char** envp) {
         }
 
         size = sizeof(buffer1);
-        PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1, NULL);
+        PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1);
 
         size = sizeof(buffer1);
-        ret = PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1, NULL);
+        ret = PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1);
         if (ret == 0 && size > 0)
             pal_printf("Process Write 1 OK\n");
 
         size = sizeof(buffer4);
-        ret = PalStreamRead(PalGetPalPublicState()->parent_process, 0, &size, buffer4, NULL, 0);
+        ret = PalStreamRead(PalGetPalPublicState()->parent_process, 0, &size, buffer4);
         if (ret == 0 && size > 0)
             pal_printf("Process Read 2: %s\n", buffer4);
 
@@ -42,19 +42,19 @@ int main(int argc, char** argv, char** envp) {
             if (ret == 0 && children[i]) {
                 pal_printf("Process created %d\n", i + 1);
                 size = sizeof(buffer4);
-                PalStreamRead(children[i], 0, &size, buffer4, NULL, 0);
+                PalStreamRead(children[i], 0, &size, buffer4);
             }
         }
 
         for (int i = 0; i < 3; i++)
             if (children[i]) {
                 size = sizeof(buffer3);
-                ret = PalStreamRead(children[i], 0, &size, buffer3, NULL, 0);
+                ret = PalStreamRead(children[i], 0, &size, buffer3);
                 if (ret == 0 && size > 0)
                     pal_printf("Process Read 1: %s\n", buffer3);
 
                 size = sizeof(buffer2);
-                ret = PalStreamWrite(children[i], 0, &size, buffer2, NULL);
+                ret = PalStreamWrite(children[i], 0, &size, buffer2);
                 if (ret == 0 && size > 0)
                     pal_printf("Process Write 2 OK\n");
             }

--- a/pal/regression/Symbols.c
+++ b/pal/regression/Symbols.c
@@ -32,7 +32,6 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(PalStreamAttributesQuery);
     PRINT_SYMBOL(PalStreamAttributesQueryByHandle);
     PRINT_SYMBOL(PalStreamAttributesSetByHandle);
-    PRINT_SYMBOL(PalStreamGetName);
     PRINT_SYMBOL(PalStreamChangeName);
     PRINT_SYMBOL(PalStreamsWaitEvents);
 

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -14,7 +14,7 @@ static void write_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
             case PAL_TYPE_FILE:
             case PAL_TYPE_PIPE:
             case PAL_TYPE_PIPECLI:
-                CHECK(PalStreamWrite(handle, 0, &this_size, buf + i, NULL));
+                CHECK(PalStreamWrite(handle, 0, &this_size, buf + i));
                 break;
             case PAL_TYPE_SOCKET:;
                 struct pal_iovec iov = {
@@ -42,7 +42,7 @@ static void read_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
         switch (type) {
             case PAL_TYPE_FILE:
             case PAL_TYPE_PIPE:
-                CHECK(PalStreamRead(handle, 0, &this_size, buf + i, NULL, 0));
+                CHECK(PalStreamRead(handle, 0, &this_size, buf + i));
                 break;
             case PAL_TYPE_SOCKET:;
                 struct pal_iovec iov = {

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -153,7 +153,6 @@ class TC_02_Symbols(RegressionTestCase):
         'PalStreamAttributesQuery',
         'PalStreamAttributesQueryByHandle',
         'PalStreamAttributesSetByHandle',
-        'PalStreamGetName',
         'PalStreamChangeName',
         'PalThreadCreate',
         'PalThreadYieldExecution',

--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -341,21 +341,7 @@ int load_trusted_or_allowed_file(struct trusted_file* tf, PAL_HANDLE file, bool 
 
     if (create) {
         assert(tf->allowed);
-
-        char* uri = malloc(URI_MAX);
-        if (!uri)
-            return -PAL_ERROR_NOMEM;
-
-        ret = _PalStreamGetName(file, uri, URI_MAX);
-        if (ret < 0) {
-            free(uri);
-            return ret;
-        }
-
-        ret = register_file(uri, /*hash_str=*/NULL, /*check_duplicates=*/true);
-
-        free(uri);
-        return ret;
+        return register_file(tf->uri, /*hash_str=*/NULL, /*check_duplicates=*/true);
     }
 
     if (tf->allowed) {
@@ -966,7 +952,7 @@ int _PalStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* out_key,
         goto out;
 
     for (int64_t bytes = 0, total = 0; total < (int64_t)sizeof(my_public); total += bytes) {
-        bytes = _PalStreamWrite(stream, 0, sizeof(my_public) - total, my_public + total, NULL, 0);
+        bytes = _PalStreamWrite(stream, 0, sizeof(my_public) - total, my_public + total);
         if (bytes < 0) {
             if (bytes == -PAL_ERROR_INTERRUPTED || bytes == -PAL_ERROR_TRYAGAIN) {
                 bytes = 0;
@@ -978,8 +964,7 @@ int _PalStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* out_key,
     }
 
     for (int64_t bytes = 0, total = 0; total < (int64_t)sizeof(peer_public); total += bytes) {
-        bytes = _PalStreamRead(stream, 0, sizeof(peer_public) - total, peer_public + total, NULL,
-                               0);
+        bytes = _PalStreamRead(stream, 0, sizeof(peer_public) - total, peer_public + total);
         if (bytes < 0) {
             if (bytes == -PAL_ERROR_INTERRUPTED || bytes == -PAL_ERROR_TRYAGAIN) {
                 bytes = 0;
@@ -1058,7 +1043,7 @@ int _PalStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* my_report_data
 
     for (bytes = 0, ret = 0; bytes < SGX_TARGETINFO_FILLED_SIZE; bytes += ret) {
         ret = _PalStreamWrite(stream, 0, SGX_TARGETINFO_FILLED_SIZE - bytes,
-                              ((void*)&target_info) + bytes, NULL, 0);
+                              ((void*)&target_info) + bytes);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 ret = 0;
@@ -1071,7 +1056,7 @@ int _PalStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* my_report_data
 
     /* B -> A: report[B -> A] */
     for (bytes = 0, ret = 0; bytes < sizeof(report); bytes += ret) {
-        ret = _PalStreamRead(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes, NULL, 0);
+        ret = _PalStreamRead(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 ret = 0;
@@ -1110,7 +1095,7 @@ int _PalStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* my_report_data
     }
 
     for (bytes = 0, ret = 0; bytes < sizeof(report); bytes += ret) {
-        ret = _PalStreamWrite(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes, NULL, 0);
+        ret = _PalStreamWrite(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 ret = 0;
@@ -1148,7 +1133,7 @@ int _PalStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* my_report_data
     /* A -> B: targetinfo[A] */
     for (bytes = 0, ret = 0; bytes < SGX_TARGETINFO_FILLED_SIZE; bytes += ret) {
         ret = _PalStreamRead(stream, 0, SGX_TARGETINFO_FILLED_SIZE - bytes,
-                             ((void*)&target_info) + bytes, NULL, 0);
+                             ((void*)&target_info) + bytes);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 ret = 0;
@@ -1167,7 +1152,7 @@ int _PalStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* my_report_data
     }
 
     for (bytes = 0, ret = 0; bytes < sizeof(report); bytes += ret) {
-        ret = _PalStreamWrite(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes, NULL, 0);
+        ret = _PalStreamWrite(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 ret = 0;
@@ -1180,7 +1165,7 @@ int _PalStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* my_report_data
 
     /* A -> B: report[A -> B] */
     for (bytes = 0, ret = 0; bytes < sizeof(report); bytes += ret) {
-        ret = _PalStreamRead(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes, NULL, 0);
+        ret = _PalStreamRead(stream, 0, sizeof(report) - bytes, ((void*)&report) + bytes);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 ret = 0;

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -71,7 +71,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
 
     hdl->file.realpath = normpath;
 
-    struct trusted_file* tf   = NULL;
+    struct trusted_file* tf = NULL;
 
     if (!(pal_options & PAL_OPTION_PASSTHROUGH)) {
         tf = get_trusted_or_allowed_file(hdl->file.realpath);
@@ -461,27 +461,7 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     return 0;
 }
 
-static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    if (!handle->file.realpath)
-        return 0;
-
-    size_t len = strlen(handle->file.realpath);
-    char* tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
-
-    if (!tmp || buffer + count < tmp + len + 1)
-        return -PAL_ERROR_TOOLONG;
-
-    memcpy(tmp, handle->file.realpath, len + 1);
-    return tmp + len - buffer;
-}
-
-static const char* file_getrealpath(PAL_HANDLE handle) {
-    return handle->file.realpath;
-}
-
 struct handle_ops g_file_ops = {
-    .getname        = &file_getname,
-    .getrealpath    = &file_getrealpath,
     .open           = &file_open,
     .read           = &file_read,
     .write          = &file_write,
@@ -676,30 +656,7 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     return 0;
 }
 
-static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    if (!handle->dir.realpath)
-        return 0;
-
-    size_t len = strlen(handle->dir.realpath);
-    char* tmp  = strcpy_static(buffer, URI_PREFIX_DIR, count);
-
-    if (!tmp || buffer + count < tmp + len + 1)
-        return -PAL_ERROR_TOOLONG;
-
-    memcpy(tmp, handle->dir.realpath, len + 1);
-    return tmp + len - buffer;
-
-    if (len + 6 >= count)
-        return -PAL_ERROR_TOOLONG;
-}
-
-static const char* dir_getrealpath(PAL_HANDLE handle) {
-    return handle->dir.realpath;
-}
-
 struct handle_ops g_dir_ops = {
-    .getname        = &dir_getname,
-    .getrealpath    = &dir_getrealpath,
     .open           = &dir_open,
     .read           = &dir_read,
     .close          = &dir_close,

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -30,10 +30,6 @@ struct pal_handle_thread {
     void* param;
 };
 
-typedef struct {
-    char str[PIPE_NAME_MAX];
-} PAL_PIPE_NAME;
-
 /* RPC streams are encrypted with 256-bit AES keys */
 typedef uint8_t PAL_SESSION_KEY[32];
 
@@ -65,7 +61,6 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
-            PAL_PIPE_NAME name;
             bool nonblocking;
             bool is_server;
             PAL_SESSION_KEY session_key;

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -237,27 +237,7 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     return 0;
 }
 
-static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    if (!handle->file.realpath)
-        return 0;
-
-    size_t len = strlen(handle->file.realpath);
-    char* tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
-
-    if (!tmp || buffer + count < tmp + len + 1)
-        return -PAL_ERROR_TOOLONG;
-
-    memcpy(tmp, handle->file.realpath, len + 1);
-    return tmp + len - buffer;
-}
-
-static const char* file_getrealpath(PAL_HANDLE handle) {
-    return handle->file.realpath;
-}
-
 struct handle_ops g_file_ops = {
-    .getname        = &file_getname,
-    .getrealpath    = &file_getrealpath,
     .open           = &file_open,
     .read           = &file_read,
     .write          = &file_write,
@@ -452,27 +432,7 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     return 0;
 }
 
-static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    if (!handle->dir.realpath)
-        return 0;
-
-    size_t len = strlen(handle->dir.realpath);
-    char* tmp = strcpy_static(buffer, URI_PREFIX_DIR, count);
-
-    if (!tmp || buffer + count < tmp + len + 1)
-        return -PAL_ERROR_TOOLONG;
-
-    memcpy(tmp, handle->dir.realpath, len + 1);
-    return tmp + len - buffer;
-}
-
-static const char* dir_getrealpath(PAL_HANDLE handle) {
-    return handle->dir.realpath;
-}
-
 struct handle_ops g_dir_ops = {
-    .getname        = &dir_getname,
-    .getrealpath    = &dir_getrealpath,
     .open           = &dir_open,
     .read           = &dir_read,
     .close          = &dir_close,

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -17,10 +17,6 @@
 #include "spinlock.h"
 
 typedef struct {
-    char str[PIPE_NAME_MAX];
-} PAL_PIPE_NAME;
-
-typedef struct {
     /* TSAI: Here we define the internal types of PAL_HANDLE
      * in PAL design, user has not to access the content inside the
      * handle, also there is no need to allocate the internal
@@ -44,7 +40,6 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
-            PAL_PIPE_NAME name;
             bool nonblocking;
         } pipe;
 

--- a/pal/src/host/skeleton/pal_files.c
+++ b/pal/src/host/skeleton/pal_files.c
@@ -67,17 +67,7 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-static const char* file_getrealpath(PAL_HANDLE handle) {
-    return NULL;
-}
-
 struct handle_ops g_file_ops = {
-    .getname        = &file_getname,
-    .getrealpath    = &file_getrealpath,
     .open           = &file_open,
     .read           = &file_read,
     .write          = &file_write,
@@ -124,17 +114,7 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-static const char* dir_getrealpath(PAL_HANDLE handle) {
-    return NULL;
-}
-
 struct handle_ops g_dir_ops = {
-    .getname        = &dir_getname,
-    .getrealpath    = &dir_getrealpath,
     .open           = &dir_open,
     .read           = &dir_read,
     .close          = &dir_close,

--- a/pal/src/host/skeleton/pal_pipes.c
+++ b/pal/src/host/skeleton/pal_pipes.c
@@ -25,9 +25,6 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
 static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, enum pal_access access,
                      pal_share_flags_t share, enum pal_create_mode create,
                      pal_stream_options_t options) {
-    if (strlen(uri) + 1 > PIPE_NAME_MAX)
-        return -PAL_ERROR_INVAL;
-
     if (!strcmp(type, URI_TYPE_PIPE_SRV))
         return pipe_listen(handle, uri, options);
 
@@ -57,12 +54,7 @@ static int pipe_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int pipe_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 struct handle_ops g_pipe_ops = {
-    .getname       = &pipe_getname,
     .open          = &pipe_open,
     .waitforclient = &pipe_waitforclient,
     .read          = &pipe_read,

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -328,7 +328,7 @@ static int load_cstring_array(const char* uri, const char*** res) {
         ret = -PAL_ERROR_NOMEM;
         goto out_fail;
     }
-    ret = _PalStreamRead(hdl, 0, file_size, buf, NULL, 0);
+    ret = _PalStreamRead(hdl, 0, file_size, buf);
     if (ret < 0)
         goto out_fail;
     if (file_size > 0 && buf[file_size - 1] != '\0') {

--- a/pal/src/pal_symbols
+++ b/pal/src/pal_symbols
@@ -30,7 +30,6 @@ PalSocketRecv
 PalSendHandle
 PalReceiveHandle
 PalStreamWaitForClient
-PalStreamGetName
 PalStreamAttributesQueryByHandle
 PalStreamAttributesQuery
 PalProcessCreate


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commit removes:
- `source` and `size` arguments from `PalStreamRead`,
- `dest` argument from `PalStreamWrite`,
- `PalStreamGetName`.
It also removes PAL internal function `_PalStreamRealpath`.
All of the above were either redundant or not used at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/856)
<!-- Reviewable:end -->
