### PR TITLE
[packaging/docker] Update dockerfile to match post v1.3 repo name

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y curl gnupg2 binutils
 
 RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' > /etc/apt/sources.list.d/gramine.list
+RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ focal main' > /etc/apt/sources.list.d/gramine.list
 
 RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' > /etc/apt/sources.list.d/intel-sgx.list


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Since v1.3 Ubuntu 20.04 has dedicated Gramine package.

## How to test this PR? <!-- (if applicable) -->
Try building docker image

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/947)
<!-- Reviewable:end -->
