### PR TITLE
[common] Split `common_dep` into several dependencies

### DIFF
--- a/common/include/api.h
+++ b/common/include/api.h
@@ -19,6 +19,7 @@
 #include "cpu.h"
 #include "list.h"
 #include "log.h"
+#include "string_utils.h"
 
 /* TODO: remove this once Gramine does not use host headers. */
 #ifndef ssize_t
@@ -219,23 +220,6 @@ int strcmp(const char* lhs, const char* rhs);
 long strtol(const char* s, char** endptr, int base);
 long long strtoll(const char* s, char** endptr, int base);
 
-/*!
- * \brief Convert a string to number.
- *
- * \param      str        Input string.
- * \param      base       Digit base, between 2 and 36.
- * \param[out] out_value  On success, set to the parsed number.
- * \param[out] out_end    On success, set to the rest of string.
- *
- * \returns 0 on success, negative on failure.
- *
- * Parses a number from the beginning of a string. The number should be non-empty, consist of digits
- * only (no `+`/`-` signs), and not overflow the `unsigned long` type. For base 16, the "0x" prefix
- * is allowed but not required.
- */
-int str_to_ulong(const char* str, unsigned int base, unsigned long* out_value,
-                 const char** out_end);
-
 int atoi(const char* nptr);
 long int atol(const char* nptr);
 
@@ -283,8 +267,6 @@ void* _real_memmove(void* dest, const void* src, size_t count);
 void* _real_memset(void* dest, int ch, size_t count);
 int _real_memcmp(const void* lhs, const void* rhs, size_t count);
 
-bool strstartswith(const char* str, const char* prefix);
-bool strendswith(const char* str, const char* suffix);
 char* strdup(const char* str);
 char* alloc_substr(const char* start, size_t len);
 char* alloc_concat(const char* a, size_t a_len, const char* b, size_t b_len);
@@ -391,24 +373,6 @@ uint16_t __htons(uint16_t x);
 uint16_t __ntohs(uint16_t x);
 
 extern const char* const* sys_errlist_internal;
-
-/* Gramine functions */
-
-int get_norm_path(const char* path, char* buf, size_t* inout_size);
-int get_base_name(const char* path, char* buf, size_t* inout_size);
-
-bool is_dot_or_dotdot(const char* name);
-
-/*!
- * \brief Parse a size (number with optional "G"/"M"/"K" suffix) into an uint64_t.
- *
- * \param      str      A string containing a non-negative, decimal number. The string may end with
- *                      "G"/"g" suffix denoting value in GBs, "M"/"m" for MBs, or "K"/"k" for KBs.
- * \param[out] out_val  Parsed size (in bytes).
- *
- * \returns 0 on success, negative if string cannot be parsed into a size (e.g., suffix is wrong).
- */
-int parse_size_str(const char* str, uint64_t* out_val);
 
 #define URI_PREFIX_SEPARATOR ":"
 

--- a/common/include/path_utils.h
+++ b/common/include/path_utils.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+bool get_norm_path(const char* path, char* buf, size_t* inout_size);
+
+bool get_base_name(const char* path, char* buf, size_t* inout_size);
+
+bool is_dot_or_dotdot(const char* name);

--- a/common/include/string_utils.h
+++ b/common/include/string_utils.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*!
+ * \brief Parse a size (number with optional "G"/"M"/"K" suffix) into an uint64_t.
+ *
+ * \param      str      A string containing a non-negative, decimal number. The string may end with
+ *                      "G"/"g" suffix denoting value in GBs, "M"/"m" for MBs, or "K"/"k" for KBs.
+ * \param[out] out_val  Parsed size (in bytes).
+ *
+ * \returns 0 on success, negative if string cannot be parsed into a size (e.g., suffix is wrong).
+ */
+int parse_size_str(const char* str, uint64_t* out_val);
+
+/*!
+ * \brief Convert a string to number.
+ *
+ * \param      str        Input string.
+ * \param      base       Digit base, between 2 and 36.
+ * \param[out] out_value  On success, set to the parsed number.
+ * \param[out] out_end    On success, set to the rest of string.
+ *
+ * \returns 0 on success, negative on failure.
+ *
+ * Parses a number from the beginning of a string. The number should be non-empty, consist of digits
+ * only (no `+`/`-` signs), and not overflow the `unsigned long` type. For base 16, the "0x" prefix
+ * is allowed but not required.
+ */
+int str_to_ulong(const char* str, unsigned int base, unsigned long* out_value,
+                 const char** out_end);
+
+bool strstartswith(const char* str, const char* prefix);
+
+bool strendswith(const char* str, const char* suffix);
+
+int parse_digit(char c, int base);

