### PR TITLE
Bump Gramine version to 1.3.1 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@
 project(
     'gramine',
     'c', 'cpp',
-    version: '1.3.1',
+    version: '1.3.1post-UNRELEASED',
     license: 'LGPLv3+',
 
     meson_version: '>=0.56',

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@
 project(
     'gramine',
     'c', 'cpp',
-    version: '1.3post-UNRELEASED',
+    version: '1.3.1',
     license: 'LGPLv3+',
 
     meson_version: '>=0.56',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We have to release 1.3.1 because of one documentation bug (https://github.com/gramineproject/gramine/pull/935) and missing dependencies in some of the packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/939)
<!-- Reviewable:end -->
