### PR TITLE
gramine-manifest: API to list python paths

### DIFF
--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -15,8 +15,9 @@ fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
-  { path = "{{ python.stdlib }}", uri = "file:{{ python.stdlib }}" },
-  { path = "{{ python.distlib }}", uri = "file:{{ python.distlib }}" },
+{% for path in python.get_sys_path(entrypoint) %}
+  { path = "{{ path }}", uri = "file:{{ path }}" },
+{% endfor %}
   { path = "{{ entrypoint }}", uri = "file:{{ entrypoint }}" },
   { path = "/etc/hosts", uri = "file:helper-files/hosts" },
 
@@ -41,8 +42,9 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:{{ python.stdlib }}/",
-  "file:{{ python.distlib }}/",
+{% for path in python.get_sys_path(entrypoint) %}
+  "file:{{ path }}{{ '/' if path.is_dir() else '' }}",
+{% endfor %}
   "file:scripts/",
   "file:helper-files/",
 ]

--- a/python/graminelibos/gen_jinja_env.py
+++ b/python/graminelibos/gen_jinja_env.py
@@ -29,6 +29,15 @@ def ldd(*args):
             ret.add(line[0])
     return sorted(ret)
 
+def python_get_sys_path(interpreter, include_nonexisting=False):
+    for path in subprocess.check_output([interpreter, '-c',
+        '''import sys; print('\\0'.join(path for path in sys.path if path), end='')'''
+    ]).split(b'\0'):
+        path = pathlib.Path(os.fsdecode(path))
+        if not include_nonexisting and not path.exists():
+            continue
+        yield path
+
 def add_globals_from_python(env):
     paths = sysconfig.get_paths()
     env.globals['python'] = {
@@ -48,6 +57,8 @@ def add_globals_from_python(env):
         'get_paths': sysconfig.get_paths,
 
         'implementation': sys.implementation,
+
+        'get_sys_path': python_get_sys_path,
     }
 
 class Runtimedir:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Because of differences between distributions, specifically filesystem layout and content of `sys.path`, it's hard to write a manifest that would run Python apps correctly on different distributions. This is an attempt to fix this.

This PR supersedes ~#977 and~ #978.

Closes #978.

## How to test this PR? <!-- (if applicable) -->

`CI-Examples/python` is modified — run in CI or manually

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/999)
<!-- Reviewable:end -->
