### PR TITLE
[tools/pf_crypt] Normalize paths during PF encrypt/decrypt

### DIFF
--- a/tools/sgx/common/meson.build
+++ b/tools/sgx/common/meson.build
@@ -18,6 +18,7 @@ sgx_util = shared_library('sgx_util',
     ],
     dependencies: [
         cjson_dep,
+        common_utils_dep,
         libcurl_dep,
         protected_files_dep,
         mbedtls_static_dep,

--- a/tools/sgx/pf_crypt/pf_crypt.c
+++ b/tools/sgx/pf_crypt/pf_crypt.c
@@ -23,8 +23,8 @@ struct option g_options[] = {
     { 0, 0, 0, 0 }
 };
 
-static void usage(void) {
-    INFO("\nUsage: pf_crypt mode [options]\n");
+static void usage(const char* argv0) {
+    INFO("\nUsage: %s mode [options]\n", argv0);
     INFO("Available modes:\n");
     INFO("  gen-key                 Generate and save wrap key to file\n");
     INFO("  encrypt                 Encrypt plaintext files\n");
@@ -80,17 +80,17 @@ int main(int argc, char* argv[]) {
                 verify = true;
                 break;
             case 'h':
-                usage();
+                usage(argv[0]);
                 exit(0);
             default:
                 ERROR("Unknown option: %c\n", this_option);
-                usage();
+                usage(argv[0]);
         }
     }
 
     if (optind >= argc) {
         ERROR("Mode not specified\n");
-        usage();
+        usage(argv[0]);
         goto out;
     }
 
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
         case 'e': /* encrypt */
             if (!input_path || !output_path) {
                 ERROR("Input or output path not specified\n");
-                usage();
+                usage(argv[0]);
                 goto out;
             }
             ret = pf_encrypt_files(input_path, output_path, wrap_key_path);
@@ -123,14 +123,14 @@ int main(int argc, char* argv[]) {
         case 'd': /* decrypt */
             if (!input_path || !output_path) {
                 ERROR("Input or output path not specified\n");
-                usage();
+                usage(argv[0]);
                 goto out;
             }
             ret = pf_decrypt_files(input_path, output_path, verify, wrap_key_path);
             break;
 
         default:
-            usage();
+            usage(argv[0]);
             goto out;
     }
 

--- a/tools/sgx/pf_tamper/pf_tamper.c
+++ b/tools/sgx/pf_tamper/pf_tamper.c
@@ -32,8 +32,8 @@ struct option g_options[] = {
     { 0, 0, 0, 0 }
 };
 
-static void usage(void) {
-    INFO("\nUsage: pf_tamper [options]\n");
+static void usage(const char* argv0) {
+    INFO("\nUsage: %s [options]\n", argv0);
     INFO("\nAvailable options:\n");
     INFO("  --help, -h           Display this help\n");
     INFO("  --verbose, -v        Enable verbose output\n");
@@ -415,29 +415,29 @@ int main(int argc, char* argv[]) {
                 set_verbose(true);
                 break;
             case 'h':
-                usage();
+                usage(argv[0]);
                 return 0;
             default:
                 ERROR("Unknown option: %c\n", option);
-                usage();
+                usage(argv[0]);
         }
     }
 
     if (!input_path) {
         ERROR("Input path not specified\n");
-        usage();
+        usage(argv[0]);
         goto out;
     }
 
     if (!g_output_dir) {
         ERROR("Output path not specified\n");
-        usage();
+        usage(argv[0]);
         goto out;
     }
 
     if (!wrap_key_path) {
         ERROR("Wrap key path not specified\n");
-        usage();
+        usage(argv[0]);
         goto out;
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Protected Files common logic requires file paths to be normalized, otherwise filename comparison (done to prevent file-swap attacks) fails. E.g., `gramine-sgx-pf-crypt encrypt ... -o ./encrypted-file` would previously save the path verbatim (`./encrypted-file`) which would confuse Gramine that expects a normalized path.

Fixes #923.

## How to test this PR? <!-- (if applicable) -->

Play with `gramine-sgx-pf-crypt` tool like this:
```
gramine-sgx-pf-crypt encrypt -w key.key -i input.file -o ./somedir/.././encrypted.file

gramine-sgx-pf-crypt decrypt -w key.key -i ./gramine/./../encrypted.file -o ./somedir/../decrypted.file -V
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/937)
<!-- Reviewable:end -->
