### PR TITLE
[CI-Examples] Harden Lighttpd example

### DIFF
--- a/CI-Examples/lighttpd/Makefile
+++ b/CI-Examples/lighttpd/Makefile
@@ -48,8 +48,7 @@ lighttpd.manifest: lighttpd.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dinstall_dir=$(INSTALL_DIR) \
-		-Dinstall_dir_abspath=$(abspath $(INSTALL_DIR)) \
+		-Dinstall_dir=$(abspath $(INSTALL_DIR)) \
 		$< >$@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
@@ -109,7 +108,7 @@ endif
 
 .PHONY: start-gramine-server
 start-gramine-server: all
-	$(GRAMINE) ./lighttpd -D -m $(INSTALL_DIR)/lib -f lighttpd.conf
+	$(GRAMINE) ./lighttpd
 
 .PHONY: clean
 clean:

--- a/CI-Examples/lighttpd/README.md
+++ b/CI-Examples/lighttpd/README.md
@@ -6,7 +6,7 @@ the Makefile and a template for generating the manifest.
 # Building lighttpd source
 
 For this example, we build lighttpd from source instead of using an existing
-binary. To build lighttpd on Ubuntu 18.04, please make sure that the following
+binary. To build lighttpd on Ubuntu 20.04, please make sure that the following
 packages are installed:
 
     sudo apt-get install -y build-essential libssl-dev zlib1g-dev
@@ -20,7 +20,7 @@ Run `make` (non-debug) or `make DEBUG=1` (debug) in the directory.
 Run `make SGX=1` (non-debug) or `make SGX=1 DEBUG=1` (debug) in the directory to
 prepare lighttpd to run on SGX.
 
-# Running lighttpd natively, under Gramine, and under Gramine-SGX
+# Running lighttpd
 
 Execute one of the following commands to start lighttpd either natively
 (non-Gramine), on Gramine or Gramine-SGX, respectively.
@@ -43,10 +43,3 @@ https://github.com/giltene/wrk2 for more information.
     ../common_tools/benchmark-http.sh http://127.0.0.1:8003
 
 Use Ctrl-C to terminate the server once you are finished testing lighttpd.
-
-# Clean up
-
-There are two commands to clean up the directory:
-
-* `make clean`: Remove manifest, signature, and token files.
-* `make distclean`: Remove the lighttpd source code and installation directory.

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -7,15 +7,14 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:{{ install_dir }}/lib"
 
-loader.insecure__use_cmdline_argv = true
+loader.argv = ["lighttpd", "-D", "-m", "{{ install_dir }}/lib", "-f", "lighttpd.conf"]
 
 sys.enable_sigterm_injection = true
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
-  { path = "/usr", uri = "file:/usr" },
-  { path = "{{ install_dir_abspath }}", uri = "file:{{ install_dir }}" },
+  { path = "{{ install_dir }}", uri = "file:{{ install_dir }}" },
 
   { type = "tmpfs", path = "/var/tmp" },
 ]
@@ -30,7 +29,6 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ install_dir }}/",
   "file:{{ arch_libdir }}/",
-  "file:/usr/{{ arch_libdir }}/",
   "file:lighttpd.conf",
   "file:lighttpd-generic.conf",
   "file:lighttpd-server.conf",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR removes the `loader.insecure__use_cmdline_argv` manifest option in favor of `loader.argv`. Also, this commit removes some other superfluous manifest options.

## How to test this PR? <!-- (if applicable) -->

CI.