### PR TITLE
[CI-Examples] Use `-Wl,--enable-new-dtags` in RA-TLS examples

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -1,6 +1,3 @@
-GRAMINEDIR ?= ../..
-GRAMINE_PKGLIBDIR ?= /usr/lib/x86_64-linux-gnu/gramine # this is debian/ubuntu specific
-
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
@@ -42,11 +39,8 @@ ssl/server.crt: ssl/ca_config.conf
 
 ############################# MBEDTLS DEPENDENCY ##############################
 
-#
-# This download is done to get headers in include/, because we currently fail
-# to provide the headers.
-# TODO: install headers, and `make install` before copying them
-#
+# This download is done to get headers in include/, because we currently fail to provide the headers
+# (`pkg-config --cflags mbedtls_gramine` in the below CFLAGS line returns a non-existing directory).
 
 MBEDTLS_VERSION ?= 3.2.1
 MBEDTLS_SRC ?= mbedtls-$(MBEDTLS_VERSION).tar.gz
@@ -78,7 +72,7 @@ mbedtls/.mbedtls_configured: mbedtls/.mbedtls_downloaded
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
 CFLAGS += -I./mbedtls/include $(shell pkg-config --cflags mbedtls_gramine)
-LDFLAGS += -ldl $(shell pkg-config --libs mbedtls_gramine)
+LDFLAGS += -ldl -Wl,--enable-new-dtags $(shell pkg-config --libs mbedtls_gramine)
 
 server: src/server.c mbedtls/.mbedtls_configured
 	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -1,6 +1,3 @@
-GRAMINEDIR ?= ../..
-GRAMINE_PKGLIBDIR ?= /usr/lib/x86_64-linux-gnu/gramine # this is debian/ubuntu specific
-
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
@@ -49,9 +46,13 @@ ssl/server.crt: ssl/ca_config.conf
 
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
+# Use hard-coded GRAMINEDIR because we currently fail to provide the headers in Gramine installation
+# (`pkg-config --cflags mbedtls_gramine` returns a non-existing directory).
+
+GRAMINEDIR ?= ../..
 CFLAGS += -Wall -std=c11 -I$(GRAMINEDIR)/tools/sgx/ra-tls \
           $(shell pkg-config --cflags mbedtls_gramine)
-LDFLAGS += $(shell pkg-config --libs mbedtls_gramine)
+LDFLAGS += -Wl,--enable-new-dtags $(shell pkg-config --libs mbedtls_gramine)
 
 secret_prov_server_epid: src/secret_prov_server.c
 	$(CC) $< $(CFLAGS) $(LDFLAGS) -lsecret_prov_verify_epid -pthread -o $@


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`ra-tls-mbedtls` and `ra-tls-secret-prov` examples link against MbedTLS version provided by Gramine, via `pkg-config --libs mbedtls_gramine` in Makefile. The pkg-config command generates a line that contains `-Wl,-rpath,<path to Gramine libs installation>`.

This line should instruct the linker to add the `DT_RUNPATH` search path, but some linkers add `DT_RPATH` instead, which results in `LD_LIBRARY_PATH` being ignored.

The final outcome is that Gramine loads e.g. host-level `/usr/lib/x86_64-linux-gnu/libc.so.6` instead of Gramine-specific `/lib/libc.so.6`, which conflicts with `/lib/ld-linux-x86-64.so.2`:

    Inconsistency detected by ld.so: dl-call-libc-early-init.c: ...

To fix this problem, this commit adds `-Wl,--enable-new-dtags` to all applications that link against `mbedtls_gramine` libs. This forces all linkers to use `DR_RUNPATH` instead of `DT_RPATH`.

Fixes #752.

## How to test this PR? <!-- (if applicable) -->

N/A. Hopefully people affected by this bug can test it (I haven't encountered it myself). On my local machines, stuff like `ldd server` and `readelf -a server | grep PATH` shows correct things:
```
$ readelf -a secret_prov_server_epid  | grep PATH
 0x000000000000001d (RUNPATH)            Library runpath: [/home/dimakuv/gramineproject/gramine/built-debug/lib/x86_64-linux-gnu]
```