### PR TITLE
[PAL/Linux-SGX] Rework SGX driver path resolving

### DIFF
--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -197,6 +197,13 @@ it's usually not needed.
 
 .. note::
 
+   If you have a DCAP driver installed on the system (e.g. on 18.04 Azure),
+   then you can still use the upstream driver and specify the `upstream header
+   file <https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/arch/x86/include/uapi/asm/sgx.h?h=v5.11>`__.
+   This is because the DCAP and the upstream drivers have compatible APIs.
+
+.. note::
+
    When installing from sources, Gramine executables are placed under
    ``/usr/local/bin``. Some Linux distributions (notably CentOS) do not search
    for executables under this path. If your system reports that Gramine

--- a/meson.build
+++ b/meson.build
@@ -112,19 +112,17 @@ if sgx
             '/usr/src/linux-headers-@0@/arch/x86/include/uapi'.format(
                 run_command('uname', '-r').stdout().strip()),
         ]
-        sgx_driver_device_default = '/dev/sgx_enclave'
     elif sgx_driver == 'oot'
         # old non-DCAP driver (https://github.com/intel/linux-sgx-driver)
         conf_sgx.set('CONFIG_SGX_DRIVER_OOT', true)
         sgx_driver_header = 'sgx_user.h'
-        sgx_driver_device_default = '/dev/isgx'
         sgx_driver_include_path_defaults = ['/opt/intel/linux-sgx-driver']
     else
         error('Unknown sgx_driver value')
     endif
 
-    if sgx_driver_device == ''
-        sgx_driver_device = sgx_driver_device_default
+    if sgx_driver_device != ''
+        conf_sgx.set_quoted('CONFIG_SGX_DRIVER_DEVICE', sgx_driver_device)
     endif
 
     if sgx_driver_include_path == ''
@@ -158,7 +156,6 @@ if sgx
   endif
 
     conf_sgx.set('CONFIG_SGX_DRIVER_HEADER_ABSPATH', sgx_driver_header_abspath)
