### PR TITLE
[LibOS] Always allocate a slot for a wakeup handle in `do_epoll_wait`

### DIFF
--- a/libos/test/regression/epoll_test.c
+++ b/libos/test/regression/epoll_test.c
@@ -135,7 +135,21 @@ static void test_epoll_oneshot(void) {
     CHECK(close(epfd));
 }
 
+static void test_epoll_empty(void) {
+    int epfd = CHECK(epoll_create1(0));
+
+    struct epoll_event event = { 0 };
+    int x = CHECK(epoll_wait(epfd, &event, 1, 0));
+    if (x != 0) {
+        ERR("epoll_wait on empty epoll instance returned: %d", x);
+    }
+
+    CHECK(close(epfd));
+}
+
 int main(void) {
+    test_epoll_empty();
+
     test_epoll_migration();
 
     test_epoll_oneshot();


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
`do_epoll_wait` gathers PAL handles from all epoll items + one PAL handle to prematurely wake up the waiter. The code missed a case where there are no epoll items (so the array should contain only the wakeup handle), which this commit fixes.

Fixes #920

## How to test this PR? <!-- (if applicable) -->
Added a test case

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/928)
<!-- Reviewable:end -->
