### PR TITLE
[LibOS,PAL] Extend DNS runtime configuration

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -157,6 +157,7 @@ This option will generate the following extra configuration:
 
 - Hostname (obtained by apps via `nodename` field in `uname` syscall),
   set to the host's hostname at initialization.
+- Pseudo-file ``/etc/hosts``, with defined `localhost` and IPv6 defaults.
 - Pseudo-file ``/etc/resolv.conf``, with keywords:
 
    - ``nameserver``

--- a/libos/src/fs/etc/fs.c
+++ b/libos/src/fs/etc/fs.c
@@ -135,10 +135,10 @@ out:
 static int provide_etc_hosts(struct libos_dentry* dent, char** out_data, size_t* out_size) {
     __UNUSED(dent);
 
-    int ret = 0;
+    int ret;
     size_t size = 0;
     const char* ipv4_hosts_value = "127.0.0.1 localhost\n";
-    const char* ipv4_hostname = "127.0.0.1 ";
+    const char* ipv4_hostname = "127.0.1.1 ";
     const char* ipv6_hosts_value = "::1     ip6-localhost ip6-loopback\n" \
                                    "fe00::0 ip6-localnet\n" \
                                    "ff00::0 ip6-mcastprefix\n" \
@@ -147,7 +147,7 @@ static int provide_etc_hosts(struct libos_dentry* dent, char** out_data, size_t*
 
     size += strlen(ipv4_hosts_value);
 
-    size += strlen(ipv4_hosts_value);
+    size += strlen(ipv4_hostname);
     size += strlen(g_pal_public_state->dns_host.hostname);
     size += 1; /* for a new line */
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commits mocks the `/etc/hosts`.
On my Ubuntu 20.10 default values from `/etc/hosts` are:
```
127.0.0.1 localhost

::1     ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
```
On other machine:
```
127.0.0.1	localhost

# The following lines are desirable for IPv6 capable hosts
::1     localhost ip6-localhost ip6-loopback
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
```

So we generate us many IPv6 entries as we can.
We also set a current hostname to point to 127.0.0.1.

## How to test this PR? <!-- (if applicable) -->

Jenkins should be enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1005)
<!-- Reviewable:end -->
