### PR TITLE
[LibOS,PAL] Support TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT socket opts

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -99,8 +99,19 @@ struct cmsghdr {
 #define SO_DOMAIN 39
 
 /* TCP options. */
-#define TCP_NODELAY 1
-#define TCP_CORK 3
+#define TCP_NODELAY 1   /* Turn off Nagle's algorithm */
+#define TCP_CORK 3      /* Never send partially complete segments */
+#define TCP_KEEPIDLE 4  /* Start keeplives after this period */
+#define TCP_KEEPINTVL 5 /* Interval between keepalives */
+#define TCP_KEEPCNT 6   /* Number of keepalives before death */
+
+#define MAX_TCP_KEEPIDLE 32767
+#define MAX_TCP_KEEPINTVL 32767
+#define MAX_TCP_KEEPCNT 127
+
+#define DEFAULT_TCP_KEEPIDLE (2 * 60 * 60) /* 2 hours */
+#define DEFAULT_TCP_KEEPINTVL 75           /* 75 seconds */
+#define DEFAULT_TCP_KEEPCNT 9              /* 9 keepalive probes */
 
 struct linger {
     int l_onoff;

--- a/libos/test/regression/getsockopt.c
+++ b/libos/test/regression/getsockopt.c
@@ -1,51 +1,60 @@
-/* Unit test for issues #92 and #644 */
-
 #define _GNU_SOURCE
-#include <assert.h>
-#include <errno.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/socket.h>
 
-int main(int argc, char** argv) {
-    int ret;
+#include "common.h"
+
+#define DEFAULT_TCP_KEEPIDLE (120 * 60)
+#define DEFAULT_TCP_KEEPINTVL 75
+#define DEFAULT_TCP_KEEPCNT 9
+
+int main(void) {
     socklen_t optlen; /* Option length */
 
-    int fd = socket(PF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        perror("socket failed");
-        return 1;
-    }
+    int fd = CHECK(socket(AF_INET, SOCK_STREAM, 0));
 
     int so_type;
     optlen = sizeof(so_type);
-    ret = getsockopt(fd, SOL_SOCKET, SO_TYPE, &so_type, &optlen);
-    if (ret < 0) {
-        perror("getsockopt(SOL_SOCKET, SO_TYPE) failed");
-        return 1;
-    }
+    CHECK(getsockopt(fd, SOL_SOCKET, SO_TYPE, &so_type, &optlen));
 
     if (optlen != sizeof(so_type) || so_type != SOCK_STREAM) {
-        fprintf(stderr, "getsockopt(SOL_SOCKET, SO_TYPE) failed\n");
-        return 1;
+        errx(1, "getsockopt(SOL_SOCKET, SO_TYPE) returned unexpected value");
     }
-
-    printf("getsockopt: Got socket type OK\n");
 
     int so_flags = 1;
     optlen = sizeof(so_flags);
-    ret = getsockopt(fd, SOL_TCP, TCP_NODELAY, (void*)&so_flags, &optlen);
-    if (ret < 0) {
-        perror("getsockopt(SOL_TCP, TCP_NODELAY) failed");
-        return 1;
-    }
+    CHECK(getsockopt(fd, SOL_TCP, TCP_NODELAY, &so_flags, &optlen));
 
     if (optlen != sizeof(so_flags) || (so_flags != 0 && so_flags != 1)) {
-        fprintf(stderr, "getsockopt(SOL_TCP, TCP_NODELAY) failed\n");
-        return 1;
+        errx(1, "getsockopt(SOL_TCP, TCP_NODELAY) returned unexpected value");
     }
 
-    printf("getsockopt: Got TCP_NODELAY flag OK\n");
+    int tcp_keepidle;
+    optlen = sizeof(tcp_keepidle);
+    CHECK(getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &tcp_keepidle, &optlen));
+
+    if (optlen != sizeof(tcp_keepidle) || tcp_keepidle != DEFAULT_TCP_KEEPIDLE) {
+        errx(1, "getsockopt(IPPROTO_TCP, TCP_KEEPIDLE) returned unexpected value");
+    }
+
+    int tcp_keepintvl;
+    optlen = sizeof(tcp_keepintvl);
+    CHECK(getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &tcp_keepintvl, &optlen));
+
+    if (optlen != sizeof(tcp_keepintvl) || tcp_keepintvl != DEFAULT_TCP_KEEPINTVL) {
+        errx(1, "getsockopt(IPPROTO_TCP, TCP_KEEPINTVL) returned unexpected value");
+    }
+
+    int tcp_keepcnt;
+    optlen = sizeof(tcp_keepcnt);
+    CHECK(getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &tcp_keepcnt, &optlen));
+
+    if (optlen != sizeof(tcp_keepcnt) || tcp_keepcnt != DEFAULT_TCP_KEEPCNT) {
+        errx(1, "getsockopt(IPPROTO_TCP, TCP_KEEPCNT) returned unexpected value");
+    }
+
+    puts("TEST OK");
     return 0;
 }

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1218,8 +1218,7 @@ class TC_50_GDB(RegressionTestCase):
 class TC_80_Socket(RegressionTestCase):
     def test_000_getsockopt(self):
         stdout, _ = self.run_binary(['getsockopt'])
