### PR TITLE
[PAL/Linux-SGX] Fix inline asm in `copy_u64s()`

### DIFF
--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -131,12 +131,10 @@ void sgx_reset_ustack(const void* old_ustack) {
 
 static void copy_u64s(void* dst, const void* untrusted_src, size_t count) {
     assert((uintptr_t)untrusted_src % 8 == 0);
-    /* The output operands are needed because we cannot specify the same register as both input and
-     * clobbered in GCC inline assembly. */
     __asm__ volatile (
         "rep movsq\n"
         : "+D"(dst), "+S"(untrusted_src), "+c"(count)
-        :  "D"(dst),  "S"(untrusted_src),  "c"(count)
+        :
         : "memory", "cc"
     );
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
It specified that some values are both read and written in an incorrect manner.

## How to test this PR? <!-- (if applicable) -->
If you were unlucky (no idea what are the exact circumstances), current master might not have compiled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/909)
<!-- Reviewable:end -->
