### PR TITLE
[LibOS] Normalize paths in URIs of `encrypted` FS mounts

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
@@ -21,7 +21,7 @@ fs.mounts = [
   { path = "/etc", uri = "file:/etc" },
   { path = "/client", uri = "file:client" },
   { path = "/ca.crt", uri = "file:../ssl/ca.crt" },
-  { path = "/files", uri = "file:enc_files", type = "encrypted" },
+  { path = "/files/", uri = "file:enc_files/", type = "encrypted" },
 ]
 
 sgx.enclave_size = "512M"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Without this normalization, Gramine would fail on syntax like this:

    fs.mounts = [ { path = "/a/", uri = "file:a/", type = "encrypted" } ]

This was because LibOS concatenated the URI and the filename by adding `/`, resulting in non-normalized URI `file:a//name`. However, the Protected Files common logic requires URIs to be normalized, otherwise filename comparison (done to prevent file-swap attacks) fails.

Fixes #904.

## How to test this PR? <!-- (if applicable) -->

`ra-tls-secret-prov` example fixed. The rest of CI passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/908)
<!-- Reviewable:end -->
