### PR TITLE
[LibOS] Add uid and gid to inodes

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -257,6 +257,9 @@ struct libos_inode {
     /* File size */
     file_off_t size;
 
+    /* credentials */
+    IDTYPE uid, gid;
+
     /* Create/modify/access time */
     time_t ctime;
     time_t mtime;

--- a/libos/src/fs/libos_dcache.c
+++ b/libos/src/fs/libos_dcache.c
@@ -361,6 +361,12 @@ struct libos_inode* get_new_inode(struct libos_mount* mount, mode_t type, mode_t
     inode->mtime = 0;
     inode->atime = 0;
 
+    struct libos_thread* current = get_cur_thread();
+    lock(&current->lock);
+    inode->uid = current->uid;
+    inode->gid = current->gid;
+    unlock(&current->lock);
+
     inode->mount = mount;
     get_mount(mount);
     inode->fs = mount->fs;
@@ -610,6 +616,9 @@ BEGIN_CP_FUNC(inode) {
         new_inode->type = inode->type;
         new_inode->perm = inode->perm;
         new_inode->size = inode->size;
+
+        new_inode->uid = inode->uid;
+        new_inode->gid = inode->gid;
 
         new_inode->ctime = inode->ctime;
         new_inode->mtime = inode->mtime;

--- a/libos/src/fs/libos_fs_pseudo.c
+++ b/libos/src/fs/libos_fs_pseudo.c
@@ -210,6 +210,9 @@ static int pseudo_istat(struct libos_dentry* dent, struct libos_inode* inode, st
     memset(buf, 0, sizeof(*buf));
     buf->st_dev = 1;
     buf->st_mode = inode->type | inode->perm;
+    buf->st_uid  = inode->uid;
+    buf->st_gid  = inode->gid;
+
     struct pseudo_node* node = inode->data;
     switch (node->type) {
         case PSEUDO_DIR: {

--- a/libos/src/fs/libos_fs_util.c
+++ b/libos/src/fs/libos_fs_util.c
@@ -62,6 +62,9 @@ static int generic_istat(struct libos_inode* inode, struct stat* buf) {
     lock(&inode->lock);
     buf->st_mode = inode->type | inode->perm;
     buf->st_size = inode->size;
+    buf->st_uid  = inode->uid;
+    buf->st_gid  = inode->gid;
+
     /* Some programs (e.g. some tests from LTP) require this value. We've picked some random,
      * pretty looking constant - exact value should not affect anything (perhaps except
      * performance). */

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -420,8 +420,8 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
 
     RUN_INIT(init_ipc);
     RUN_INIT(init_process);
-    RUN_INIT(init_mount_root);
     RUN_INIT(init_threading);
+    RUN_INIT(init_mount_root);
     RUN_INIT(init_mount);
     RUN_INIT(init_std_handles);
 

--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -121,8 +121,20 @@ skip = yes
 [chmod07]
 skip = yes
 
-# chown() does nothing
-[chown*]
+# 16-bit unsupported
+[chown*_16]
+skip = yes
+
+# chown() does not clear setuid/setgid bits set on executable files
+[chown02]
+skip = yes
+
+# no seteuid()
+[chown03]
+skip = yes
+
+# requires using a device
+[chown04]
 skip = yes
 
 # no seteuid()
@@ -355,8 +367,24 @@ skip = yes
 [fchmodat01]
 timeout = 40
 
-# fchown* does nothing
-[fchown*]
+# 16-bit unsupported
+[fchown*_16]
+skip = yes
+
+# fchown() does not clear setuid/setgid bits set on executable files
+[fchown02]
+skip = yes
+
+# no seteuid()
+[fchown03]
+skip = yes
+
+# requires using a device
+[fchown04]
+skip = yes
+
+# no utimensat()
+[fchownat*]
 skip = yes
 
 [fcntl02_64]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, inodes didn't have user/group IDs, thus `stat("file")` returned `statbuf.st_uid == statbuf.st_uid == 0`. This is wrong because Gramine allows to specify initial user/group IDs via `loader.uid` and `loader.gid` manifest options, and file ownership must default to these.

This PR adds `inode->uid` and `inode->gid`. Also, `chown()`, `fchown()` and `fchownat()` syscalls now change file uid/gid. Several LTP tests were enabled to test this feature.

## How to test this PR? <!-- (if applicable) -->

I enabled some LTP tests.