### PR TITLE
[CI-Examples] Harden Redis example

### DIFF
--- a/CI-Examples/redis/Makefile
+++ b/CI-Examples/redis/Makefile
@@ -63,10 +63,10 @@ endif
 
 ################################ REDIS MANIFEST ###############################
 
-# The template file contains almost all necessary information to run Redis under
-# Gramine / Gramine-SGX. We create redis-server.manifest (to be run under
-# non-SGX Gramine) by replacing variables in the template file using the
-# "gramine-manifest" script.
+# The template file is a Jinja2 template and contains almost all necessary
+# information to run Redis under Gramine / Gramine-SGX. We create
+# redis-server.manifest (to be run under non-SGX Gramine) by replacing variables
+# in the template file using the "gramine-manifest" script.
 
 redis-server.manifest: redis-server.manifest.template
 	gramine-manifest \
@@ -109,6 +109,7 @@ redis-server: $(SRCDIR)/src/redis-server
 	cp $< $@
 
 ############################## RUNNING TESTS ##################################
+
 .PHONY: start-native-server
 start-native-server: all
 	./redis-server --save '' --protected-mode no
@@ -119,9 +120,10 @@ else
 GRAMINE = gramine-sgx
 endif
 
+# Note that command-line arguments are hardcoded in the manifest file.
 .PHONY: start-gramine-server
 start-gramine-server: all
-	$(GRAMINE) redis-server --save '' --protected-mode no
+	$(GRAMINE) redis-server
 
 ################################## CLEANUP ####################################
 

--- a/CI-Examples/redis/README.md
+++ b/CI-Examples/redis/README.md
@@ -4,11 +4,11 @@ This directory contains the Makefile and the template manifest for the most
 recent version of Redis (as of this writing, version 6.0.5).
 
 The Makefile and the template manifest contain extensive comments and are made
-self-explanatory. Please review them to gain understanding of Gramine-SGX and
-requirements for applications running under Gramine-SGX. If you want to
-contribute a new example to Gramine and you take this Redis example as a
-template, we recommend to remove the comments from your copies as they only add
-noise (see e.g. Memcached for a "stripped-down" example).
+self-explanatory. Please review them to gain understanding of Gramine and
+requirements for applications running under Gramine. If you want to contribute a
+new example to Gramine and you take this Redis example as a template, we
+recommend to remove the comments from your copies as they only add noise (see
+e.g. Memcached for a "stripped-down" example).
 
 
 # Quick Start
@@ -18,36 +18,40 @@ noise (see e.g. Memcached for a "stripped-down" example).
 make SGX=1
 
 # run original Redis against a benchmark (redis-benchmark supplied with Redis)
-./redis-server --save '' --protected-mode no &
+./redis-server --save '' &
 src/src/redis-benchmark
 kill %%
 
-# run Redis in non-SGX Gramine against a benchmark
-gramine-direct redis-server --save '' --protected-mode no &
+# run Redis in non-SGX Gramine against a benchmark (args are hardcoded in manifest)
+gramine-direct redis-server &
 src/src/redis-benchmark
 kill %%
 
-# run Redis in Gramine-SGX against a benchmark
-gramine-sgx redis-server --save '' --protected-mode no &
+# run Redis in Gramine-SGX against a benchmark (args are hardcoded in manifest)
+gramine-sgx redis-server &
 src/src/redis-benchmark
 kill %%
 ```
 
 # Why this Redis configuration?
 
-Notice that we run Redis with two parameters: `save ''` and `protected-mode no`:
+Notice that we run Redis with the `save ''` setting. This setting disables
+saving DB to disk (both RDB snapshots and AOF logs). We use this setting
+because:
 
-- `save ''` disables saving DB to disk (both RDB snapshots and AOF logs). We use
-  this parameter to side-step some bugs in Gramine triggered during the
-  graceful shutdown of Redis.
+- saving DB to disk is a slow operation (Redis uses fork internally which is
+  implemented as a slow checkpoint-and-restore in Gramine and requires creating
+  a new SGX enclave);
+- saved RDB snapshots and AOF logs must be encrypted and integrity-protected for
+  DB confidentiality reasons, which requires marking the corresponding
+  directories and files as `encrypted` in Gramine manifest; we skip it for
+  simplicity.
 
-- `protected-mode no` allows clients to connect to Redis on any network
-  interface. Even though we use the loopback interface (which is always allowed
-  in Redis), Gramine hides this information. Therefore, we ask Redis to allow
-  clients on all interfaces.
+In Gramine case, this setting is hardcoded in the manifest file, see
+`loader.argv` there.
 
 # Redis with Select
 
 By default, Redis uses the epoll mechanism of Linux to monitor client
-connections.  To test Redis with select, add `USE_SELECT=1`, e.g., `make SGX=1
+connections. To test Redis with select, add `USE_SELECT=1`, e.g., `make SGX=1
 USE_SELECT=1`.

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -17,48 +17,39 @@ loader.log_level = "{{ log_level }}"
 
 ################################# ARGUMENTS ###################################
 
-# Read application arguments directly from the command line. Don't use this on production!
-loader.insecure__use_cmdline_argv = true
+# Hardcode application arguments. See README for explanations.
+loader.argv = ["redis-server", "--save", ""]
 
 ################################# ENV VARS ####################################
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
-# applies. Paths must be in-Gramine visible paths, not host-OS paths (i.e.,
+# applies. Paths must be in-Gramine visible paths, not host paths (i.e.,
 # paths must be taken from fs.mounts[...].path, not fs.mounts[...].uri).
 #
 # In case of Redis:
 # - /lib is searched for Glibc libraries (ld, libc, libpthread)
