### PR TITLE
[CI-Examples] Harden `ra-tls-secret-prov` example

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/helper-files/hosts
+++ b/CI-Examples/ra-tls-secret-prov/helper-files/hosts
@@ -1,0 +1,8 @@
+127.0.0.1   localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters

--- a/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
@@ -7,15 +7,13 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
-loader.insecure__use_cmdline_argv = true
-
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
-  { path = "/etc", uri = "file:/etc" },
   { path = "/client", uri = "file:client" },
   { path = "/ca.crt", uri = "file:../ssl/ca.crt" },
+  { path = "/etc/hosts", uri = "file:../helper-files/hosts" },
 ]
 
 sys.enable_extra_runtime_domain_names_conf = true
@@ -34,14 +32,5 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:../ssl/ca.crt",
-]
-
-sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
+  "file:../helper-files/",
 ]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
@@ -11,15 +11,13 @@ loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
 loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "/ca.crt"
 loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdummy:4433"
 
-loader.insecure__use_cmdline_argv = true
-
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
-  { path = "/etc", uri = "file:/etc" },
   { path = "/client", uri = "file:client" },
   { path = "/ca.crt", uri = "file:../ssl/ca.crt" },
+  { path = "/etc/hosts", uri = "file:../helper-files/hosts" },
 ]
 
 sys.enable_extra_runtime_domain_names_conf = true
@@ -38,14 +36,5 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:../ssl/ca.crt",
-]
-
-sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
+  "file:../helper-files/",
 ]

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
@@ -12,15 +12,13 @@ loader.env.SECRET_PROVISION_SET_KEY = "default"
 loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "/ca.crt"
 loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdummy:4433"
 
-loader.insecure__use_cmdline_argv = true
-
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
-  { path = "/etc", uri = "file:/etc" },
   { path = "/client", uri = "file:client" },
   { path = "/ca.crt", uri = "file:../ssl/ca.crt" },
+  { path = "/etc/hosts", uri = "file:../helper-files/hosts" },
   { path = "/files/", uri = "file:enc_files/", type = "encrypted" },
 ]
 
@@ -40,14 +38,5 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:../ssl/ca.crt",
-]
-
-sgx.allowed_files = [
-  "file:/etc/nsswitch.conf",
-  "file:/etc/ethers",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/gai.conf",
+  "file:../helper-files/",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR removes the following insecure manifest options:
- `loader.insecure__use_cmdline_argv` since it is not needed,
- `sgx.allowed_files`, they are not needed at all.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/963)
<!-- Reviewable:end -->
