### PR TITLE
[LibOS] Strip trailing spaces in the shebang line

### DIFF
--- a/libos/test/regression/scripts/foo.sh
+++ b/libos/test/regression/scripts/foo.sh
@@ -1,1 +1,4 @@
-#!scripts/bar.sh ALPHA BRAVO CHARLIE DELTA
+#!scripts/bar.sh   ALPHA BRAVO CHARLIE DELTA
+
+#               ^^^
+# three intermediate spaces in the shebang line above are for testing purposes

--- a/libos/test/regression/shebang_test_script.sh
+++ b/libos/test/regression/shebang_test_script.sh
@@ -1,2 +1,6 @@
-#!/bin/sh
+#!	/bin/sh		  
+
+# ^               ^^
+# leading tab and trailing tabs+spaces in the shebang line above are for testing purposes
+
 exec scripts/foo.sh


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the "load shebang" logic didn't strip trailing spaces, which resulted in additional empty arguments to the interpreter (e.g., `#!/bin/bash ` was interpreted as "start `/bin/bash` with the first argument ` `" -- and Bash failed because it expected the first argument to be the program to run).

Kudos to @svenkata9 for finding this bug. It was found on one Docker image that had such a problematic entrypoint Bash script (with trailing spaces in the shebang line), when trying to graminize this image via GSC.

## How to test this PR? <!-- (if applicable) -->

CI is enough. Modified the `test_212_shebang_test_script` example (the Bash script) to contain trailing spaces.

Without this PR, the modified example fails like this:
```
test_libos.py:244: in test_212_shebang_test_script
    stdout, _ = self.run_binary(['shebang_test_script'])
../../../built-debug/lib/python3.8/site-packages/graminelibos/regression.py:221: in run_binary
    _returncode, stdout, stderr = run_command(cmd, timeout=timeout, **kwds)
../../../built-debug/lib/python3.8/site-packages/graminelibos/regression.py:159: in run_command
    raise subprocess.CalledProcessError(proc.returncode, cmd, raw_stdout, raw_stderr)
E   subprocess.CalledProcessError: Command '['/home/dimakuv/gramineproject/gramine/built-debug/lib/x86_64-linux-gnu/gramine/direct/loader', '/home/dimakuv/gramineproject/gramine/built-debug/lib/x86_64-linux-gnu/gramine/direct/libpal.so', 'init', 'shebang_test_script']' returned non-zero exit status 127.

[0.020] /bin/sh: 0: Can't open
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/944)
<!-- Reviewable:end -->
