### PR TITLE
[LibOS,PAL] Extend extra runtime configuration to include hostname

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -153,24 +153,26 @@ Domain names configuration
     sys.enable_extra_runtime_domain_names_conf = [true|false]
     (Default: false)
 
-This option will generate following extra runtime files:
+This option will generate the following extra configuration:
 
-- ``/etc/resolv.conf``
-   Supported keywords:
+- Hostname (obtained by apps via `nodename` field in `uname` syscall),
+  set to the host's hostname at initialization.
+- Pseudo-file ``/etc/resolv.conf``, with keywords:
 
    - ``nameserver``
    - ``search``
    - ``options`` (``inet6`` | ``rotate``)
 
-Unsupported keywords and malformed lines are ignored, and invalid values are
-reported as an error.
+  Unsupported keywords and malformed lines from ``/etc/resolv.conf`` are ignored.
 
-This functionality is achieved by taking the host's configuration via various
+The functionality is achieved by taking the host's configuration via various
 APIs and reading the host's configuration files. In the case of Linux PAL,
 most information comes from the host's ``/etc``. The gathered information is
 used to create ``/etc`` files inside Gramine's file system, or change Gramine
 process configuration. For security-enforcing modes (such as SGX), Gramine
-additionally sanitizes the information gathered from the host.
+additionally sanitizes the information gathered from the host. Invalid host's
+configuration is reported as an error (e.g. invalid hostname, or invalid IPv4
+address in ``nameserver`` keyword).
 
 Note that Gramine supports only a subset of the configuration.
 Refer to the list of supported keywords.

--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -153,6 +153,8 @@ bool handle_signal(PAL_CONTEXT* context);
  */
 long pal_to_unix_errno(long err);
 
+int set_hostname(const char* name, size_t len);
+
 void warn_unsupported_syscall(unsigned long sysno);
 void debug_print_syscall_before(unsigned long sysno, ...);
 void debug_print_syscall_after(unsigned long sysno, ...);

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -487,6 +487,10 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
      * communicates with server over a "loopback" IPC connection. */
     RUN_INIT(init_sync_client);
 
+    /* XXX: this will break uname checkpointing (if we implement it). */
+    RUN_INIT(set_hostname, g_pal_public_state->dns_host.hostname,
+             strlen(g_pal_public_state->dns_host.hostname));
+
     log_debug("LibOS initialized");
 
     libos_tcb_t* cur_tcb = libos_get_tcb();

