### PR TITLE
[LibOS] Remove unneeded fcntl flags from `libos_parser.c`

### DIFF
--- a/libos/src/libos_parser.c
+++ b/libos/src/libos_parser.c
@@ -1319,15 +1319,6 @@ static void parse_fcntlop(struct print_buf* buf, va_list* ap) {
         case F_GETSIG:
             buf_puts(buf, "F_GETSIG");
             break;
-        case F_GETLK64:
-            buf_puts(buf, "F_GETLK64");
-            break;
-        case F_SETLK64:
-            buf_puts(buf, "F_SETLK64");
-            break;
-        case F_SETLKW64:
-            buf_puts(buf, "F_SETLKW64");
-            break;
         case F_SETOWN_EX:
             buf_puts(buf, "F_SETOWN_EX");
             break;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
These removed flags are used only in compat syscalls, which Gramine does not implement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1015)
<!-- Reviewable:end -->
