### PR TITLE
Python does not have distlib path in CentOS/RHEL.

### DIFF
--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -3,6 +3,8 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
+loader.env.OMP_NUM_THREADS = "4"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -15,8 +17,9 @@ fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
-  { path = "{{ python.stdlib }}", uri = "file:{{ python.stdlib }}" },
-  { path = "{{ python.distlib }}", uri = "file:{{ python.distlib }}" },
+  {% for path in python.get_sys_paths() %}
+    { path = "{{ path }}", uri = "file:{{ path }}" },
+  {% endfor %}
   { path = "{{ entrypoint }}", uri = "file:{{ entrypoint }}" },
   { path = "/etc/hosts", uri = "file:helper-files/hosts" },
 
@@ -28,7 +31,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.debug = true
 sgx.nonpie_binary = true
-sgx.enclave_size = "512M"
+sgx.enclave_size = "1G"
 sgx.thread_num = 32
 
 sgx.remote_attestation = "{{ ra_type }}"
@@ -41,8 +44,9 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:{{ python.stdlib }}/",
-  "file:{{ python.distlib }}/",
+  {% for path in python.get_sys_paths() %}
+    "file:{{ path }}/",
+  {% endfor %}
   "file:scripts/",
   "file:helper-files/",
 ]

--- a/python/graminelibos/gen_jinja_env.py
+++ b/python/graminelibos/gen_jinja_env.py
@@ -29,6 +29,11 @@ def ldd(*args):
             ret.add(line[0])
     return sorted(ret)
 
+def get_python_sys_paths():
+    for path in sys.path:
+        if os.path.exists(path) and os.access(path, os.R_OK):
+            yield path
+
 def add_globals_from_python(env):
     paths = sysconfig.get_paths()
     env.globals['python'] = {
@@ -46,6 +51,7 @@ def add_globals_from_python(env):
 
         'get_path': sysconfig.get_path,
         'get_paths': sysconfig.get_paths,
+        'get_sys_paths': get_python_sys_paths,
 
         'implementation': sys.implementation,
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

To support Python for CentOS, RHEL & Ubuntu from Gramine, we need to replace distlib with numpy, scipy & six libraries path, because distlib path does not exist in CentOS & RHEL

Fixes #973. See it for context.


## How to test this PR? <!-- (if applicable) -->
1. Make Python example using make SGX=1 on CentOS/RHEL
2. make SGX=1 check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/978)
<!-- Reviewable:end -->


[rhel_python3_sysconfig.txt](https://github.com/gramineproject/gramine/files/9798424/rhel_python3_sysconfig.txt)
[centos_python3_sysconfig.txt](https://github.com/gramineproject/gramine/files/9798426/centos_python3_sysconfig.txt)
