### PR TITLE
[LibOS] Add support for execv with argv = NULL

### DIFF
--- a/libos/src/sys/libos_exec.c
+++ b/libos/src/sys/libos_exec.c
@@ -134,17 +134,22 @@ static int libos_syscall_execve_rtld(struct libos_handle* hdl, char** argv,
 
 long libos_syscall_execve(const char* file, const char* const* argv, const char* const* envp) {
     int ret = 0, argc = 0;
+    const char* const empty_argv[1] = {NULL};
 
     if (!is_user_string_readable(file))
         return -EFAULT;
 
-    for (const char* const* a = argv; /* no condition*/; a++, argc++) {
-        if (!is_user_memory_readable(a, sizeof(*a)))
-            return -EFAULT;
-        if (*a == NULL)
-            break;
-        if (!is_user_string_readable(*a))
-            return -EFAULT;
+    if (!argv) {
+        argv = empty_argv;
+    } else {
+        for (const char* const* a = argv; /* no condition */; a++, argc++) {
+            if (!is_user_memory_readable(a, sizeof(*a)))
+                return -EFAULT;
+            if (*a == NULL)
+                break;
+            if (!is_user_string_readable(*a))
+                return -EFAULT;
+        }
     }
 
     /* TODO: This should be removed, but: https://github.com/gramineproject/graphene/issues/2081 */

--- a/libos/test/regression/exec_null.c
+++ b/libos/test/regression/exec_null.c
@@ -1,0 +1,8 @@
+#define _GNU_SOURCE
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int main(void) {
+    syscall(__NR_execve, "./exec_victim", NULL, NULL);
+    return 1;
+}

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -20,6 +20,7 @@ tests = {
     'exec': {},
     'exec_fork': {},
     'exec_invalid_args': {},
+    'exec_null': {},
     'exec_same': {},
     'exec_script': {},
     'exec_victim': {},

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -238,9 +238,14 @@ class TC_01_Bootstrap(RegressionTestCase):
             'ALPHA BRAVO CHARLIE DELTA '
             'scripts/foo.sh STRING FROM EXECVE', stdout)
 
+    def test_212_exec_null(self):
+        stdout, _ = self.run_binary(['exec_null'])
+        self.assertIn('Hello World ((null))!', stdout)
+        self.assertIn('envp[\'IN_EXECVE\'] = (null)', stdout)
+
     @unittest.skipIf(USES_MUSL,
         'Test uses /bin/sh from the host which is usually built against glibc')
-    def test_212_shebang_test_script(self):
+    def test_213_shebang_test_script(self):
         stdout, _ = self.run_binary(['shebang_test_script'])
         self.assertRegex(stdout, r'Printing Args: '
             r'scripts/baz\.sh ECHO FOXTROT GOLF scripts/bar\.sh '

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -23,6 +23,7 @@ manifests = [
   "exec",
   "exec_fork",
   "exec_invalid_args",
+  "exec_null",
   "exec_same",
   "exec_script",
   "exec_victim",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -25,6 +25,7 @@ manifests = [
   "exec",
   "exec_fork",
   "exec_invalid_args",
+  "exec_null",
   "exec_same",
   "exec_script",
   "exec_victim",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Add support for execv with argv = NULL.

## How to test this PR? <!-- (if applicable) -->

Run added LibOS regression test case.

Resolves: https://github.com/gramineproject/gramine/issues/794

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/979)
<!-- Reviewable:end -->
