### PR TITLE
[tools/sgx] Remove unneeded include deps for RA-TLS and secret-prov libs

### DIFF
--- a/pal/src/host/linux-sgx/meson.build
+++ b/pal/src/host/linux-sgx/meson.build
@@ -4,10 +4,16 @@ gsgx_h = configure_file(
     configuration: conf_sgx,
 )
 
-sgx_inc = [
-    includes_pal_common,
+pal_sgx_inc = [
     include_directories(
         '.',
+    ),
+]
+
+sgx_inc = [
+    includes_pal_common,
+    pal_sgx_inc,
+    include_directories(
         '../../../include/arch/@0@/linux'.format(host_machine.cpu_family()),
         '../../../include/host/linux-common',
     ),

--- a/tools/sgx/common/meson.build
+++ b/tools/sgx/common/meson.build
@@ -13,7 +13,7 @@ sgx_util = shared_library('sgx_util',
     ],
 
     include_directories: [
-        sgx_inc,
+        pal_sgx_inc, # this is only for `sgx_arch.h` and `sgx_attest.h`
         common_inc,
     ],
     dependencies: [
@@ -31,7 +31,7 @@ sgx_util_dep = declare_dependency(
     link_with: sgx_util,
     include_directories: [
         include_directories('.'),
-        sgx_inc, # this is mostly for sgx_arch.h
+        pal_sgx_inc, # this is only for `sgx_arch.h` and `sgx_attest.h`
         protected_files_inc,
     ],
 )

--- a/tools/sgx/ra-tls/meson.build
+++ b/tools/sgx/ra-tls/meson.build
@@ -11,7 +11,7 @@ ra_tls_args = [
 libra_tls_attest = shared_library('ra_tls_attest',
     'ra_tls_attest.c',
     c_args: ra_tls_args,
-    include_directories: sgx_inc,
+    include_directories: pal_sgx_inc, # this is only for `sgx_arch.h` and `sgx_attest.h`
     dependencies: [
         mbedtls_static_dep,
     ],
@@ -29,7 +29,7 @@ libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
     'ra_tls.h',
 
     c_args: ra_tls_args,
-    include_directories: sgx_inc,
+    include_directories: pal_sgx_inc,
     dependencies: [
         sgx_util_dep,
         mbedtls_static_dep,
@@ -50,7 +50,7 @@ libsecret_prov_attest = shared_library('secret_prov_attest',
     'secret_prov.h',
 
     c_args: ra_tls_args,
-    include_directories: sgx_inc,
+    include_directories: pal_sgx_inc,
     dependencies: [
         mbedtls_static_dep,
         sgx_util_dep,
@@ -72,7 +72,7 @@ libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
     'secret_prov.h',
 
     c_args: ra_tls_args,
-    include_directories: sgx_inc,
+    include_directories: pal_sgx_inc,
     dependencies: [
         threads_dep,
         sgx_util_dep,
@@ -93,7 +93,7 @@ if dcap
         'ra_tls.h',
 
         c_args: ra_tls_args,
-        include_directories: sgx_inc,
+        include_directories: pal_sgx_inc,
         dependencies: [
             sgx_dcap_quoteverify_dep,
             sgx_util_dep,
@@ -114,7 +114,7 @@ if dcap
         'ra_tls.h',
 
         c_args: ra_tls_args,
-        include_directories: sgx_inc,
+        include_directories: pal_sgx_inc,
         dependencies: [
             sgx_dcap_quoteverify_dep,
             sgx_util_dep,
@@ -137,7 +137,7 @@ if dcap
         'secret_prov.h',
 
         c_args: ra_tls_args,
-        include_directories: sgx_inc,
+        include_directories: pal_sgx_inc,
         dependencies: [
             threads_dep,
             sgx_dcap_quoteverify_dep,


### PR DESCRIPTION
Gramine RA-TLS and Secret Provisioning libraries actually only need `sgx_arch.h` and `sgx_attest.h` from `PAL/Linux-SGX` (for some SGX-hardware-specific structs). However, `sgx_inc` which contains unnecessary includes e.g., `common_inc` is currently used for them.

This patch removes `sgx_inc` from RA-TLS and Secret Provisioning libs' include dependencies and includes only the needed from `PAL/Linux-SGX`.

Resolves https://github.com/gramineproject/gramine/issues/876.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1008)
<!-- Reviewable:end -->
