### PR TITLE
[LibOS,PAL] Introduce Netlink socket support

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -8,6 +8,7 @@
 #include <asm/fcntl.h>
 #include <linux/in.h>
 #include <linux/in6.h>
+#include <linux/netlink.h>
 #include <linux/un.h>
 #include <stddef.h>
 
@@ -66,6 +67,7 @@ struct cmsghdr {
 #define SOCK_TYPE_MASK 0xf
 #define SOCK_STREAM 1
 #define SOCK_DGRAM 2
+#define SOCK_RAW 3
 
 #define SOCK_CLOEXEC O_CLOEXEC
 #define SOCK_NONBLOCK O_NONBLOCK
@@ -82,6 +84,7 @@ struct cmsghdr {
 /* Option levels. */
 #define SOL_SOCKET 1
 #define SOL_TCP 6
+#define SOL_NETLINK 270
 
 /* Socket options. */
 #define SO_REUSEADDR 2

--- a/common/src/socket_utils.c
+++ b/common/src/socket_utils.c
@@ -37,6 +37,15 @@ void pal_to_linux_sockaddr(const struct pal_socket_addr* pal_addr,
             memcpy(linux_addr, &sa_ipv6, sizeof(sa_ipv6));
             *linux_addr_len = sizeof(sa_ipv6);
             break;
+        case PAL_NL:;
+            struct sockaddr_nl sa_nl = {
+                .nl_family = AF_NETLINK,
+                .nl_pid = pal_addr->nl.pid,
+                .nl_groups = pal_addr->nl.groups,
+            };
+            memcpy(linux_addr, &sa_nl, sizeof(sa_nl));
+            *linux_addr_len = sizeof(sa_nl);
+            break;
         default:
             BUG();
     }
@@ -65,6 +74,13 @@ void linux_to_pal_sockaddr(const void* linux_addr, struct pal_socket_addr* pal_a
             static_assert(sizeof(pal_addr->ipv6.addr) == sizeof(sa_ipv6.sin6_addr.s6_addr), "ops");
             memcpy(pal_addr->ipv6.addr, sa_ipv6.sin6_addr.s6_addr, sizeof(pal_addr->ipv6.addr));
             pal_addr->ipv6.port = sa_ipv6.sin6_port;
+            break;
+        case AF_NETLINK:;
+            struct sockaddr_nl sa_nl;
+            memcpy(&sa_nl, linux_addr, sizeof(sa_nl));
+            pal_addr->domain = PAL_NL;
+            pal_addr->nl.pid = sa_nl.nl_pid;
+            pal_addr->nl.groups = sa_nl.nl_groups;
             break;
         case AF_UNSPEC:
             pal_addr->domain = PAL_DISCONNECT;

--- a/libos/include/libos_socket.h
+++ b/libos/include/libos_socket.h
@@ -117,6 +117,7 @@ struct libos_handle* get_new_socket_handle(int family, int type, int protocol,
 
 extern struct libos_sock_ops sock_unix_ops;
 extern struct libos_sock_ops sock_ip_ops;
+extern struct libos_sock_ops sock_nl_ops;
 
 ssize_t do_recvmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len, void* addr,
                    size_t* addrlen, unsigned int* flags);

--- a/libos/src/meson.build
+++ b/libos/src/meson.build
@@ -66,6 +66,7 @@ libos_sources = files(
     'libos_syscalls.c',
     'libos_utils.c',
     'net/ip.c',
+    'net/nl.c',
     'net/unix.c',
     'sync/libos_sync_client.c',
     'sync/libos_sync_server.c',

--- a/libos/src/net/ip.c
+++ b/libos/src/net/ip.c
@@ -122,7 +122,7 @@ static int create(struct libos_handle* handle) {
     /* We don't need to take the lock - handle was just created. */
     pal_stream_options_t options = handle->flags & O_NONBLOCK ? PAL_OPTION_NONBLOCK : 0;
     PAL_HANDLE pal_handle = NULL;
-    int ret = PalSocketCreate(pal_domain, pal_type, options, &pal_handle);
+    int ret = PalSocketCreate(pal_domain, pal_type, /*protocol=*/0, options, &pal_handle);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }

--- a/libos/src/net/nl.c
+++ b/libos/src/net/nl.c
@@ -1,0 +1,246 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Kailun Qin <kailun.qin@intel.com>
+ */
+
+/*
+ * Implementation of Netlink sockets.
+ * For such sockets `handle->info.sock.pal_handle` is always set, hence does not need atomicity on
+ * accesses.
+ */
+
+#include "libos_fs.h"
+#include "libos_socket.h"
+#include "pal.h"
+#include "socket_utils.h"
+
+static int verify_sockaddr(int expected_family, void* addr, size_t* addrlen) {
+    unsigned short family;
+    switch (expected_family) {
+        case AF_NETLINK:
+            if (*addrlen < sizeof(struct sockaddr_nl)) {
+                return -EINVAL;
+            }
+            memcpy(&family, (char*)addr + offsetof(struct sockaddr_nl, nl_family), sizeof(family));
+            if (family != AF_NETLINK) {
+                return -EAFNOSUPPORT;
+            }
+            /* Cap the address at the maximal possible size - rest of the input buffer (if any) is
+             * ignored. */
+            *addrlen = sizeof(struct sockaddr_nl);
+            break;
+        default:
+            BUG();
+    }
+    return 0;
+}
+
+static int create(struct libos_handle* handle) {
+    assert(handle->info.sock.domain == AF_NETLINK);
+    assert(handle->info.sock.type == SOCK_RAW || handle->info.sock.type == SOCK_DGRAM);
+
+    enum pal_socket_domain pal_domain;
+    switch (handle->info.sock.domain) {
+        case AF_NETLINK:
+            pal_domain = PAL_NL;
+            break;
+        default:
+            BUG();
+    }
+
+    enum pal_socket_type pal_type;
+    switch (handle->info.sock.type) {
+        case SOCK_DGRAM:
+        case SOCK_RAW:
+            pal_type = PAL_SOCKET_NL;
+            /* Netlink sockets are ready for communication instantly. */
+            handle->info.sock.can_be_read = true;
+            handle->info.sock.can_be_written = true;
+            break;
+        default:
+            BUG();
+    }
+
+    int protocol = handle->info.sock.protocol;
+    if (protocol < 0 || protocol >= MAX_LINKS) {
+        return -EPROTONOSUPPORT;
+    }
+
+    /* We don't need to take the lock - handle was just created. */
+    pal_stream_options_t options = handle->flags & O_NONBLOCK ? PAL_OPTION_NONBLOCK : 0;
+    PAL_HANDLE pal_handle = NULL;
+    int ret = PalSocketCreate(pal_domain, pal_type, protocol, options, &pal_handle);
+    if (ret < 0) {
+        return pal_to_unix_errno(ret);
+    }
+    handle->info.sock.pal_handle = pal_handle;
+    return 0;
+}
+
+static int bind(struct libos_handle* handle, void* addr, size_t addrlen) {
+    struct libos_sock_handle* sock = &handle->info.sock;
+    assert(locked(&sock->lock));
+
+    int ret = verify_sockaddr(sock->domain, addr, &addrlen);
+    if (ret < 0) {
+        return ret;
+    }
+
+    struct pal_socket_addr pal_nl_addr;
+    linux_to_pal_sockaddr(addr, &pal_nl_addr);
+
+    ret = PalSocketBind(sock->pal_handle, &pal_nl_addr);
+    if (ret < 0) {
+        return (ret == -PAL_ERROR_STREAMEXIST) ? -EADDRINUSE : pal_to_unix_errno(ret);
+    }
+
+    pal_to_linux_sockaddr(&pal_nl_addr, &sock->local_addr, &sock->local_addrlen);
+    return 0;
+}
+
+static int connect(struct libos_handle* handle, void* addr, size_t addrlen) {
+    struct libos_sock_handle* sock = &handle->info.sock;
+    assert(locked(&sock->lock));
+
+    int ret = verify_sockaddr(sock->domain, addr, &addrlen);
+    if (ret < 0) {
+        return ret;
+    }
+
+    struct pal_socket_addr pal_remote_addr;
+    linux_to_pal_sockaddr(addr, &pal_remote_addr);
+    struct pal_socket_addr pal_local_addr;
+
+    /* XXX: this connect is always blocking (regardless of actual setting of nonblockingness on
+     * `sock->pal_handle`. See also the comment in netlink connect implementation in Linux PAL. */
+    ret = PalSocketConnect(sock->pal_handle, &pal_remote_addr, &pal_local_addr);
+    if (ret < 0) {
+        return ret == -PAL_ERROR_CONNFAILED ? -ECONNREFUSED : pal_to_unix_errno(ret);
+    }
+
+    memcpy(&sock->remote_addr, addr, addrlen);
+    sock->remote_addrlen = addrlen;
+    if (sock->state != SOCK_BOUND) {
+        assert(sock->state == SOCK_NEW);
+        assert(!sock->was_bound);
+        pal_to_linux_sockaddr(&pal_local_addr, &sock->local_addr, &sock->local_addrlen);
+    }
+    return 0;
+}
+
+static int disconnect(struct libos_handle* handle) {
+    struct libos_sock_handle* sock = &handle->info.sock;
+    assert(locked(&sock->lock));
+
+    struct pal_socket_addr pal_nl_addr = {
+        .domain = PAL_DISCONNECT,
+    };
+    int ret = PalSocketConnect(sock->pal_handle, &pal_nl_addr, /*local_addr=*/NULL);
+    return pal_to_unix_errno(ret);
+}
+
+static int setsockopt(struct libos_handle* handle, int level, int optname, void* optval,
+                      size_t len) {
+    /* Nothing to do here. */
+    __UNUSED(handle);
+    __UNUSED(level);
+    __UNUSED(optname);
+    __UNUSED(optval);
+    __UNUSED(len);
+    return -ENOPROTOOPT;
+}
+
+static int getsockopt(struct libos_handle* handle, int level, int optname, void* optval,
+                      size_t* len) {
+    /* Nothing to do here. */
+    __UNUSED(handle);
+    __UNUSED(level);
+    __UNUSED(optname);
+    __UNUSED(optval);
+    __UNUSED(len);
+    return -ENOPROTOOPT;
+}
+
+static int send(struct libos_handle* handle, struct iovec* iov, size_t iov_len, size_t* out_size,
+                void* addr, size_t addrlen, bool force_nonblocking) {
+    assert(handle->type == TYPE_SOCK);
+
+    struct libos_sock_handle* sock = &handle->info.sock;
+    struct sockaddr_storage sock_addr;
+
+    switch (sock->type) {
+        case SOCK_DGRAM:
+        case SOCK_RAW:
+            if (!addr) {
+                lock(&sock->lock);
+                if (sock->remote_addr.ss_family == AF_UNSPEC) {
+                    /* Not connected. */
+                    unlock(&sock->lock);
+                    return -ENOTCONN;
+                }
+                addrlen = sock->remote_addrlen;
+                assert(addrlen <= sizeof(sock_addr));
+                memcpy(&sock_addr, &sock->remote_addr, addrlen);
+                addr = &sock_addr;
+                unlock(&sock->lock);
+            }
+            break;
+        default:
+            __builtin_unreachable();
+    }
+
+    struct pal_socket_addr pal_sockaddr;
+    if (addr) {
+        int ret = verify_sockaddr(sock->domain, addr, &addrlen);
+        if (ret < 0) {
+            return ret;
+        }
+        linux_to_pal_sockaddr(addr, &pal_sockaddr);
+    }
+
+    int ret = PalSocketSend(sock->pal_handle, iov, iov_len, out_size, addr ? &pal_sockaddr : NULL,
+                            force_nonblocking);
+    ret = (ret == -PAL_ERROR_TOOLONG) ? -EMSGSIZE : pal_to_unix_errno(ret);
+    return ret;
+}
+
+static int recv(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
+                size_t* out_total_size, void* addr, size_t* addrlen, bool force_nonblocking) {
+    assert(handle->type == TYPE_SOCK);
+
+    switch (handle->info.sock.type) {
+        case SOCK_DGRAM:
+        case SOCK_RAW:
+            break;
+        default:
+            __builtin_unreachable();
+    }
+
+    struct pal_socket_addr pal_sockaddr;
+    int ret = PalSocketRecv(handle->info.sock.pal_handle, iov, iov_len, out_total_size,
+                            addr ? &pal_sockaddr : NULL, force_nonblocking);
+    if (ret < 0) {
+        return pal_to_unix_errno(ret);
+    }
+    if (addr) {
+        struct sockaddr_storage linux_addr;
+        size_t linux_addr_len = sizeof(linux_addr);
+        pal_to_linux_sockaddr(&pal_sockaddr, &linux_addr, &linux_addr_len);
+        /* If the user provided buffer is too small, the address is truncated, but we report
+         * the actual address size in `addrlen`. */
+        memcpy(addr, &linux_addr, MIN(*addrlen, linux_addr_len));
+        *addrlen = linux_addr_len;
+    }
+    return 0;
+}
+
+struct libos_sock_ops sock_nl_ops = {
+    .create = create,
+    .bind = bind,
+    .connect = connect,
+    .disconnect = disconnect,
+    .getsockopt = getsockopt,
+    .setsockopt = setsockopt,
+    .send = send,
+    .recv = recv,
+};

--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -72,6 +72,9 @@ struct libos_handle* get_new_socket_handle(int family, int type, int protocol,
         case AF_INET6:
             sock->ops = &sock_ip_ops;
             break;
+        case AF_NETLINK:
+            sock->ops = &sock_nl_ops;
+            break;
     }
 
     if (!create_lock(&sock->lock) || !create_lock(&sock->recv_lock)) {
@@ -87,6 +90,7 @@ long libos_syscall_socket(int family, int type, int protocol) {
         case AF_UNIX:
         case AF_INET:
         case AF_INET6:
+        case AF_NETLINK:
             break;
         default:
             log_warning("%s: unsupported socket domain %d", __func__, family);
@@ -104,6 +108,7 @@ long libos_syscall_socket(int family, int type, int protocol) {
     switch (type) {
         case SOCK_STREAM:
         case SOCK_DGRAM:
+        case SOCK_RAW:
             break;
         default:
             log_warning("%s: unsupported socket type %d", __func__, type);

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -47,12 +47,16 @@ enum pal_socket_domain {
     PAL_DISCONNECT,
     PAL_IPV4,
     PAL_IPV6,
+    PAL_NL,
 };
 
 enum pal_socket_type {
     PAL_SOCKET_TCP,
     PAL_SOCKET_UDP,
+    PAL_SOCKET_NL,
 };
+
+typedef int pal_socket_protocol;
 
 #ifdef IN_PAL
 
@@ -524,6 +528,10 @@ struct pal_socket_addr {
             uint8_t addr[16];
             uint16_t port;
         } ipv6;
+        struct {
+            uint32_t pid;
+            uint32_t groups;
+        } nl;
     };
 };
 
@@ -532,13 +540,15 @@ struct pal_socket_addr {
  *
  * \param      domain      Domain of the socket.
  * \param      type        Type of the socket.
+ * \param      protocol    Protocol of the socket.
  * \param      options     Flags to set on the handle.
  * \param[out] out_handle  On success contains the socket handle.
  *
  * \returns 0 on success, negative error code on failure.
  */
 int PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
-                    pal_stream_options_t options, PAL_HANDLE* out_handle);
+                    pal_socket_protocol protocol, pal_stream_options_t options,
+                    PAL_HANDLE* out_handle);
 
 /*!
  * \brief Bind a socket to a local address.

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -179,7 +179,8 @@ int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo);
 int _PalReceiveHandle(PAL_HANDLE source_process, PAL_HANDLE* out_cargo);
 
 int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
-                     pal_stream_options_t options, PAL_HANDLE* out_handle);
+                     pal_socket_protocol protocol, pal_stream_options_t options,
+                     PAL_HANDLE* out_handle);
 int _PalSocketBind(PAL_HANDLE handle, struct pal_socket_addr* addr);
 int _PalSocketListen(PAL_HANDLE handle, unsigned int backlog);
 int _PalSocketAccept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDLE* out_client,

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -103,7 +103,7 @@ static void do_parent(void) {
     PalObjectClose(handle);
 
     /* TCP socket */
-    CHECK(PalSocketCreate(PAL_IPV4, PAL_SOCKET_TCP, /*options=*/0, &handle));
+    CHECK(PalSocketCreate(PAL_IPV4, PAL_SOCKET_TCP, /*protocol=*/0, /*options=*/0, &handle));
     struct pal_socket_addr addr = {
         .domain = PAL_IPV4,
         .ipv4 = {
@@ -117,13 +117,13 @@ static void do_parent(void) {
     CHECK(PalSendHandle(child_process, handle));
     PalObjectClose(handle);
 
-    CHECK(PalSocketCreate(PAL_IPV4, PAL_SOCKET_TCP, /*options=*/0, &handle));
+    CHECK(PalSocketCreate(PAL_IPV4, PAL_SOCKET_TCP, /*protocol=*/0, /*options=*/0, &handle));
     CHECK(PalSocketConnect(handle, &addr, /*local_addr=*/NULL));
     recv_and_check(handle, PAL_TYPE_SOCKET);
     PalObjectClose(handle);
 
     /* UDP IPv6 socket */
-    CHECK(PalSocketCreate(PAL_IPV6, PAL_SOCKET_UDP, /*options=*/0, &handle));
+    CHECK(PalSocketCreate(PAL_IPV6, PAL_SOCKET_UDP, /*protocol=*/0, /*options=*/0, &handle));
     addr = (struct pal_socket_addr) {
         .domain = PAL_IPV6,
         .ipv6 = {
@@ -136,7 +136,7 @@ static void do_parent(void) {
     CHECK(PalSendHandle(child_process, handle));
     PalObjectClose(handle);
 
-    CHECK(PalSocketCreate(PAL_IPV6, PAL_SOCKET_UDP, /*options=*/0, &handle));
+    CHECK(PalSocketCreate(PAL_IPV6, PAL_SOCKET_UDP, /*protocol=*/0, /*options=*/0, &handle));
     CHECK(PalSocketConnect(handle, &addr, /*local_addr=*/NULL));
     write_msg(handle, PAL_TYPE_SOCKET);
     PalObjectClose(handle);

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -50,7 +50,7 @@ int ocall_getdents(int fd, struct linux_dirent64* dirp, size_t size);
 
 int ocall_socket(int family, int type, int protocol);
 
-int ocall_bind(int fd, struct sockaddr_storage* addr, size_t addrlen, uint16_t* out_new_port);
+int ocall_bind(int fd, struct sockaddr_storage* addr, size_t addrlen, uint16_t* out_new_port, uint32_t* new_nl_pid);
 
 int ocall_listen_simple(int fd, unsigned int backlog);
 

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -328,6 +328,11 @@ static long sgx_ocall_bind(void* args) {
                    (char*)&addr + offsetof(struct sockaddr_in6, sin6_port),
                    sizeof(ocall_bind_args->new_port));
             break;
+        case AF_NETLINK:
+            memcpy(&ocall_bind_args->new_nl_pid,
+                   (char*)&addr + offsetof(struct sockaddr_nl, nl_pid),
+                   sizeof(ocall_bind_args->new_nl_pid));
+            break;
         default:
             log_error("%s: unknown address family: %d", __func__, addr.ss_family);
             DO_SYSCALL(exit_group, 1);

--- a/pal/src/host/linux-sgx/pal_ocall_types.h
+++ b/pal/src/host/linux-sgx/pal_ocall_types.h
@@ -210,6 +210,7 @@ struct ocall_bind {
     struct sockaddr* addr;
     size_t addrlen;
     uint16_t new_port;
+    uint32_t new_nl_pid;
 };
 
 struct ocall_listen_simple {

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -15,8 +15,10 @@
 
 static struct handle_ops g_tcp_handle_ops;
 static struct handle_ops g_udp_handle_ops;
+static struct handle_ops g_nl_handle_ops;
 static struct socket_ops g_tcp_sock_ops;
 static struct socket_ops g_udp_sock_ops;
+static struct socket_ops g_nl_sock_ops;
 
 /* Default values on a modern Linux kernel. */
 static size_t g_default_recv_buf_size = 0x20000;
@@ -30,7 +32,7 @@ static size_t sanitize_size(size_t size) {
     return size;
 }
 
-static int verify_ip_addr(enum pal_socket_domain domain, struct sockaddr_storage* addr,
+static int verify_sockaddr(enum pal_socket_domain domain, struct sockaddr_storage* addr,
                           size_t addrlen) {
     if (addrlen < offsetof(struct sockaddr_storage, ss_family) + sizeof(addr->ss_family)) {
         return -PAL_ERROR_DENIED;
@@ -49,6 +51,14 @@ static int verify_ip_addr(enum pal_socket_domain domain, struct sockaddr_storage
                 return -PAL_ERROR_DENIED;
             }
             if (addrlen != sizeof(struct sockaddr_in6)) {
+                return -PAL_ERROR_DENIED;
+            }
+            break;
+        case PAL_NL:
+            if (addr->ss_family != AF_NETLINK) {
+                return -PAL_ERROR_DENIED;
+            }
+            if (addrlen != sizeof(struct sockaddr_nl)) {
                 return -PAL_ERROR_DENIED;
             }
             break;
@@ -90,7 +100,8 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
 }
 
 int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
-                     pal_stream_options_t options, PAL_HANDLE* out_handle) {
+                     pal_socket_protocol protocol, pal_stream_options_t options,
+                     PAL_HANDLE* out_handle) {
     int linux_domain;
     int linux_type;
     switch (domain) {
@@ -99,6 +110,9 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
             break;
         case PAL_IPV6:
             linux_domain = AF_INET6;
+            break;
+        case PAL_NL:
+            linux_domain = AF_NETLINK;
             break;
         default:
             BUG();
@@ -116,6 +130,11 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
             handle_ops = &g_udp_handle_ops;
             sock_ops = &g_udp_sock_ops;
             break;
+        case PAL_SOCKET_NL:
+            linux_type = SOCK_RAW;
+            handle_ops = &g_nl_handle_ops;
+            sock_ops = &g_nl_sock_ops;
+            break;
         default:
             BUG();
     }
@@ -125,7 +144,7 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
     }
     linux_type |= SOCK_CLOEXEC;
 
-    int fd = ocall_socket(linux_domain, linux_type, 0);
+    int fd = ocall_socket(linux_domain, linux_type, protocol);
     if (fd < 0) {
         return unix_to_pal_error(fd);
     }
@@ -164,8 +183,9 @@ static int bind(PAL_HANDLE handle, struct pal_socket_addr* addr) {
     pal_to_linux_sockaddr(addr, &sa_storage, &linux_addrlen);
     assert(linux_addrlen <= INT_MAX);
     uint16_t new_port = 0;
+    uint32_t new_nl_pid = 0;
 
-    int ret = ocall_bind(handle->sock.fd, &sa_storage, linux_addrlen, &new_port);
+    int ret = ocall_bind(handle->sock.fd, &sa_storage, linux_addrlen, &new_port, &new_nl_pid);
     if (ret < 0) {
         return unix_to_pal_error(ret);
     }
@@ -179,6 +199,11 @@ static int bind(PAL_HANDLE handle, struct pal_socket_addr* addr) {
         case PAL_IPV6:
             if (!addr->ipv6.port) {
                 addr->ipv6.port = new_port;
+            }
+            break;
+        case PAL_NL:
+            if (!addr->nl.pid) {
+                addr->nl.pid = new_nl_pid;
             }
             break;
         default:
@@ -222,12 +247,12 @@ static int tcp_accept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDL
         return -PAL_ERROR_NOMEM;
     }
 
-    int ret = verify_ip_addr(client->sock.domain, &client_addr, client_addrlen);
+    int ret = verify_sockaddr(client->sock.domain, &client_addr, client_addrlen);
     if (ret < 0) {
         _PalObjectClose(client);
         return ret;
     }
-    ret = verify_ip_addr(client->sock.domain, &local_addr, local_addrlen);
+    ret = verify_sockaddr(client->sock.domain, &local_addr, local_addrlen);
     if (ret < 0) {
         _PalObjectClose(client);
         return ret;
@@ -264,7 +289,7 @@ static int connect(PAL_HANDLE handle, struct pal_socket_addr* addr,
     }
 
     if (out_local_addr) {
-        ret = verify_ip_addr(handle->sock.domain, &sa_storage, linux_addrlen);
+        ret = verify_sockaddr(handle->sock.domain, &sa_storage, linux_addrlen);
         if (ret < 0) {
             return ret;
         }
@@ -454,6 +479,12 @@ static int attrsetbyhdl_udp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     return attrsetbyhdl_common(handle, attr);
 }
 
+static int attrsetbyhdl_nl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
+    assert(handle->sock.type == PAL_SOCKET_NL);
+
+    return attrsetbyhdl_common(handle, attr);
+}
+
 static int send(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                 struct pal_socket_addr* addr, bool force_nonblocking) {
     assert(handle->hdr.type == PAL_TYPE_SOCKET);
@@ -498,7 +529,7 @@ static int recv(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* ou
     }
     size_t size = ret;
     if (addr) {
-        ret = verify_ip_addr(handle->sock.domain, &sa_storage, linux_addrlen);
+        ret = verify_sockaddr(handle->sock.domain, &sa_storage, linux_addrlen);
         if (ret < 0) {
             return ret;
         }
@@ -535,6 +566,12 @@ static int delete_udp(PAL_HANDLE handle, enum pal_delete_mode mode) {
     return 0;
 }
 
+static int delete_nl(PAL_HANDLE handle, enum pal_delete_mode mode) {
+    __UNUSED(handle);
+    __UNUSED(mode);
+    return 0;
+}
+
 static struct socket_ops g_tcp_sock_ops = {
     .bind = bind,
     .listen = tcp_listen,
@@ -545,6 +582,13 @@ static struct socket_ops g_tcp_sock_ops = {
 };
 
 static struct socket_ops g_udp_sock_ops = {
+    .bind = bind,
+    .connect = connect,
+    .send = send,
+    .recv = recv,
+};
+
+static struct socket_ops g_nl_sock_ops = {
     .bind = bind,
     .connect = connect,
     .send = send,
@@ -562,6 +606,13 @@ static struct handle_ops g_udp_handle_ops = {
     .attrquerybyhdl = attrquerybyhdl,
     .attrsetbyhdl = attrsetbyhdl_udp,
     .delete = delete_udp,
+    .close = close,
+};
+
+static struct handle_ops g_nl_handle_ops = {
+    .attrquerybyhdl = attrquerybyhdl,
+    .attrsetbyhdl = attrsetbyhdl_nl,
+    .delete = delete_nl,
     .close = close,
 };
 

--- a/pal/src/host/linux/pal_sockets.c
+++ b/pal/src/host/linux/pal_sockets.c
@@ -16,8 +16,10 @@
 
 static struct handle_ops g_tcp_handle_ops;
 static struct handle_ops g_udp_handle_ops;
+static struct handle_ops g_nl_handle_ops;
 static struct socket_ops g_tcp_sock_ops;
 static struct socket_ops g_udp_sock_ops;
+static struct socket_ops g_nl_sock_ops;
 
 static size_t g_default_recv_buf_size = 0;
 static size_t g_default_send_buf_size = 0;
@@ -81,7 +83,8 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
 }
 
 int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
-                     pal_stream_options_t options, PAL_HANDLE* out_handle) {
+                     pal_socket_protocol protocol, pal_stream_options_t options,
+                     PAL_HANDLE* out_handle) {
     int linux_domain;
     int linux_type;
     switch (domain) {
@@ -90,6 +93,9 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
             break;
         case PAL_IPV6:
             linux_domain = AF_INET6;
+            break;
+        case PAL_NL:
+            linux_domain = AF_NETLINK;
             break;
         default:
             BUG();
@@ -107,6 +113,11 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
             handle_ops = &g_udp_handle_ops;
             sock_ops = &g_udp_sock_ops;
             break;
+        case PAL_SOCKET_NL:
+            linux_type = SOCK_RAW;
+            handle_ops = &g_nl_handle_ops;
+            sock_ops = &g_nl_sock_ops;
+            break;
         default:
             BUG();
     }
@@ -116,7 +127,7 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
     }
     linux_type |= SOCK_CLOEXEC;
 
-    int fd = DO_SYSCALL(socket, linux_domain, linux_type, 0);
+    int fd = DO_SYSCALL(socket, linux_domain, linux_type, protocol);
     if (fd < 0) {
         return unix_to_pal_error(fd);
     }
@@ -160,6 +171,7 @@ static int bind(PAL_HANDLE handle, struct pal_socket_addr* addr) {
         struct sockaddr_storage sa_storage;
         struct sockaddr_in addr_ipv4;
         struct sockaddr_in6 addr_ipv6;
+        struct sockaddr_nl addr_nl;
     } linux_addr;
     size_t linux_addrlen;
     pal_to_linux_sockaddr(addr, &linux_addr.sa_storage, &linux_addrlen);
@@ -193,6 +205,18 @@ static int bind(PAL_HANDLE handle, struct pal_socket_addr* addr) {
                 }
                 assert(linux_addr.addr_ipv6.sin6_family == AF_INET6);
                 addr->ipv6.port = linux_addr.addr_ipv6.sin6_port;
+            }
+            break;
+        case PAL_NL:
+            if (!addr->nl.pid) {
+                ret = do_getsockname(handle->sock.fd, &linux_addr.sa_storage);
+                if (ret < 0) {
+                    /* This should never happen, but we have to handle it somehow. Socket was bound,
+                     * but something is wrong... */
+                    return ret;
+                }
+                assert(linux_addr.addr_nl.nl_family == AF_NETLINK);
+                addr->nl.pid = linux_addr.addr_nl.nl_pid;
             }
             break;
         default:
@@ -501,6 +525,12 @@ static int attrsetbyhdl_udp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     return attrsetbyhdl_common(handle, attr);
 }
 
+static int attrsetbyhdl_nl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
+    assert(handle->sock.type == PAL_SOCKET_NL);
+
+    return attrsetbyhdl_common(handle, attr);
+}
+
 static int send(PAL_HANDLE handle, struct iovec* iov, size_t iov_len, size_t* out_size,
                 struct pal_socket_addr* addr, bool force_nonblocking) {
     assert(handle->hdr.type == PAL_TYPE_SOCKET);
@@ -586,6 +616,12 @@ static int delete_udp(PAL_HANDLE handle, enum pal_delete_mode mode) {
     return 0;
 }
 
+static int delete_nl(PAL_HANDLE handle, enum pal_delete_mode mode) {
+    __UNUSED(handle);
+    __UNUSED(mode);
+    return 0;
+}
+
 static struct socket_ops g_tcp_sock_ops = {
     .bind = bind,
     .listen = tcp_listen,
@@ -596,6 +632,13 @@ static struct socket_ops g_tcp_sock_ops = {
 };
 
 static struct socket_ops g_udp_sock_ops = {
+    .bind = bind,
+    .connect = connect,
+    .send = send,
+    .recv = recv,
+};
+
+static struct socket_ops g_nl_sock_ops = {
     .bind = bind,
     .connect = connect,
     .send = send,
@@ -613,6 +656,13 @@ static struct handle_ops g_udp_handle_ops = {
     .attrquerybyhdl = attrquerybyhdl,
     .attrsetbyhdl = attrsetbyhdl_udp,
     .delete = delete_udp,
+    .close = close,
+};
+
+static struct handle_ops g_nl_handle_ops = {
+    .attrquerybyhdl = attrquerybyhdl,
+    .attrsetbyhdl = attrsetbyhdl_nl,
+    .delete = delete_nl,
     .close = close,
 };
 

--- a/pal/src/pal_sockets.c
+++ b/pal/src/pal_sockets.c
@@ -7,8 +7,9 @@
 #include "pal_internal.h"
 
 int PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
-                    pal_stream_options_t options, PAL_HANDLE* out_handle) {
-    return _PalSocketCreate(domain, type, options, out_handle);
+                    pal_socket_protocol protocol, pal_stream_options_t options,
+                    PAL_HANDLE* out_handle) {
+    return _PalSocketCreate(domain, type, protocol, options, out_handle);
 }
 
 int PalSocketBind(PAL_HANDLE handle, struct pal_socket_addr* addr) {


### PR DESCRIPTION
The Netlink socket family is a Linux kernel interface used for inter-process communication (IPC) between both the kernel and userspace processes, and between different userspace processes. There are applications relying on Netlink for high-performance asynchronous messaging.

This version does not support setting (via `setsockopt()`) or getting (via `getsockopt()`) a netlink socket option.

Resolves https://github.com/gramineproject/gramine/issues/181.