-# - {{ arch_libdir }} is searched for Name Service Switch (NSS) libraries
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib"
 
 ################################## SIGNALS ####################################
 
-# Allow for injecting SIGTERM signal from the host.
+# Allow for injecting SIGTERM signal from the host. Without this option,
+# pressing `Ctrl + C` wouldn't terminate Redis.
 sys.enable_sigterm_injection = true
 
-################################# MOUNT FS  ###################################
+################################# MOUNT FS ####################################
 
 # General notes:
-# - There is only one supported type of mount points: 'chroot'.
-# - Directory names are (somewhat confusingly) prepended by 'file:'.
-# - Names of mount entries (lib, lib2, lib3) are irrelevant but must be unique.
-# - In-Gramine visible path names may be arbitrary but we reuse host-OS URIs
-#   for simplicity (except for the first 'lib' case).
+# - All mount points are mounted using the default 'chroot' type.
+# - `path`: names of directories and files in Gramine environment; they may be
+#           arbitrary but here we mostly reuse host URIs for simplicity (except
+#           for the first `/lib` mount point).
+# - `uri`:  names of directories and files on the host, somewhat confusingly
+#           prepended by the 'file:' keyword.
 
 fs.mounts = [
-  # Mount host-OS directory to Gramine glibc/runtime libraries (in 'uri') into
+  # Mount on-host directory to Gramine glibc/runtime libraries (in 'uri') into
   # in-Gramine visible directory /lib (in 'path').
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
-
-  # Mount host-OS directory to Name Service Switch (NSS) libraries (in 'uri')
-  # into in-Gramine visible directory /lib/x86_64-linux-gnu (in 'path').
-  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
-
-  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
-
-  # Mount host-OS directory to NSS files required by Glibc + NSS libs (in 'uri')
-  # into in-Gramine visible directory /etc (in 'path').
-  { path = "/etc", uri = "file:/etc" },
 
   # Mount redis-server executable (located in the current directory) under the
   # in-Gramine visible root directory.
@@ -80,7 +71,7 @@ sgx.debug = true
 sgx.enclave_size = "1024M"
 
 # Set maximum number of in-enclave threads (somewhat arbitrarily) to 8. Recall
-# that SGX v1 requires to specify the maximum number of simulteneous threads at
+# that SGX v1 requires to specify the maximum number of simultaneous threads at
 # enclave creation time.
 #
 # Note that internally Gramine may spawn two additional threads, one for IPC
@@ -92,10 +83,10 @@ sgx.thread_num = 8
 # Redis executable is typically a PIE (Position Independent Executable) on most
 # modern OS distros (e.g., Ubuntu 18.04). However, on some OS distros (notably,
 # CentOS), Redis executable is built as non-PIE. We mark Redis as a non-PIE
-# binary for the SGX PAL unconditionally -- this makes it work on CentOS and
-# doesn't hurt on Ubuntu. (Note that the Linux PAL correctly distinguishes
-# between PIE and non-PIE binaries, but for SGX we need to prearrange enclave
-# memory layout, hence the below option.)
+# binary unconditionally -- this makes it work on CentOS and doesn't hurt on
+# Ubuntu. (Note that non-SGX Gramine correctly distinguishes between PIE and
+# non-PIE binaries, but for SGX we need to prearrange enclave memory layout,
+# hence the below option.)
 sgx.nonpie_binary = true
 
 ############################# SGX: TRUSTED FILES ###############################
@@ -104,43 +95,22 @@ sgx.nonpie_binary = true
 # which can be loaded at runtime via dlopen), as well as other static read-only
 # files (like configuration files).
 #
-# The paths to files are host-OS paths. These files will be searched for in
+# The paths to files are on-host paths. These files will be searched for in
 # in-Gramine visible paths according to mount points above.
 #
 # As part of the build process, Gramine-SGX script (`gramine-sgx-sign`) finds
 # each specified file, measures its hash, and adds it to the manifest entry for
 # that file (converting each entry to a table with "uri" and "sha256" keys).
-# Note that this happens on the developer machine or a build server.
+# Note that this happens on the developer machine or a build server. If a
+# directory is specified in the list below, then this directory is recursively
+# traversed and each found file is processed as described above.
 #
 # At runtime, during loading of each "trusted file", Gramine-SGX measures its
 # hash and compares with the "sha256" value in the corresponding manifest entry.
 # If hashes match, this file is trusted and allowed to be loaded and used. Note
-# that this happens on the client machine.
+# that this happens on the deployment machine.
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:redis-server",
   "file:{{ gramine.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-]
-
-
-############################# SGX: ALLOWED FILES ###############################
-
-# Specify all non-static files used by app. These files may be accessed by
-# Gramine-SGX but their integrity is not verified (Gramine-SGX does not
-# measure their hashes). This may pose a security risk!
-
-sgx.allowed_files = [
-  # Name Service Switch (NSS) files. Glibc reads these files as part of name-
-  # service information gathering. For more info, see 'man nsswitch.conf'.
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-
-  # getaddrinfo(3) configuration file. Glibc reads this file to correctly find
-  # network addresses. For more info, see 'man gai.conf'.
-  "file:/etc/gai.conf",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

After Gramine v1.3, we have nice features and can finally get rid of insecure manifest options.

This PR removes the following insecure manifest options:
- `loader.insecure__use_cmdline_argv` in favor of `loader.argv`,
- `sgx.allowed_files`, they are not needed at all.

## How to test this PR? <!-- (if applicable) -->

CI is enough. Also tested manually, including on a cloud machine with a public IP and connecting remotely (this was for testing `--protected-mode no`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/954)
<!-- Reviewable:end -->
