### PR TITLE
[Docs] Reflect new way of packaging in v1.3

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -24,24 +24,26 @@ VM instances. The description below uses a *DCsv3 VM* running Ubuntu
 Install Gramine
 ^^^^^^^^^^^^^^^
 
-Add a Gramine repository::
+On Ubuntu 18.04::
 
    sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' | sudo tee /etc/apt/sources.list.d/gramine.list
-
-Add Intel SGX repository::
+   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ bionic main' | sudo tee /etc/apt/sources.list.d/gramine.list
 
    curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-   # (if you're on Ubuntu 18.04, write "bionic" instead of "focal" above)
-
-Install Gramine (DCAP driver version) on Ubuntu 18.04::
+   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 
    sudo apt-get update
    sudo apt-get install gramine-dcap
 
-Install Gramine (in-kernel driver version) on Ubuntu 20.04::
+On Ubuntu 20.04::
 
+   sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
+   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ focal main' | sudo tee /etc/apt/sources.list.d/gramine.list
+
+   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+
+   sudo apt-get update
    sudo apt-get install gramine
 
 Prepare a signing key

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -24,15 +24,27 @@ package (see below).
 Install Gramine
 ---------------
 
-On Ubuntu 18.04 or 20.04 (for 18.04, in :file:`intel-sgx.list`, replace
-``focal`` with ``bionic``)::
+On Ubuntu 18.04::
 
    sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' | sudo tee /etc/apt/sources.list.d/gramine.list
+   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ bionic main' | sudo tee /etc/apt/sources.list.d/gramine.list
+
+   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+
+   sudo apt-get update
+
+   sudo apt-get install gramine      # for 5.11+ upstream, in-kernel driver
+   sudo apt-get install gramine-oot  # for out-of-tree SDK driver
+   sudo apt-get install gramine-dcap # for out-of-tree DCAP driver
+
+On Ubuntu 20.04::
+
+   sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
+   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ focal main' | sudo tee /etc/apt/sources.list.d/gramine.list
 
    curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-   # (if you're on Ubuntu 18.04, remember to write "bionic" instead of "focal")
 
    sudo apt-get update
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

v1.3 uses `bionic` and `focal` Gramine repositories for Ubuntu 18.04 and 20.04 instead of the common `stable` repo.

## How to test this PR? <!-- (if applicable) -->

N/A.