### PR TITLE
[PAL/Linux-SGX] Mitigate CVE-2022-21233 aka INTEL-SA-00657

### DIFF
--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -24,9 +24,6 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.thread_num = 4
 
-# Nginx benefits from Exitless. Uncomment the below line to use it.
-#sgx.rpc_thread_num = 4
-
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ install_dir }}/sbin/nginx",

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -511,7 +511,7 @@ Number of RPC threads (Exitless feature)
 
 ::
 
-    sgx.rpc_thread_num = [NUM]
+    sgx.insecure__rpc_thread_num = [NUM]
     (Default: 0)
 
 This syntax specifies the number of RPC threads that are created outside of
@@ -524,7 +524,7 @@ the enclave (except for a few syscalls where there is no benefit, e.g.,
 If user specifies ``0`` or omits this directive, then no RPC threads are
 created and all system calls perform an enclave exit ("normal" execution).
 
-Note that the number of created RPC threads must match the maximum number of
+Note that the number of created RPC threads should match the maximum number of
 simultaneous enclave threads. If there are more RPC threads, then CPU time is
 wasted. If there are less RPC threads, some enclave threads may starve,
 especially if there are many blocking system calls by other enclave threads.
@@ -534,6 +534,9 @@ OCALLs/ECALLs for fast shared-memory communication at the cost of occupying
 more CPU cores and burning more CPU cycles. For example, a single-threaded
 Redis instance on Linux becomes 5-threaded on Gramine with Exitless. Thus,
 Exitless may negatively impact throughput but may improve latency.
+
+This feature is currently marked as insecure, because it reads untrusted memory
+in potentially insecure manner - susceptible to CVE-2022-21233 (INTEL-SA-00657).
 
 Optional CPU features (AVX, AVX512, MPX, PKRU, AMX)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -163,6 +163,9 @@ to OCALLs:
 Exitless feature
 ----------------
 
+Note this feature is currently insecure and not recommended for production
+usage (potentially susceptible to CVE-2022-21233 aka INTEL-SA-00657).
+
 Gramine supports the Exitless (or Switchless) feature – it trades off CPU cores
 for faster OCALL execution. More specifically, with Exitless, enclave threads do
 not exit the enclave on OCALLs but instead busy wait for untrusted helper
@@ -172,28 +175,28 @@ requests for OCALLs from enclave threads (untrusted helper threads periodically
 sleep if there have been no OCALL requests for a long time to save some CPU
 cycles).
 
-Exitless is configured by ``sgx.rpc_thread_num = xyz``. By default, the Exitless
-feature is disabled – all enclave threads perform an actual OCALL for each
-system call and exit the enclave. The feature can be disabled by specifying
-``sgx.rpc_thread_num = 0``.
+Exitless is configured by ``sgx.insecure__rpc_thread_num = xyz``. By default,
+the Exitless feature is disabled – all enclave threads perform an actual OCALL
+for each system call and exit the enclave. The feature can be disabled by
+specifying ``sgx.insecure__rpc_thread_num = 0``.
 
 You must decide how many untrusted helper RPC threads your application needs. A
-rule of thumb: specify ``sgx.rpc_thread_num == sgx.thread_num``, i.e., the
-number of untrusted RPC threads should be the same as the number of enclave
+rule of thumb: specify ``sgx.insecure__rpc_thread_num == sgx.thread_num``, i.e.,
+the number of untrusted RPC threads should be the same as the number of enclave
 threads. For example, native Redis 6.0 uses 3-4 enclave threads during its
 execution, plus Gramine uses another 1-2 helper enclave threads. So Redis
 manifest has an over-approximation of this number: ``sgx.thread_num = 8``. Thus,
-to correctly enable the Exitless feature, specify ``sgx.rpc_thread_num = 8``.
-Here is an example:
+to correctly enable the Exitless feature, specify
+``sgx.insecure__rpc_thread_num = 8``. Here is an example:
 
 ::
 
-   # exitless disabled: `sgx.thread_num = 8` and `sgx.rpc_thread_num = 0`
+   # exitless disabled: `sgx.thread_num = 8` and `sgx.insecure__rpc_thread_num = 0`
    CI-Examples/redis$ gramine-sgx redis-server --save '' --protected-mode no &
    CI-Examples/redis$ src/src/redis-benchmark -t set
    43010.75 requests per second
 
-   # exitless enabled: `sgx.thread_num = 8` and `sgx.rpc_thread_num = 8`
+   # exitless enabled: `sgx.thread_num = 8` and `sgx.insecure__rpc_thread_num = 8`
    CI-Examples/redis$ gramine-sgx redis-server --save '' --protected-mode no &
    CI-Examples/redis$ src/src/redis-benchmark -t set
    68119.89 requests per second

--- a/libos/test/regression/multi_pthread_exitless.manifest.template
+++ b/libos/test/regression/multi_pthread_exitless.manifest.template
@@ -10,7 +10,7 @@ fs.mounts = [
 
 # app runs with 4 parallel threads + Gramine has couple internal threads
 sgx.thread_num = 8
-sgx.rpc_thread_num = 8
+sgx.insecure__rpc_thread_num = 8
 
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/pal/regression/Thread2_exitless.manifest.template
+++ b/pal/regression/Thread2_exitless.manifest.template
@@ -3,7 +3,7 @@
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 
 sgx.thread_num = 2
-sgx.rpc_thread_num = 2
+sgx.insecure__rpc_thread_num = 2
 sgx.enable_stats = true
 sgx.nonpie_binary = true
 sgx.debug = true

--- a/pal/src/host/linux-sgx/enclave_api.h
+++ b/pal/src/host/linux-sgx/enclave_api.h
@@ -16,10 +16,17 @@ void* sgx_alloc_on_ustack(uint64_t size);
 void* sgx_copy_to_ustack(const void* ptr, uint64_t size);
 void sgx_reset_ustack(const void* old_ustack);
 
+void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size);
 bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize);
 void* sgx_import_array_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt);
 void* sgx_import_array2d_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt1,
                                     size_t elem_cnt2);