-        self.assertIn('getsockopt: Got socket type OK', stdout)
-        self.assertIn('getsockopt: Got TCP_NODELAY flag OK', stdout)
+        self.assertIn('TEST OK', stdout)
 
     def test_010_epoll(self):
         stdout, _ = self.run_binary(['epoll_test'])

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -478,6 +478,9 @@ typedef struct _PAL_STREAM_ATTR {
             bool keepalive;
             bool broadcast;
             bool tcp_cork;
+            uint32_t tcp_keepidle;
+            uint32_t tcp_keepintvl;
+            uint8_t tcp_keepcnt;
             bool tcp_nodelay;
             bool ipv6_v6only;
         } socket;

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -101,6 +101,9 @@ typedef struct {
             bool keepalive;
             bool broadcast;
             bool tcp_cork;
+            uint32_t tcp_keepidle;
+            uint32_t tcp_keepintvl;
+            uint8_t tcp_keepcnt;
             bool tcp_nodelay;
             bool ipv6_v6only;
         } sock;

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -83,6 +83,9 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.keepalive = false;
     handle->sock.broadcast = false;
     handle->sock.tcp_cork = false;
+    handle->sock.tcp_keepidle = DEFAULT_TCP_KEEPIDLE;
+    handle->sock.tcp_keepintvl = DEFAULT_TCP_KEEPINTVL;
+    handle->sock.tcp_keepcnt = DEFAULT_TCP_KEEPCNT;
     handle->sock.tcp_nodelay = false;
     handle->sock.ipv6_v6only = false;
 
@@ -293,6 +296,9 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.keepalive = handle->sock.keepalive;
     attr->socket.broadcast = handle->sock.broadcast;
     attr->socket.tcp_cork = handle->sock.tcp_cork;
+    attr->socket.tcp_keepidle = handle->sock.tcp_keepidle;
+    attr->socket.tcp_keepintvl = handle->sock.tcp_keepintvl;
+    attr->socket.tcp_keepcnt = handle->sock.tcp_keepcnt;
     attr->socket.tcp_nodelay = handle->sock.tcp_nodelay;
     attr->socket.ipv6_v6only = handle->sock.ipv6_v6only;
 
@@ -434,6 +440,36 @@ static int attrsetbyhdl_tcp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
         }
         handle->sock.tcp_cork = attr->socket.tcp_cork;
