### PR TITLE
[LibOS] Use unlinkat instead of rmdir

### DIFF
--- a/libos/src/sys/libos_file.c
+++ b/libos/src/sys/libos_file.c
@@ -68,6 +68,11 @@ long libos_syscall_unlinkat(int dfd, const char* pathname, int flag) {
         if (ret < 0) {
             goto out;
         }
+    } else {
+        if (flag & AT_REMOVEDIR) {
+            ret = -EACCES;
+            goto out;
+        }
     }
 
     put_inode(dent->inode);

--- a/libos/test/regression/synthetic.c
+++ b/libos/test/regression/synthetic.c
@@ -49,8 +49,8 @@ int main(void) {
 
     test_list(path, subpath);
 
-    if (unlinkat(AT_FDCWD, path, AT_REMOVEDIR) != -1 || errno != EACCES)
-        err(1, "unlink should return EACCES");
+    if (rmdir(path) != -1 || errno != EACCES)
+        err(1, "rmdir should return EACCES");
 
     if (stat(path, &statbuf) == -1)
         err(1, "stat");

--- a/libos/test/regression/synthetic.c
+++ b/libos/test/regression/synthetic.c
@@ -49,8 +49,8 @@ int main(void) {
 
     test_list(path, subpath);
 
-    if (rmdir(path) != -1 || errno != EACCES)
-        err(1, "rmdir should return EACCES");
+    if (unlinkat(AT_FDCWD, path, AT_REMOVEDIR) != -1 || errno != EACCES)
+        err(1, "unlink should return EACCES");
 
     if (stat(path, &statbuf) == -1)
         err(1, "stat");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Unlinkat() implements a superset of functionality of rmdir() and we can use it for rmdir() and remove duplicate code. First, though, fix an error return code of unlinkat() when a directory is to be removed and -EACCES is expected to be returned in a test case.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Run test cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/886)
<!-- Reviewable:end -->
