### PR TITLE
[LibOS,PAL] Remove `struct pal_iovec`

### DIFF
--- a/Documentation/Doxyfile-pal
+++ b/Documentation/Doxyfile-pal
@@ -1,7 +1,7 @@
 @INCLUDE = Doxyfile
 PROJECT_NAME = "PAL"
 OUTPUT_DIRECTORY = _build/doxygen-pal
-INPUT = ../pal/include/arch/x86_64 ../pal/include/pal ../pal/include
+INPUT = ../pal/include/arch/x86_64 ../pal/include/pal ../pal/include ../common/include/iovec.h
 MACRO_EXPANSION = YES
 EXPAND_ONLY_PREDEF = YES
 PREDEFINED = noreturn= __x86_64__=1

--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -241,7 +241,7 @@ Socket handling
 .. doxygenstruct:: pal_socket_addr
    :project: pal
 
-.. doxygenstruct:: pal_iovec
+.. doxygenstruct:: iovec
    :project: pal
 
 .. doxygenfunction:: PalSocketCreate

--- a/common/include/iovec.h
+++ b/common/include/iovec.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+
+#pragma once
+
+struct iovec {
+    void* iov_base;
+    size_t iov_len;
+};

--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -11,6 +11,8 @@
 #include <linux/un.h>
 #include <stddef.h>
 
+#include "iovec.h"
+
 #define SOCKADDR_MAX_SIZE 128
 
 struct sockaddr_storage {
@@ -19,11 +21,6 @@ struct sockaddr_storage {
         char _size[SOCKADDR_MAX_SIZE];
         void* _align;
     };
-};
-
-struct iovec {
-    void* iov_base;
-    size_t iov_len;
 };
 
 struct msghdr {
@@ -40,6 +37,24 @@ struct mmsghdr {
     struct msghdr msg_hdr;
     unsigned int msg_len;
 };
+
+struct cmsghdr {
+    size_t cmsg_len;
+    int cmsg_level;
+    int cmsg_type;
+    unsigned char __cmsg_data[];
+};
+
+#define CMSG_DATA(cmsg) ((cmsg)->__cmsg_data)
+#define CMSG_FIRSTHDR(mhdr)                                   \
+    ((size_t)(mhdr)->msg_controllen >= sizeof(struct cmsghdr) \
+         ? (struct cmsghdr*)(mhdr)->msg_control               \
+         : (struct cmsghdr*)0)
+#define CMSG_ALIGN(len) ALIGN_UP(len, sizeof(size_t))
+#define CMSG_SPACE(len) (CMSG_ALIGN(sizeof(struct cmsghdr)) + CMSG_ALIGN(len))
+#define CMSG_LEN(len)   (CMSG_ALIGN(sizeof(struct cmsghdr)) + (len))
+
+#define SCM_RIGHTS 1
 
 #define AF_UNSPEC 0
 #define AF_UNIX 1

--- a/libos/src/net/ip.c
+++ b/libos/src/net/ip.c
@@ -652,19 +652,9 @@ static int send(struct libos_handle* handle, struct iovec* iov, size_t iov_len, 
         linux_to_pal_sockaddr(addr, &pal_ip_addr);
     }
 
-    struct pal_iovec* pal_iov = malloc(iov_len * sizeof(*pal_iov));
-    if (!pal_iov) {
-        return -ENOMEM;
-    }
-    for (size_t i = 0; i < iov_len; i++) {
-        pal_iov[i].iov_base = iov[i].iov_base;
-        pal_iov[i].iov_len = iov[i].iov_len;
-    }
-
-    int ret = PalSocketSend(sock->pal_handle, pal_iov, iov_len, out_size,
-                            addr ? &pal_ip_addr : NULL, force_nonblocking);
+    int ret = PalSocketSend(sock->pal_handle, iov, iov_len, out_size, addr ? &pal_ip_addr : NULL,
+                            force_nonblocking);
     ret = (ret == -PAL_ERROR_TOOLONG) ? -EMSGSIZE : pal_to_unix_errno(ret);
-    free(pal_iov);
     return ret;
 }
 