+    }
+
+    if (attr->socket.tcp_keepidle != handle->sock.tcp_keepidle) {
+        assert(attr->socket.tcp_keepidle >= 1 && attr->socket.tcp_keepidle <= MAX_TCP_KEEPIDLE);
+        int val = attr->socket.tcp_keepidle;
+        int ret = ocall_setsockopt(handle->sock.fd, SOL_TCP, TCP_KEEPIDLE, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_keepidle = attr->socket.tcp_keepidle;
+    }
+
+    if (attr->socket.tcp_keepintvl != handle->sock.tcp_keepintvl) {
+        assert(attr->socket.tcp_keepintvl >= 1 && attr->socket.tcp_keepintvl <= MAX_TCP_KEEPINTVL);
+        int val = attr->socket.tcp_keepintvl;
+        int ret = ocall_setsockopt(handle->sock.fd, SOL_TCP, TCP_KEEPINTVL, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_keepintvl = attr->socket.tcp_keepintvl;
+    }
+
+    if (attr->socket.tcp_keepcnt != handle->sock.tcp_keepcnt) {
+        assert(attr->socket.tcp_keepcnt >= 1 && attr->socket.tcp_keepcnt <= MAX_TCP_KEEPCNT);
+        int val = attr->socket.tcp_keepcnt;
+        int ret = ocall_setsockopt(handle->sock.fd, SOL_TCP, TCP_KEEPCNT, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_keepcnt = attr->socket.tcp_keepcnt;
     }
 
     if (attr->socket.tcp_nodelay != handle->sock.tcp_nodelay) {

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -78,6 +78,9 @@ typedef struct {
             bool broadcast;
             bool keepalive;
             bool tcp_cork;
+            uint32_t tcp_keepidle;
+            uint32_t tcp_keepintvl;
+            uint8_t tcp_keepcnt;
             bool tcp_nodelay;
             bool ipv6_v6only;
         } sock;

--- a/pal/src/host/linux/pal_sockets.c
+++ b/pal/src/host/linux/pal_sockets.c
@@ -74,6 +74,9 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.broadcast = false;
     handle->sock.keepalive = false;
     handle->sock.tcp_cork = false;
+    handle->sock.tcp_keepidle = DEFAULT_TCP_KEEPIDLE;
+    handle->sock.tcp_keepintvl = DEFAULT_TCP_KEEPINTVL;
+    handle->sock.tcp_keepcnt = DEFAULT_TCP_KEEPCNT;
     handle->sock.tcp_nodelay = false;
     handle->sock.ipv6_v6only = false;
 
@@ -325,6 +328,9 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.broadcast = handle->sock.broadcast;
     attr->socket.keepalive = handle->sock.keepalive;
     attr->socket.tcp_cork = handle->sock.tcp_cork;
+    attr->socket.tcp_keepidle = handle->sock.tcp_keepidle;
+    attr->socket.tcp_keepintvl = handle->sock.tcp_keepintvl;
+    attr->socket.tcp_keepcnt = handle->sock.tcp_keepcnt;
     attr->socket.tcp_nodelay = handle->sock.tcp_nodelay;
     attr->socket.ipv6_v6only = handle->sock.ipv6_v6only;
 
@@ -481,6 +487,36 @@ static int attrsetbyhdl_tcp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
         }
         handle->sock.tcp_cork = attr->socket.tcp_cork;
+    }
+
+    if (attr->socket.tcp_keepidle != handle->sock.tcp_keepidle) {
+        assert(attr->socket.tcp_keepidle >= 1 && attr->socket.tcp_keepidle <= MAX_TCP_KEEPIDLE);
+        int val = attr->socket.tcp_keepidle;
+        int ret = DO_SYSCALL(setsockopt, handle->sock.fd, SOL_TCP, TCP_KEEPIDLE, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_keepidle = attr->socket.tcp_keepidle;
+    }
+
+    if (attr->socket.tcp_keepintvl != handle->sock.tcp_keepintvl) {
+        assert(attr->socket.tcp_keepintvl >= 1 && attr->socket.tcp_keepintvl <= MAX_TCP_KEEPINTVL);
+        int val = attr->socket.tcp_keepintvl;
+        int ret = DO_SYSCALL(setsockopt, handle->sock.fd, SOL_TCP, TCP_KEEPINTVL, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_keepintvl = attr->socket.tcp_keepintvl;
+    }
+
+    if (attr->socket.tcp_keepcnt != handle->sock.tcp_keepcnt) {
+        assert(attr->socket.tcp_keepcnt >= 1 && attr->socket.tcp_keepcnt <= MAX_TCP_KEEPCNT);
+        int val = attr->socket.tcp_keepcnt;
+        int ret = DO_SYSCALL(setsockopt, handle->sock.fd, SOL_TCP, TCP_KEEPCNT, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_keepcnt = attr->socket.tcp_keepcnt;
     }
 
     if (attr->socket.tcp_nodelay != handle->sock.tcp_nodelay) {


### PR DESCRIPTION
Gramine currently doesn't support set (via `setsockopt()`) or get (via `getsockopt()`) `TCP_KEEPIDLE`, `TCP_KEEPINTVL` and `TCP_KEEPCNT` socket options. This may lead to some applications failures when they try to set these socket options but find out they are unsupported.

This patch implements support for the above TCP socket options.

Resolves https://github.com/gramineproject/gramine/issues/902.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1007)
<!-- Reviewable:end -->
