### PR TITLE
[LibOS] Add `/proc/[pid]/stat` and `/proc/[pid]/statm` pseudo-file

### DIFF
--- a/libos/include/libos_fs_pseudo.h
+++ b/libos/include/libos_fs_pseudo.h
@@ -216,6 +216,8 @@ int proc_thread_follow_link(struct libos_dentry* dent, char** out_target);
 int proc_thread_maps_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int proc_thread_cmdline_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 int proc_thread_status_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
+int proc_thread_statm_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
+int proc_thread_stat_load(struct libos_dentry* dent, char** out_data, size_t* out_size);
 bool proc_thread_fd_name_exists(struct libos_dentry* parent, const char* name);
 int proc_thread_fd_list_names(struct libos_dentry* parent, readdir_callback_t callback, void* arg);
 int proc_thread_fd_follow_link(struct libos_dentry* dent, char** out_target);

--- a/libos/include/libos_vma.h
+++ b/libos/include/libos_vma.h
@@ -133,3 +133,6 @@ void debug_print_all_vmas(void);
 
 /* Returns the peak amount of memory usage */
 size_t get_peak_memory_usage(void);
+
+/* Returns total memory usage */
+size_t get_total_memory_usage(void);

--- a/libos/src/bookkeep/libos_vma.c
+++ b/libos/src/bookkeep/libos_vma.c
@@ -1568,3 +1568,10 @@ void debug_print_all_vmas(void) {
 size_t get_peak_memory_usage(void) {
     return __atomic_load_n(&g_peak_total_memory_size, __ATOMIC_RELAXED);
 }
+
+size_t get_total_memory_usage(void) {
+    spinlock_lock(&vma_tree_lock);
+    size_t total_memory_size = g_total_memory_size;
+    spinlock_unlock(&vma_tree_lock);
+    return total_memory_size;
+}

--- a/libos/src/fs/proc/fs.c
+++ b/libos/src/fs/proc/fs.c
@@ -29,6 +29,8 @@ static void init_thread_dir(struct pseudo_node* ent) {
     pseudo_add_str(ent, "maps", &proc_thread_maps_load);
     pseudo_add_str(ent, "cmdline", &proc_thread_cmdline_load);
     pseudo_add_str(ent, "status", &proc_thread_status_load);
+    pseudo_add_str(ent, "statm", &proc_thread_statm_load);
+    pseudo_add_str(ent, "stat", &proc_thread_stat_load);
 
     struct pseudo_node* fd = pseudo_add_dir(ent, "fd");
     struct pseudo_node* fd_link = pseudo_add_link(fd, /*name=*/NULL, &proc_thread_fd_follow_link);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
The `/proc/[self-pid]/statm` and `/proc/[self-pid]/stat` files are required by the `psutil` module of Python. 
In most cases, workloads that use this module don't really care about the values in them. The mean of each value are listed in `man proc`.
This PR emulate `stat` and `statm` only in `/proc/[self-pid]`. And only a few values are filled. Dummy values in correct format are enough. 

Resolves #967

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1024)
<!-- Reviewable:end -->
