### PR TITLE
[PAL] Remove `PAL_OPTION_CLOEXEC` flag

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -61,6 +61,7 @@ struct mmsghdr {
 #define MSG_TRUNC 0x20
 #define MSG_DONTWAIT 0x40
 #define MSG_NOSIGNAL 0x4000
+#define MSG_CMSG_CLOEXEC 0x40000000
 
 /* Option levels. */
 #define SOL_SOCKET 1

--- a/libos/include/libos_flags_conv.h
+++ b/libos/include/libos_flags_conv.h
@@ -53,6 +53,5 @@ static inline enum pal_create_mode LINUX_OPEN_FLAGS_TO_PAL_CREATE(int flags) {
 }
 
 static inline pal_stream_options_t LINUX_OPEN_FLAGS_TO_PAL_OPTIONS(int flags) {
-    return (flags & O_CLOEXEC  ? PAL_OPTION_CLOEXEC  : 0) |
-           (flags & O_NONBLOCK ? PAL_OPTION_NONBLOCK : 0);
+    return flags & O_NONBLOCK ? PAL_OPTION_NONBLOCK : 0;
 }

--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -23,7 +23,7 @@ int create_pollable_event(struct libos_pollable_event* event) {
     PAL_HANDLE write_handle;
     do {
         ret = PalStreamOpen(uri, PAL_ACCESS_RDWR, /*share_flags=*/0, PAL_CREATE_IGNORED,
-                            PAL_OPTION_NONBLOCK | PAL_OPTION_CLOEXEC, &write_handle);
+                            PAL_OPTION_NONBLOCK, &write_handle);
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         log_error("%s: PalStreamOpen failed: %d", __func__, ret);

--- a/libos/src/sys/libos_eventfd.c
+++ b/libos/src/sys/libos_eventfd.c
@@ -45,7 +45,6 @@ static int create_eventfd(PAL_HANDLE* efd, uint64_t initial_count, int flags) {
     int pal_flags = 0;
 
     pal_flags |= flags & EFD_NONBLOCK ? PAL_OPTION_NONBLOCK : 0;
-    pal_flags |= flags & EFD_CLOEXEC ? PAL_OPTION_CLOEXEC : 0;
     pal_flags |= flags & EFD_SEMAPHORE ? PAL_OPTION_EFD_SEMAPHORE : 0;
 
     ret = PalStreamOpen(URI_PREFIX_EVENTFD, PAL_ACCESS_RDWR, /*share_flags=*/0,

--- a/libos/test/regression/fdleak.c
+++ b/libos/test/regression/fdleak.c
@@ -1,27 +1,81 @@
+#define _GNU_SOURCE
+#include <err.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
-/* This is supposed to expose resource leaks where close()d files are not properly cleaned up. */
+#include "common.h"
 
-int main(int argc, char** argv) {
-    for (int i = 0; i < 10000; i++) {
-        int fd = open(argv[0], O_RDONLY);
-        if (fd == -1)
-            abort();
-        char buf[1024];
-        ssize_t read_ret = read(fd, buf, sizeof(buf));
-        if (read_ret == -1)
-            abort();
-        int ret = close(fd);
-        if (ret == -1)
-            abort();
+#define OPEN_CLOSE_FILES_COUNT 1000
+#define INITIAL_OPEN_FDS 10
+#define SPAWN_CHILDREN_COUNT 10
+
+static void test_open_close(const char* fname) {
+    for (size_t i = 0; i < OPEN_CLOSE_FILES_COUNT; i++) {
+        int fd = CHECK(open(fname, O_RDONLY));
+        char buf[0x10];
+        ssize_t ret = CHECK(read(fd, buf, sizeof(buf)));
+        if (ret != sizeof(buf)) {
+            errx(1, "short read on a file: %zd", ret);
+        }
+        CHECK(close(fd));
+    }
+}
+
+static void test_open_fork(const char* fname) {
+    int fds[INITIAL_OPEN_FDS];
+    for (size_t i = 0; i < ARRAY_LEN(fds); i++) {
+        fds[i] = CHECK(open(fname, O_RDONLY));
     }
 
-    puts("Test succeeded.");
+    int pipefds[2];
+    CHECK(pipe(pipefds));
 
+    pid_t p = CHECK(fork());
+    if (p == 0) {
+        CHECK(close(pipefds[0]));
+
+        for (size_t i = 0; i < SPAWN_CHILDREN_COUNT; i++) {
+            p = CHECK(fork());
+            if (p != 0) {
+                /* Parent just exits. */
+                exit(0);
+            }
+            /* Child continues and spawns the next child (nested forks). */
+        }
+
+        /* Last child done, inform the first process. */
+        char c = 0;
+        CHECK(write(pipefds[1], &c, sizeof(c)));
+        exit(0);
+    }
+
+    CHECK(close(pipefds[1]));
+
+    char c = 0;
+    ssize_t ret = CHECK(read(pipefds[0], &c, sizeof(c)));
+    if (ret != sizeof(c)) {
+        errx(1, "confirmation message too short: %zd", ret);
+    }
+    CHECK(wait(NULL));
+
+    for (size_t i = 0; i < ARRAY_LEN(fds); i++) {
+        CHECK(close(fds[i]));
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 1) {
+        errx(1, "unexpected argc: %d (expected 1)", argc);
+    }
+
+    test_open_close(argv[0]);
+
+    test_open_fork(argv[0]);
+
+    puts("TEST OK");
     return 0;
 }

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1019,8 +1019,11 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/proc/stat test passed', stdout)
 
     def test_030_fdleak(self):
-        stdout, _ = self.run_binary(['fdleak'], timeout=10)
-        self.assertIn("Test succeeded.", stdout)
+        # The fd limit is rather arbitrary, but must be in sync with numbers from the test.
+        # Currently test opens 10 fds simultaneously, so 50 is a safe margin for any fds that
+        # Gramine might open internally.
+        stdout, _ = self.run_binary(['fdleak'], timeout=40, open_fds_limit=50)
+        self.assertIn("TEST OK", stdout)
 
     def get_cache_levels_cnt(self):
         cpu0 = '/sys/devices/system/cpu/cpu0/'

--- a/pal/include/host/linux-common/pal_flags_conv.h
+++ b/pal/include/host/linux-common/pal_flags_conv.h
@@ -63,7 +63,6 @@ static inline int PAL_CREATE_TO_LINUX_OPEN(enum pal_create_mode create) {
 }
 
 static inline int PAL_OPTION_TO_LINUX_OPEN(pal_stream_options_t options) {
-    assert(WITHIN_MASK(options, PAL_OPTION_CLOEXEC | PAL_OPTION_NONBLOCK | PAL_OPTION_PASSTHROUGH));
-    return (options & PAL_OPTION_CLOEXEC  ? O_CLOEXEC  : 0) |
-           (options & PAL_OPTION_NONBLOCK ? O_NONBLOCK : 0);
+    assert(WITHIN_MASK(options, PAL_OPTION_NONBLOCK | PAL_OPTION_PASSTHROUGH));
+    return options & PAL_OPTION_NONBLOCK ? O_NONBLOCK : 0;
 }

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -50,6 +50,12 @@ typedef struct {
     struct handle_ops* ops;
 } PAL_HDR;
 
+/*
+ * This header provides `PAL_HANDLE` type definition.
+ * All host resources being part of `PAL_HANDLE` must be released when spawning another process
+ * (`PalProcessCreate`), e.g. Linux PAL must set `OCLOEXEC` flag on all open file descriptors.
+ * LibOS layer takes care of migrating all necessary handles using `PalSendHandle`.
+ */
 #include "pal_host.h"
 
 static inline void init_handle_hdr(PAL_HANDLE handle, int pal_type) {
@@ -259,11 +265,10 @@ enum pal_create_mode {
 
 /*! stream misc flags */
 typedef uint32_t pal_stream_options_t; /* bitfield */
-#define PAL_OPTION_CLOEXEC         0x1
-#define PAL_OPTION_EFD_SEMAPHORE   0x2 /*!< specific to `eventfd` syscall */
-#define PAL_OPTION_NONBLOCK        0x4
-#define PAL_OPTION_PASSTHROUGH     0x8 /*!< Disregard `sgx.{allowed,trusted}_files` */
-#define PAL_OPTION_MASK            0xF
+#define PAL_OPTION_EFD_SEMAPHORE   0x1 /*!< specific to `eventfd` syscall */
+#define PAL_OPTION_NONBLOCK        0x2
+#define PAL_OPTION_PASSTHROUGH     0x4 /*!< Disregard `sgx.{allowed,trusted}_files` */
+#define PAL_OPTION_MASK            0x7
 
 /*!
  * \brief Open/create a stream resource specified by `uri`.

--- a/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.c
+++ b/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.c
@@ -429,7 +429,7 @@ static int open_memdevice(pid_t tid, int* out_memdev, struct enclave_dbginfo** o
     }
 
     snprintf(memdev_path, sizeof(memdev_path), "/proc/%d/mem", tid);
-    fd = open(memdev_path, O_RDWR);
+    fd = open(memdev_path, O_RDWR | O_CLOEXEC);
     if (fd < 0) {
         DEBUG_LOG("Cannot open %s\n", memdev_path);
         ret = -2;

--- a/pal/src/host/linux-sgx/host_log.c
+++ b/pal/src/host/linux-sgx/host_log.c
@@ -24,7 +24,7 @@ int host_log_init(const char* path) {
             return ret;
     }
 
-    ret = DO_SYSCALL(open, path, O_WRONLY | O_APPEND | O_CREAT, PERM_rw_______);
+    ret = DO_SYSCALL(open, path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, PERM_rw_______);
     if (ret < 0)
         return ret;
     g_host_log_fd = ret;

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -214,7 +214,8 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     /* this array may overflow the stack, so we allocate it in BSS */
     static void* tcs_addrs[MAX_DBG_THREADS];
 
-    enclave_image = DO_SYSCALL(open, enclave->libpal_uri + URI_PREFIX_FILE_LEN, O_RDONLY, 0);
+    enclave_image = DO_SYSCALL(open, enclave->libpal_uri + URI_PREFIX_FILE_LEN,
+                               O_RDONLY | O_CLOEXEC, 0);
     if (enclave_image < 0) {
         log_error("Cannot find enclave image: %s", enclave->libpal_uri);
         ret = enclave_image;
@@ -558,7 +559,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
 
     if (g_sgx_enable_stats || g_vtune_profile_enabled) {
         /* set TCS.FLAGS.DBGOPTIN in all enclave threads to enable perf counters, Intel PT, etc */
-        ret = DO_SYSCALL(open, "/proc/self/mem", O_RDWR | O_LARGEFILE, 0);
+        ret = DO_SYSCALL(open, "/proc/self/mem", O_RDWR | O_LARGEFILE | O_CLOEXEC, 0);
         if (ret < 0) {
             log_error("Setting TCS.FLAGS.DBGOPTIN failed: %d", ret);
             goto out;
@@ -1132,6 +1133,11 @@ int main(int argc, char* argv[], char* envp[]) {
 
         /* We'll receive our argv and config via IPC. */
         parent_stream_fd = atoi(argv[3]);
+        ret = DO_SYSCALL(fcntl, parent_stream_fd, F_SETFD, FD_CLOEXEC);
+        if (ret < 0) {
+            return ret;
+        }
+
         ret = sgx_init_child_process(parent_stream_fd, &g_pal_enclave.application_path, &manifest);
         if (ret < 0)
             return ret;

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -117,11 +117,7 @@ static long sgx_ocall_cpuid(void* pms) {
 
 static long sgx_ocall_open(void* pms) {
     ms_ocall_open_t* ms = (ms_ocall_open_t*)pms;
-    long ret;
-    // FIXME: No idea why someone hardcoded O_CLOEXEC here. We should drop it and carefully
-    // investigate if this cause any descriptor leaks.
-    ret = DO_SYSCALL_INTERRUPTIBLE(open, ms->ms_pathname, ms->ms_flags | O_CLOEXEC, ms->ms_mode);
-    return ret;
+    return DO_SYSCALL_INTERRUPTIBLE(open, ms->ms_pathname, ms->ms_flags, ms->ms_mode);
 }
 
 static long sgx_ocall_close(void* pms) {
@@ -312,7 +308,7 @@ static long sgx_ocall_futex(void* pms) {
 
 static long sgx_ocall_socket(void* pms) {
     ms_ocall_socket_t* ms = pms;
-    return DO_SYSCALL(socket, ms->ms_family, ms->ms_type | SOCK_CLOEXEC, ms->ms_protocol);
+    return DO_SYSCALL(socket, ms->ms_family, ms->ms_type, ms->ms_protocol);
 }
 
 static long sgx_ocall_bind(void* pms) {
@@ -362,7 +358,7 @@ static long sgx_ocall_listen(void* pms) {
         goto err;
     }
 
-    ret = DO_SYSCALL(socket, ms->ms_domain, ms->ms_type | SOCK_CLOEXEC, ms->ms_protocol);
+    ret = DO_SYSCALL(socket, ms->ms_domain, ms->ms_type, ms->ms_protocol);
     if (ret < 0)
         goto err;
 
@@ -416,7 +412,7 @@ static long sgx_ocall_accept(void* pms) {
         return -EINVAL;
     }
     int addrlen = ms->ms_addrlen;
-    int options = ms->options | SOCK_CLOEXEC;
+    int options = ms->options;
     assert(WITHIN_MASK(options, SOCK_CLOEXEC | SOCK_NONBLOCK));
 
     ret = DO_SYSCALL_INTERRUPTIBLE(accept4, ms->ms_sockfd, ms->ms_addr, &addrlen, options);
@@ -451,7 +447,7 @@ static long sgx_ocall_connect(void* pms) {
         goto err;
     }
 
-    ret = DO_SYSCALL(socket, ms->ms_domain, ms->ms_type | SOCK_CLOEXEC, ms->ms_protocol);
+    ret = DO_SYSCALL(socket, ms->ms_domain, ms->ms_type, ms->ms_protocol);
     if (ret < 0)
         goto err;
 

--- a/pal/src/host/linux-sgx/host_perf_data.c
+++ b/pal/src/host/linux-sgx/host_perf_data.c
@@ -143,7 +143,7 @@ static int pd_write(struct perf_data* pd, const void* data, size_t size) {
 struct perf_data* pd_open(const char* file_name, bool with_stack) {
     int ret;
 
-    int fd = DO_SYSCALL(open, file_name, O_WRONLY | O_TRUNC | O_CREAT, PERM_rw_r__r__);
+    int fd = DO_SYSCALL(open, file_name, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, PERM_rw_r__r__);
     if (fd < 0) {
         log_error("pd_open: cannot open %s for writing: %d", file_name, fd);
         return NULL;

--- a/pal/src/host/linux-sgx/host_platform.c
+++ b/pal/src/host/linux-sgx/host_platform.c
@@ -50,7 +50,7 @@ static const sgx_ql_att_key_id_t g_default_ecdsa_p256_att_key_id = {
  * for each request to the AESM service.
  */
 static int connect_aesm_service(void) {
-    int sock = DO_SYSCALL(socket, AF_UNIX, SOCK_STREAM, 0);
+    int sock = DO_SYSCALL(socket, AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (sock < 0)
         return sock;
 

--- a/pal/src/host/linux-sgx/host_process.c
+++ b/pal/src/host/linux-sgx/host_process.c
@@ -79,6 +79,7 @@ int sgx_create_process(size_t nargs, const char** args, const char* manifest, in
 
     /* TODO: add error checking. */
     DO_SYSCALL(close, fds[0]); /* child stream */
+    fds[0] = -1;
 
     struct proc_args proc_args;
     proc_args.application_path_size = strlen(g_pal_enclave.application_path);

--- a/pal/src/host/linux-sgx/host_profile.c
+++ b/pal/src/host/linux-sgx/host_profile.c
@@ -112,7 +112,7 @@ int sgx_profile_init(void) {
     g_profile_period = NSEC_IN_SEC / g_pal_enclave.profile_frequency;
     g_profile_mode = g_pal_enclave.profile_mode;
 
-    ret = DO_SYSCALL(open, "/proc/self/mem", O_RDONLY | O_LARGEFILE, 0);
+    ret = DO_SYSCALL(open, "/proc/self/mem", O_RDONLY | O_LARGEFILE | O_CLOEXEC, 0);
     if (ret < 0) {
         log_error("sgx_profile_init: opening /proc/self/mem failed: %d", ret);
         goto out;
@@ -327,7 +327,7 @@ void sgx_profile_report_elf(const char* filename, void* addr) {
 
     // Open the file and mmap it.
 
-    int fd = DO_SYSCALL(open, path, O_RDONLY, 0);
+    int fd = DO_SYSCALL(open, path, O_RDONLY | O_CLOEXEC, 0);
     if (fd < 0) {
         log_error("sgx_profile_report_elf(%s): open failed: %d", filename, fd);
         return;

--- a/pal/src/host/linux-sgx/pal_devices.c
+++ b/pal/src/host/linux-sgx/pal_devices.c
@@ -58,7 +58,8 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
 
         ret = ocall_open(uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
                               PAL_CREATE_TO_LINUX_OPEN(create)  |
-                              PAL_OPTION_TO_LINUX_OPEN(options),
+                              PAL_OPTION_TO_LINUX_OPEN(options) |
+                              O_CLOEXEC,
                          share);
         if (ret < 0) {
             ret = unix_to_pal_error(ret);
@@ -148,7 +149,7 @@ static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* att
         attr->pending_size = 0;
     } else {
         /* other devices must query the host */
-        int fd = ocall_open(uri, 0, 0);
+        int fd = ocall_open(uri, O_RDONLY | O_CLOEXEC, 0);
         if (fd < 0)
             return unix_to_pal_error(fd);
 

--- a/pal/src/host/linux-sgx/pal_eventfd.c
+++ b/pal/src/host/linux-sgx/pal_eventfd.c
@@ -16,12 +16,9 @@
 #include "pal_linux_error.h"
 
 static inline int eventfd_type(int options) {
-    int type = 0;
+    int type = EFD_CLOEXEC;
     if (options & PAL_OPTION_NONBLOCK)
         type |= EFD_NONBLOCK;
-
-    if (options & PAL_OPTION_CLOEXEC)
-        type |= EFD_CLOEXEC;
 
     if (options & PAL_OPTION_EFD_SEMAPHORE)
         type |= EFD_SEMAPHORE;

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -39,9 +39,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
     bool do_create = (pal_create == PAL_CREATE_ALWAYS) || (pal_create == PAL_CREATE_TRY);
 
     struct stat st;
-    int flags = PAL_ACCESS_TO_LINUX_OPEN(pal_access) |
-                PAL_CREATE_TO_LINUX_OPEN(pal_create) |
-                PAL_OPTION_TO_LINUX_OPEN(pal_options);
+    int flags = PAL_ACCESS_TO_LINUX_OPEN(pal_access) | PAL_CREATE_TO_LINUX_OPEN(pal_create)
+                | PAL_OPTION_TO_LINUX_OPEN(pal_options) | O_CLOEXEC;
 
     if (strcmp(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
@@ -383,7 +382,7 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
 
     /* open the file with O_NONBLOCK to avoid blocking the current thread if it is actually a FIFO
      * pipe; O_NONBLOCK will be reset below if it is a regular file */
-    int fd = ocall_open(uri, O_NONBLOCK, 0);
+    int fd = ocall_open(uri, O_NONBLOCK | O_CLOEXEC, 0);
     if (fd < 0)
         return unix_to_pal_error(fd);
 
@@ -499,7 +498,7 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         }
     }
 
-    int fd = ocall_open(uri, O_DIRECTORY | PAL_OPTION_TO_LINUX_OPEN(options), 0);
+    int fd = ocall_open(uri, O_DIRECTORY | O_CLOEXEC | PAL_OPTION_TO_LINUX_OPEN(options), 0);
     if (fd < 0)
         return unix_to_pal_error(fd);
 

--- a/pal/src/host/linux-sgx/pal_misc.c
+++ b/pal/src/host/linux-sgx/pal_misc.c
@@ -649,7 +649,7 @@ int _PalGetSpecialKey(const char* name, void* key, size_t* key_size) {
 ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size) {
     int fd;
 
-    fd = ocall_open(filename, O_RDONLY, 0);
+    fd = ocall_open(filename, O_RDONLY | O_CLOEXEC, 0);
     if (fd < 0)
         return fd;
 

--- a/pal/src/host/linux/pal_devices.c
+++ b/pal/src/host/linux/pal_devices.c
@@ -56,7 +56,8 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
 
         ret = DO_SYSCALL(open, uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
                                     PAL_CREATE_TO_LINUX_OPEN(create)  |
-                                    PAL_OPTION_TO_LINUX_OPEN(options),
+                                    PAL_OPTION_TO_LINUX_OPEN(options) |
+                                    O_CLOEXEC,
                          share);
         if (ret < 0) {
             ret = unix_to_pal_error(ret);

--- a/pal/src/host/linux/pal_eventfd.c
+++ b/pal/src/host/linux/pal_eventfd.c
@@ -19,12 +19,9 @@
 #include "pal_linux_error.h"
 
 static inline int eventfd_type(pal_stream_options_t options) {
-    int type = 0;
+    int type = EFD_CLOEXEC;
     if (options & PAL_OPTION_NONBLOCK)
         type |= EFD_NONBLOCK;
-
-    if (options & PAL_OPTION_CLOEXEC)
-        type |= EFD_CLOEXEC;
 
     if (options & PAL_OPTION_EFD_SEMAPHORE)
         type |= EFD_SEMAPHORE;

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -26,8 +26,6 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
     assert(WITHIN_MASK(options, PAL_OPTION_MASK));
 
     /* try to do the real open */
-    // FIXME: No idea why someone hardcoded O_CLOEXEC here. We should drop it and carefully
-    // investigate if this causes any descriptor leaks.
     int ret = DO_SYSCALL(open, uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
                                     PAL_CREATE_TO_LINUX_OPEN(create)  |
                                     PAL_OPTION_TO_LINUX_OPEN(options) |
@@ -182,7 +180,6 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
         return -PAL_ERROR_INVAL;
 
     struct stat stat_buf;
-    /* try to do the real open */
     int ret = DO_SYSCALL(stat, uri, &stat_buf);
 
     /* if it failed, return the right error code */

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -383,6 +383,11 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     } else {
         // Children receive their argv and config via IPC.
         int parent_stream_fd = atoi(argv[3]);
+        ret = DO_SYSCALL(fcntl, parent_stream_fd, F_SETFD, FD_CLOEXEC);
+        if (ret < 0) {
+            INIT_FAIL("Failed to set `CLOEXEC` flag on `parent_stream_fd`: %d",
+                      unix_to_pal_error(ret));
+        }
         init_child_process(parent_stream_fd, &parent, &manifest, &instance_id);
     }
     assert(manifest);

--- a/pal/src/host/linux/pal_memory.c
+++ b/pal/src/host/linux/pal_memory.c
@@ -90,7 +90,7 @@ int _PalVirtualMemoryProtect(void* addr, size_t size, pal_prot_flags_t prot) {
 }
 
 static int read_proc_meminfo(const char* key, unsigned long* val) {
-    int fd = DO_SYSCALL(open, "/proc/meminfo", O_RDONLY, 0);
+    int fd = DO_SYSCALL(open, "/proc/meminfo", O_RDONLY | O_CLOEXEC, 0);
 
     if (fd < 0)
         return -PAL_ERROR_DENIED;

--- a/pal/src/host/linux/pal_pipes.c
+++ b/pal/src/host/linux/pal_pipes.c
@@ -99,7 +99,7 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     if (handle->pipe.fd == PAL_IDX_POISON)
         return -PAL_ERROR_DENIED;
 
-    static_assert(O_CLOEXEC == SOCK_CLOEXEC && O_NONBLOCK == SOCK_NONBLOCK, "assumed below");
+    static_assert(O_NONBLOCK == SOCK_NONBLOCK, "assumed below");
     int flags = PAL_OPTION_TO_LINUX_OPEN(options) | SOCK_CLOEXEC;
     int newfd = DO_SYSCALL(accept4, handle->pipe.fd, NULL, NULL, flags);
     if (newfd < 0)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This flag was used to control `CLOEXEC` flag of host OS fd, and as such, was Linux specific. It was also not really needed - Linux and Linux SGX PALs always set it on host fd anyway.
This commit also adds all missing `CLOEXEC` flag usages in Linux and Linux SGX PALs.

Fixes #864

## How to test this PR? <!-- (if applicable) -->
`fdleak` test augmented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/866)
<!-- Reviewable:end -->
