### PR TITLE
[CI-Examples] Harden Memcached example

### DIFF
--- a/CI-Examples/memcached/Makefile
+++ b/CI-Examples/memcached/Makefile
@@ -8,8 +8,6 @@ MEMCACHED_MIRRORS ?= \
 
 MEMCACHED_SHA256 ?= e3d10c06db755b220f43d26d3b68d15ebf737a69c7663529b504ab047efe92f4
 
-UBUNTU_VER = $(shell lsb_release --short --id)$(shell lsb_release --short --release)
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -69,7 +67,7 @@ endif
 
 .PHONY: start-gramine-server
 start-gramine-server: all
-	$(GRAMINE) memcached -u nobody
+	$(GRAMINE) memcached
 
 .PHONY: clean
 clean:

--- a/CI-Examples/memcached/README.md
+++ b/CI-Examples/memcached/README.md
@@ -18,26 +18,15 @@ make SGX=1
 # install the benchmark on your host OS first)
 ./memcached &
 memtier_benchmark --port=11211 --protocol=memcache_binary --hide-histogram
-killall memcached
+kill %%
 
 # run Memcached in non-SGX Gramine against a benchmark
-gramine-direct memcached -u nobody &
+gramine-direct memcached &
 memtier_benchmark --port=11211 --protocol=memcache_binary --hide-histogram
-killall pal-Linux
+kill %%
 
 # run Memcached in Gramine-SGX against a benchmark
-gramine-sgx memcached -u nobody &
+gramine-sgx memcached &
 memtier_benchmark --port=11211 --protocol=memcache_binary --hide-histogram
-killall pal-Linux-SGX
+kill %%
 ```
-
-# Why this Memcached configuration?
-
-Notice that we run Memcached with `-u nobody` (means "user is nobody"). User
-argument is required because Gramine currently emulates real/effective user ID
-as 0 (root). This leads Memcached to believe it is run under root. For security
-reasons, Memcached drops privileges and assumes non-privileged user ID which
-must be specified as command-line argument. The assumed user ID is irrelevant
-for consequent Memcached execution, so we use an existing host-OS username
-"nobody" (this username is forwarded from the host because we mount host's
-`/etc/passwd` file, see the manifest).

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -5,18 +5,22 @@ libos.entrypoint = "/memcached"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+# the only dependency is libevent.so, found under `/usr/{{ arch_libdir }}`
+loader.env.LD_LIBRARY_PATH = "/lib:/usr/{{ arch_libdir }}"
 
-loader.insecure__use_cmdline_argv = true
+# Gramine by default reports the root user (uid = 0) to applications. This default behavior forces
+# Memcached to attempt to drop privileges and assume some non-privileged user ID via setuid(), which
+# is meaningless in Gramine. Instead, we set up a dummy user (uid = 1000); this is irrelevant for
+# consequent Memcached execution anyway.
+loader.uid = 1000
+loader.gid = 1000
 
 sys.enable_sigterm_injection = true
 
 fs.mounts = [
-  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
-  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
-  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
-  { path = "/etc", uri = "file:/etc" },
   { path = "/memcached", uri = "file:memcached" },
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
 ]
 
 sgx.debug = true
@@ -30,18 +34,8 @@ sgx.thread_num = 16
 sgx.enclave_size = "1024M"
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:memcached",
   "file:{{ gramine.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-]
-
-sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
+  "file:{{ gramine.libos }}",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR removes the following insecure manifest options:
- `loader.insecure__use_cmdline_argv` as we use `loader.uid` now and thus don't need `-u nobody` argument,
- `sgx.allowed_files`, they are not needed at all.

## How to test this PR? <!-- (if applicable) -->

CI and manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/957)
<!-- Reviewable:end -->
