### PR TITLE
[CI-Examples] Harden SQLite example

### DIFF
--- a/CI-Examples/sqlite/.gitignore
+++ b/CI-Examples/sqlite/.gitignore
@@ -1,3 +1,3 @@
 /OUTPUT
-/scripts/testdir/*
-!/scripts/testdir/.dummy
+/db/*
+!/db/.gitkeep

--- a/CI-Examples/sqlite/Makefile
+++ b/CI-Examples/sqlite/Makefile
@@ -39,23 +39,24 @@ else
 GRAMINE = gramine-sgx
 endif
 
+# Note that command-line arguments are hardcoded in the manifest file.
 .PHONY: regression
 regression: all
-	@rm -f scripts/testdir/*
+	@$(RM) db/*
 
-	$(GRAMINE) sqlite3 scripts/testdir/test.db < scripts/create.sql
+	$(GRAMINE) sqlite3 < scripts/create.sql
 	@echo "[ Success 1/3 ]"
 
-	$(GRAMINE) sqlite3 scripts/testdir/test.db < scripts/update.sql
+	$(GRAMINE) sqlite3 < scripts/update.sql
 	@echo "[ Success 2/3 ]"
 
-	$(GRAMINE) sqlite3 scripts/testdir/test.db < scripts/select.sql > OUTPUT
+	$(GRAMINE) sqlite3 < scripts/select.sql > OUTPUT
 	diff OUTPUT scripts/select.txt
 	@echo "[ Success 3/3 ]"
 
 .PHONY: clean
 clean:
-	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT scripts/testdir/*
+	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT db/*
 
 .PHONY: distclean
 distclean: clean

--- a/CI-Examples/sqlite/README.md
+++ b/CI-Examples/sqlite/README.md
@@ -21,21 +21,42 @@ Run `make SGX=1` (non-debug) or `make SGX=1 DEBUG=1` (debug) in the directory.
 
 # Running SQLite with Gramine
 
-Here's an example of running SQLite under Gramine:
+Here's an example of running SQLite under Gramine (note that command-line options are hardcoded in
+the manifest file):
 
 Without SGX:
 ```
-gramine-direct sqlite3 scripts/testdir/test.db < scripts/create.sql
-gramine-direct sqlite3 scripts/testdir/test.db < scripts/update.sql
-gramine-direct sqlite3 scripts/testdir/test.db < scripts/select.sql
+gramine-direct sqlite3 < scripts/create.sql
+gramine-direct sqlite3 < scripts/update.sql
+gramine-direct sqlite3 < scripts/select.sql
 ```
 
 With SGX:
 ```
-gramine-sgx sqlite3 scripts/testdir/test.db < scripts/create.sql
-gramine-sgx sqlite3 scripts/testdir/test.db < scripts/update.sql
-gramine-sgx sqlite3 scripts/testdir/test.db < scripts/select.sql
+gramine-sgx sqlite3 < scripts/create.sql
+gramine-sgx sqlite3 < scripts/update.sql
+gramine-sgx sqlite3 < scripts/select.sql
 ```
+
+# Note about security of database files
+
+In this example, SQLite stores the database files under the directory `db/`. The
+files are encrypted by Gramine using the "encrypted" FS mount point (see the
+manifest file). However, the key with which the `db/` files are encrypted is
+hardcoded in the manifest. This renders this example deployment **insecure**.
+
+A secure version will require to replace this hardcoded key with one of the
+following options:
+
+- `key_name = "_sgx_mrenclave"` or `key_name = "_sgx_mrsigner"` in the FS mount
+  point in the manifest. This way, the database files will be sealed to the
+  particular SGX platform and cannot be decrypted on other platforms.
+
+- `key_name = "<provisioned key name>"` in the FS mount point in the manifest,
+  plus using a key provisioning flow with SGX remote attestation (see e.g.
+  `ra-tls-secret-prov` example). This way, the database files will be encrypted
+  with the provisioned key and can be later decrypted on other platforms that
+  possess the same key.
 
 # Note about concurrency
 

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -5,7 +5,7 @@ libos.entrypoint = "{{ execdir }}/sqlite3"
 
 loader.log_level = "{{ log_level }}"
 
-loader.insecure__use_cmdline_argv = true
+loader.argv = ["sqlite3", "/db/test.db"]
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}"
 loader.env.PATH = "{{ execdir }}"
@@ -16,7 +16,15 @@ fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "{{ execdir }}/sqlite3", uri = "file:{{ execdir }}/sqlite3" },
+
+  # SQLite creates several helper files for the DB, so we specify a path instead of a single file
+  { type = "encrypted", path = "/db/", uri = "file:db/", key_name = "default" },
 ]
+
+# Unfortunately, non-SGX Gramine cannot use special keys such as "_sgx_mrenclave", so for this
+# example to work on both non-SGX and SGX versions we hardcode a dummy key. In SGX production case,
+# it is recommended to remove this insecure key and instead use "_sgx_mrenclave"/"_sgx_mrsigner".
+fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
 
 sgx.debug = true
 sgx.enclave_size = "256M"
@@ -27,8 +35,5 @@ sgx.trusted_files = [
   "file:{{ execdir }}/sqlite3",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
-]
-
-sgx.allowed_files = [
   "file:scripts/",
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR removes the following insecure manifest options:
- `loader.insecure__use_cmdline_argv` in favor of `loader.argv`,
- `sgx.allowed_files` in favor of an "encrypted" FS mount.

The database files are now stored under the `db/` directory which is mounted as "encrypted" in Gramine. For the SGX case, the encryption key is MRENCLAVE-based; for non-SGX case, the key is a hardcoded dummy.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/964)
<!-- Reviewable:end -->
