### PR TITLE
[LibOS] Add `sys.disallow_subprocesses` manifest option

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -337,6 +337,27 @@ Be careful! In SGX environment, the untrusted host could inject that signal in
 an arbitrary moment. Examine what your application's `SIGTERM` handler does and
 whether it poses any security threat.
 
+Disallowing subprocesses (fork)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sys.disallow_subprocesses = [true|false]
+    (Default: false)
+
+This specifies whether to block applications from creating child processes (e.g.
+via ``fork()`` or ``clone()`` system calls). The intuition is that many
+applications have fallbacks when they fail to spawn a child process (e.g.
+Python). Could be useful in SGX environments: child processes consume
+:term:`EPC` memory which is a limited resource.
+
+.. note ::
+   This option is *not* a security feature - Gramine by-design is only a one-way
+   sandbox, which doesn't protect the host from the enclave. Don't use this
+   option if you want to somehow mitigate running untrusted enclaves. Instead,
+   to achieve this, you need to run the whole Gramine inside a proper security
+   sandbox.
+
 Root FS mount point
 ^^^^^^^^^^^^^^^^^^^
 

--- a/libos/test/regression/fork_disallowed.manifest.template
+++ b/libos/test/regression/fork_disallowed.manifest.template
@@ -1,0 +1,25 @@
+{% set entrypoint = "fork_and_exec" -%}
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.log_level = "warning"
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+# must print a warning: "The app tried to create a subprocess, but this is disabled"
+sys.disallow_subprocesses = true
+
+sgx.nonpie_binary = true
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -206,21 +206,29 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
-    def test_203_vfork_and_exec(self):
+    def test_203_fork_disallowed(self):
+        try:
+            self.run_binary(['fork_disallowed'])
+            self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode()
+            self.assertIn('The app tried to create a subprocess, but this is disabled', stderr)
+
+    def test_204_vfork_and_exec(self):
         stdout, _ = self.run_binary(['vfork_and_exec'], timeout=60)
 
         # vfork and exec 2 page child binary
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
-    def test_204_exec_fork(self):
+    def test_205_exec_fork(self):
         stdout, _ = self.run_binary(['exec_fork'], timeout=60)
         self.assertNotIn('Handled SIGCHLD', stdout)
         self.assertIn('Set up handler for SIGCHLD', stdout)
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
-    def test_205_double_fork(self):
+    def test_206_double_fork(self):
         stdout, stderr = self.run_binary(['double_fork'])
         self.assertIn('TEST OK', stdout)
         self.assertNotIn('grandchild', stderr)

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -37,6 +37,7 @@ manifests = [
   "file_size",
   "fopen_cornercases",
   "fork_and_exec",
+  "fork_disallowed",
   "fp_multithread",
   "fstat_cwd",
   "futex_bitset",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -39,6 +39,7 @@ manifests = [
   "file_size",
   "fopen_cornercases",
   "fork_and_exec",
+  "fork_disallowed",
   "fp_multithread",
   "fstat_cwd",
   "futex_bitset",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some apps (in particular Python) tend to spawn helper subprocesses. There is no simple way to disable such functionality in the apps themselves, so we introduce a new manifest option to force apps to use only the main process and fall back to no-subprocesses logic.

~~**This is a draft for quick testing! After we'll test that it helps sometimes, we can have discussions on the terribleness of this approach.**~~ Based on customer feedback, this looks like useful feature, so I mark this PR as ready-for-review.

This PR literally disables `fork/vfork/clone` syscalls used to spawn subprocesses.

## How to test this PR? <!-- (if applicable) -->

Tested some Python workloads; they stopped spawning child enclaves and still behave correctly.

Here is an example of Flask:
- Install Flask: `pip3 install Flask` (installs in HOME dir of user)
- Improve manifest file:
```diff
diff --git a/CI-Examples/python/python.manifest.template b/CI-Examples/python/python.manifest.template
index da1a904e..9ba70b14 100644
@@ -8,2 +8,5 @@ loader.log_level = "{{ log_level }}"
 loader.env.LD_LIBRARY_PATH = "/lib:/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+loader.env.HOME = { passthrough = true }  # so that Python knows where to search for home-installed modules
+
+sys.disallow_subprocesses = true

@@ -27,2 +30,3 @@ fs.mounts = [
   { path = "/etc/hosts", uri = "file:helper-files/hosts" },
+  { path = "/bin/uname", uri = "file:/bin/uname" },  # this is the binary that is fork+execve'd

@@ -55,2 +59,3 @@ sgx.trusted_files = [
   "file:helper-files/",
+  "file:/bin/uname",
 ]
```
- Improve Helloworld Python script:
```diff
diff --git a/CI-Examples/python/scripts/helloworld.py b/CI-Examples/python/scripts/helloworld.py
index b11fb8ab..24f90b94 100644
@@ -2,2 +2,4 @@

+from flask import Flask
+
 print("Hello World")
```
- Run with `sys.disallow_subprocesses = true` commented out (old behavior):
```sh
~/gramineproject/gramine/CI-Examples/python$ time gramine-sgx python scripts/helloworld.py
Hello World

real    0m34.935s
user    0m9.781s
sys     0m8.668s
```
- Run with `sys.disallow_subprocesses = true`  (new behavior):
```sh
~/gramineproject/gramine/CI-Examples/python$ time gramine-sgx python  scripts/helloworld.py
Hello World

real    0m17.889s
user    0m9.462s
sys     0m8.390s
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/983)
<!-- Reviewable:end -->
