### PR TITLE
[CI-Examples] Harden Busybox example

### DIFF
--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -35,10 +35,6 @@ $(SRCDIR)/.config: $(SRCDIR)/Makefile
 	# Enable usage of Busybox's built-in applets
 	sed -e 's/.*CONFIG_FEATURE_SH_STANDALONE.*/CONFIG_FEATURE_SH_STANDALONE=y/' \
 		-i $(SRCDIR)/.config
-	# Currently '/proc/self/exe' is bugged in gramine, so manually set path
-	# to the Busybox binary
-	sed -e 's/.*CONFIG_BUSYBOX_EXEC_PATH.*/CONFIG_BUSYBOX_EXEC_PATH="\/busybox"/' \
-		-i $(SRCDIR)/.config
 
 $(SRCDIR)/busybox: $(SRCDIR)/.config
 	$(MAKE) -C $(SRCDIR)

--- a/CI-Examples/busybox/README.md
+++ b/CI-Examples/busybox/README.md
@@ -26,8 +26,8 @@ make SGX=1 RA_TYPE=epid RA_CLIENT_SPID=12345678901234567890123456789012 \
 ```
 
 The above dummy values will suffice for simple experiments, but if you wish to
-run `sgx-quote.py` and verify the output, you will need to provide an
-[SPID recognized by Intel][spid].
+generate real SGX quotes, you will need to provide an [SPID recognized by
+Intel][spid].
 
 [spid]: https://gramine.readthedocs.io/en/latest/sgx-intro.html#term-spid
 

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -5,21 +5,20 @@ libos.entrypoint = "/busybox"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}"
-loader.env.PATH = "/:/usr/sbin:/usr/bin:/sbin:/bin"
-loader.env.USERNAME = ""
-loader.env.HOME = ""
-loader.env.PWD = ""
-loader.env.HOSTNAME = "test"
+loader.env.LD_LIBRARY_PATH = "/lib"
 
 loader.insecure__use_cmdline_argv = true
 
 fs.mounts = [
-  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
-  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
-  { path = "/etc", uri = "file:/etc" },
   { path = "/busybox", uri = "file:busybox" },
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+
+  # hardcoded mappings of local hostnames to IP addresses, required by e.g. `hostname` applet
+  { path = "/etc/hosts", uri = "file:helper-files/hosts" },
 ]
+
+# required by e.g. `wget` applet
+sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.debug = true
 
@@ -28,18 +27,7 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:busybox",
   "file:{{ gramine.runtimedir() }}/",
-  "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
-]
-
-sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/localtime",
+  "file:{{ gramine.libos }}",
 ]

--- a/CI-Examples/busybox/helper-files/hosts
+++ b/CI-Examples/busybox/helper-files/hosts
@@ -1,0 +1,8 @@
+127.0.0.1   localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR removes the `sgx.allowed_files` insecure manifest option, since the files there are not needed at all. Also, this commit removes many other superfluous manifest options.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/958)
<!-- Reviewable:end -->
