### PR TITLE
[tests] Fix retval checks

### DIFF
--- a/libos/test/fs/common.c
+++ b/libos/test/fs/common.c
@@ -30,10 +30,11 @@ void read_fd(const char* path, int fd, void* buffer, size_t size) {
     off_t offset = 0;
     while (size > 0) {
         ssize_t ret = read(fd, buffer + offset, size);
-        if (ret == -EINTR)
-            continue;
-        if (ret < 0)
+        if (ret < 0) {
+            if (errno == EAGAIN || errno == EINTR)
+                continue;
             fatal_error("Failed to read file %s: %s\n", path, strerror(errno));
+        }
         if (ret == 0)
             break;
         size -= ret;
@@ -68,10 +69,11 @@ void write_fd(const char* path, int fd, const void* buffer, size_t size) {
     off_t offset = 0;
     while (size > 0) {
         ssize_t ret = write(fd, buffer + offset, size);
-        if (ret == -EINTR)
-            continue;
-        if (ret < 0)
+        if (ret < 0) {
+            if (errno == EAGAIN || errno == EINTR)
+                continue;
             fatal_error("Failed to write file %s: %s\n", path, strerror(errno));
+        }
         size -= ret;
         offset += ret;
     }
@@ -80,11 +82,12 @@ void write_fd(const char* path, int fd, const void* buffer, size_t size) {
 void sendfile_fd(const char* input_path, const char* output_path, int fi, int fo, size_t size) {
     while (size > 0) {
         ssize_t ret = sendfile(fo, fi, /*offset=*/NULL, size);
-        if (ret == -EAGAIN)
-            continue;
-        if (ret < 0)
+        if (ret < 0) {
+            if (errno == EAGAIN || errno == EINTR)
+                continue;
             fatal_error("Failed to sendfile from %s to %s: %s\n", input_path, output_path,
                         strerror(errno));
+        }
         size -= ret;
     }
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
All these functions use libc:
```
#0  __GI___libc_read (fd=3, buf=0x6c323d475010, nbytes=1048576) at ../sysdeps/unix/sysv/linux/read.c:25
#1  0x00006c323d8b1951 in read_fd (path=0x6c323d8f6ff4 "tmp/a", fd=3, buffer=0x6c323d475010, size=1048576) at ../libos/test/fs/common.c:32
#2  0x00006c323d8b1557 in read_write (file_path=0x6c323d8f6ff4 "tmp/a") at ../libos/test/fs/read_write.c:15
#3  0x00006c323d8b1741 in main (argc=3, argv=0x6c323d8f6ec8) at ../libos/test/fs/read_write.c:45
```

The return value for read(2)/write(2)/sendfile(2) should be -1 and errno should be set
to indicate the type of error.

Beside that:
- sendfile(2) should check if it wasn't interrupted,
- read(2) and write(2) aren't used with non-blocking fds, but because
  we are here, let's also verify the EAGAIN error.

## How to test this PR? <!-- (if applicable) -->

```
gramine-test -C libos/test/fs pytest
gramine-test --sgx -C libos/test/fs pytest
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/859)
<!-- Reviewable:end -->
