### PR TITLE
[CI-Examples] Use `--malicious-quote` arg for ra-tls-mbedtls server

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -164,7 +164,7 @@ check_epid: app epid
 
 .PHONY: check_epid_fail
 check_epid_fail: app epid
-	gramine-sgx server dummy-option >/dev/null & SERVER_ID=$$!; \
+	gramine-sgx server --test-malicious-quote >/dev/null & SERVER_ID=$$!; \
 	sleep 30; \
 	./client epid && exit 1 || echo "[ Success 1/1 ]"; \
 	kill -9 $$SERVER_ID
@@ -184,7 +184,7 @@ check_dcap: app dcap
 
 .PHONY: check_dcap_fail
 check_dcap_fail: app dcap
-	gramine-sgx server dummy-option >/dev/null & SERVER_ID=$$!; \
+	gramine-sgx server --test-malicious-quote >/dev/null & SERVER_ID=$$!; \
 	sleep 30; \
 	./client dcap && exit 1 || echo "[ Success 1/1 ]"; \
 	kill -9 $$SERVER_ID

--- a/CI-Examples/ra-tls-mbedtls/README.md
+++ b/CI-Examples/ra-tls-mbedtls/README.md
@@ -26,9 +26,9 @@ The server is supposed to run in the SGX enclave with Gramine and RA-TLS
 dlopen-loaded. If the server is started not in the SGX enclave, then it falls
 back to using normal X.509 PKI flows.
 
-If server is run with a command-line argument (the only important thing is to
-have at least one argument), then the server will maliciously modify the SGX
-quote before sending to the client. This is useful for testing purposes.
+If server is run with a command-line argument ``--test-malicious-quote``, then
+the server will maliciously modify the SGX quote before sending to the client.
+This is useful for testing purposes.
 
 ## RA-TLS client
 
@@ -149,7 +149,7 @@ kill %%
 make clean
 make app dcap RA_TYPE=dcap
 
-gramine-sgx ./server dummy-option &
+gramine-sgx ./server --test-malicious-quote &
 ./client dcap
 
 # client will fail to verify the malicious SGX quote and will *not* connect to the server

--- a/CI-Examples/ra-tls-mbedtls/src/server.c
+++ b/CI-Examples/ra-tls-mbedtls/src/server.c
@@ -178,6 +178,12 @@ int main(int argc, char** argv) {
         mbedtls_printf(" ok\n");
 
         if (argc > 1) {
+            if (strcmp(argv[1], "--test-malicious-quote") != 0) {
+                mbedtls_printf("Unrecognized command-line argument `%s` (only "
+                               "`--test-malicious-quote` is recognized)\n", argv[1]);
+                return 1;
+            }
+
             /* user asks to maliciously modify the embedded SGX quote (for testing purposes) */
             mbedtls_printf("  . Maliciously modifying SGX quote embedded in RA-TLS cert...");
             fflush(stdout);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the server in the `ra-tls-mbedtls` example corrupted the SGX quote (for testing purposes) when it was started with *any* arguments. With this commit, the server recognizes only `--malicious-quote` arg and complains on other arguments. This change prevents users from accidentally corrupting the SGX quote when they mistype something like `gramine-sgx server dcap`.

For the context, see https://github.com/gramineproject/gramine/issues/941.

## How to test this PR? <!-- (if applicable) -->

CI is enough (it tests `make check_epid_fail`). I also tested manually on an EPID machine and on a Azure DCAP machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/943)
<!-- Reviewable:end -->
