### PR TITLE
[Pal/Linux-SGX] Drop support for old SGX drivers

### DIFF
--- a/.ci/lib/config-docker.jenkinsfile
+++ b/.ci/lib/config-docker.jenkinsfile
@@ -16,9 +16,6 @@ if (fileExists('/dev/sgx_enclave')) {
 if (fileExists('/dev/isgx')) {
     env.DOCKER_ARGS_SGX += ' --device=/dev/isgx:/dev/isgx'
 }
-if (fileExists('/dev/gsgx')) {
-    env.DOCKER_ARGS_SGX += ' --device=/dev/gsgx:/dev/gsgx'
-}
 if (fileExists('/var/run/aesmd/aesm.socket')) {
     env.DOCKER_ARGS_SGX += ' --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket'
 }

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -6,14 +6,6 @@ stage('build') {
         git checkout 276c5c6a064d22358542f5e0aa96b1c0ace5d695
     '''
 
-    sh '''
-        cd /opt/intel
-        git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git
-        cd SGXDataCenterAttestationPrimitives
-        git checkout DCAP_1.6
-        # no need to build, we only need the SGX header file (sgx_oot.h)
-    '''
-
     env.MESON_OPTIONS = ''
     if (env.UBSAN == '1') {
         env.MESON_OPTIONS += ' -Dubsan=enabled'
@@ -23,24 +15,6 @@ stage('build') {
     }
     if (env.CC == 'clang') {
         env.MESON_OPTIONS += ' -Dmusl=disabled'
-    }
-
-    try {
-        sh '''
-            meson setup build-dcap/ \
-                --werror \
-                --prefix="$PREFIX" \
-                --buildtype="$BUILDTYPE" \
-                -Ddirect=disabled \
-                -Dsgx=enabled \
-                -Dtests=enabled \
-                -Dsgx_driver=dcap1.6 \
-                $MESON_OPTIONS
-            ninja -vC build-dcap
-        '''
-    } finally {
-        archiveArtifacts 'build-dcap/meson-logs/**/*'
-        sh 'rm -rf build-dcap'
     }
 
     try {

--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -187,15 +187,14 @@ The ``-Dsgx_driver`` parameter controls which SGX driver to use:
 
 * ``upstream`` (default) for upstreamed in-kernel driver (mainline Linux kernel
   5.11+),
-* ``dcap1.6`` for Intel DCAP version 1.6 or higher,  but below 1.10,
-* ``dcap1.10`` for Intel DCAP version 1.10 or higher,
 * ``oot`` for non-DCAP, out-of-tree version of the driver.
 
 The ``-Dsgx_driver_include_path`` parameter must point to the absolute path
 where the SGX driver was downloaded or installed in the previous step. For
-example, for the DCAP version 1.41 of the SGX driver, you must specify
-``-Dsgx_driver_include_path="/usr/src/sgx-1.41/include/"``. If this parameter is
-omitted, Gramine's build system will try to determine the right path.
+example, for the OOT driver installed at the default path, you can specify
+``-Dsgx_driver_include_path="/opt/intel/linux-sgx-driver"``. If this parameter
+is omitted, Gramine's build system will try to determine the right path, so,
+it's usually not needed.
 
 .. note::
 

--- a/Documentation/sgx-intro.rst
+++ b/Documentation/sgx-intro.rst
@@ -90,9 +90,10 @@ For historical reasons, there are three SGX drivers currently (January 2021):
   deprecated
 
 - https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver
-  -- new one, out-of-tree, supports both non-DCAP software infrastructure (with
-  old EPID remote-attestation technique) and the new DCAP (with new ECDSA and
-  more "normal" PKI infrastructure).
+  -- out-of-tree, supports both non-DCAP software infrastructure (with old EPID
+  remote-attestation technique) and the new DCAP (with new ECDSA and
+  more "normal" PKI infrastructure). Deprecated in favor of the upstreamed
+  driver (see below).
 
 - SGX support was upstreamed to the Linux mainline starting from 5.11.
   It currently supports only DCAP attestation. The driver is accessible through

--- a/meson.build
+++ b/meson.build
@@ -119,22 +119,6 @@ if sgx
         sgx_driver_header = 'sgx_user.h'
         sgx_driver_device_default = '/dev/isgx'
         sgx_driver_include_path_defaults = ['/opt/intel/linux-sgx-driver']
-    elif sgx_driver == 'dcap1.6'
-        # DCAP 1.6+ but below 1.10 (https://github.com/intel/SGXDataCenterAttestationPrimitives)
-        conf_sgx.set('CONFIG_SGX_DRIVER_DCAP_1_6', true)
-        sgx_driver_header = 'uapi/asm/sgx_oot.h'
-        sgx_driver_device_default = '/dev/sgx/enclave'
-        sgx_driver_include_path_defaults = [
-            '/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux/include',
-        ]
-    elif sgx_driver == 'dcap1.10'
-        # DCAP 1.10+ (https://github.com/intel/SGXDataCenterAttestationPrimitives)
-        conf_sgx.set('CONFIG_SGX_DRIVER_DCAP_1_10', true)
-        sgx_driver_header = 'sgx_user.h'
-        sgx_driver_device_default = '/dev/sgx/enclave'
-        sgx_driver_include_path_defaults = [
-            '/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux/include',
-        ]
     else
         error('Unknown sgx_driver value')
     endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,7 +24,7 @@ option('libgomp', type: 'combo', choices: ['disabled', 'enabled'],
     description: 'Build patched libgomp (takes long time)')
 
 option('sgx_driver', type: 'combo',
-    choices: ['upstream', 'dcap1.6', 'dcap1.10', 'oot'],
+    choices: ['upstream', 'oot'],
     description: 'Flavour of the SGX driver')
 option('sgx_driver_include_path', type: 'string',
     description: 'Path to SGX driver headers (default value depends on sgx_driver)')

--- a/pal/src/host/linux-sgx/generated_offsets.c
+++ b/pal/src/host/linux-sgx/generated_offsets.c
@@ -1,7 +1,7 @@
 #include <asm/errno.h>
 
 #include "generated_offsets_build.h"
-#include "host_gsgx.h"
+#include "host_sgx_driver.h"
 #include "pal.h"
 #include "pal_ecall_types.h"
 #include "pal_linux_defs.h"

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -61,7 +61,7 @@ struct pal_enclave {
 
 extern struct pal_enclave g_pal_enclave;
 
-int open_sgx_driver(bool need_gsgx);
+int open_sgx_driver(void);
 bool is_wrfsbase_supported(void);
 
 int read_enclave_token(int token_file, sgx_arch_token_t* token);

--- a/pal/src/host/linux-sgx/host_platform.c
+++ b/pal/src/host/linux-sgx/host_platform.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 #include "aesm.pb-c.h"
-#include "host_gsgx.h"
+#include "host_sgx_driver.h"
 #include "host_internal.h"
 #include "host_log.h"
 #include "linux_utils.h"

--- a/pal/src/host/linux-sgx/host_sgx_driver.h.in
+++ b/pal/src/host/linux-sgx/host_sgx_driver.h.in
@@ -15,8 +15,6 @@
 #include <@CONFIG_SGX_DRIVER_HEADER_ABSPATH@>
 
 #mesondefine CONFIG_SGX_DRIVER_UPSTREAM
-#mesondefine CONFIG_SGX_DRIVER_DCAP_1_6
-#mesondefine CONFIG_SGX_DRIVER_DCAP_1_10
 #mesondefine CONFIG_SGX_DRIVER_OOT
 
 #mesondefine CONFIG_SGX_DRIVER_DEVICE
@@ -26,8 +24,6 @@
 #endif
 
 #define ISGX_FILE CONFIG_SGX_DRIVER_DEVICE
-
-#define GSGX_FILE  "/dev/gsgx"
 
 /* Gramine needs the below subset of SGX instructions' return values */
 #ifndef SGX_INVALID_SIG_STRUCT
@@ -52,10 +48,4 @@
 
 #ifndef SGX_INVALID_CPUSVN
 #define SGX_INVALID_CPUSVN      32
-#endif
-
-/* SGX_INVALID_LICENSE was renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
- *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
-#ifndef SGX_INVALID_LICENSE
-#define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
 #endif

--- a/pal/src/host/linux-sgx/meson.build
+++ b/pal/src/host/linux-sgx/meson.build
@@ -1,6 +1,6 @@
-gsgx_h = configure_file(
-    input: 'host_gsgx.h.in',
-    output: 'host_gsgx.h',
+host_sgx_driver_h = configure_file(
+    input: 'host_sgx_driver.h.in',
+    output: 'host_sgx_driver.h',
     configuration: conf_sgx,
 )
 
@@ -84,7 +84,7 @@ libpal_sgx = shared_library('pal',
     pal_sgx_asm_offsets_h,
     pal_common_sources,
     pal_linux_common_sources_enclave,
-    gsgx_h,
+    host_sgx_driver_h,
 
     include_directories: sgx_inc,
 
@@ -147,7 +147,7 @@ libpal_sgx_host = executable('loader',
     pal_linux_common_sources_host,
     pal_sgx_asm_offsets_h,
     aesm_proto_ch,
-    gsgx_h,
+    host_sgx_driver_h,
 
     include_directories: sgx_inc,
     c_args: [


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

AFAIK all of these (DCAP <= 1.6, super-old OOT version, gsgx) are not being used by anyone since long time ago.

## How to test this PR? <!-- (if applicable) -->

CI should be enough, but if you have some unusual config then you may want to try it yourself.
Please verify that I removed everything, there may be more leftovers I missed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/997)
<!-- Reviewable:end -->
