### PR TITLE
Generate unique sgx trusted files for manifest.sgx

### DIFF
--- a/python/graminelibos/gen_jinja_env.py
+++ b/python/graminelibos/gen_jinja_env.py
@@ -29,6 +29,12 @@ def ldd(*args):
             ret.add(line[0])
     return sorted(ret)
 
+def get_python_sys_paths():
+    for path in sys.path:
+        if "gramine" not in path:
+            if os.path.exists(path) and os.access(path, os.R_OK):
+                yield path
+
 def add_globals_from_python(env):
     paths = sysconfig.get_paths()
     env.globals['python'] = {
@@ -46,6 +52,7 @@ def add_globals_from_python(env):
 
         'get_path': sysconfig.get_path,
         'get_paths': sysconfig.get_paths,
+        'get_sys_path':get_python_sys_paths,
 
         'implementation': sys.implementation,
     }


### PR DESCRIPTION
Gramine currently does not throw error when there are duplicate
entries in manifest.sgx
It will generate unique entries for sgx trusted files in manifest.sgx

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Python example reference has been taken to test this PR
1. Create duplicate entries for sgx.trusted section in python.manifest.template.
2. make SGX=1
3. Notice in manifest.sgx there will be unique set of entries for trusted file section

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/977)
<!-- Reviewable:end -->
