### PR TITLE
[LibOS] Add missing rlimit check on newfd to dup3()

### DIFF
--- a/libos/src/sys/libos_dup.c
+++ b/libos/src/sys/libos_dup.c
@@ -57,6 +57,9 @@ long libos_syscall_dup3(unsigned int oldfd, unsigned int newfd, int flags) {
     if ((flags & ~O_CLOEXEC) || oldfd == newfd)
         return -EINVAL;
 
+    if (newfd >= get_rlimit_cur(RLIMIT_NOFILE))
+        return -EBADF;
+
     struct libos_handle_map* handle_map = get_thread_handle_map(NULL);
     assert(handle_map);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Add missing rlimit check on newfd to dup3().

Also see here: https://elixir.bootlin.com/linux/latest/source/fs/file.c#L1217

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/887)
<!-- Reviewable:end -->