+
+#define COPY_UNTRUSTED_VALUE(untrusted_ptr) ({                          \
+    __typeof__(*(untrusted_ptr)) val;                                   \
+    sgx_copy_to_enclave_verified(&val, (untrusted_ptr), sizeof(val));   \
+    val;                                                                \
+})
 
 /*!
  * \brief Low-level wrapper around EREPORT instruction leaf.

--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -129,13 +129,76 @@ void sgx_reset_ustack(const void* old_ustack) {
     UPDATE_USTACK(old_ustack);
 }
 
+static void copy_u64s(void* dst, const void* untrusted_src, size_t count) {
+    assert((uintptr_t)untrusted_src % 8 == 0);
+    /* The output operands are needed because we cannot specify the same register as both input and
+     * clobbered in GCC inline assembly. */
+    __asm__ volatile (
+        "rep movsq\n"
+        : "+D"(dst), "+S"(untrusted_src), "+c"(count)
+        :  "D"(dst),  "S"(untrusted_src),  "c"(count)
+        : "memory", "cc"
+    );
+}
+
+void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size) {
+    assert(sgx_is_valid_untrusted_ptr(uptr, size, /*alignment=*/1));
+    assert(sgx_is_completely_within_enclave(ptr, size));
+
+    if (size == 0) {
+        return;
+    }
+
+    /*
+     * This should be simple `memcpy(ptr, uptr, size)`, but CVE-2022-21233 (INTEL-SA-00657).
+     * To mitigate this issue, all reads of untrusted memory from within the enclave must be done
+     * in 8-byte chunks aligned to 8-bytes boundary. Since x64 allocates memory in pages of
+     * (at least) 0x1000 in size, we can safely 8-align the pointer down and the size up.
+     */
+    size_t copy_len;
+    size_t prefix_misalignment = (uintptr_t)uptr & 7;
+    if (prefix_misalignment) {
+        /* Beginning of the copied range is misaligned. */
+        char prefix_val[8] = { 0 };
+        copy_u64s(prefix_val, (char*)uptr - prefix_misalignment, /*count=*/1);
+
+        copy_len = MIN(sizeof(prefix_val) - prefix_misalignment, size);
+        memcpy(ptr, prefix_val + prefix_misalignment, copy_len);
+        ptr = (char*)ptr + copy_len;
+        uptr = (const char*)uptr + copy_len;
+        size -= copy_len;
+
+        if (size == 0) {
+            return;
+        }
+    }
+    assert((uintptr_t)uptr % 8 == 0);
+
+    size_t suffix_misalignment = size & 7;
+    copy_len = size - suffix_misalignment;
+    assert(copy_len % 8 == 0);
+    copy_u64s(ptr, uptr, copy_len / 8);
+    ptr = (char*)ptr + copy_len;
+    uptr = (const char*)uptr + copy_len;
+    size -= copy_len;
+
+    assert(size == suffix_misalignment);
+    if (suffix_misalignment) {
+        /* End of the copied range is misaligned. */
+        char suffix_val[8] = { 0 };
+        copy_u64s(suffix_val, uptr, /*count=*/1);
+        memcpy(ptr, suffix_val, suffix_misalignment);
+    }
+}
+
 bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize) {
     if (usize > maxsize ||
         !sgx_is_valid_untrusted_ptr(uptr, usize, /*alignment=*/1) ||
         !sgx_is_completely_within_enclave(ptr, maxsize)) {
         return false;
     }
-    memcpy(ptr, uptr, usize);
+
+    sgx_copy_to_enclave_verified(ptr, uptr, usize);
     return true;
 }
 

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -683,15 +683,16 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
     }
 
     int64_t rpc_thread_num_int64;
