### PR TITLE
[PAL/Linux-SGX] Introduce `sgx.cpu_features.[...]` manifest options

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -540,18 +540,36 @@ Optional CPU features (AVX, AVX512, MPX, PKRU, AMX)
 
 ::
 
-    sgx.require_avx    = [true|false]
-    sgx.require_avx512 = [true|false]
-    sgx.require_mpx    = [true|false]
-    sgx.require_pkru   = [true|false]
-    sgx.require_amx    = [true|false]
-    (Default: false)
+    sgx.cpu_features.mpx    = "[autodetect|required]"
+    sgx.cpu_features.pkru   = "[autodetect|required]"
+    sgx.cpu_features.avx    = "[autodetect|required|disabled]"
+    sgx.cpu_features.avx512 = "[autodetect|required|disabled]"
+    sgx.cpu_features.amx    = "[autodetect|required|disabled]"
+    (Default: "autodetect")
 
-This syntax ensures that the CPU features are available and enabled for the
-enclave. If the options are set in the manifest but the features are unavailable
-on the platform, enclave initialization will fail. If the options are unset,
-enclave initialization will succeed even if these features are unavailable on
-the platform.
+The ``"autodetect"`` syntax means that the enclave initialization will succeed
+regardless of whether the CPU feature is available on the platform or not. The
+CPU feature will be enabled in the enclave if it is available on the platform.
+
+The ``"required"`` syntax ensures that the CPU feature is available and enabled
+for the enclave. If such option is set in the manifest but the CPU feature is
+unavailable on the platform, enclave initialization will fail.
+
+The ``"disabled"`` syntax disables the CPU feature inside the enclave even if
+this CPU feature is available on the platform.  This may improve enclave
+performance because this CPU feature will *not* be saved and restored during
+enclave entry/exit. This syntax is provided to improve performance of
+applications that are known to *not* rely on certain CPU features. Be aware that
+if the application relies on some disabled CPU features, the application will
+fail with SIGILL ("illegal instruction"). For example, if the application is
+built with AVX support, and AVX is disabled in the manifest, the application
+will crash. Only not-security-critical CPU features may be disabled (currently
+these are AVX, AVX512 and AMX).
+
+In case of doubt, it is recommended to keep the default values for these
+features (e.g. ``sgx.cpu_features.avx = "autodetect"``). In this case, Gramine
+auto-detects the corresponding CPU features on the platform and enables them if
+available, regardless of whether the application uses them or not.
 
 ISV Product ID and SVN
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -950,3 +968,19 @@ value has been replaced with the string value. The ``none`` value in the new
 syntax corresponds to the ``false`` boolean value in the deprecated syntax. The
 explicit ``epid`` and ``dcap`` values in the new syntax replace the ambiguous
 ``true`` boolean value in the deprecated syntax.
+
+
+Optional CPU features (deprecated syntax)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.require_avx    = [true|false]
+    sgx.require_avx512 = [true|false]
+    sgx.require_mpx    = [true|false]
+    sgx.require_pkru   = [true|false]
+    sgx.require_amx    = [true|false]
+
+This syntax specified whether to require certain CPU features to be available on
+the platform where the enclave executes. This syntax has been replaced with
+``sgx.cpu_features.[avx|avx512|mpx|pkru|amx]``.

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -216,22 +216,30 @@ Optional CPU features (AVX, AVX512, MPX, PKRU, AMX)
 ---------------------------------------------------
 
 SGX technology allows to specify which CPU features are required to run the SGX
