### PR TITLE
Update the manifest defaults for importing numpy package

### DIFF
--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -7,6 +7,11 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
+# Python's NumPy spawns as many threads as there are CPU cores, and each thread
+# consumes a chunk of memory, so on large machines 1G enclave size may be not enough.
+# We limit the number of spawned threads via OMP_NUM_THREADS env variable.
+loader.env.OMP_NUM_THREADS = "4"
+
 loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
@@ -29,7 +34,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.debug = true
 sgx.nonpie_binary = true
-sgx.enclave_size = "512M"
+sgx.enclave_size = "1G"
 sgx.max_threads = 32
 
 sgx.remote_attestation = "{{ ra_type }}"


### PR DESCRIPTION
Signed-off-by: TejaswineeL <tejaswinee.ramdas.langhe@intel.com>

## Description of the changes <!-- (reasons and measures) -->
-test_numpy.py executable imports a package called Numpy
-While executing test_numpy.py with SGX, it demands an extra space to load the package to enclave.
-Increase the enclave size to 1G and internal pal memory size to 128M (for manifest). This resolves the insufficient space issue.
-OMP_num_threads limits the number of Numpy threads creation.
-During runtime, SGX requests for python local installation path and in turn the Numpy package location. 
-Add the relevant path in the SGX trusted files.

## How to test this PR? <!-- (if applicable) -->
-run test-numpy.py file from the python examples with "gramine-sgx ./python scripts/test-numpy.py"
-the .py file should successfully execute by importing numpy package with SGX

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/938)
<!-- Reviewable:end -->
