### PR TITLE
[LibOS, PAL] Support corking flags in socket related syscalls

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -61,11 +61,13 @@ struct mmsghdr {
 #define MSG_TRUNC 0x20
 #define MSG_DONTWAIT 0x40
 #define MSG_NOSIGNAL 0x4000
+#define MSG_MORE 0x8000
 #define MSG_CMSG_CLOEXEC 0x40000000
 
 /* Option levels. */
 #define SOL_SOCKET 1
 #define SOL_TCP 6
+#define SOL_UDP 17
 
 /* Socket options. */
 #define SO_REUSEADDR 2
@@ -85,6 +87,9 @@ struct mmsghdr {
 /* TCP options. */
 #define TCP_NODELAY 1
 #define TCP_CORK 3
+
+/* UDP options. */
+#define UDP_CORK 1
 
 struct linger {
     int l_onoff;

--- a/libos/include/libos_socket.h
+++ b/libos/include/libos_socket.h
@@ -87,9 +87,11 @@ struct libos_sock_ops {
      * \param      addrlen            The length of \p addr.
      * \param      force_nonblocking  If `true` this request should not block. Otherwise just use
      *                                whatever mode the handle is in.
+     * \param      force_cork         If `true` this request is corked. Otherwise just use
+     *                                whatever mode the handle is in.
      */
     int (*send)(struct libos_handle* handle, struct iovec* iov, size_t iov_len, size_t* out_size,
-                void* addr, size_t addrlen, bool force_nonblocking);
+                void* addr, size_t addrlen, bool force_nonblocking, bool force_cork);
 
     /*!
      * \brief Receive continuous data into an array of buffers.

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -404,12 +404,17 @@ again:
 }
 
 static int send(struct libos_handle* handle, struct iovec* iov, size_t iov_len, size_t* out_size,
-                void* addr, size_t addrlen, bool force_nonblocking) {
+                void* addr, size_t addrlen, bool force_nonblocking, bool force_cork) {
     __UNUSED(addr);
     __UNUSED(addrlen);
 
     if (handle->info.sock.type == SOCK_DGRAM) {
         /* We do not support datagram UNIX sockets. */
+        BUG();
+    }
+
+    if (force_cork == true) {
+        /* MSG_MORE flag is not supported by UNIX domain sockets. */
         BUG();
     }
 

--- a/libos/test/regression/getsockopt.c
+++ b/libos/test/regression/getsockopt.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <netinet/tcp.h>
+#include <netinet/udp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -47,5 +48,24 @@ int main(int argc, char** argv) {
     }
 
     printf("getsockopt: Got TCP_NODELAY flag OK\n");
+
+    int fd2 = socket(PF_INET, SOCK_DGRAM, 0);
+    if (fd2 < 0) {
+        perror("socket failed");
+        return 1;
+    }
+    ret = getsockopt(fd2, SOL_UDP, UDP_CORK, (void*)&so_flags, &optlen);
+    if (ret < 0) {
+        perror("getsockopt(SOL_UDP, UDP_CORK) failed");
+        return 1;
+    }
+
+    if (optlen != sizeof(so_flags) || (so_flags != 0 && so_flags != 1)) {
+        fprintf(stderr, "getsockopt(SOL_UDP, UDP_CORK) failed\n");
+        return 1;
+    }
+
+    printf("getsockopt: Got UDP_CORK flag OK\n");
+
     return 0;
 }

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1215,6 +1215,7 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['getsockopt'])
         self.assertIn('getsockopt: Got socket type OK', stdout)
         self.assertIn('getsockopt: Got TCP_NODELAY flag OK', stdout)
+        self.assertIn('getsockopt: Got UDP_CORK flag OK', stdout)
 
     def test_010_epoll(self):
         stdout, _ = self.run_binary(['epoll_test'])

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -460,6 +460,7 @@ typedef struct _PAL_STREAM_ATTR {
             bool tcp_cork;
             bool tcp_nodelay;
             bool ipv6_v6only;
+            bool udp_cork;
         } socket;
     };
 } PAL_STREAM_ATTR;
@@ -596,13 +597,15 @@ int PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
  * \param      addr               Destination address. Can be NULL if the socket was connected.
  * \param      force_nonblocking  If `true` this request should not block. Otherwise just use
  *                                whatever mode the handle is in.
+ * \param      force_cork         If `true` this request is corked. Otherwise just use
+ *                                whatever mode the handle is in.
  *
  * \returns 0 on success, negative error code on failure.
  *
  * Data is sent atomically, i.e. data from two `PalSocketSend` calls will not be interleaved.
  */
 int PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
-                  struct pal_socket_addr* addr, bool force_nonblocking);
+                  struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork);
 
 /*!
  * \brief Receive data.

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -119,7 +119,7 @@ struct socket_ops {
     int (*connect)(PAL_HANDLE handle, struct pal_socket_addr* addr,
                    struct pal_socket_addr* out_local_addr);
     int (*send)(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
-                struct pal_socket_addr* addr, bool force_nonblocking);
+                struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork);
     int (*recv)(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
                 struct pal_socket_addr* addr, bool force_nonblocking);
 };
@@ -192,7 +192,7 @@ int _PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE
 int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
                       struct pal_socket_addr* out_local_addr);
 int _PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
-                   struct pal_socket_addr* addr, bool force_nonblocking);
+                   struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork);
 int _PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,
                    struct pal_socket_addr* addr, bool force_nonblocking);
 

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -22,7 +22,7 @@ static void write_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
                     .iov_len = this_size,
                 };
                 CHECK(PalSocketSend(handle, &iov, 1, &this_size, /*addr=*/NULL,
