### PR TITLE
[tools/sgx] Switch signing algo for RA-TLS certs from RSA-3072 to ECDSA-384

### DIFF
--- a/common/src/crypto/adapters/mbedtls_adapter.c
+++ b/common/src/crypto/adapters/mbedtls_adapter.c
@@ -36,6 +36,7 @@ static int mbedtls_to_pal_error(int error) {
 
         case MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE:
         case MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE:
+        case MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE:
             return -PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE;
 
         case MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA:
@@ -43,9 +44,11 @@ static int mbedtls_to_pal_error(int error) {
         case MBEDTLS_ERR_HKDF_BAD_INPUT_DATA:
         case MBEDTLS_ERR_MD_BAD_INPUT_DATA:
         case MBEDTLS_ERR_MPI_BAD_INPUT_DATA:
+        case MBEDTLS_ERR_PK_BAD_INPUT_DATA:
         case MBEDTLS_ERR_RSA_BAD_INPUT_DATA:
         case MBEDTLS_ERR_RSA_PUBLIC_FAILED:  // see mbedtls_rsa_public()
         case MBEDTLS_ERR_RSA_PRIVATE_FAILED: // see mbedtls_rsa_private()
+        case MBEDTLS_ERR_ECP_BAD_INPUT_DATA:
             return -PAL_ERROR_CRYPTO_BAD_INPUT_DATA;
 
         case MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE:
@@ -56,6 +59,8 @@ static int mbedtls_to_pal_error(int error) {
         case MBEDTLS_ERR_MD_ALLOC_FAILED:
         case MBEDTLS_ERR_SSL_ALLOC_FAILED:
         case MBEDTLS_ERR_PK_ALLOC_FAILED:
+        case MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL:
+        case MBEDTLS_ERR_ECP_ALLOC_FAILED:
             return -PAL_ERROR_NOMEM;
 
         case MBEDTLS_ERR_CIPHER_INVALID_PADDING:
@@ -86,18 +91,23 @@ static int mbedtls_to_pal_error(int error) {
             return -PAL_ERROR_CRYPTO_KEY_GEN_FAILED;
 
         case MBEDTLS_ERR_RSA_KEY_CHECK_FAILED:
+        case MBEDTLS_ERR_ECP_INVALID_KEY:
             return -PAL_ERROR_CRYPTO_INVALID_KEY;
 
         case MBEDTLS_ERR_RSA_VERIFY_FAILED:
+        case MBEDTLS_ERR_ECP_VERIFY_FAILED:
+        case MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH:
             return -PAL_ERROR_CRYPTO_VERIFY_FAILED;
 
         case MBEDTLS_ERR_RSA_RNG_FAILED:
+        case MBEDTLS_ERR_ECP_RANDOM_FAILED:
             return -PAL_ERROR_CRYPTO_RNG_FAILED;
 
         case MBEDTLS_ERR_SSL_WANT_READ:
         case MBEDTLS_ERR_SSL_WANT_WRITE:
         case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
         case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS:
+        case MBEDTLS_ERR_ECP_IN_PROGRESS:
             return -PAL_ERROR_TRYAGAIN;
 
         case MBEDTLS_ERR_NET_CONN_RESET:

--- a/tools/sgx/ra-tls/ra_tls.h
+++ b/tools/sgx/ra-tls/ra_tls.h
@@ -27,9 +27,6 @@
 #define RA_TLS_CERT_TIMESTAMP_NOT_AFTER  "RA_TLS_CERT_TIMESTAMP_NOT_AFTER"
 
 #define SHA256_DIGEST_SIZE       32
-#define RSA_PUB_3072_KEY_LEN     3072
-#define RSA_PUB_3072_KEY_DER_LEN 422
-#define RSA_PUB_EXPONENT         65537
 #define PUB_KEY_SIZE_MAX         512
 #define IAS_REQUEST_NONCE_LEN    32
 
@@ -101,18 +98,19 @@ int ra_tls_verify_callback_der(uint8_t* der_crt, size_t der_crt_size);
 /*!
  * \brief Generic function to generate a key and a corresponding RA-TLS certificate (DER format).
  *
- * \param[out] der_key       Pointer to buffer populated with generated RSA keypair in DER format.
- * \param[out] der_key_size  Pointer to size of generated RSA keypair.
+ * \param[out] der_key       Pointer to buffer populated with generated ECDSA keypair in DER format.
+ * \param[out] der_key_size  Pointer to size of generated ECDSA keypair.
  * \param[out] der_crt       Pointer to buffer populated with self-signed RA-TLS certificate.
  * \param[out] der_crt_size  Pointer to size of self-signed RA-TLS certificate.
  *
  * \returns 0 on success, specific mbedTLS error code (negative int) otherwise.
  *
- * The function first generates a random RSA keypair with PKCS#1 v1.5 encoding. Then it calculates
- * the SHA256 hash over the generated public key and retrieves an SGX quote with report_data equal
- * to the calculated hash (this ties the generated certificate key to the SGX quote). Finally, it
- * generates the X.509 self-signed certificate with this key and the SGX quote embedded. The
- * function allocates memory for key and certificate; user is expected to free them after use.
+ * The function first generates a random ECDSA keypair with NIST P-384 (SECP384R1) elliptic curve.
+ * Then it calculates the SHA256 hash over the generated public key and retrieves an SGX quote with
+ * report_data equal to the calculated hash (this ties the generated certificate key to the SGX
+ * quote). Finally, it generates the X.509 self-signed certificate with this key and the SGX quote
+ * embedded. The function allocates memory for key and certificate; user is expected to free them
+ * after use.
  */
 __attribute__ ((visibility("default")))
 int ra_tls_create_key_and_crt_der(uint8_t** der_key, size_t* der_key_size, uint8_t** der_crt,

--- a/tools/sgx/ra-tls/ra_tls_verify_common.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_common.c
@@ -164,12 +164,19 @@ int find_oid(const uint8_t* exts, size_t exts_len, const uint8_t* oid, size_t oi
 
 /*! calculate sha256 over public key from \p crt and copy it into \p sha */
 static int sha256_over_crt_pk(mbedtls_x509_crt* crt, uint8_t* sha) {
+    /* TODO: Gramine now accepts only ECDSA key with P-384 curve. Remove below once the support for
+     * more than one cipher scheme is added. */
+    if (mbedtls_pk_get_type(&crt->pk) != MBEDTLS_PK_ECKEY ||
+            mbedtls_pk_ec(crt->pk)->MBEDTLS_PRIVATE(grp).id != MBEDTLS_ECP_DP_SECP384R1) {
+        return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
+    }
+
     uint8_t pk_der[PUB_KEY_SIZE_MAX] = {0};
 
     /* below function writes data at the end of the buffer */
-    int pk_der_size_byte = mbedtls_pk_write_pubkey_der(&crt->pk, pk_der, PUB_KEY_SIZE_MAX);
-    if (pk_der_size_byte != RSA_PUB_3072_KEY_DER_LEN)
-        return MBEDTLS_ERR_PK_INVALID_PUBKEY;
+    int pk_der_size_byte = mbedtls_pk_write_pubkey_der(&crt->pk, pk_der, sizeof(pk_der));
+    if (pk_der_size_byte < 0)
+        return pk_der_size_byte;
 
     /* move the data to the beginning of the buffer, to avoid pointer arithmetic later */
     memmove(pk_der, pk_der + PUB_KEY_SIZE_MAX - pk_der_size_byte, pk_der_size_byte);


### PR DESCRIPTION
Previously, RA-TLS generated only RSA-3072 keypairs (used them to sign RA-TLS X.509 certificates). This commit switches the default signing algo for RA-TLS to ECDSA P-384.

This is a replacement for https://github.com/gramineproject/gramine/pull/748 after some discussions.

Resolves https://github.com/gramineproject/gramine/issues/156.