@@ -684,19 +674,9 @@ static int recv(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
             __builtin_unreachable();
     }
 
-    struct pal_iovec* pal_iov = malloc(iov_len * sizeof(*pal_iov));
-    if (!pal_iov) {
-        return -ENOMEM;
-    }
-    for (size_t i = 0; i < iov_len; i++) {
-        pal_iov[i].iov_base = iov[i].iov_base;
-        pal_iov[i].iov_len = iov[i].iov_len;
-    }
-
     struct pal_socket_addr pal_ip_addr;
-    int ret = PalSocketRecv(handle->info.sock.pal_handle, pal_iov, iov_len, out_total_size,
+    int ret = PalSocketRecv(handle->info.sock.pal_handle, iov, iov_len, out_total_size,
                             addr ? &pal_ip_addr : NULL, force_nonblocking);
-    free(pal_iov);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <stdnoreturn.h>
 
+#include "iovec.h"
+
 // TODO: fix this (but see pal/include/arch/x86_64/pal_arch.h)
 #define INSIDE_PAL_H
 
@@ -509,13 +511,6 @@ struct pal_socket_addr {
     };
 };
 
-/* This could be just `struct iovec` from Linux, but we don't want to set a precedent of using Linux
- * types in PAL API. */
-struct pal_iovec {
-    void* iov_base;
-    size_t iov_len;
-};
-
 /*!
  * \brief Create a socket handle.
  *
@@ -602,8 +597,12 @@ int PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
  * \returns 0 on success, negative error code on failure.
  *
  * Data is sent atomically, i.e. data from two `PalSocketSend` calls will not be interleaved.
+ *
+ * We use Linux `struct iovec` as argument here, because the alternative is to use a custom
+ * structure, but it would contain exactly the same fields, which would achieve nothing, but could
+ * worsen performance in certain cases.
  */
-int PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
+int PalSocketSend(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                   struct pal_socket_addr* addr, bool force_nonblocking);
 
 /*!
@@ -622,8 +621,12 @@ int PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size
  * \returns 0 on success, negative error code on failure.
  *
  * Data is received atomically, i.e. data from two `PalSocketRecv` calls will not be interleaved.
+ *
+ * We use Linux `struct iovec` as argument here, because the alternative is to use a custom
+ * structure, but it would contain exactly the same fields, which would achieve nothing, but could
+ * worsen performance in certain cases.
  */
-int PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,
+int PalSocketRecv(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_total_size,
                   struct pal_socket_addr* addr, bool force_nonblocking);
 
 /*

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -118,9 +118,9 @@ struct socket_ops {
                   struct pal_socket_addr* out_client_addr, struct pal_socket_addr* out_local_addr);
     int (*connect)(PAL_HANDLE handle, struct pal_socket_addr* addr,
                    struct pal_socket_addr* out_local_addr);
-    int (*send)(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
+    int (*send)(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                 struct pal_socket_addr* addr, bool force_nonblocking);
-    int (*recv)(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
+    int (*recv)(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                 struct pal_socket_addr* addr, bool force_nonblocking);
 };
 
@@ -191,9 +191,9 @@ int _PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE
                      struct pal_socket_addr* out_local_addr);
 int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
                       struct pal_socket_addr* out_local_addr);
-int _PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
+int _PalSocketSend(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                    struct pal_socket_addr* addr, bool force_nonblocking);
-int _PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,
+int _PalSocketRecv(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_total_size,
                    struct pal_socket_addr* addr, bool force_nonblocking);
 
 /* PalProcess and PalThread calls */

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -17,7 +17,7 @@ static void write_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
                 CHECK(PalStreamWrite(handle, 0, &this_size, buf + i));
                 break;
             case PAL_TYPE_SOCKET:;