-                                    /*force_nonblocking=*/false));
+                                    /*force_nonblocking=*/false, /*force_cork=*/false));
                 break;
             default:
                 BUG();

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -103,6 +103,7 @@ typedef struct {
             bool tcp_cork;
             bool tcp_nodelay;
             bool ipv6_v6only;
+            bool udp_cork;
         } sock;
 
         struct {

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -80,6 +80,7 @@ typedef struct {
             bool tcp_cork;
             bool tcp_nodelay;
             bool ipv6_v6only;
+            bool udp_cork;
         } sock;
 
         struct {

--- a/pal/src/host/linux/pal_sockets.c
+++ b/pal/src/host/linux/pal_sockets.c
@@ -76,6 +76,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.tcp_cork = false;
     handle->sock.tcp_nodelay = false;
     handle->sock.ipv6_v6only = false;
+    handle->sock.udp_cork = false;
 
     return handle;
 }
@@ -327,6 +328,7 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.tcp_cork = handle->sock.tcp_cork;
     attr->socket.tcp_nodelay = handle->sock.tcp_nodelay;
     attr->socket.ipv6_v6only = handle->sock.ipv6_v6only;
+    attr->socket.udp_cork = handle->sock.udp_cork;
 
     return 0;
 };
@@ -498,11 +500,25 @@ static int attrsetbyhdl_tcp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 static int attrsetbyhdl_udp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     assert(handle->sock.type == PAL_SOCKET_UDP);
 
-    return attrsetbyhdl_common(handle, attr);
+    int ret = attrsetbyhdl_common(handle, attr);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (attr->socket.udp_cork != handle->sock.udp_cork) {
+        int val = attr->socket.udp_cork;
+        int ret = DO_SYSCALL(setsockopt, handle->sock.fd, SOL_UDP, UDP_CORK, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.udp_cork = attr->socket.udp_cork;
+    }
+
+    return 0;
 }
 
 static int send(PAL_HANDLE handle, struct pal_iovec* pal_iov, size_t iov_len, size_t* out_size,
-                struct pal_socket_addr* addr, bool force_nonblocking) {
+                struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork) {
     assert(handle->hdr.type == PAL_TYPE_SOCKET);
 
     struct sockaddr_storage sa_storage;
@@ -524,7 +540,8 @@ static int send(PAL_HANDLE handle, struct pal_iovec* pal_iov, size_t iov_len, si
         iov[i].iov_len = pal_iov[i].iov_len;
     }
 
-    unsigned int flags = force_nonblocking ? MSG_DONTWAIT : 0;
+    unsigned int flags = (force_nonblocking ? MSG_DONTWAIT : 0) |
+                         (force_cork ? MSG_MORE : 0);
     struct msghdr msg = {
         .msg_name = addr ? &sa_storage : NULL,
         .msg_namelen = linux_addrlen,
@@ -684,11 +701,12 @@ int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
 }
 
 int _PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
-                   struct pal_socket_addr* addr, bool force_nonblocking) {
+                   struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork) {
     if (!handle->sock.ops->send) {
         return -PAL_ERROR_NOTSUPPORT;
     }
-    return handle->sock.ops->send(handle, iov, iov_len, out_size, addr, force_nonblocking);
+    return handle->sock.ops->send(handle, iov, iov_len, out_size, addr, force_nonblocking,
+                                  force_cork);
 }
 
 int _PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,

--- a/pal/src/host/skeleton/pal_sockets.c
+++ b/pal/src/host/skeleton/pal_sockets.c
@@ -30,7 +30,7 @@ int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
 }
 
 int _PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
-                   struct pal_socket_addr* addr, bool force_nonblocking) {
+                   struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/pal/src/pal_sockets.c
+++ b/pal/src/pal_sockets.c
@@ -35,9 +35,9 @@ int PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
 }
 
 int PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
-                  struct pal_socket_addr* addr, bool force_nonblocking) {
+                  struct pal_socket_addr* addr, bool force_nonblocking, bool force_cork) {
     assert(handle->hdr.type == PAL_TYPE_SOCKET);
-    return _PalSocketSend(handle, iov, iov_len, out_size, addr, force_nonblocking);
+    return _PalSocketSend(handle, iov, iov_len, out_size, addr, force_nonblocking, force_cork);
 }
 
 int PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,


### PR DESCRIPTION
## Description of the changes
Gramine currently supports `setsockopt(SOL_TCP, TCP_CORK/TCP_NODELAY)` and doesn't support `setsockopt(SOL_UDP, UDP_CORK)` and `send(MSG_MORE)`. These flags are inter-related to cork partial frames/segments or sent data as soon as possible.

Some applications use these flags and fails when they are not supported, such Pytorch. Source code can be seen in
https://github.com/pytorch/pytorch/blob/614d6f19e3d30cac0d77059e738d1f25d75eb408/torch/csrc/distributed/c10d/Utils.hpp#L559

This PR supports `MSG_MORE` flag in `send/sendto/sendmsg` syscalls by add a `force_cork` parameter to `PalSocketSend` interface and related functions.
Also support `UDP_CORK` flags in `setsockopt` and `getsockopt` syscalls.

Fixes #823 

## How to test this PR

updated regression test getsockopt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/936)
<!-- Reviewable:end -->
