### PR TITLE
[Docs] Remove rule about matching .c and .h files

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -102,11 +102,11 @@ Code formatting
 
    Groups:
 
-   #. Matching :file:`.h` header for :file:`.c` files.
    #. Standard library headers.
    #. Non-standard headers not included in Gramine's repository (e.g. from
       external dependencies, like :file:`curl.h`).
-   #. Gramine's headers.
+   #. Gramine's headers (including matching :file:`.h` header for :file:`.c`
+      files).
 
 #. Assignments may be aligned when assigning some structurized data (e.g. struct
    members). Example::

--- a/libos/src/libos_checkpoint.c
+++ b/libos/src/libos_checkpoint.c
@@ -5,12 +5,11 @@
  * This file contains implementation of checkpoint and restore.
  */
 
-#include "libos_checkpoint.h"
-
 #include <asm/mman.h>
 #include <stdarg.h>
 #include <stdint.h>
 
+#include "libos_checkpoint.h"
 #include "libos_internal.h"
 #include "libos_ipc.h"
 #include "libos_process.h"

--- a/pal/src/host/linux-sgx/enclave_ecalls.c
+++ b/pal/src/host/linux-sgx/enclave_ecalls.c
@@ -1,8 +1,7 @@
-#include "enclave_ecalls.h"
-
 #include <stdalign.h>
 
 #include "api.h"
+#include "enclave_ecalls.h"
 #include "pal_ecall_types.h"
 #include "pal_linux.h"
 #include "pal_rpc_queue.h"

--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -18,8 +18,6 @@
  *        values and report success instead of injecting -EINTR).
  */
 
-#include "enclave_ocalls.h"
-
 #include <asm/errno.h>
 #include <linux/futex.h>
 #include <stdalign.h>
@@ -29,6 +27,7 @@
 #include "api.h"
 #include "asan.h"
 #include "cpu.h"
+#include "enclave_ocalls.h"
 #include "pal_internal.h"
 #include "pal_ocall_types.h"
 #include "pal_rpc_queue.h"

--- a/pal/src/host/linux-sgx/enclave_pages.c
+++ b/pal/src/host/linux-sgx/enclave_pages.c
@@ -1,7 +1,6 @@
-#include "enclave_pages.h"
-
 #include "api.h"
 #include "asan.h"
+#include "enclave_pages.h"
 #include "list.h"
 #include "pal_error.h"
 #include "pal_linux.h"

--- a/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.c
+++ b/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.c
@@ -1,5 +1,4 @@
 #define _GNU_SOURCE
-#include "sgx_gdb.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -17,6 +16,7 @@
 #include <wait.h>
 
 #include "assert.h"
+#include "sgx_gdb.h"
 #include "../sgx_arch.h"
 
 /* Used by GDB with PTRACE_GETREGSET. */

--- a/pal/src/host/linux-sgx/host_ecalls.c
+++ b/pal/src/host/linux-sgx/host_ecalls.c
@@ -2,7 +2,6 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 #include "host_ecalls.h"
-
 #include "host_internal.h"
 #include "pal_ecall_types.h"
 #include "pal_rpc_queue.h"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

@dimakuv and @boryspoplawski in https://github.com/gramineproject/gramine/pull/850 proposed to remove a rule about matching .c and .h files.
I went through all files in `pal/src`, `pal/regression`, `libos/src/`, `libos/test/abi`, `libos/test/fs`, `libos/test/regression`, and there subdirectories - it seems like this rule isn't applied often.

## How to test this PR? <!-- (if applicable) -->

Build should be enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/861)
<!-- Reviewable:end -->