-    conf_sgx.set_quoted('CONFIG_SGX_DRIVER_DEVICE', sgx_driver_device)
 endif
 
 gen_symbol_map_cmd = [

--- a/pal/src/host/linux-sgx/generated_offsets.c
+++ b/pal/src/host/linux-sgx/generated_offsets.c
@@ -181,9 +181,12 @@ const struct generated_offset generated_offsets[] = {
     DEFINE(PAL_XSTATE_ALIGN, PAL_XSTATE_ALIGN),
     DEFINE(PAL_FP_XSTATE_MAGIC2_SIZE, PAL_FP_XSTATE_MAGIC2_SIZE),
 
-    /* SGX_DCAP */
-#ifdef SGX_DCAP
-    DEFINE(SGX_DCAP, SGX_DCAP),
+    /* driver type */
+#ifdef CONFIG_SGX_DRIVER_OOT
+    DEFINE(CONFIG_SGX_DRIVER_OOT, 1),
+#endif
+#ifdef CONFIG_SGX_DRIVER_UPSTREAM
+    DEFINE(CONFIG_SGX_DRIVER_UPSTREAM, 1),
 #endif
 
     OFFSET_END,

--- a/pal/src/host/linux-sgx/host_framework.c
+++ b/pal/src/host/linux-sgx/host_framework.c
@@ -12,15 +12,32 @@ static void*  g_zero_pages      = NULL;
 static size_t g_zero_pages_size = 0;
 
 int open_sgx_driver(void) {
-    int ret = DO_SYSCALL(open, ISGX_FILE, O_RDWR | O_CLOEXEC, 0);
-    if (ret < 0) {
-        log_error("Cannot open device " ISGX_FILE ". "
-                  "Please make sure the Intel SGX kernel module is loaded.");
-        return ret;
+    const char* paths_to_try[] = {
+#ifdef CONFIG_SGX_DRIVER_DEVICE
+    /* Always try to use the device path specified in the build config first. */
+    CONFIG_SGX_DRIVER_DEVICE,
+#endif
+#if defined(CONFIG_SGX_DRIVER_OOT)
+    "/dev/isgx",
+#elif defined(CONFIG_SGX_DRIVER_UPSTREAM)
+    /* DCAP and upstreamed version used different paths in the past. */
+    "/dev/sgx_enclave",
+    "/dev/sgx/enclave",
+#else
+    #error This config should be unreachable.
+#endif
+    };
+    int ret;
+    for (size_t i = 0; i < ARRAY_SIZE(paths_to_try); i++) {
+        ret = DO_SYSCALL(open, paths_to_try[i], O_RDWR | O_CLOEXEC, 0);
+        if (ret >= 0) {
+            g_isgx_device = ret;
+            return 0;
+        }
     }
-    g_isgx_device = ret;
-
-    return 0;
+    log_error("Cannot open SGX driver device. Please make sure you're using an up-to-date kernel "
+              "or the standalone Intel SGX kernel module is loaded.");
+    return ret;
 }
 
 int read_enclave_token(int token_file, sgx_arch_token_t* token) {
@@ -39,7 +56,7 @@ int read_enclave_token(int token_file, sgx_arch_token_t* token) {
     if (bytes < 0)
         return bytes;
 
-#ifdef SGX_DCAP
+#ifndef CONFIG_SGX_DRIVER_OOT
     log_debug("Read dummy DCAP token");
 #else
     char hex[64 * 2 + 1]; /* large enough to hold any of the below fields */
@@ -112,7 +129,7 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
     uint64_t request_mmap_addr = secs->base;
     uint64_t request_mmap_size = secs->size;
 
-#ifdef SGX_DCAP
+#ifndef CONFIG_SGX_DRIVER_OOT
     /* newer DCAP/in-kernel SGX drivers allow starting enclave address space with non-zero;
      * the below trick to start from MMAP_MIN_ADDR is to avoid vm.mmap_min_addr==0 issue */
     if (request_mmap_addr < MMAP_MIN_ADDR) {
@@ -123,10 +140,10 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
 
     uint64_t addr = DO_SYSCALL(mmap, request_mmap_addr, request_mmap_size,
                                PROT_NONE, /* newer DCAP driver requires such initial mmap */
-#ifdef SGX_DCAP
-                               MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-#else
+#ifdef CONFIG_SGX_DRIVER_OOT
                                MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
+#else
+                               MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #endif
 
     if (IS_PTR_ERR(addr)) {
@@ -255,7 +272,38 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         log_debug("Adding pages to enclave: %p-%p [%s:%s] (%s)%s", addr, addr + size, t, p,
                   comment, m);
 
-#ifdef SGX_DCAP
+#ifdef CONFIG_SGX_DRIVER_OOT
+    /* legacy out-of-tree driver only supports adding one page at a time */
+    struct sgx_enclave_add_page param = {
+        .addr    = (uint64_t)addr,
+        .src     = (uint64_t)(user_addr ?: g_zero_pages),
+        .secinfo = (uint64_t)&secinfo,
+        .mrmask  = skip_eextend ? 0 : (uint16_t)-1,
+    };
+
+    uint64_t added_size = 0;
+    while (added_size < size) {
+        ret = DO_SYSCALL(ioctl, g_isgx_device, SGX_IOC_ENCLAVE_ADD_PAGE, &param);
+        if (ret < 0) {
+            if (ret == -EINTR)
+                continue;
+            log_error("Enclave EADD returned %d", ret);
+            return ret;
+        }
+
+        param.addr += g_page_size;
+        if (param.src != (uint64_t)g_zero_pages)
+            param.src += g_page_size;
+        added_size += g_page_size;
+    }
+
+    /* need to change permissions for EADDed pages since the initial mmap was with PROT_NONE */
+    ret = DO_SYSCALL(mprotect, addr, size, prot);
+    if (ret < 0) {
+        log_error("Changing protections of EADDed pages returned %d", ret);
+        return ret;
+    }
+#else
     if (!user_addr && g_zero_pages_size < size) {
         /* not enough contigious zero pages to back up enclave pages, allocate more */
         /* TODO: this logic can be removed if we introduce a size cap in ENCLAVE_ADD_PAGES ioctl */
@@ -275,7 +323,6 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         g_zero_pages_size = size;
     }
 
-    /* newer DCAP driver (version 1.6+) allows adding a range of pages for performance, use it */
     struct sgx_enclave_add_pages param = {
         .offset  = (uint64_t)addr - secs->base,
         .src     = (uint64_t)(user_addr ?: g_zero_pages),
@@ -325,45 +372,14 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         log_error("Cannot map enclave pages %d", ret);
         return ret;
     }
-#else
-    /* older drivers (DCAP v1.5- and old out-of-tree) only supports adding one page at a time */
-    struct sgx_enclave_add_page param = {
-        .addr    = (uint64_t)addr,
-        .src     = (uint64_t)(user_addr ?: g_zero_pages),
-        .secinfo = (uint64_t)&secinfo,
-        .mrmask  = skip_eextend ? 0 : (uint16_t)-1,
-    };
-
-    uint64_t added_size = 0;
-    while (added_size < size) {
-        ret = DO_SYSCALL(ioctl, g_isgx_device, SGX_IOC_ENCLAVE_ADD_PAGE, &param);
-        if (ret < 0) {
-            if (ret == -EINTR)
-                continue;
-            log_error("Enclave EADD returned %d", ret);
-            return ret;
-        }
-
-        param.addr += g_page_size;
-        if (param.src != (uint64_t)g_zero_pages)
-            param.src += g_page_size;
-        added_size += g_page_size;
-    }
-
-    /* need to change permissions for EADDed pages since the initial mmap was with PROT_NONE */
-    ret = DO_SYSCALL(mprotect, addr, size, prot);
-    if (ret < 0) {
-        log_error("Changing protections of EADDed pages returned %d", ret);
-        return ret;
-    }
-#endif /* SGX_DCAP */
+#endif /* CONFIG_SGX_DRIVER_OOT */
 
     return 0;
 }
 
 int init_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct,
                  sgx_arch_token_t* token) {
-#ifdef SGX_DCAP
+#ifndef CONFIG_SGX_DRIVER_OOT
     __UNUSED(token);
 #endif
     unsigned long enclave_valid_addr = secs->base + secs->size - g_page_size;
@@ -376,11 +392,11 @@ int init_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct,
                                                 hex, sizeof(hex)));
 
     struct sgx_enclave_init param = {
-#ifndef SGX_DCAP
+#ifdef CONFIG_SGX_DRIVER_OOT
         .addr = enclave_valid_addr,
 #endif
         .sigstruct = (uint64_t)sigstruct,
-#ifndef SGX_DCAP
+#ifdef CONFIG_SGX_DRIVER_OOT
         .einittoken = (uint64_t)token,
 #endif
     };

--- a/pal/src/host/linux-sgx/host_sgx_driver.h.in
+++ b/pal/src/host/linux-sgx/host_sgx_driver.h.in
@@ -19,12 +19,6 @@
 
 #mesondefine CONFIG_SGX_DRIVER_DEVICE
 
-#if !defined(CONFIG_SGX_DRIVER_OOT)
-#define SGX_DCAP 1
-#endif
-
-#define ISGX_FILE CONFIG_SGX_DRIVER_DEVICE
-
 /* Gramine needs the below subset of SGX instructions' return values */
 #ifndef SGX_INVALID_SIG_STRUCT
 #define SGX_INVALID_SIG_STRUCT  1

--- a/python/graminelibos/sgx_get_token.py
+++ b/python/graminelibos/sgx_get_token.py
@@ -41,9 +41,9 @@ def get_optional_sgx_features(sig):
 
     return new_xfrms
 
-def is_dcap():
-    '''Check if we're dealing with DCAP driver.'''
-    return hasattr(offs, 'SGX_DCAP')
+def is_oot():
+    '''Check if we're dealing with OOT driver.'''
+    return hasattr(offs, 'CONFIG_SGX_DRIVER_OOT')
 
 def p64(x):
     return x.to_bytes(8, byteorder='little')
@@ -145,9 +145,9 @@ def get_token(sig, verbose=False):
         print(f'    date:        {sig["date_year"]:04d}-{sig["date_month"]:02d}-'
               f'{sig["date_day"]:02d}')
 
-    if is_dcap():
-        token = create_dummy_token(sig['attribute_flags'], xfrms, sig['misc_select'])
-    else:
+    if is_oot():
         token = connect_aesmd(sig['enclave_hash'], sig['modulus'], sig['attribute_flags'], xfrms)
+    else:
+        token = create_dummy_token(sig['attribute_flags'], xfrms, sig['misc_select'])
 
     return token


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Continuation of https://github.com/gramineproject/gramine/pull/997, where we planned to move resolving of DCAP/upstream driver paths to the runtime, so that we can have a single build supporting both the upstreamed driver and the legacy DCAP one.

## How to test this PR? <!-- (if applicable) -->

Same as with https://github.com/gramineproject/gramine/pull/997, please run on different drivers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1027)
<!-- Reviewable:end -->
