### PR TITLE
[LibOS,PAL] Extend DNS runtime configuration

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -161,7 +161,7 @@ This option will generate the following extra configuration:
 
    - ``nameserver``
    - ``search``
-   - ``options`` (``inet6`` | ``rotate``)
+   - ``options`` [``edns0``] [``inet6``] [``rotate``] [``use-vc``]
 
   Unsupported keywords and malformed lines from ``/etc/resolv.conf`` are ignored.
 

--- a/libos/src/fs/etc/fs.c
+++ b/libos/src/fs/etc/fs.c
@@ -12,8 +12,10 @@
 #include "libos_fs.h"
 #include "libos_fs_pseudo.h"
 
+#define OPTION_EDNS0 "options edns0\n"
 #define OPTION_INET6 "options inet6\n"
 #define OPTION_ROTATE "options rotate\n"
+#define OPTION_USE_VC "options use-vc\n"
 
 static int put_string(char** buf, size_t* bufsize, const char* fmt, ...) {
     va_list ap;
@@ -44,8 +46,11 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
     size += g_pal_public_state->dns_host.dn_search_count * (PAL_HOSTNAME_MAX + 1);
     size += 1;
     /* and let's add some space for each option */
-    size += (g_pal_public_state->dns_host.inet6 ? strlen(OPTION_INET6) : 0) +
-            (g_pal_public_state->dns_host.rotate ? strlen(OPTION_ROTATE) : 0);
+    size += (g_pal_public_state->dns_host.edns0 ? strlen(OPTION_EDNS0) : 0)
+            + (g_pal_public_state->dns_host.inet6 ? strlen(OPTION_INET6) : 0)
+            + (g_pal_public_state->dns_host.rotate ? strlen(OPTION_ROTATE) : 0)
+            + (g_pal_public_state->dns_host.use_vc ? strlen(OPTION_USE_VC) : 0);
+
     /* make space for terminating character */
     size += 1;
 
@@ -87,6 +92,11 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
         if (ret < 0)
             goto out;
     }
+    if (g_pal_public_state->dns_host.edns0) {
+        ret = put_string(&ptr, &space_left, OPTION_EDNS0);
+        if (ret < 0)
+            goto out;
+    }
     if (g_pal_public_state->dns_host.inet6) {
         ret = put_string(&ptr, &space_left, OPTION_INET6);
         if (ret < 0)
@@ -94,6 +104,11 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
     }
     if (g_pal_public_state->dns_host.rotate) {
         ret = put_string(&ptr, &space_left, OPTION_ROTATE);
+        if (ret < 0)
+            goto out;
+    }
+    if (g_pal_public_state->dns_host.use_vc) {
+        ret = put_string(&ptr, &space_left, OPTION_USE_VC);
         if (ret < 0)
             goto out;
     }

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -116,8 +116,10 @@ struct pal_dns_host_conf {
     char dn_search[PAL_MAX_DN_SEARCH][PAL_HOSTNAME_MAX];
     size_t dn_search_count;
 
+    bool edns0;
     bool inet6;
     bool rotate;
+    bool use_vc;
 
     char hostname[PAL_HOSTNAME_MAX];
 };

--- a/pal/src/host/linux-common/etc_host_info.c
+++ b/pal/src/host/linux-common/etc_host_info.c
@@ -280,10 +280,14 @@ static void resolv_options_setter(struct pal_dns_host_conf* conf, const char* pt
     memcpy(option, ptr, length);
     option[length] = 0x00;
 
-    if (strcmp(option, "inet6") == 0) {
+    if (strcmp(option, "edns0") == 0) {
+        conf->edns0 = true;
+    } else if (strcmp(option, "inet6") == 0) {
         conf->inet6 = true;
     } else if (strcmp(option, "rotate") == 0) {
         conf->rotate = true;
+    } else if (strcmp(option, "use-vc") == 0) {
+        conf->use_vc = true;
     }
 }
 

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -376,11 +376,15 @@ static int import_and_init_extra_runtime_domain_names(struct pal_dns_host_conf* 
     }
     pub_dns->dn_search_count = j;
 
+    coerce_untrusted_bool(&untrusted_dns.edns0);
     coerce_untrusted_bool(&untrusted_dns.inet6);
     coerce_untrusted_bool(&untrusted_dns.rotate);
+    coerce_untrusted_bool(&untrusted_dns.use_vc);
 
+    pub_dns->edns0 = untrusted_dns.edns0;
     pub_dns->inet6 = untrusted_dns.inet6;
     pub_dns->rotate = untrusted_dns.rotate;
+    pub_dns->use_vc = untrusted_dns.use_vc;
 
     untrusted_dns.hostname[sizeof(untrusted_dns.hostname) - 1] = 0x00;
     if (!is_hostname_valid(untrusted_dns.hostname)) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR build upon the recent feature of domain name extra runtime configuration (aka emulating `/etc/resolv.conf`). In previous PR we emulated only two options: `inet6` and `rotate`.
@dimakuv in review to https://github.com/gramineproject/gramine/pull/889 proposed propagating fallowing options:
* `options edns0`
* `ndots:n`
* `use-vc`
This PR tries to address this request.

## Useful link

* [resolv.conf](https://man7.org/linux/man-pages/man5/resolv.conf.5.html)
* [Resolv GLIBC parser](https://elixir.bootlin.com/glibc/latest/source/resolv/res_init.c#L645)
* [Resolv GLIBC header limits](https://elixir.bootlin.com/glibc/latest/source/resolv/resolv.h#L69)

## Issue

https://github.com/gramineproject/gramine/issues/689

## How to test this PR? <!-- (if applicable) -->

Check the value of `resolv.conf` with multiple different hosts configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/932)
<!-- Reviewable:end -->
