### PR TITLE
[common] Add truncation to arbitrary size to Protected Files

### DIFF
--- a/common/src/protected_files/README.rst
+++ b/common/src/protected_files/README.rst
@@ -66,7 +66,9 @@ Some tests in ``libos/test/regression`` also work with encrypted files.
 TODO
 ====
 
-- Shrinking protected files via truncate(2) to arbitrary size is not yet implemented.
+- Shrinking protected files via truncate(2) to arbitrary size is implemented in
+  a slow and trivial way: read the file's contents into a temporary buffer,
+  shrink the file to zero, write back the contents into the file.
 - The recovery file feature is disabled, this needs to be discussed if it's
   needed in Gramine.
 - Tests for invalid/malformed/corrupted files need to be ported to the new

--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -1236,10 +1236,13 @@ pf_status_t pf_set_size(pf_context_t* pf, uint64_t size) {
         return PF_STATUS_SUCCESS;
     }
 
-    /* shrink the file
-     *    - to zero: emulated by recreating the file metadata as if it was just created
+    /* Shrink the file:
+     *    - to zero: emulated by recreating the file metadata as if it was just created,
      *    - to arbitrary size: emulated by reading file contents in a buffer, shrinking the file to
-     *                         zero as above, and writing back contents into the file */
+     *                         zero as above, and writing back contents into the file.
+     *
+     * TODO: implement "shrink to arbitrary size" properly.
+     */
     int ret;
     char* buf = NULL;
 

--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -270,8 +270,7 @@ pf_status_t pf_get_size(pf_context_t* pf, uint64_t* size);
  *
  * \returns PF status.
  *
- * If the file is extended, added bytes are zero. Shrinking to arbitrary size is not implemented
- * yet (TODO).
+ * If the file is extended, added bytes are zero.
  */
 pf_status_t pf_set_size(pf_context_t* pf, uint64_t size);
 

--- a/libos/test/fs/test_enc.py
+++ b/libos/test/fs/test_enc.py
@@ -132,8 +132,7 @@ class TC_50_EncryptedFiles(test_fs.TC_00_FileSystem):
         self.verify_size(path_1, size_out)
         self.verify_size(path_2, size_out)
 
-    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted) and
-    # because file truncation from greater to small size is not yet implemented
+    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
     def test_140_file_truncate(self):
         enc_path = self.ENCRYPTED_FILES[-1] # existing file
         path_1 = os.path.join(self.OUTPUT_DIR, 'test_140a') # writable files
@@ -141,12 +140,19 @@ class TC_50_EncryptedFiles(test_fs.TC_00_FileSystem):
         self.copy_input(enc_path, path_1) # encrypt
         self.copy_input(enc_path, path_2) # encrypt
 
+        # test shrinking to zero
         self.verify_truncate_test(path_1, path_2, 0)
         self.verify_truncate_test(path_1, path_2, 200)
         self.verify_truncate_test(path_1, path_2, 0)
         self.verify_truncate_test(path_1, path_2, 1000)
         self.verify_truncate_test(path_1, path_2, 1000)
         self.verify_truncate_test(path_1, path_2, 0)
+        self.verify_truncate_test(path_1, path_2, 0)
+
+        # test shrinking to arbitrary size
+        self.verify_truncate_test(path_1, path_2, 1000)
+        self.verify_truncate_test(path_1, path_2, 200)
+        self.verify_truncate_test(path_1, path_2, 100)
         self.verify_truncate_test(path_1, path_2, 0)
 
     def test_150_file_rename(self):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Truncation of PFs to arbitrary size is implemented in a slow and trivial way: read the file's contents into a temporary buffer, shrink the file to zero, write back the contents into the file.

Fixes #950.

## How to test this PR? <!-- (if applicable) -->

CI. I added tests to `libos/test/fs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/972)
<!-- Reviewable:end -->