--- a/common/src/meson.build
+++ b/common/src/meson.build
@@ -1,10 +1,14 @@
-common_src = files(
+common_src_utils = files(
+    'path_utils.c',
+    'string_utils.c',
+)
+
+common_src_internal = files(
     'avl_tree.c',
     'init.c',
     'location.c',
     'network/hton.c',
     'network/inet_pton.c',
-    'path.c',
     'printf.c',
     'socket_utils.c',
     'stack_protector.c',
@@ -19,27 +23,35 @@ common_src = files(
     'string/strspn.c',
     'string/strstr.c',
     'string/toml_utils.c',
-    'string/utils.c',
+    'string/util.c',
 )
 
 # Arch-specific meson.build must define the following Meson variables:
 #   - `common_src_arch` - a list of arch-specific sources.
 subdir('arch')
-common_src += common_src_arch
+# Current common arch-specific sources are for `common_src_internal` only.
+common_src_internal += common_src_arch
 
 if asan
-    common_src += files('asan.c')
+    common_src_internal += files('asan.c')
 endif
 if ubsan
-    common_src += files('ubsan.c')
+    common_src_internal += files('ubsan.c')
 endif
 
+common_utils_dep = declare_dependency(
+    sources: common_src_utils,
+
+    include_directories: common_inc,
+)
+
 common_dep = declare_dependency(
-    sources: common_src,
+    sources: common_src_internal,
 
     include_directories: common_inc,
 
     dependencies: [
+        common_utils_dep,
         uthash_dep,
         tomlc99_dep,
     ],

--- a/common/src/string/atoi.c
+++ b/common/src/string/atoi.c
@@ -43,23 +43,6 @@ static void begin_number(const char* str, int base, const char** out_s, int* out
     *out_sign = sign;
 }
 
-static int parse_digit(char c, int base) {
-    int digit;
-
-    if (c >= '0' && c <= '9') {
-        digit = c - '0';
-    } else if (c >= 'a' && c <= 'z') {
-        digit = c - 'a' + 10;
-    } else if (c >= 'A' && c <= 'Z') {
-        digit = c - 'A' + 10;
-    } else {
-        return -1;
-    }
-    if (digit >= base)
-        return -1;
-    return digit;
-}
-
 long strtol(const char* str, char** out_end, int base) {
     bool nothing_parsed = true;
     const char* s;
@@ -89,35 +72,6 @@ long strtol(const char* str, char** out_end, int base) {
     if (out_end)
         *out_end = (char*)(nothing_parsed ? str : s);
     return value;
-}
-
-int str_to_ulong(const char* str, unsigned int base, unsigned long* out_value,
-                 const char** out_end) {
-    if (base == 16 && str[0] == '0' && str[1] == 'x')
-        str += 2;
-
-    unsigned long value = 0;
-    const char* s = str;
-    while (*s != '\0') {
-        int digit = parse_digit(*s, base);
-        if (digit == -1)
-            break;
-
-        if (__builtin_mul_overflow(value, base, &value))
-            return -1;
-
-        if (__builtin_add_overflow(value, digit, &value))
-            return -1;
-
-        s++;
-    }
-
-    if (s == str)
-        return -1;
-
-    *out_value = value;
-    *out_end = s;
-    return 0;
 }
 
 #ifdef __LP64__
@@ -154,36 +108,4 @@ long int atol(const char* str) {
         s++;
     }
     return value;
-}
-
-int parse_size_str(const char* str, uint64_t* out_val) {
-    const char* endptr = NULL;
-    unsigned long size;
-    int ret = str_to_ulong(str, 10, &size, &endptr);
-    if (ret < 0)
-        return -1;
-
-    unsigned long unit = 1;
-    if (*endptr == 'G' || *endptr == 'g') {
-        unit = 1024 * 1024 * 1024;
-        endptr++;
-    } else if (*endptr == 'M' || *endptr == 'm') {
-        unit = 1024 * 1024;
-        endptr++;
-    } else if (*endptr == 'K' || *endptr == 'k') {
-        unit = 1024;
-        endptr++;
-    }
-
-    if (__builtin_mul_overflow(size, unit, &size))
-        return -1;
-
-    if (*endptr != '\0')
-        return -1; /* garbage found after the size string */
-
-    if (OVERFLOWS(__typeof__(*out_val), size))
-        return -1;
-
-    *out_val = size;
-    return 0;
 }

--- a/common/src/string/util.c
+++ b/common/src/string/util.c
@@ -40,25 +40,3 @@ char* alloc_concat3(const char* a, size_t a_len, const char* b, size_t b_len,
     buf[a_len + b_len + c_len] = '\0';
     return buf;
 }
-
-bool strstartswith(const char* str, const char* prefix) {
-    size_t prefix_len = strlen(prefix);
-    size_t str_len = strnlen(str, prefix_len);
-
-    if (str_len < prefix_len) {
-        return false;
-    }
-
-    return !memcmp(str, prefix, prefix_len);
-}
-
-bool strendswith(const char* str, const char* suffix) {
-    size_t str_len = strlen(str);
-    size_t suffix_len = strlen(suffix);
-
-    if (str_len < suffix_len) {
-        return false;
-    }
-
-    return !memcmp(&str[str_len - suffix_len], suffix, suffix_len);
-}

--- a/common/src/string_utils.c
+++ b/common/src/string_utils.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University
+ * Copyright (C) 2020 Invisible Things Lab
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ * Copyright (C) 2020 Intel Corporation
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef USE_STDLIB
+#include <string.h>
+#else
+#include "api.h"
+#endif
+
+#include "string_utils.h"
+
+int parse_size_str(const char* str, uint64_t* out_val) {
+    const char* endptr = NULL;
+    unsigned long size;
+    int ret = str_to_ulong(str, 10, &size, &endptr);
+    if (ret < 0)
+        return -1;
+
+    unsigned long unit = 1;
+    if (*endptr == 'G' || *endptr == 'g') {
+        unit = 1024 * 1024 * 1024;
+        endptr++;
+    } else if (*endptr == 'M' || *endptr == 'm') {
+        unit = 1024 * 1024;
+        endptr++;
+    } else if (*endptr == 'K' || *endptr == 'k') {
+        unit = 1024;
+        endptr++;
+    }
+
+    if (__builtin_mul_overflow(size, unit, &size))
+        return -1;
+
+    if (*endptr != '\0')
+        return -1; /* garbage found after the size string */
+
+    uint64_t value = 0;
+    if (__builtin_add_overflow(size, 0, &value))
+        return -1;
+
+    *out_val = size;
+    return 0;
+}
+
+int str_to_ulong(const char* str, unsigned int base, unsigned long* out_value,
+                 const char** out_end) {
+    if (base == 16 && str[0] == '0' && str[1] == 'x')
+        str += 2;
+
+    unsigned long value = 0;
+    const char* s = str;
+    while (*s != '\0') {
+        int digit = parse_digit(*s, base);
+        if (digit == -1)
+            break;
+
+        if (__builtin_mul_overflow(value, base, &value))
+            return -1;
+
+        if (__builtin_add_overflow(value, digit, &value))
+            return -1;
+
+        s++;
+    }
+
+    if (s == str)
+        return -1;
+
+    *out_value = value;
+    *out_end = s;
+    return 0;
+}
+
+bool strstartswith(const char* str, const char* prefix) {
+    size_t prefix_len = strlen(prefix);
+    size_t str_len = strnlen(str, prefix_len);
+
+    if (str_len < prefix_len) {
+        return false;
+    }
+
+    return !memcmp(str, prefix, prefix_len);
+}
+
+bool strendswith(const char* str, const char* suffix) {
+    size_t str_len = strlen(str);
+    size_t suffix_len = strlen(suffix);
+
+    if (str_len < suffix_len) {
+        return false;
+    }
+
+    return !memcmp(&str[str_len - suffix_len], suffix, suffix_len);
+}
+
+int parse_digit(char c, int base) {
+    int digit;
+
+    if (c >= '0' && c <= '9') {
+        digit = c - '0';
+    } else if (c >= 'a' && c <= 'z') {
+        digit = c - 'a' + 10;
+    } else if (c >= 'A' && c <= 'Z') {
+        digit = c - 'A' + 10;
+    } else {
+        return -1;
+    }
+    if (digit >= base)
+        return -1;
+    return digit;
+}

--- a/libos/src/fs/libos_fs.c
+++ b/libos/src/fs/libos_fs.c
@@ -16,6 +16,7 @@
 #include "libos_utils.h"
 #include "list.h"
 #include "pal.h"
+#include "path_utils.h"
 #include "toml.h"
 #include "toml_utils.h"
 

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -11,6 +11,7 @@
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_utils.h"
+#include "path_utils.h"
 #include "protected_files.h"
 #include "toml_utils.h"
 
@@ -182,9 +183,8 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
         goto out;
     }
 
-    ret = get_norm_path(path, normpath, &normpath_size);
-    if (ret < 0) {
-        ret = pal_to_unix_errno(ret);
+    if (!get_norm_path(path, normpath, &normpath_size)) {
+        ret = -EINVAL;
         goto out;
     }
 
@@ -663,9 +663,8 @@ int encrypted_file_rename(struct libos_encrypted_file* enc, const char* new_uri)
         goto out;
     }
 
-    ret = get_norm_path(new_path, new_normpath, &new_normpath_size);
-    if (ret < 0) {
-        ret = pal_to_unix_errno(ret);
+    if (!get_norm_path(new_path, new_normpath, &new_normpath_size)) {
+        ret = -EINVAL;
         goto out;
     }
 

--- a/pal/regression/normalize_path.c
+++ b/pal/regression/normalize_path.c
@@ -1,6 +1,7 @@
 #include "api.h"
 #include "pal_error.h"
 #include "pal_regression.h"
+#include "path_utils.h"
 
 static const char* get_norm_path_cases[][2] = {
     {"/", "/"},
@@ -39,7 +40,7 @@ static const char* get_base_name_cases[][2] = {
 
 static const char* (*cases)[2];
 static size_t cases_len;
-static int (*func_to_test)(const char*, char*, size_t*);
+static bool (*func_to_test)(const char*, char*, size_t*);
 static const char* func_name;
 
 char buf[4096] = {0};
@@ -47,10 +48,9 @@ char buf[4096] = {0};
 static int run_test(void) {
     for (size_t i = 0; i < cases_len; i++) {
         size_t size = sizeof(buf);
-        int ret = func_to_test(cases[i][0], buf, &size);
 
-        if (ret < 0) {
-            print_err(func_name, i, "failed with error: %d\n", ret);
+        if (!func_to_test(cases[i][0], buf, &size)) {
+            print_err(func_name, i, "failed\n");
             return 1;
         }
 

--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -9,6 +9,7 @@
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
+#include "path_utils.h"
 #include "sgx_arch.h"
 #include "spinlock.h"
 #include "toml.h"
@@ -715,9 +716,10 @@ static int normalize_and_register_file(const char* uri, const char* hash_str) {
 
     memcpy(norm_uri, URI_PREFIX_FILE, URI_PREFIX_FILE_LEN);
     size_t norm_path_size = norm_uri_size - URI_PREFIX_FILE_LEN;
-    ret = get_norm_path(uri + URI_PREFIX_FILE_LEN, norm_uri + URI_PREFIX_FILE_LEN, &norm_path_size);
-    if (ret < 0) {
-        log_error("Path (%s) normalization failed: %s", uri, pal_strerror(ret));
+    if (!get_norm_path(uri + URI_PREFIX_FILE_LEN, norm_uri + URI_PREFIX_FILE_LEN,
+                       &norm_path_size)) {
+        log_error("Path (%s) normalization failed", uri);
+        ret = -PAL_ERROR_INVAL;
         goto out;
     }
 

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -20,6 +20,7 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "path_utils.h"
 #include "stat.h"
 
 /* this macro is used to emulate mmap() via pread() in chunks of 128MB (mmapped files may be many
@@ -48,9 +49,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri,
     if (!normpath)
         return -PAL_ERROR_NOMEM;
 
-    ret = get_norm_path(uri, normpath, &normpath_size);
-    if (ret < 0) {
-        log_warning("Could not normalize path (%s): %s", uri, pal_strerror(ret));
+    if (!get_norm_path(uri, normpath, &normpath_size)) {
+        log_warning("Could not normalize path (%s)", uri);
         free(normpath);
         return -PAL_ERROR_DENIED;
     }
@@ -394,9 +394,9 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
         ret = -PAL_ERROR_NOMEM;
         goto out;
     }
-    ret = get_norm_path(uri, path, &path_size);
-    if (ret < 0) {
-        log_warning("Could not normalize path (%s): %s", uri, pal_strerror(ret));
+    if (!get_norm_path(uri, path, &path_size)) {
+        log_warning("Could not normalize path (%s)", uri);
+        ret = -PAL_ERROR_INVAL;
         goto out;
     }
 

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -13,6 +13,7 @@
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
+#include "path_utils.h"
 #include "stat.h"
 
 /* 'open' operation for file streams */
@@ -54,12 +55,11 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, enum
         return -PAL_ERROR_NOMEM;
     }
 
-    ret = get_norm_path(uri, path, &uri_size);
-    if (ret < 0) {
+    if (!get_norm_path(uri, path, &uri_size)) {
         DO_SYSCALL(close, hdl->file.fd);
         free(hdl);
         free(path);
-        return ret;
+        return -PAL_ERROR_INVAL;
     }
 
     hdl->file.realpath = path;


### PR DESCRIPTION
Currently, all `common/` source files are supplied via a single `common_dep`. However in some cases, we may only want to reuse the part of the utility functions in `common/` without importing the other part of Gramine-supplied mini-libc (which might lead to colliding issues).

This patch separates `common/` into several dependencies for more flexible usage.

The original requirement was from https://github.com/gramineproject/gramine/pull/937. For details, pls kindly refer to that PR thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1002)
<!-- Reviewable:end -->
