### PR TITLE
Implement SO_REUSEPORT support

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -92,6 +92,7 @@ struct cmsghdr {
 #define SO_RCVBUF 8
 #define SO_KEEPALIVE 9
 #define SO_LINGER 13
+#define SO_REUSEPORT 15
 #define SO_RCVTIMEO 20
 #define SO_SNDTIMEO 21
 #define SO_ACCEPTCONN 30

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -76,8 +76,8 @@ enum libos_sock_state {
 
 /*
  * Access to `state`, `remote_addr`, `remote_addrlen`, `local_addr`, `local_addrlen, `last_error`,
- * `sendtimeout_us`, `receivetimeout_us`, `can_be_read`, `can_be_written` and `was_bound` are
- * protected by `lock`.
+ * `sendtimeout_us`, `receivetimeout_us`, `can_be_read`, `can_be_written`, `was_bound`, `reuseaddr`,
+ * `reuseport` and `broadcast` are protected by `lock`.
  * `ops`, `domain`, `type` and `protocol` are read-only and do not need any locking.
  * Access to `peek` struct is protected by `recv_lock`. This lock also ensures proper ordering of
  * stream reads (see the comment in `do_recvmsg` in "libos/src/sys/libos_socket.c").
@@ -120,6 +120,7 @@ struct libos_sock_handle {
     /* Same as above but for `send`/`write`. */
     bool can_be_written;
     bool reuseaddr;
+    bool reuseport;
     bool broadcast;
 };
 

--- a/libos/src/net/ip.c
+++ b/libos/src/net/ip.c
@@ -388,6 +388,9 @@ static int set_socket_option(struct libos_handle* handle, int optname, void* opt
         case SO_REUSEADDR:
             required_len = sizeof(int);
             break;
+        case SO_REUSEPORT:
+            required_len = sizeof(int);
+            break;
         case SO_BROADCAST:
             required_len = sizeof(int);
             break;
@@ -456,6 +459,9 @@ static int set_socket_option(struct libos_handle* handle, int optname, void* opt
         case SO_REUSEADDR:
             attr.socket.reuseaddr = value.i;
             break;
+        case SO_REUSEPORT:
+            attr.socket.reuseport = value.i;
+            break;
         case SO_BROADCAST:
             if (sock->type == SOCK_STREAM) {
                 /* This option has no effect on stream-oriented sockets. */
@@ -476,6 +482,9 @@ static int set_socket_option(struct libos_handle* handle, int optname, void* opt
     switch (optname) {
         case SO_REUSEADDR:
             sock->reuseaddr = attr.socket.reuseaddr;
+            break;
+        case SO_REUSEPORT:
+            sock->reuseport = attr.socket.reuseport;
             break;
         case SO_BROADCAST:
             sock->broadcast = attr.socket.broadcast;

--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -63,6 +63,7 @@ struct libos_handle* get_new_socket_handle(int family, int type, int protocol,
     sock->can_be_read = false;
     sock->can_be_written = false;
     sock->reuseaddr = false;
+    sock->reuseport = false;
     sock->broadcast = false;
     switch (family) {
         case AF_UNIX:
@@ -1307,6 +1308,9 @@ static int get_socket_option(struct libos_handle* handle, int optname, char* opt
             break;
         case SO_REUSEADDR:
             value.i = sock->reuseaddr;
+            break;
+        case SO_REUSEPORT:
+            value.i = sock->reuseport;
             break;
         case SO_BROADCAST:
             value.i = sock->broadcast;

--- a/libos/test/regression/tcp_ipv6_v6only.c
+++ b/libos/test/regression/tcp_ipv6_v6only.c
@@ -1,3 +1,4 @@
+#define _DEFAULT_SOURCE
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netinet/in.h>
@@ -118,6 +119,20 @@ int main(int argc, char** argv) {
     if (ret != -1 || errno != EADDRINUSE) {
         fprintf(stderr,
                 "bind(ipv4) was successful even though there is no IPV6_V6ONLY on same port\n");
+        return 1;
+    }
+
+    if (setsockopt(socket_ipv6, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable)) < 0) {
+        perror("setsockopt(ipv6, SO_REUSEPORT = 1)");
+        return 1;
+    }
+    if (setsockopt(socket_ipv4, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable)) < 0) {
+        perror("setsockopt(ipv4, SO_REUSEPORT = 1)");
+        return 1;
+    }
+
+    if (bind(socket_ipv4, (struct sockaddr*)&address_ipv4, sizeof(address_ipv4)) < 0) {
+        perror("bind(ipv4) failed even though SO_REUSEPORT has been called on both sockets");
         return 1;
     }
 

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -475,6 +475,7 @@ typedef struct _PAL_STREAM_ATTR {
             size_t send_buf_size;
             uint64_t receivetimeout_us, sendtimeout_us;
             bool reuseaddr;
+            bool reuseport;
             bool keepalive;
             bool broadcast;
             bool tcp_cork;

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -98,6 +98,7 @@ typedef struct {
             uint64_t sendtimeout_us;
             bool is_nonblocking;
             bool reuseaddr;
+            bool reuseport;
             bool keepalive;
             bool broadcast;
             bool tcp_cork;

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -80,6 +80,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.sendtimeout_us = 0;
     handle->sock.is_nonblocking = is_nonblocking;
     handle->sock.reuseaddr = false;
+    handle->sock.reuseport = false;
     handle->sock.keepalive = false;
     handle->sock.broadcast = false;
     handle->sock.tcp_cork = false;
@@ -294,6 +295,7 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.receivetimeout_us = handle->sock.recvtimeout_us;
     attr->socket.sendtimeout_us = handle->sock.sendtimeout_us;
     attr->socket.reuseaddr = handle->sock.reuseaddr;
+    attr->socket.reuseport = handle->sock.reuseport;
     attr->socket.keepalive = handle->sock.keepalive;
     attr->socket.broadcast = handle->sock.broadcast;
     attr->socket.tcp_cork = handle->sock.tcp_cork;
@@ -404,6 +406,15 @@ static int attrsetbyhdl_common(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
         }
         handle->sock.reuseaddr = attr->socket.reuseaddr;
+    }
+
+    if (attr->socket.reuseport != handle->sock.reuseport) {
+        int val = attr->socket.reuseport;
+        int ret = ocall_setsockopt(handle->sock.fd, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.reuseport = attr->socket.reuseport;
     }
 
     if (attr->socket.broadcast != handle->sock.broadcast) {

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -75,6 +75,7 @@ typedef struct {
             uint64_t sendtimeout_us;
             bool is_nonblocking;
             bool reuseaddr;
+            bool reuseport;
             bool broadcast;
             bool keepalive;
             bool tcp_cork;

--- a/pal/src/host/linux/pal_sockets.c
+++ b/pal/src/host/linux/pal_sockets.c
@@ -71,6 +71,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.sendtimeout_us = 0;
     handle->sock.is_nonblocking = is_nonblocking;
     handle->sock.reuseaddr = false;
+    handle->sock.reuseport = false;
     handle->sock.broadcast = false;
     handle->sock.keepalive = false;
     handle->sock.tcp_cork = false;
@@ -326,6 +327,7 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.receivetimeout_us = handle->sock.recvtimeout_us;
     attr->socket.sendtimeout_us = handle->sock.sendtimeout_us;
     attr->socket.reuseaddr = handle->sock.reuseaddr;
+    attr->socket.reuseport = handle->sock.reuseport;
     attr->socket.broadcast = handle->sock.broadcast;
     attr->socket.keepalive = handle->sock.keepalive;
     attr->socket.tcp_cork = handle->sock.tcp_cork;
@@ -449,6 +451,16 @@ static int attrsetbyhdl_common(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
         }
         handle->sock.reuseaddr = attr->socket.reuseaddr;
+    }
+
+    if (attr->socket.reuseport != handle->sock.reuseport) {
+        int val = attr->socket.reuseport;
+        int ret = DO_SYSCALL(setsockopt, handle->sock.fd, SOL_SOCKET, SO_REUSEPORT, &val,
+                             sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.reuseport = attr->socket.reuseport;
     }
 
     if (attr->socket.broadcast != handle->sock.broadcast) {


### PR DESCRIPTION
This PR adds support for the SO_REUSEPORT option in Gramine.
This PR is related to issues #238,  #361 and #763.

A regression test has been added to the `tcp_ipv6_v6only.c` file. Please let me know if other tests are needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1031)
<!-- Reviewable:end -->
