### PR TITLE
[PAL] Introduce `loader.argv` manifest option

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -116,12 +116,18 @@ or
 
 ::
 
+   loader.argv = ["arg0", "arg1", "arg2", ...]
+
+or
+
+::
+
    loader.argv_src_file = "file:file_with_serialized_argv"
 
 If you want your application to use commandline arguments you need to either set
-``loader.insecure__use_cmdline_argv`` (insecure in almost all cases) or point
-``loader.argv_src_file`` to a file containing output of
-:ref:`gramine-argv-serializer<gramine-argv-serializer>`.
+``loader.insecure__use_cmdline_argv`` (insecure in almost all cases), put them
+into ``loader.argv`` array or point ``loader.argv_src_file`` to a file
+containing output of :ref:`gramine-argv-serializer<gramine-argv-serializer>`.
 
 ``loader.argv_src_file`` is intended to point to either a trusted file or an
 encrypted file. The former allows to securely hardcode arguments (current
@@ -132,6 +138,9 @@ arguments to be provided at runtime from an external (trusted) source.
    Pointing to an encrypted file is currently not supported, due to the fact
    that encryption key provisioning currently happens after setting up
    arguments.
+
+The ``loader.insecure__use_cmdline_argv``, ``loader.argv``, and
+``loader.argv_src_file`` options are mutually exclusive.
 
 If none of the above arguments-handling manifest options is specified in the
 manifest, the application will get ``argv = [ <libos.entrypoint value> ]``.

--- a/libos/test/regression/argv_from_manifest.manifest.template
+++ b/libos/test/regression/argv_from_manifest.manifest.template
@@ -1,0 +1,28 @@
+{% set entrypoint = "bootstrap" -%}
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.argv = [
+  "{{ entrypoint }}",
+  "THIS",
+  "SHOULD GO",
+  "TO",
+  "THE",
+  "APP ", # note the trailing space (app should see this trailing space in its argv[5])
+]
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.nonpie_binary = true
+sgx.debug = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -170,6 +170,13 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('User Program Started', stdout)
         self.assertIn('Exception \'test runtime error\' caught', stdout)
 
+    def test_111_argv_from_manifest(self):
+        expected_argv = ['bootstrap', 'THIS', 'SHOULD GO', 'TO', 'THE', 'APP ']
+        stdout, _ = self.run_binary(['argv_from_manifest'])
+        self.assertIn(f'# of arguments: {len(expected_argv)}\n', stdout)
+        for i, arg in enumerate(expected_argv):
+            self.assertIn(f'argv[{i}] = {arg}\n', stdout)
+
     def test_200_exec(self):
         stdout, _ = self.run_binary(['exec'])
 

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -2,6 +2,7 @@ binary_dir = "@GRAMINE_PKGLIBDIR@/tests/libos/regression"
 
 manifests = [
   "argv_from_file",
+  "argv_from_manifest",
   "abort",
   "abort_multithread",
   "bootstrap",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -4,6 +4,7 @@ libc = "musl"
 
 manifests = [
   "argv_from_file",
+  "argv_from_manifest",
   "abort",
   "abort_multithread",
   "bootstrap",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR implements the `loader.argv` described in #761. In this issue @mkow raises the question about `loader.argv0_override` , however this option was recently removed by @dimakuv in f91a2c18370858701a33c00620b0c7954f6779bf.
The whole section was converted to use the table. This was done because currently Gramine version of tomlc99 doesn't support dot notation in `toml_array_in`.

Fixes #761.

## How to test this PR? <!-- (if applicable) -->

New tests was added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/858)
<!-- Reviewable:end -->