-    ret = toml_int_in(manifest_root, "sgx.rpc_thread_num", /*defaultval=*/0, &rpc_thread_num_int64);
+    ret = toml_int_in(manifest_root, "sgx.insecure__rpc_thread_num", /*defaultval=*/0,
+                      &rpc_thread_num_int64);
     if (ret < 0) {
-        log_error("Cannot parse 'sgx.rpc_thread_num'");
+        log_error("Cannot parse 'sgx.insecure__rpc_thread_num'");
         ret = -EINVAL;
         goto out;
     }
 
     if (rpc_thread_num_int64 < 0) {
-        log_error("Negative 'sgx.rpc_thread_num' is impossible");
+        log_error("Negative 'sgx.insecure__rpc_thread_num' is impossible");
         ret = -EINVAL;
         goto out;
     }
@@ -699,7 +700,8 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
     enclave_info->rpc_thread_num = rpc_thread_num_int64;
 
     if (enclave_info->rpc_thread_num > MAX_RPC_THREADS) {
-        log_error("Too large 'sgx.rpc_thread_num', maximum allowed is %d", MAX_RPC_THREADS);
+        log_error("Too large 'sgx.insecure__rpc_thread_num', maximum allowed is %d",
+                  MAX_RPC_THREADS);
         ret = -EINVAL;
         goto out;
     }

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -73,7 +73,8 @@ extern size_t g_pal_internal_mem_size;
 
 noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void* uptr_args,
                              size_t args_size, void* uptr_env, size_t env_size,
-                             int parent_stream_fd, void* uptr_qe_targetinfo, void* uptr_topo_info);
+                             int parent_stream_fd, void* uptr_qe_targetinfo, void* uptr_topo_info,
+                             void* uptr_rpc_queue);
 void pal_start_thread(void);
 
 extern char __text_start, __text_end, __data_start, __data_end;

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -10,6 +10,8 @@
  * arguments and manifest.
  */
 
+#include <stdalign.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdnoreturn.h>
 
@@ -21,6 +23,7 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "pal_rpc_queue.h"
 #include "pal_rtld.h"
 #include "pal_topology.h"
 #include "toml.h"