-enclave. Gramine "inherits" this and has the following manifest options:
-``sgx.require_avx``, ``sgx.require_avx512``, ``sgx.require_mpx``,
-``sgx.require_pkru``, ``sgx.require_amx``. By default, all of them are set to
-``false`` – this means that SGX hardware will allow running the SGX enclave on
-any system, whether the system has AVX/AVX512/MPX/PKRU/AMX features or not.
+enclave. Gramine "inherits" this and has the manifest options for
+AVX/AVX512/MPX/PKRU/AMX CPU features under ``sgx.cpu_features``. By default, all
+the CPU features are set to ``"autodetect"`` -- this means that Gramine will
+allow running the SGX enclave on any platform, whether the platform has the CPU
+features or not.
 
 Gramine typically correctly identifies the features of the underlying platform
 and propagates the information on AVX/AVX512/MPX/PKRU/AMX inside the enclave and
 to the application. It is recommended to leave these manifest options as-is (set
-to ``false``). However, we observed on some platforms that the graminized
+to ``"autodetect"``). However, we observed on some platforms that the graminized
 application cannot detect these features and falls back to a slow
 implementation. For example, some crypto libraries do not recognize AVX on the
 platform and use very slow functions, leading to 10-100x overhead over native
 (we still don't know the reason for this behavior). If you suspect this can be
-your case, enable the features in the manifest, e.g., set ``sgx.require_avx =
-true``.
+your case, enable the features in the manifest, e.g., set ``sgx.cpu_features.avx
+= "required"``.
+
+Gramine also allows to explicitly disable not-security-critical CPU features
+(AVX, AVX512 and AMX) using the ``"disabled"`` keyword -- this disables the
+corresponding CPU feature inside the SGX enclave even if this CPU feature is
+available on the system. This may improve enclave performance because this CPU
+feature will *not* be saved and restored during enclave entry/exit. But be aware
+that if the graminized application relies on this CPU feature, the application
+will crash with "illegal instruction".
 
 For more information on SGX logic regarding optional CPU features, see the Intel
 Software Developer Manual, Table 38-3 ("Layout of ATTRIBUTES Structure") under

--- a/pal/src/host/linux-sgx/host_framework.c
+++ b/pal/src/host/linux-sgx/host_framework.c
@@ -58,7 +58,9 @@ int read_enclave_token(int token_file, sgx_arch_token_t* token) {
         return bytes;
 
 #ifdef SGX_DCAP
-    log_debug("Read dummy DCAP token");
+    log_debug("Read dummy DCAP token (only `attr` field is used):");
+    log_debug("    attr.flags:            0x%016lx", token->body.attributes.flags);
+    log_debug("    attr.xfrm:             0x%016lx", token->body.attributes.xfrm);
 #else
     char hex[64 * 2 + 1]; /* large enough to hold any of the below fields */
 #define BYTES2HEX(bytes) (bytes2hex(bytes, sizeof(bytes), hex, sizeof(hex)))
@@ -120,6 +122,14 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
     secs->ssa_frame_size = SSA_FRAME_SIZE / g_page_size; /* SECS expects SSA frame size in pages */
     secs->misc_select    = token->masked_misc_select_le;
     memcpy(&secs->attributes, &token->body.attributes, sizeof(sgx_attributes_t));
+
+    /* disable not-security-critical HW features for XSAVE/AEX performance; see also sgx_arch.h */
+    if (g_pal_enclave.avx_disabled)
+        secs->attributes.xfrm &= ~SGX_XFRM_AVX;
+    if (g_pal_enclave.avx512_disabled)
+        secs->attributes.xfrm &= ~SGX_XFRM_AVX512;
+    if (g_pal_enclave.amx_disabled)
+        secs->attributes.xfrm &= ~SGX_XFRM_AMX;
 
     /* Do not initialize secs->mr_signer and secs->mr_enclave here as they are
      * not used by ECREATE to populate the internal SECS. SECS's mr_enclave is

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -51,6 +51,11 @@ struct pal_enclave {
     enum sgx_attestation_type attestation_type;
     char* libpal_uri; /* Path to the PAL binary */
 
+    /* disable not-security-critical HW features (for performance of XSAVE/XRSTOR/AEX) */
+    bool avx_disabled;
+    bool avx512_disabled;
+    bool amx_disabled;
+
 #ifdef DEBUG
     /* profiling */
     bool profile_enable;

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -91,14 +91,16 @@ class Manifest:
         sgx.setdefault('isvsvn', 0)
         sgx.setdefault('remote_attestation', "none")
         sgx.setdefault('debug', False)
-        sgx.setdefault('require_avx', False)
-        sgx.setdefault('require_avx512', False)
-        sgx.setdefault('require_mpx', False)
-        sgx.setdefault('require_pkru', False)
-        sgx.setdefault('require_amx', False)
         sgx.setdefault('support_exinfo', False)
         sgx.setdefault('nonpie_binary', False)
         sgx.setdefault('enable_stats', False)
+
+        sgx_cpu_features = sgx.setdefault('cpu_features', {})
+        sgx_cpu_features.setdefault('mpx', "autodetect")
+        sgx_cpu_features.setdefault('pkru', "autodetect")
+        sgx_cpu_features.setdefault('avx', "autodetect")
+        sgx_cpu_features.setdefault('avx512', "autodetect")
+        sgx_cpu_features.setdefault('amx', "autodetect")
 
         if not isinstance(sgx['trusted_files'], list):
             raise ValueError("Unsupported trusted files syntax, more info: " +


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Introduce `sgx.cpu_features.[...] = "[autodetect|required|disabled]"` instead of `sgx.require_[...] = true|false`.

Mapping of deprecated and new manifest options:
- `sgx.cpu_features.[...] = "autodetect"` -> `sgx.require_[...] = false`
- `sgx.cpu_features.[...] = "required"` -> `sgx.require_[...] = true`

`sgx.cpu_features.[...] = "disabled"` is new and it disables the corresponding CPU feature inside the SGX enclave even if this CPU
feature is available on the system: this may improve enclave performance because this CPU feature will *not* be saved and restored during enclave entry/exit.

This PR is a re-creation of https://github.com/gramineproject/gramine/pull/321 and https://github.com/gramineproject/gramine/pull/461, since it turned out to be useful for performance. Without disclosing any perf numbers, I performed a set of micro-benchmarks and they prove that disabling Intel AMX inside of the enclave (when it is available on the machine but is not needed by the app inside the enclave) gives a measurable performance boost (for the worst-case scenarios). So this change actually is beneficial.

## How to test this PR? <!-- (if applicable) -->

I tested this PR manually on the AMX-enabled machine:
```bash
# with nothing, should default to sgx.cpu_features.amx = "autodetect"
$ gramine-sgx helloworld
debug: LibOS xsave_enabled 1, xsave_size 0x2b00(11008), xsave_features 0x600e7

# with sgx.cpu_features.amx = "autodetect"
$ gramine-sgx helloworld
debug: LibOS xsave_enabled 1, xsave_size 0x2b00(11008), xsave_features 0x600e7 

# with sgx.cpu_features.amx = "required"
$ gramine-sgx helloworld
debug: LibOS xsave_enabled 1, xsave_size 0x2b00(11008), xsave_features 0x600e7

# with sgx.cpu_features.amx = "disabled"
$ gramine-sgx helloworld
debug: LibOS xsave_enabled 1, xsave_size 0xa80(2688), xsave_features 0xe7
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/877)
<!-- Reviewable:end -->
