### PR TITLE
[LibOS,PAL] Avoid `g_pal_public_state` from being overwritten by LibOS

### DIFF
--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -23,7 +23,8 @@ noreturn void libos_init(const char* const* argv, const char* const* envp);
 
 extern int g_log_level;
 
-extern struct pal_public_state* g_pal_public_state;
+extern const struct pal_public_state* g_pal_public_state;
+extern struct pal_public_initial_state g_pal_public_initial_state;
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -57,7 +57,7 @@ struct libos_signal_queue {
     struct libos_rt_signal_queue rt_signal_queues[SIGS_CNT - SIGRTMIN + 1];
 };
 
-#define GET_CPU_MASK_LEN() (BITS_TO_LONGS(g_pal_public_state->topo_info.threads_cnt))
+#define GET_CPU_MASK_LEN() (BITS_TO_LONGS(g_pal_public_initial_state.topo_info.threads_cnt))
 
 DEFINE_LIST(libos_thread);
 DEFINE_LISTP(libos_thread);

--- a/libos/src/fs/etc/fs.c
+++ b/libos/src/fs/etc/fs.c
@@ -39,17 +39,17 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
 
     /* Estimate the size of buffer: */
     /* nameservers - let's assume all entries will be IPv6 plus a new line */
-    size += g_pal_public_state->dns_host.nsaddr_list_count
+    size += g_pal_public_initial_state.dns_host.nsaddr_list_count
             * (strlen("nameserver ") + MAX_IPV6_ADDR_LEN + 1);
     /* search - let's assume maximum length of entries, plus a new line and white spaces */
     size += strlen("search");
-    size += g_pal_public_state->dns_host.dn_search_count * (PAL_HOSTNAME_MAX + 1);
+    size += g_pal_public_initial_state.dns_host.dn_search_count * (PAL_HOSTNAME_MAX + 1);
     size += 1;
     /* and let's add some space for each option */
-    size += (g_pal_public_state->dns_host.edns0 ? strlen(OPTION_EDNS0) : 0)
-            + (g_pal_public_state->dns_host.inet6 ? strlen(OPTION_INET6) : 0)
-            + (g_pal_public_state->dns_host.rotate ? strlen(OPTION_ROTATE) : 0)
-            + (g_pal_public_state->dns_host.use_vc ? strlen(OPTION_USE_VC) : 0);
+    size += (g_pal_public_initial_state.dns_host.edns0 ? strlen(OPTION_EDNS0) : 0)
+            + (g_pal_public_initial_state.dns_host.inet6 ? strlen(OPTION_INET6) : 0)
+            + (g_pal_public_initial_state.dns_host.rotate ? strlen(OPTION_ROTATE) : 0)
+            + (g_pal_public_initial_state.dns_host.use_vc ? strlen(OPTION_USE_VC) : 0);
 
     /* make space for terminating character */
     size += 1;
@@ -63,14 +63,14 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
     size_t space_left = size;
     char* ptr = data;
     int ret;