-                struct pal_iovec iov = {
+                struct iovec iov = {
                     .iov_base = buf + i,
                     .iov_len = this_size,
                 };
@@ -45,7 +45,7 @@ static void read_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
                 CHECK(PalStreamRead(handle, 0, &this_size, buf + i));
                 break;
             case PAL_TYPE_SOCKET:;
-                struct pal_iovec iov = {
+                struct iovec iov = {
                     .iov_base = buf + i,
                     .iov_len = this_size,
                 };

--- a/pal/src/host/linux-sgx/pal_linux_types.h
+++ b/pal/src/host/linux-sgx/pal_linux_types.h
@@ -40,23 +40,3 @@ struct sockaddr {
     unsigned short sa_family;
     char sa_data[128 - sizeof(unsigned short)];
 };
-
-struct cmsghdr {
-    size_t cmsg_len;
-    int cmsg_level;
-    int cmsg_type;
-};
-
-#ifndef SCM_RIGHTS
-#define SCM_RIGHTS 1
-#endif
-
-#define CMSG_DATA(cmsg)         ((unsigned char*)((struct cmsghdr*)(cmsg) + 1))
-#define CMSG_NXTHDR(mhdr, cmsg) __cmsg_nxthdr(mhdr, cmsg)
-#define CMSG_FIRSTHDR(mhdr)                                   \
-    ((size_t)(mhdr)->msg_controllen >= sizeof(struct cmsghdr) \
-         ? (struct cmsghdr*)(mhdr)->msg_control               \
-         : (struct cmsghdr*)0)
-#define CMSG_ALIGN(len) ALIGN_UP(len, sizeof(size_t))
-#define CMSG_SPACE(len) (CMSG_ALIGN(len) + CMSG_ALIGN(sizeof(struct cmsghdr)))
-#define CMSG_LEN(len)   (CMSG_ALIGN(sizeof(struct cmsghdr)) + (len))

--- a/pal/src/host/linux-sgx/pal_streams.c
+++ b/pal/src/host/linux-sgx/pal_streams.c
@@ -16,6 +16,7 @@
 #include "api.h"
 #include "crypto.h"
 #include "enclave_pages.h"
+#include "linux_socket.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "pal_internal.h"

--- a/pal/src/host/linux/pal_streams.c
+++ b/pal/src/host/linux/pal_streams.c
@@ -6,11 +6,11 @@
  */
 
 #include <asm/fcntl.h>
-#include <netinet/in.h>
 #include <stdalign.h>
 #include <stdbool.h>
 
 #include "api.h"
+#include "linux_socket.h"
 #include "linux_utils.h"
 #include "pal.h"
 #include "pal_error.h"

--- a/pal/src/host/skeleton/pal_sockets.c
+++ b/pal/src/host/skeleton/pal_sockets.c
@@ -29,12 +29,12 @@ int _PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
+int _PalSocketSend(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                    struct pal_socket_addr* addr, bool force_nonblocking) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,
+int _PalSocketRecv(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_total_size,
                    struct pal_socket_addr* addr, bool force_nonblocking) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/pal/src/pal_sockets.c
+++ b/pal/src/pal_sockets.c
@@ -34,13 +34,13 @@ int PalSocketConnect(PAL_HANDLE handle, struct pal_socket_addr* addr,
     return _PalSocketConnect(handle, addr, local_addr);
 }
 
-int PalSocketSend(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_size,
+int PalSocketSend(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                   struct pal_socket_addr* addr, bool force_nonblocking) {
     assert(handle->hdr.type == PAL_TYPE_SOCKET);
     return _PalSocketSend(handle, iov, iov_len, out_size, addr, force_nonblocking);
 }
 
-int PalSocketRecv(PAL_HANDLE handle, struct pal_iovec* iov, size_t iov_len, size_t* out_total_size,
+int PalSocketRecv(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_total_size,
                   struct pal_socket_addr* addr, bool force_nonblocking) {
     assert(handle->hdr.type == PAL_TYPE_SOCKET);
     return _PalSocketRecv(handle, iov, iov_len, out_total_size, addr, force_nonblocking);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This struct was essentially `struct iovec` from Linux and it's usage required some otherwise unneeded `malloc()` + `free()`, which became a performance bottleneck in some cases.
This commit also removes erroneous include of `sys/socket.h`, which also got in the way of these changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/946)
<!-- Reviewable:end -->
