### PR TITLE
[docs] Add KSS description to SGX introduction

### DIFF
--- a/Documentation/sgx-intro.rst
+++ b/Documentation/sgx-intro.rst
@@ -28,6 +28,8 @@ Features which might be considered part of SGX2:
 - :term:`EDMM` (Enclave Dynamic Memory Management) is part of SGX2
 - :term:`FLC` (Flexible Launch Control), not strictly part of SGX2, but was not
   part of original SGX hardware either
+- :term:`KSS` (Key Separation and Sharing), also not part of SGX2, but was not
+  part of original SGX hardware either
 
 As of now there is hardware support (on a |~| limited set of CPUs) for FLC and
 (on an even more limited set of CPUs) SGX2/EDMM. Most of the literature
@@ -346,6 +348,37 @@ SGX terminology
             Announcement
 
          :term:`DCAP`
+
+   Key Separation and Sharing
+   KSS
+      A feature that lets developer define additional enclave identity
+      attributes and configuration identifier. Extended enclave identity
+      is defined by the developer on enclave build. Enclave configuration is
+      defined on enclave launch and cannot be modified afterwards.
+
+      In addition to the calculated enclave and signer measurements, developer
+      is expected to define a product ID and :term:`SVN` for her enclaves.
+      These identifiers are part of the :term:`SGX Report` and are expected to
+      be used in :term:`Attestation`. They are also used by SGX key derivation
+      to derive different keys per configuration.
+
+      KSS adds two more attributes for enclave build and two new ones for
+      enclave launch, which are part of the :term:`SGX Report`.
+      Additionally, key policy attributes are extended to provide fine-grained
+      control over key derivation.
+
+      New build attributes:
+
+      - Extended product ID
+      - Family ID
+
+      New enclave launch attributes:
+
+      - Config ID
+      - Config SVN
+
+      This feature was not part of original SGX and therefore not supported by
+      all SGX-enabled hardware.
 
    Launch Enclave
    LE


### PR DESCRIPTION
KSS stands for Key Separation and Sharing,
a feature added to the SGX hardware and
not yet implemented in Gramine

Signed-off-by: Lavi, Nir <nir.lavi@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/873)
<!-- Reviewable:end -->
