### PR TITLE
[LibOS] Return -EINVAL for unsupport timer in setitimer syscall

### DIFF
--- a/libos/src/sys/libos_alarm.c
+++ b/libos/src/sys/libos_alarm.c
@@ -78,7 +78,7 @@ static void signal_itimer(IDTYPE caller, void* arg) {
 long libos_syscall_setitimer(int which, struct __kernel_itimerval* value,
                              struct __kernel_itimerval* ovalue) {
     if (which != ITIMER_REAL)
-        return -ENOSYS;
+        return -EINVAL;
 
     if (!value)
         return -EFAULT;

--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -1999,9 +1999,6 @@ skip = yes
 [sethostname03]
 skip = yes
 
-[setitimer03]
-skip = yes
-
 [setns01]
 skip = yes
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Return -EINVAL for an unsupported timer in setitimer syscall and enable the LTP test case setitimer03.


<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Run LTP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/929)
<!-- Reviewable:end -->
