### PR TITLE
[Docs] Improve wording about commandline arguments

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -124,26 +124,26 @@ or
 
    loader.argv_src_file = "file:file_with_serialized_argv"
 
-If you want your application to use commandline arguments you need to either set
-``loader.insecure__use_cmdline_argv`` (insecure in almost all cases), put them
-into ``loader.argv`` array or point ``loader.argv_src_file`` to a file
-containing output of :ref:`gramine-argv-serializer<gramine-argv-serializer>`.
+If you want your application to use commandline arguments, you must choose one
+of the three mutually exclusive options:
+
+- set ``loader.insecure__use_cmdline_argv`` (insecure in almost all cases),
+- put commandline arguments into ``loader.argv`` array,
+- point ``loader.argv_src_file`` to a file
+  containing output of :ref:`gramine-argv-serializer<gramine-argv-serializer>`.
+
+If none of the above arguments-handling manifest options is specified in the
+manifest, the application will get ``argv = [ <libos.entrypoint value> ]``.
 
 ``loader.argv_src_file`` is intended to point to either a trusted file or an
-encrypted file. The former allows to securely hardcode arguments (current
-manifest syntax doesn't allow to include them inline), the latter allows the
-arguments to be provided at runtime from an external (trusted) source.
+encrypted file. The former allows to securely hardcode arguments, the latter
+allows the arguments to be provided at runtime from an external (trusted)
+source.
 
 .. note ::
    Pointing to an encrypted file is currently not supported, due to the fact
    that encryption key provisioning currently happens after setting up
    arguments.
-
-The ``loader.insecure__use_cmdline_argv``, ``loader.argv``, and
-``loader.argv_src_file`` options are mutually exclusive.
-
-If none of the above arguments-handling manifest options is specified in the
-manifest, the application will get ``argv = [ <libos.entrypoint value> ]``.
 
 Environment variables
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The wording is slightly less verbose and represented as a bullet list now. Reads easier.

One person complained about the previous paragraph with three options (it was confusingly written). Also, the `Note` kinda splits the section into two halves, and people didn't notice the second half.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/880)
<!-- Reviewable:end -->