--- a/libos/src/sys/libos_uname.c
+++ b/libos/src/sys/libos_uname.c
@@ -21,7 +21,7 @@
  * our `uname` implementation. */
 static struct new_utsname g_current_uname = {
     .sysname  = "Linux",
-    .nodename = "localhost",
+    .nodename = "(none)", /* overwritten by PAL-provided value at startup */
     .release  = "3.10.0",
     .version  = "1",
 #ifdef __x86_64__
@@ -40,6 +40,16 @@ long libos_syscall_uname(struct new_utsname* buf) {
     return 0;
 }
 
+int set_hostname(const char* name, size_t len) {
+    if (len >= sizeof(g_current_uname.nodename))
+        return -EINVAL;
+
+    memcpy(&g_current_uname.nodename, name, len);
+    memset(&g_current_uname.nodename[len], 0, sizeof(g_current_uname.nodename) - len);
+
+    return 0;
+}
+
 long libos_syscall_sethostname(char* name, int len) {
     if (len < 0 || (size_t)len >= sizeof(g_current_uname.nodename))
         return -EINVAL;
@@ -47,9 +57,7 @@ long libos_syscall_sethostname(char* name, int len) {
     if (!is_user_memory_readable(name, len))
         return -EFAULT;
 
-    memcpy(&g_current_uname.nodename, name, len);
-    memset(&g_current_uname.nodename[len], 0, sizeof(g_current_uname.nodename) - len);
-    return 0;
+    return set_hostname(name, len);
 }
 
 long libos_syscall_setdomainname(char* name, int len) {

--- a/libos/test/regression/hostname.c
+++ b/libos/test/regression/hostname.c
@@ -1,0 +1,57 @@
+#define _DEFAULT_SOURCE BSD /* This is required for gethostname */
+
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void test_fork(const char* tag, const char* expected_name,
+                      void (*f)(const char*, const char*)) {
+    int status;
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        err(1, "%s: unable to fork", tag);
+    }
+
+    if (pid == 0) {
+        f(tag, expected_name);
+        exit(0);
+    }
+
+    if (wait(&status) == -1) {
+        err(1, "%s: wait failed", tag);
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        errx(1, "%s: exit status of child is not zero", tag);
+    }
+}
+
+static void test_gethostname(const char* tag, const char* expected_name) {
+    char buf[512] = {0};
+
+    if (gethostname(buf, sizeof(buf)) != 0) {
+        err(1, "%s: failed", tag);
+    }
+
+    if (strcmp(buf, expected_name) != 0) {
+        errx(1, "%s: result doesn't match hostname (expected: %s, got: %s)",
+             tag, expected_name, buf);
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        printf("Usage: %s [hostname]\n", argv[0]);
+        return 1;
+    }
+
+    test_gethostname("gethostname", argv[1]);
+    test_fork("gethostname after fork", argv[1], test_gethostname);
+
+    printf("TEST OK\n");
+    return 0;
+}

--- a/libos/test/regression/hostname_extra_runtime_conf.manifest.template
+++ b/libos/test/regression/hostname_extra_runtime_conf.manifest.template
@@ -1,0 +1,21 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "hostname"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.insecure__use_cmdline_argv = true
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/hostname", uri = "file:{{ binary_dir }}/hostname" },
+]
+
+sys.enable_extra_runtime_domain_names_conf = true
+
+sgx.debug = true
+sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/hostname",
+]

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -49,6 +49,7 @@ tests = {
     'groups': {},
     'helloworld': {},
     'host_root_fs': {},
+    'hostname': {},
     'init_fail': {},
     'keys': {},
     'kill_all': {},

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import signal
+import socket
 import subprocess
 import unittest
 
@@ -911,6 +912,15 @@ class TC_30_Syscall(RegressionTestCase):
             if os.path.exists('tmp/lock_file'):
                 os.remove('tmp/lock_file')
         self.assertIn('TEST OK', stdout)
+
+    def test_120_gethostname_default(self):
+        # The generic manifest (manifest.template) doesn't use extra runtime conf.
+        stdout, _ = self.run_binary(['hostname', 'localhost'])
+        self.assertIn("TEST OK", stdout)
+
+    def test_121_gethostname_pass_etc(self):
+        stdout, _ = self.run_binary(['hostname_extra_runtime_conf', socket.gethostname()])
+        self.assertIn("TEST OK", stdout)
 
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -50,6 +50,8 @@ manifests = [
   "gettimeofday",
   "groups",
   "helloworld",
+  "hostname",
+  "hostname_extra_runtime_conf",
   "host_root_fs",
   "init_fail",
   "keys",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -52,6 +52,8 @@ manifests = [
   "gettimeofday",
   "groups",
   "helloworld",
+  "hostname",
+  "hostname_extra_runtime_conf",
   "host_root_fs",
   "init_fail",
   "keys",

--- a/pal/include/host/linux-common/etc_host_info.h
+++ b/pal/include/host/linux-common/etc_host_info.h
@@ -8,3 +8,5 @@
 #include "pal.h"
 
 int parse_resolv_conf(struct pal_dns_host_conf* conf);
+
+int get_hosts_hostname(char* hostname, size_t size);

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -118,6 +118,8 @@ struct pal_dns_host_conf {
 
     bool inet6;
     bool rotate;
+
+    char hostname[PAL_HOSTNAME_MAX];
 };
 
 /* Part of PAL state which is shared between all PALs and accessible (read-only) by the binary

--- a/pal/regression/ipv4_parser.c
+++ b/pal/regression/ipv4_parser.c
@@ -8,14 +8,6 @@
 #include "pal_error.h"
 #include "pal_regression.h"
 
-/* We define this to not link with many unneeded files, which are required by functions in
- * etc_host_info.c which we don't use here. */
-void read_text_file_to_cstr(void);
-void read_text_file_to_cstr(void) {
-    pal_printf("This function is a mock function and shouldn't be called\n");
-    PalProcessExit(1);
-}
-
 static int ipv4_valid(const char* buf, uint32_t reference_addr) {
     uint32_t addr;
     const char* ptr = buf;

--- a/pal/regression/ipv6_parser.c
+++ b/pal/regression/ipv6_parser.c
@@ -8,14 +8,6 @@
 #include "pal_error.h"
 #include "pal_regression.h"
 
-/* We define this to not link with many unneeded files, which are required by functions in
- * etc_host_info.c which we don't use here. */
-void read_text_file_to_cstr(void);
-void read_text_file_to_cstr(void) {
-    pal_printf("This function is a mock function and shouldn't be called\n");
-    PalProcessExit(1);
-}
-
 static int ipv6_valid(const char* buf, uint16_t reference_addr[static 8]) {
     uint16_t addr[8];
     const char* ptr = buf;

--- a/pal/regression/meson.build
+++ b/pal/regression/meson.build
@@ -24,6 +24,10 @@ tests = {
             'ipv4_parser.c',
             '../src/host/linux-common/etc_host_info.c',
         ],
+        'c_args': [
+            '-DPARSERS_ONLY',
+            '-Wno-unused-function',
+        ],
         'include_directories': include_directories(
             # for `etc_host_info_internal.h`
             join_paths('../include/host/linux-common'),
@@ -33,6 +37,10 @@ tests = {
         'filenames': [
             'ipv6_parser.c',
             '../src/host/linux-common/etc_host_info.c',
+        ],
+        'c_args': [
+            '-DPARSERS_ONLY',
+            '-Wno-unused-function',
         ],
         'include_directories': include_directories(
             # for `etc_host_info_internal.h`

--- a/pal/src/host/linux-common/etc_host_info.c
+++ b/pal/src/host/linux-common/etc_host_info.c
@@ -6,12 +6,17 @@
 /*
  * This file contains the APIs to retrieve information from the host:
  *   - parses host file `/etc/resolv.conf` into `struct pal_dns_host_conf`
+ *   - gets host's hostname through uname syscall
  */
+
+#include <asm/errno.h>
+#include <linux/utsname.h>
 
 #include "api.h"
 #include "etc_host_info.h"
 #include "etc_host_info_internal.h"
 #include "linux_utils.h"
+#include "syscall.h"
 
 static void jmp_to_end_of_line(const char** pptr) {
     const char* ptr = *pptr;
@@ -175,6 +180,7 @@ bool parse_ip_addr_ipv6(const char** pptr, uint16_t addr[static 8]) {
     return true;
 }
 
+#ifndef PARSERS_ONLY
 static void resolv_nameserver(struct pal_dns_host_conf* conf, const char** pptr) {
     const char* ptr = *pptr;
     bool is_ipv6 = false;
@@ -336,3 +342,20 @@ int parse_resolv_conf(struct pal_dns_host_conf* conf) {
     free(buf);
     return 0;
 }
+
+int get_hosts_hostname(char* hostname, size_t size) {
+    struct new_utsname c_uname;
+
+    int ret = DO_SYSCALL(uname, &c_uname);
+    if (ret < 0)
+        return ret;
+
+    size_t node_size = strlen(c_uname.nodename) + 1;
+    memcpy(hostname, c_uname.nodename, MIN(node_size, size));
+
+    assert(size > 0);
+    hostname[size - 1] = 0;
+
+    return 0;
+}
+#endif /* ifndef PARSERS_ONLY */

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -957,6 +957,11 @@ static int load_enclave(struct pal_enclave* enclave, char* args, size_t args_siz
                 log_error("Unable to parse host's /etc/resolv.conf");
                 return ret;
             }
+            ret = get_hosts_hostname(dns_conf.hostname, sizeof(dns_conf.hostname));
+            if (ret < 0) {
+                log_error("Unable to get host's hostname");
+                return ret;
+            }
         }
     }
 

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -382,6 +382,14 @@ static int import_and_init_extra_runtime_domain_names(struct pal_dns_host_conf* 
     pub_dns->inet6 = untrusted_dns.inet6;
     pub_dns->rotate = untrusted_dns.rotate;
 
+    untrusted_dns.hostname[sizeof(untrusted_dns.hostname) - 1] = 0x00;
+    if (!is_hostname_valid(untrusted_dns.hostname)) {
+        log_warning("The hostname on the host seems to be invalid. "
+                    "The Gramine hostname will be set to \"localhost\".");
+    } else {
+        memcpy(pub_dns->hostname, untrusted_dns.hostname, sizeof(pub_dns->hostname));
+    }
+
     return 0;
 }
 

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -129,6 +129,11 @@ static void get_host_etc_configs(void) {
     if (parse_resolv_conf(&g_pal_public_state.dns_host) < 0) {
         INIT_FAIL("Unable to parse /etc/resolv.conf");
     }
+
+    if (get_hosts_hostname(g_pal_public_state.dns_host.hostname,
+                           sizeof(g_pal_public_state.dns_host.hostname)) < 0) {
+        INIT_FAIL("Unable to get hostname");
+    }
 }
 
 #ifdef ASAN

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -21,6 +21,9 @@ struct pal_common_state g_pal_common_state;
 struct pal_public_state g_pal_public_state = {
     /* Enable log to catch early initialization errors; it will be overwritten in pal_main(). */
     .log_level = PAL_LOG_DEFAULT_LEVEL,
+    .dns_host = {
+        .hostname = "localhost",
+    },
 };
 
 struct pal_public_state* PalGetPalPublicState(void) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a continuation of the issue https://github.com/gramineproject/gramine/issues/689.

From what I can see, most applications use the uname(2) syscall to obtain a current hostname, for example, gethostame.
The /etc/hostname is read during startup, and the sethostname(2) is called. For example, this is done on Ubuntu 20.04 with /etc/init/hostname.conf script.

Because of that we decided not to create a `/etc/hostname` file but just to set the Gramine hostname to the host's hostname.

The Gramine hostname has to be a valid domain. This is a difference from Linux, as Linux accepts any hostname value. That said, Linux doesn't assume that the root user tries to exploit it through hostname, and Gramine should.

This change doesn't address the support of the sethostname(2). The hostname can change after initialisation, however new process (after fork inside Gramine) will inherit an initial value of hostname. We probably should separately propagate the current value of the hostname. We are also missing a mechanism for propagating the hostname across multiple processes. We might also decide just to remove sethostname(2) completely. My understanding is that we have it only to enable LTP tests.

## How to test this PR? <!-- (if applicable) -->

New tests are added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/919)
<!-- Reviewable:end -->
