### PR TITLE
[LibOS] Allow and ignore `MSG_MORE` flag for TCP socket in `sendto`

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -61,6 +61,7 @@ struct mmsghdr {
 #define MSG_TRUNC 0x20
 #define MSG_DONTWAIT 0x40
 #define MSG_NOSIGNAL 0x4000
+#define MSG_MORE 0x8000
 #define MSG_CMSG_CLOEXEC 0x40000000
 
 /* Option levels. */


### PR DESCRIPTION
## Description of the changes 

Some applications use `MSG_MORE` flag and fail when they are not supported, such as Pytorch. Source code can be seen in
https://github.com/pytorch/pytorch/blob/614d6f19e3d30cac0d77059e738d1f25d75eb408/torch/csrc/distributed/c10d/Utils.hpp#L559

Ignoring `MSG_MORE` flag in `sendto` syscall is correct semantically for TCP socket and fixes Pytorch workloads that use above `namespace tcputil`.  I don't encounter performance issue.

Fixes #823.

## How to test this PR?

straightforward change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/966)
<!-- Reviewable:end -->