-    for (size_t i = 0; i < g_pal_public_state->dns_host.nsaddr_list_count; i++) {
-        if (!g_pal_public_state->dns_host.nsaddr_list[i].is_ipv6) {
-            uint32_t addr = g_pal_public_state->dns_host.nsaddr_list[i].ipv4;
+    for (size_t i = 0; i < g_pal_public_initial_state.dns_host.nsaddr_list_count; i++) {
+        if (!g_pal_public_initial_state.dns_host.nsaddr_list[i].is_ipv6) {
+            uint32_t addr = g_pal_public_initial_state.dns_host.nsaddr_list[i].ipv4;
             ret = put_string(&ptr, &space_left, "nameserver %u.%u.%u.%u\n",
                              (addr & 0xFF000000) >> 24, (addr & 0x00FF0000) >> 16,
                              (addr & 0x0000FF00) >> 8, (addr & 0x000000FF));
         } else {
-            uint16_t* addrv6 = g_pal_public_state->dns_host.nsaddr_list[i].ipv6;
+            uint16_t* addrv6 = g_pal_public_initial_state.dns_host.nsaddr_list[i].ipv6;
             ret = put_string(&ptr, &space_left, "nameserver %x:%x:%x:%x:%x:%x:%x:%x\n",
                              addrv6[0], addrv6[1], addrv6[2], addrv6[3], addrv6[4], addrv6[5],
                              addrv6[6], addrv6[7]);
@@ -79,12 +79,12 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
             goto out;
     }
 
-    if (g_pal_public_state->dns_host.dn_search_count > 0) {
+    if (g_pal_public_initial_state.dns_host.dn_search_count > 0) {
         ret = put_string(&ptr, &space_left, "search");
         if (ret < 0)
             goto out;
-        for (size_t i = 0; i < g_pal_public_state->dns_host.dn_search_count; i++) {
-            ret = put_string(&ptr, &space_left, " %s", g_pal_public_state->dns_host.dn_search[i]);
+        for (size_t i = 0; i < g_pal_public_initial_state.dns_host.dn_search_count; i++) {
+            ret = put_string(&ptr, &space_left, " %s", g_pal_public_initial_state.dns_host.dn_search[i]);
             if (ret < 0)
                 goto out;
         }
@@ -92,22 +92,22 @@ static int provide_etc_resolv_conf(struct libos_dentry* dent, char** out_data, s
         if (ret < 0)
             goto out;
     }
-    if (g_pal_public_state->dns_host.edns0) {
+    if (g_pal_public_initial_state.dns_host.edns0) {
         ret = put_string(&ptr, &space_left, OPTION_EDNS0);
         if (ret < 0)
             goto out;
     }
-    if (g_pal_public_state->dns_host.inet6) {
+    if (g_pal_public_initial_state.dns_host.inet6) {
         ret = put_string(&ptr, &space_left, OPTION_INET6);
         if (ret < 0)
             goto out;
     }
-    if (g_pal_public_state->dns_host.rotate) {
+    if (g_pal_public_initial_state.dns_host.rotate) {
         ret = put_string(&ptr, &space_left, OPTION_ROTATE);
         if (ret < 0)
             goto out;
     }
-    if (g_pal_public_state->dns_host.use_vc) {
+    if (g_pal_public_initial_state.dns_host.use_vc) {
         ret = put_string(&ptr, &space_left, OPTION_USE_VC);
         if (ret < 0)
             goto out;
@@ -154,9 +154,9 @@ BEGIN_CP_FUNC(etc_info) {
     __UNUSED(objp);
 
     /* Propagate DNS configuration */
-    size_t off = ADD_CP_OFFSET(sizeof(g_pal_public_state->dns_host));
+    size_t off = ADD_CP_OFFSET(sizeof(g_pal_public_initial_state.dns_host));
     struct dns_host* new_dns_host = (struct dns_host*)(base + off);
-    memcpy(new_dns_host, &g_pal_public_state->dns_host, sizeof(g_pal_public_state->dns_host));
+    memcpy(new_dns_host, &g_pal_public_initial_state.dns_host, sizeof(g_pal_public_initial_state.dns_host));
 
     ADD_CP_FUNC_ENTRY(off);
 }
@@ -167,6 +167,6 @@ BEGIN_RS_FUNC(etc_info) {
     __UNUSED(rebase);
 
     const struct dns_host* dns_host = (const struct dns_host*)(base + GET_CP_FUNC_ENTRY());
-    memcpy(&g_pal_public_state->dns_host, dns_host, sizeof(g_pal_public_state->dns_host));
+    memcpy(&g_pal_public_initial_state.dns_host, dns_host, sizeof(g_pal_public_initial_state.dns_host));
 }
 END_RS_FUNC(etc_info)

--- a/libos/src/fs/etc/fs.c
+++ b/libos/src/fs/etc/fs.c
@@ -156,7 +156,8 @@ BEGIN_CP_FUNC(etc_info) {
     /* Propagate DNS configuration */
     size_t off = ADD_CP_OFFSET(sizeof(g_pal_public_initial_state.dns_host));
     struct dns_host* new_dns_host = (struct dns_host*)(base + off);
-    memcpy(new_dns_host, &g_pal_public_initial_state.dns_host, sizeof(g_pal_public_initial_state.dns_host));
+    memcpy(new_dns_host, &g_pal_public_initial_state.dns_host,
+           sizeof(g_pal_public_initial_state.dns_host));
 
     ADD_CP_FUNC_ENTRY(off);
 }
@@ -167,6 +168,7 @@ BEGIN_RS_FUNC(etc_info) {
     __UNUSED(rebase);
 
     const struct dns_host* dns_host = (const struct dns_host*)(base + GET_CP_FUNC_ENTRY());
-    memcpy(&g_pal_public_initial_state.dns_host, dns_host, sizeof(g_pal_public_initial_state.dns_host));
+    memcpy(&g_pal_public_initial_state.dns_host, dns_host,
+           sizeof(g_pal_public_initial_state.dns_host));
 }
 END_RS_FUNC(etc_info)

--- a/libos/src/fs/proc/info.c
+++ b/libos/src/fs/proc/info.c
@@ -136,7 +136,7 @@ int proc_cpuinfo_load(struct libos_dentry* dent, char** out_data, size_t* out_si
     if (!str)
         return -ENOMEM;
 
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     const struct pal_cpu_info* cpu = &g_pal_public_state->cpu_info;
     for (size_t i = 0; i < topo->threads_cnt; i++) {
         struct pal_cpu_thread_info* thread = &topo->threads[i];
@@ -203,8 +203,8 @@ int proc_stat_load(struct libos_dentry* dent, char** out_data, size_t* out_size)
      * (see Linux's fs/proc/stat.c) */
     ADD_INFO("cpu  %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", user, nice, system, idle, iowait,
              irq, softirq, steal, guest, guest_nice);
-    for (size_t i = 0; i < g_pal_public_state->topo_info.threads_cnt; i++) {
-        if (!g_pal_public_state->topo_info.threads[i].is_online)
+    for (size_t i = 0; i < g_pal_public_initial_state.topo_info.threads_cnt; i++) {
+        if (!g_pal_public_initial_state.topo_info.threads[i].is_online)
             continue;
         ADD_INFO("cpu%lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu\n", i, user, nice, system, idle,
                  iowait, irq, softirq, steal, guest, guest_nice);

--- a/libos/src/fs/sys/cache_info.c
+++ b/libos/src/fs/sys/cache_info.c
@@ -21,7 +21,7 @@ struct callback_arg {
 
 static bool is_same_cache(size_t idx, const void* _arg) {
     const struct callback_arg* arg = _arg;
-    const struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[idx];
+    const struct pal_cpu_thread_info* thread = &g_pal_public_initial_state.topo_info.threads[idx];
     return thread->is_online
            && thread->ids_of_caches[arg->cache_class] == arg->cache_id_to_match;
 }
@@ -41,7 +41,7 @@ int sys_cache_load(struct libos_dentry* dent, char** out_data, size_t* out_size)
 
     const char* name = dent->name;
 
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     size_t cache_idx = topo->threads[thread_id].ids_of_caches[cache_class];
     const struct pal_cache_info* cache = &topo->caches[cache_idx];
     char str[PAL_SYSFS_MAP_FILESZ] = {'\0'};

--- a/libos/src/fs/sys/cpu_info.c
+++ b/libos/src/fs/sys/cpu_info.c
@@ -14,7 +14,7 @@
 
 static bool is_online(size_t ind, const void* arg) {
     __UNUSED(arg);
-    return g_pal_public_state->topo_info.threads[ind].is_online;
+    return g_pal_public_initial_state.topo_info.threads[ind].is_online;
 }
 
 static bool return_true(size_t ind, const void* arg) {
@@ -25,7 +25,7 @@ static bool return_true(size_t ind, const void* arg) {
 
 int sys_cpu_general_load(struct libos_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     const char* name = dent->name;
     char str[PAL_SYSFS_BUF_FILESZ];
 
@@ -46,15 +46,15 @@ int sys_cpu_general_load(struct libos_dentry* dent, char** out_data, size_t* out
 
 static bool is_in_same_core(size_t thread_id, const void* _arg) {
     size_t arg_id = *(const size_t*)_arg;
-    struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[thread_id];
+    struct pal_cpu_thread_info* thread = &g_pal_public_initial_state.topo_info.threads[thread_id];
     return thread->is_online && thread->core_id == arg_id;
 }
 
 static bool is_in_same_socket(size_t thread_id, const void* _arg) {
     size_t arg_id = *(const size_t*)_arg;
-    struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[thread_id];
+    struct pal_cpu_thread_info* thread = &g_pal_public_initial_state.topo_info.threads[thread_id];
     return thread->is_online
-        && g_pal_public_state->topo_info.cores[thread->core_id].socket_id == arg_id;
+        && g_pal_public_initial_state.topo_info.cores[thread->core_id].socket_id == arg_id;
 }
 
 int sys_cpu_load_online(struct libos_dentry* dent, char** out_data, size_t* out_size) {
@@ -71,7 +71,7 @@ int sys_cpu_load_online(struct libos_dentry* dent, char** out_data, size_t* out_
     if (thread_id == 0)
         return -ENOENT;
 
-    struct pal_cpu_thread_info* thread = &g_pal_public_state->topo_info.threads[thread_id];
+    struct pal_cpu_thread_info* thread = &g_pal_public_initial_state.topo_info.threads[thread_id];
     return sys_load(thread->is_online ? "1\n" : "0\n", out_data, out_size);
 }
 
@@ -83,7 +83,7 @@ int sys_cpu_load_topology(struct libos_dentry* dent, char** out_data, size_t* ou
         return ret;
 
     const char* name = dent->name;
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     struct pal_cpu_thread_info* thread = &topo->threads[thread_id];
     assert(thread->is_online); // `cpuX/topology/` should not exist for offline threads.
     struct pal_cpu_core_info* core = &topo->cores[thread->core_id];
@@ -130,6 +130,6 @@ bool sys_cpu_exists_only_if_online(struct libos_dentry* parent, const char* name
     if (ret < 0)
         return false;
 
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     return topo->threads[thread_id].is_online;
 }

--- a/libos/src/fs/sys/fs.c
+++ b/libos/src/fs/sys/fs.c
@@ -85,7 +85,7 @@ int sys_print_as_bitmask(char* buf, size_t buf_size, size_t count,
 }
 
 static int sys_resource_info(const char* parent_name, size_t* out_total, const char** out_prefix) {
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     if (strcmp(parent_name, "node") == 0) {
         *out_total = topo->numa_nodes_cnt;
         *out_prefix = "node";
@@ -281,7 +281,7 @@ BEGIN_CP_FUNC(topo_info) {
     __UNUSED(obj);
     __UNUSED(objp);
 
-    struct pal_topo_info* topo_info = &g_pal_public_state->topo_info;
+    struct pal_topo_info* topo_info = &g_pal_public_initial_state.topo_info;
     size_t off = ADD_CP_OFFSET(sizeof(*topo_info));
     struct pal_topo_info* new_topo_info = (void*)(base + off);
     memset(new_topo_info, 0, sizeof(*new_topo_info));
@@ -331,6 +331,6 @@ BEGIN_RS_FUNC(topo_info) {
     CP_REBASE(topo_info->numa_nodes);
     CP_REBASE(topo_info->numa_distance_matrix);
 
-    memcpy(&g_pal_public_state->topo_info, topo_info, sizeof(*topo_info));
+    memcpy(&g_pal_public_initial_state.topo_info, topo_info, sizeof(*topo_info));
 }
 END_RS_FUNC(topo_info)

--- a/libos/src/fs/sys/node_info.c
+++ b/libos/src/fs/sys/node_info.c
@@ -16,7 +16,7 @@
 
 static bool is_online(size_t ind, const void* arg) {
     __UNUSED(arg);
-    return g_pal_public_state->topo_info.numa_nodes[ind].is_online;
+    return g_pal_public_initial_state.topo_info.numa_nodes[ind].is_online;
 }
 
 static bool return_true(size_t ind, const void* arg) {
@@ -27,7 +27,7 @@ static bool return_true(size_t ind, const void* arg) {
 
 int sys_node_general_load(struct libos_dentry* dent, char** out_data, size_t* out_size) {
     int ret;
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     const char* name = dent->name;
     char str[PAL_SYSFS_BUF_FILESZ];
     if (strcmp(name, "online") == 0) {
@@ -47,10 +47,10 @@ int sys_node_general_load(struct libos_dentry* dent, char** out_data, size_t* ou
 
 static bool is_in_same_node(size_t idx, const void* _arg) {
     unsigned int arg_node_id = *(const unsigned int*)_arg;
-    if (!g_pal_public_state->topo_info.threads[idx].is_online)
+    if (!g_pal_public_initial_state.topo_info.threads[idx].is_online)
         return false;
-    size_t core_id = g_pal_public_state->topo_info.threads[idx].core_id;
-    size_t node_id = g_pal_public_state->topo_info.cores[core_id].node_id;
+    size_t core_id = g_pal_public_initial_state.topo_info.threads[idx].core_id;
+    size_t node_id = g_pal_public_initial_state.topo_info.cores[core_id].node_id;
     return node_id == arg_node_id;
 }
 
@@ -62,7 +62,7 @@ int sys_node_load(struct libos_dentry* dent, char** out_data, size_t* out_size) 
         return ret;
 
     const char* name = dent->name;
-    const struct pal_topo_info* topo = &g_pal_public_state->topo_info;
+    const struct pal_topo_info* topo = &g_pal_public_initial_state.topo_info;
     const struct pal_numa_node_info* numa_node = &topo->numa_nodes[node_id];
     char str[PAL_SYSFS_MAP_FILESZ] = {0};
     if (strcmp(name, "cpumap") == 0) {
@@ -101,7 +101,7 @@ int sys_node_load(struct libos_dentry* dent, char** out_data, size_t* out_size) 
 }
 
 int sys_node_meminfo_load(struct libos_dentry* dent, char** out_data, size_t* out_size) {
-    size_t numa_nodes_cnt = g_pal_public_state->topo_info.numa_nodes_cnt;
+    size_t numa_nodes_cnt = g_pal_public_initial_state.topo_info.numa_nodes_cnt;
     /* Simply "mimic" a typical environment: split memory evenly between each NUMA node */
     size_t node_mem_total = g_pal_public_state->mem_total / numa_nodes_cnt;
     size_t node_mem_free = PalMemoryAvailableQuota() / numa_nodes_cnt;

--- a/libos/src/sys/libos_sched.c
+++ b/libos/src/sys/libos_sched.c
@@ -184,13 +184,13 @@ long libos_syscall_sched_setaffinity(pid_t pid, unsigned int user_mask_size,
     memcpy(cpu_mask, user_mask_ptr, MIN(user_mask_size, cpu_mask_size));
 
     bool seen_online = false;
-    size_t threads_count = g_pal_public_state->topo_info.threads_cnt;
+    size_t threads_count = g_pal_public_initial_state.topo_info.threads_cnt;
     /* Remove offline cores from mask. */
     for (size_t i = 0; i < GET_CPU_MASK_LEN(); i++) {
         for (size_t j = 0; j < BITS_IN_TYPE(__typeof__(*cpu_mask)); j++) {
             size_t thread_idx = i * BITS_IN_TYPE(__typeof__(*cpu_mask)) + j;
             if (thread_idx >= threads_count
-                    || !g_pal_public_state->topo_info.threads[thread_idx].is_online) {
+                    || !g_pal_public_initial_state.topo_info.threads[thread_idx].is_online) {
                 cpu_mask[i] &= ~(1ul << j);
             }
             if (cpu_mask[i] & (1ul << j)) {
@@ -305,14 +305,14 @@ long libos_syscall_getcpu(unsigned* cpu, unsigned* node, struct getcpu_cache* un
     unlock(&thread->lock);
 
     assert(cpu_current < GET_CPU_MASK_LEN() * BITS_IN_TYPE(__typeof__(*thread->cpu_affinity_mask)));
-    assert(g_pal_public_state->topo_info.threads[cpu_current].is_online);
+    assert(g_pal_public_initial_state.topo_info.threads[cpu_current].is_online);
 
     if (cpu)
         *cpu = cpu_current;
 
     if (node) {
-        size_t core_id = g_pal_public_state->topo_info.threads[cpu_current].core_id;
-        *node = g_pal_public_state->topo_info.cores[core_id].node_id;
+        size_t core_id = g_pal_public_initial_state.topo_info.threads[cpu_current].core_id;
+        *node = g_pal_public_initial_state.topo_info.cores[core_id].node_id;
     }
 
     return 0;

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -176,9 +176,15 @@ struct pal_public_state {
     struct pal_dns_host_conf dns_host;
 };
 
-/* We cannot mark this as returning a pointer to `const` object, because LibOS can
- * change `pal_public_state.topo_info` during checkpoint restore in the child */
-struct pal_public_state* PalGetPalPublicState(void);
+/* Part of PAL initial state which is copied into the LibOS, only used by the parent Gramine process
+ * and later checkpointed to the child process. */
+struct pal_public_initial_state {
+    struct pal_topo_info topo_info; /* received from untrusted host, but sanitized */
+
+    struct pal_dns_host_conf dns_host;
+};
+
+const struct pal_public_state* PalGetPalPublicState(void);
 
 /*
  * MEMORY ALLOCATION

--- a/pal/regression/memory_management.c
+++ b/pal/regression/memory_management.c
@@ -63,7 +63,7 @@ int mem_bkeep_free(uintptr_t addr, size_t size) {
 }
 
 void init_memory_management(void) {
-    struct pal_public_state* pal_public_state = PalGetPalPublicState();
+    const struct pal_public_state* pal_public_state = PalGetPalPublicState();
     /* Because we are looking at free space between memory ranges, we need a VMA marking the end of
      * available memory. This dummy VMA is never freed. */
     g_vmas[0] = (struct vma){

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -30,7 +30,7 @@ struct pal_public_state g_pal_public_state = {
     .initial_mem_ranges_len = 0,
 };
 
-struct pal_public_state* PalGetPalPublicState(void) {
+const struct pal_public_state* PalGetPalPublicState(void) {
     return &g_pal_public_state;
 }
 


### PR DESCRIPTION
The `g_pal_public_state` global variable is supposed to be constant. However previously, some LibOS code overwrote it which violated the original intention.

This patch adds a new object namely `g_pal_public_initial_state` (containing just a subset of `g_pal_public_state` fields), which is copied into the LibOS, only used by the parent Gramine process and later checkpointed to the child process. This guarantees `g_pal_public_state` to be constant and not overwritten by LibOS any more.

Resolves https://github.com/gramineproject/gramine/issues/872.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1026)
<!-- Reviewable:end -->
