### PR TITLE
[LibOS] Create file on host corresponding to named UNIX socket

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -890,6 +890,9 @@ struct libos_inode* get_new_inode(struct libos_mount* mount, mode_t type, mode_t
 void get_inode(struct libos_inode* inode);
 void put_inode(struct libos_inode* inode);
 
+/* same as libos_syscall_openat() but filename can be in Gramine-private address space */
+long do_openat(int dfd, const char* filename, int flags, int mode);
+
 /*
  * Hashing utilities for paths.
  *

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -127,6 +127,7 @@ tests = {
     'udp': {},
     'uid_gid': {},
     'unix': {},
+    'unix_subprocesses': {},
     'vfork_and_exec': {},
 }
 

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1284,10 +1284,10 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('[parent] TEST OK', stdout)
 
     def test_100_socket_unix(self):
-        if os.path.exists("dummy"):
-            os.remove("dummy")
-        if os.path.exists("u"):
-            os.remove("u")
+        if os.path.exists("tmp/dummy"):
+            os.remove("tmp/dummy")
+        if os.path.exists("tmp/u"):
+            os.remove("tmp/u")
 
         stdout, _ = self.run_binary(['unix'])
         self.assertIn('Data: This is packet 0', stdout)
@@ -1300,6 +1300,13 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('Data: This is packet 7', stdout)
         self.assertIn('Data: This is packet 8', stdout)
         self.assertIn('Data: This is packet 9', stdout)
+
+    def test_101_socket_unix_subprocesses(self):
+        if os.path.exists("tmp/uds_subprocesses"):
+            os.remove("tmp/uds_subprocesses")
+
+        stdout, _ = self.run_binary(['unix_subprocesses'])
+        self.assertIn('TEST OK', stdout)
 
     def test_200_socket_udp(self):
         stdout, _ = self.run_binary(['udp'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -111,6 +111,7 @@ manifests = [
   "udp",
   "uid_gid",
   "unix",
+  "unix_subprocesses",
   "vfork_and_exec",
 ]
 

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -112,6 +112,7 @@ manifests = [
   "udp",
   "uid_gid",
   "unix",
+  "unix_subprocesses",
   "vfork_and_exec",
 ]
 

--- a/libos/test/regression/unix.c
+++ b/libos/test/regression/unix.c
@@ -47,7 +47,7 @@ static int server_dummy_socket(void) {
         printf("Dummy socket was created\n");
 
     address.sun_family = AF_UNIX;
-    strncpy(address.sun_path, "dummy", sizeof(address.sun_path));
+    strncpy(address.sun_path, "tmp/dummy", sizeof(address.sun_path));
     socklen_t minimal_address_size = offsetof(struct sockaddr_un, sun_path) +
                                      strlen(address.sun_path) + 1;
 
@@ -78,7 +78,7 @@ static int server(void) {
         printf("The socket was created\n");
 
     address.sun_family = AF_UNIX;
-    strncpy(address.sun_path, "u", sizeof(address.sun_path));
+    strncpy(address.sun_path, "tmp/u", sizeof(address.sun_path));
 
     if (bind(create_socket, (struct sockaddr*)&address, sizeof(address)) < 0) {
         perror("bind");
@@ -155,7 +155,7 @@ static int client(void) {
         printf("The socket was created\n");
 
     address.sun_family = AF_UNIX;
-    strncpy(address.sun_path, "u", sizeof(address.sun_path));
+    strncpy(address.sun_path, "tmp/u", sizeof(address.sun_path));
 
     if (connect(create_socket, (struct sockaddr*)&address, sizeof(address)) == 0)
         printf("The connection was accepted with the server\n");

--- a/libos/test/regression/unix_subprocesses.c
+++ b/libos/test/regression/unix_subprocesses.c
@@ -1,0 +1,125 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#define SRV_ADDR "tmp/uds_subprocesses"
+
+static const char g_buffer[] = "Hello from UDS server!";
+
+static void server(int pipefd) {
+    int s = CHECK(socket(AF_UNIX, SOCK_STREAM, 0));
+
+    struct sockaddr_un sa;
+    sa.sun_family = AF_UNIX;
+    strncpy(sa.sun_path, SRV_ADDR, sizeof(sa.sun_path));
+
+    CHECK(bind(s, (void*)&sa, sizeof(sa)));
+    CHECK(listen(s, 5));
+
+    char c = 0;
+    ssize_t x = CHECK(write(pipefd, &c, sizeof(c)));
+    if (x != 1) {
+        errx(1, "client terminated unexpectedly");
+    }
+    CHECK(close(pipefd));
+
+    int client = CHECK(accept(s, NULL, NULL));
+
+    CHECK(close(s));
+
+    size_t written = 0;
+    while (written < sizeof(g_buffer)) {
+        x = CHECK(write(client, g_buffer + written, sizeof(g_buffer) - written));
+        if (!x) {
+            /* technically impossible, but let's fail loudly if we ever hit this */
+            errx(1, "write to client returned zero");
+        }
+        written += x;
+    }
+
+    CHECK(close(client));
+}
+
+static void client(int pipefd) {
+    char c = 0;
+    ssize_t x = CHECK(read(pipefd, &c, sizeof(c)));
+    if (x != 1) {
+        errx(1, "server terminated unexpectedly");
+    }
+    CHECK(close(pipefd));
+
+    /* named UNIX domain sockets must create FS files, verify it; recall that by default Gramine
+     * creates files with root UID/GID permissions if not specified otherwise in manifest */
+    struct stat statbuf;
+    CHECK(stat(SRV_ADDR, &statbuf));
+    if (statbuf.st_uid != 0 || statbuf.st_gid != 0) {
+        errx(1, "unexpected UID/GID of file `%s`", SRV_ADDR);
+    }
+
+    int s = CHECK(socket(AF_UNIX, SOCK_STREAM, 0));
+
+    struct sockaddr_un sa;
+    sa.sun_family = AF_UNIX;
+    strncpy(sa.sun_path, SRV_ADDR, sizeof(sa.sun_path));
+
+    CHECK(connect(s, (void*)&sa, sizeof(sa)));
+
+    char buf[sizeof(g_buffer) + 1] = { 0 };
+    size_t got = 0;
+    while (got < sizeof(g_buffer)) {
+        x = CHECK(read(s, buf + got, sizeof(g_buffer) - got));
+        if (!x) {
+            /* let's fail loudly if there is no data from server */
+            errx(1, "read from server returned zero");
+        }
+        got += x;
+    }
+
+    if (strcmp(buf, g_buffer)) {
+        errx(1, "unexpected message from server: expected %s, got %s", g_buffer, buf);
+    }
+
+    CHECK(close(s));
+}
+
+int main(void) {
+    int pipefds[2];
+    CHECK(pipe(pipefds));
+
+    pid_t p_s = CHECK(fork());
+    if (p_s == 0) {
+        CHECK(close(pipefds[0]));
+        server(pipefds[1]);
+        return 0;
+    }
+
+    pid_t p_c = CHECK(fork());
+    if (p_c == 0) {
+        CHECK(close(pipefds[1]));
+        client(pipefds[0]);
+        return 0;
+    }
+
+    for (int i = 0; i < 2; i++) {
+        int status = 0;
+        CHECK(wait(&status));
+        if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+            errx(1, "child wait status: %#x", status);
+        }
+    }
+
+    puts("TEST OK");
+    return 0;
+}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Named UNIX domain sockets are expected to be backed by files. Previously, Gramine didn't have such backing files. However, some workloads require this, e.g., two subprocesses spawned in the same Gramine instance and communicating over a named UNIX socket.

This is a poor-man's implementation: LibOS creates a dummy regular file on the host, so that both subprocesses can see it. This poor implementatoin is chosen because there is no file synchronization mechanism available in Gramine.

See also discussions in #984.

## How to test this PR? <!-- (if applicable) -->

A new LibOS regression test is added that tests this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/986)
<!-- Reviewable:end -->