@@ -48,6 +51,22 @@ void _PalGetAvailableUserAddressRange(void** out_start, void** out_end) {
         log_error("Not enough enclave memory, please increase enclave size!");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
+}
+
+static bool verify_and_init_rpc_queue(void* untrusted_rpc_queue) {
+    if (!untrusted_rpc_queue) {
+        /* user app didn't request RPC queue (i.e., the app didn't request exitless syscalls) */
+        return true;
+    }
+
+    if (!sgx_is_valid_untrusted_ptr(untrusted_rpc_queue, sizeof(*g_rpc_queue),
+                                    alignof(__typeof__(*g_rpc_queue)))) {
+        /* malicious RPC queue object, return error */
+        return false;
+    }
+
+    g_rpc_queue = untrusted_rpc_queue;
+    return true;
 }
 
 /*
@@ -418,7 +437,8 @@ static void do_preheat_enclave(void) {
 __attribute_no_stack_protector
 noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void* uptr_args,
                              size_t args_size, void* uptr_env, size_t env_size,
-                             int parent_stream_fd, void* uptr_qe_targetinfo, void* uptr_topo_info) {
+                             int parent_stream_fd, void* uptr_qe_targetinfo, void* uptr_topo_info,
+                             void* uptr_rpc_queue) {
     /* All our arguments are coming directly from the host. We are responsible to check them. */
     int ret;
 
@@ -565,6 +585,20 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
     }
     g_pal_common_state.raw_manifest_data = manifest_addr;
     g_pal_public_state.manifest_root = manifest_root;
+
+    int64_t rpc_thread_num;
+    ret = toml_int_in(g_pal_public_state.manifest_root, "sgx.insecure__rpc_thread_num",
+                      /*defaultval=*/0, &rpc_thread_num);
+    if (ret < 0) {
+        log_error("Cannot parse 'sgx.insecure__rpc_thread_num'");
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+    if (rpc_thread_num > 0) {
+        if (!verify_and_init_rpc_queue(uptr_rpc_queue)) {
+            log_error("Invalid rpc queue pointer");
+            ocall_exit(1, /*is_exitgroup=*/true);
+        }
+    }
 
     /* Get host topology information only for the first process. This information will be
      * checkpointed and restored during forking of the child process(es). */

--- a/pal/src/host/linux-sgx/pal_rpc_queue.h
+++ b/pal/src/host/linux-sgx/pal_rpc_queue.h
@@ -1,4 +1,9 @@
 /*
+ * FIXME: This feature is currently insecure. It keeps most objects in untrusted memory and uses
+ * some functions, like `spinlock_lock`, on that memory. Since we have to use 8-byte naturally
+ * aligned untrusted memory accesses to mitigate CVE-2022-21233, we must mark this feature as
+ * insecure until we rewrite it or that CVE is fully fixed in hardware or microcode.
+ *
  * RPC threads are helper threads that run in untrusted mode alongside enclave threads. RPC threads
  * issue system calls on behalf of enclave threads. This allows "exitless" design when app threads
  * never leave the enclave (except for a few syscalls where there is no benefit, e.g., nanosleep).
@@ -6,9 +11,9 @@
  * "Exitless" design alleviates expensive OCALLs/ECALLs. This was first proposed by SCONE (by
  * Arnautov et al at OSDI 2016) and by Eleos (by Orenbach et al at EuroSys 2017).
  *
- * Brief description: user must specify "sgx.rpc_thread_num = 2" in manifest to create two RPC
- * threads. If user specifies "0" or omits this directive, then no RPC threads are created and all
- * syscalls perform an enclave exit (as in previous versions of Gramine).
+ * Brief description: user must specify "sgx.insecure__rpc_thread_num = 2" in manifest to create two
+ * RPC threads. If user specifies "0" or omits this directive, then no RPC threads are created and
+ * all syscalls perform an enclave exit (as in previous versions of Gramine).
  *
  * All enclave and RPC threads work on a single shared RPC queue (global variable `g_rpc_queue`).
  * To issue a syscall, enclave thread enqueues syscall request in the queue and spins waiting for


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
If malicious host maps APIC registers in some untrusted memory (MMIO) and this memory is subsequently read by the enclave (e.g. when reading some results of an ocall) such read can potentially return some stale, enclave-originated data. Naturally aligned 8-byte reads are not affected by this vulnerability, so as software mitigation, this commit makes all untrusted memory accesses 8-byte wide and naturally aligned.

As a side effect the exitless ocalls feature becomes potentially insecure. It uses untrusted memory in some complex manner, which we did not bother changing for now, as the feature is not widely used.

Fixes #846

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/894)
<!-- Reviewable:end -->
