### PR TITLE
[LibOS/regression] Remove a note about a bug in `exec_same`

### DIFF
--- a/libos/test/regression/exec_same.c
+++ b/libos/test/regression/exec_same.c
@@ -32,20 +32,12 @@ int main(int argc, char** argv) {
     g_argv0 = argv[0];
     g_argv = &argv[1];
 
-    /*
-     * XXX: THIS PART OF TEST IS CURRENTLY DISABLED!!!
-     * Unfortunately there is a bug somewhere, that sometimes causes some data race: the hash of
-     * the first chunk of the executable file ('exec_same') is different from what's expected, even
-     * though the hashed data matches. The function that does this hashing is: `load_trusted_file`.
-     * This bug existed even before changes from PR introducing this test case.
-     */
-    (void)thread_func; // to satisfy compiler
     /* Creating another thread and doing a race on execve. Only one thread should survive. */
-    // pthread_t th;
-    // if (pthread_create(&th, NULL, thread_func, NULL) != 0) {
-    //     perror("pthread_create failed");
-    //     return 1;
-    // }
+    pthread_t th;
+    if (pthread_create(&th, NULL, thread_func, NULL) != 0) {
+        perror("pthread_create failed");
+        return 1;
+    }
 
     do_exec();
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This bug was fixed over two years ago by "[Pal/Linux-SGX] Fix race in accessing trusted files hashes list".

## How to test this PR? <!-- (if applicable) -->
Try running the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/965)
<!-- Reviewable:end -->
