### PR TITLE
Make logs more verbose (add file, line, number and function information)

### DIFF
--- a/common/include/callbacks.h
+++ b/common/include/callbacks.h
@@ -45,7 +45,8 @@
  *
  * Used by `log_*` macros in `log.h`.
  */
-void _log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+void _log(int level, const char* file, const char* func, uint64_t line,
+          const char* fmt, ...) __attribute__((format(printf, 5, 6)));
 
 /*
  * Terminate the process. Should perform an equivalent of `_exit(ENOTRECOVERABLE)`.

--- a/common/include/log.h
+++ b/common/include/log.h
@@ -14,9 +14,31 @@ enum {
     LOG_LEVEL_ALL     = 5,
 };
 
+/*
+ * __FILE_NAME__ was introduced in GCC12 and clang9.
+ * If it's not defined we have to do our own magic.
+ */
+#ifndef __FILE_NAME__
+static inline const char* truncate_file_name(const char* filename) {
+    const char* ret = filename;
+
+    while (*filename != '\0') {
+        if (*filename == '/') {
+            ret = filename + 1;
+        }
+        filename++;
+    }
+
+    return ret;
+}
+
+#define __FILE_NAME__ (truncate_file_name(__FILE__))
+#endif
+
 /* All of them implicitly append a newline at the end of the message. */
-#define log_always(fmt...)   _log(LOG_LEVEL_NONE, fmt)
-#define log_error(fmt...)    _log(LOG_LEVEL_ERROR, fmt)
-#define log_warning(fmt...)  _log(LOG_LEVEL_WARNING, fmt)
-#define log_debug(fmt...)    _log(LOG_LEVEL_DEBUG, fmt)
-#define log_trace(fmt...)    _log(LOG_LEVEL_TRACE, fmt)
+#define log_always(fmt...)   _log(LOG_LEVEL_NONE, __FILE_NAME__, __func__, __LINE__, fmt)
+#define log_error(fmt...)    _log(LOG_LEVEL_ERROR, __FILE_NAME__, __func__, __LINE__, fmt)
+#define log_warning(fmt...)  _log(LOG_LEVEL_WARNING, __FILE_NAME__, __func__, __LINE__, fmt)
+#define log_debug(fmt...)    _log(LOG_LEVEL_DEBUG, __FILE_NAME__, __func__, __LINE__, fmt)
+
+#define log_trace(fmt...)    _log(LOG_LEVEL_TRACE, __FILE_NAME__, __func__, __LINE__, fmt)

--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -27,12 +27,8 @@ extern struct pal_public_state* g_pal_public_state;
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
-void libos_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-
-#define DEBUG_HERE()                                             \
-    do {                                                         \
-        log_debug("%s (" __FILE__ ":%d)", __func__, __LINE__);   \
-    } while (0)
+void libos_log(int level, const char* file, const char* func, uint64_t line,
+               const char* fmt, ...) __attribute__((format(printf, 5, 6)));
 
 /*!
  * \brief High-level syscall emulation entrypoint.

--- a/libos/include/libos_refcount.h
+++ b/libos/include/libos_refcount.h
@@ -38,4 +38,4 @@ static inline refcount_t _refcount_dec(refcount_t* ref, const char* fname, size_
     return new_count;
 }
 
-#define refcount_dec(ref) _refcount_dec((ref), __FILE__, __LINE__)
+#define refcount_dec(ref) _refcount_dec((ref), __FILE_NAME__, __LINE__)

--- a/libos/src/bookkeep/libos_pid.c
+++ b/libos/src/bookkeep/libos_pid.c
@@ -70,7 +70,7 @@ IDTYPE get_new_id(IDTYPE move_ownership_to) {
     if (!g_last_range) {
         g_last_range = malloc(sizeof(*g_last_range));
         if (!g_last_range) {
-            log_debug("OOM in %s:%d", __FILE__, __LINE__);
+            log_debug("OOM");
             goto out;
         }
         IDTYPE start;
@@ -113,7 +113,7 @@ IDTYPE get_new_id(IDTYPE move_ownership_to) {
         } else {
             struct id_range* range = malloc(sizeof(*range));
             if (!range) {
-                log_debug("OOM in %s:%d", __FILE__, __LINE__);
+                log_debug("OOM");
                 g_last_used_id--;
                 ret_id = 0;
                 goto out;
@@ -128,7 +128,7 @@ IDTYPE get_new_id(IDTYPE move_ownership_to) {
         }
         if (ipc_change_id_owner(ret_id, move_ownership_to) < 0) {
             /* Good luck unwinding all of above operations. Better just kill everything. */
-            log_error("Unrecoverable error in %s:%d", __FILE__, __LINE__);
+            log_error("Unrecoverable error");
             PalProcessExit(1);
         }
     } else {

--- a/libos/src/fs/libos_fs_util.c
+++ b/libos/src/fs/libos_fs_util.c
@@ -175,8 +175,7 @@ int generic_emulated_mmap(struct libos_handle* hdl, void* addr, size_t size, int
 err:;
     int free_ret = PalVirtualMemoryFree(addr, size);
     if (free_ret < 0) {
-        log_debug("%s: PalVirtualMemoryFree failed on cleanup: %s", __func__,
-                  pal_strerror(free_ret));
+        log_debug("PalVirtualMemoryFree failed on cleanup: %s", pal_strerror(free_ret));
         BUG();
     }
     return ret;
@@ -213,7 +212,7 @@ int generic_emulated_msync(struct libos_handle* hdl, void* addr, size_t size, in
         }
 
         if (count == 0) {
-            log_debug("%s: Failed to write back the whole mapping", __func__);
+            log_debug("Failed to write back the whole mapping");
             ret = -EIO;
             goto out;
         }
@@ -229,8 +228,7 @@ out:
     if (pal_prot != pal_prot_readable) {
         int protect_ret = PalVirtualMemoryProtect(addr, size, pal_prot);
         if (protect_ret < 0) {
-            log_debug("%s: PalVirtualMemoryProtect failed on cleanup: %s", __func__,
-                      pal_strerror(protect_ret));
+            log_debug("PalVirtualMemoryProtect failed on cleanup: %s", pal_strerror(protect_ret));
             BUG();
         }
     }

--- a/libos/src/ipc/libos_ipc.c
+++ b/libos/src/ipc/libos_ipc.c
@@ -215,7 +215,7 @@ static int ipc_send_message_to_conn(struct libos_ipc_connection* conn, struct li
     lock(&conn->lock);
     if (conn->seen_error) {
         ret = conn->seen_error;
-        log_debug("%s: returning previously seen error: %s", __func__, unix_strerror(ret));
+        log_debug("returning previously seen error: %s", unix_strerror(ret));
         goto out;
     }
 

--- a/libos/src/ipc/libos_ipc_pid.c
+++ b/libos/src/ipc/libos_ipc_pid.c
@@ -250,7 +250,7 @@ int ipc_alloc_id_range(IDTYPE* out_start, IDTYPE* out_end) {
     }
     init_ipc_msg(msg, IPC_MSG_ALLOC_ID_RANGE, msg_size);
 
-    log_debug("%s: sending a request", __func__);
+    log_debug("sending a request");
 
     void* resp = NULL;
     int ret = ipc_send_msg_and_get_response(g_process_ipc_ids.leader_vmid, msg, &resp);
@@ -267,7 +267,7 @@ int ipc_alloc_id_range(IDTYPE* out_start, IDTYPE* out_end) {
         ret = -EAGAIN;
     }
 
-    log_debug("%s: got a response: [%u..%u]", __func__, range->start, range->end);
+    log_debug("got a response: [%u..%u]", range->start, range->end);
 
 out:
     free(resp);
@@ -285,7 +285,7 @@ int ipc_alloc_id_range_callback(IDTYPE src, void* data, uint64_t seq) {
         end = 0;
     }
 
-    log_debug("%s: %d (%s)", __func__, ret, unix_strerror(ret));
+    log_debug("alloc_id_range: %s", unix_strerror(ret));
 
     struct ipc_id_range_msg range = {
         .start = start,
@@ -317,10 +317,10 @@ int ipc_release_id_range(IDTYPE start, IDTYPE end) {
     init_ipc_msg(msg, IPC_MSG_RELEASE_ID_RANGE, msg_size);
     memcpy(&msg->data, &range, sizeof(range));
 
-    log_debug("%s: sending a request: [%u..%u]", __func__, start, end);
+    log_debug("sending a request: [%u..%u]", start, end);
 
     int ret = ipc_send_message(g_process_ipc_ids.leader_vmid, msg);
-    log_debug("%s: ipc_send_message: %s", __func__, unix_strerror(ret));
+    log_debug("ipc_send_message: %s", unix_strerror(ret));
     free(msg);
     return ret;
 }
@@ -330,7 +330,7 @@ int ipc_release_id_range_callback(IDTYPE src, void* data, uint64_t seq) {
     __UNUSED(seq);
     struct ipc_id_range_msg* range = data;
     release_id_range(range->start, range->end);
-    log_debug("%s: release_id_range(%u..%u)", __func__, range->start, range->end);
+    log_debug("release_id_range(%u..%u)", range->start, range->end);
     return 0;
 }
 
@@ -351,10 +351,10 @@ int ipc_change_id_owner(IDTYPE id, IDTYPE new_owner) {
     init_ipc_msg(msg, IPC_MSG_CHANGE_ID_OWNER, msg_size);
     memcpy(&msg->data, &owner_msg, sizeof(owner_msg));
 
-    log_debug("%s: sending a request (%u, %u)", __func__, id, new_owner);
+    log_debug("sending a request (%u, %u)", id, new_owner);
 
     int ret = ipc_send_msg_and_get_response(g_process_ipc_ids.leader_vmid, msg, /*resp=*/NULL);
-    log_debug("%s: ipc_send_msg_and_get_response: %s", __func__, unix_strerror(ret));
+    log_debug("ipc_send_msg_and_get_response: %s", unix_strerror(ret));
     free(msg);
     return ret;
 }
@@ -362,8 +362,7 @@ int ipc_change_id_owner(IDTYPE id, IDTYPE new_owner) {
 int ipc_change_id_owner_callback(IDTYPE src, void* data, uint64_t seq) {
     struct ipc_id_owner_msg* owner_msg = data;
     int ret = change_id_owner(owner_msg->id, owner_msg->owner);
-    log_debug("%s: change_id_owner(%u, %u): %s", __func__, owner_msg->id, owner_msg->owner,
-              unix_strerror(ret));
+    log_debug("change_id_owner(%u, %u): %s", owner_msg->id, owner_msg->owner, unix_strerror(ret));
     if (ret < 0) {
         return ret;
     }
@@ -389,7 +388,7 @@ int ipc_get_id_owner(IDTYPE id, IDTYPE* out_owner) {
     init_ipc_msg(msg, IPC_MSG_GET_ID_OWNER, msg_size);
     memcpy(&msg->data, &id, sizeof(id));
 
-    log_debug("%s: sending a request: %u", __func__, id);
+    log_debug("sending a request: %u", id);
 
     void* resp = NULL;
     int ret = ipc_send_msg_and_get_response(g_process_ipc_ids.leader_vmid, msg, &resp);
@@ -400,7 +399,7 @@ int ipc_get_id_owner(IDTYPE id, IDTYPE* out_owner) {
     *out_owner = *(IDTYPE*)resp;
     ret = 0;
 
-    log_debug("%s: got a response: %u", __func__, *out_owner);
+    log_debug("got a response: %u", *out_owner);
 
 out:
     free(resp);
@@ -411,7 +410,7 @@ out:
 int ipc_get_id_owner_callback(IDTYPE src, void* data, uint64_t seq) {
     IDTYPE* id = data;
     IDTYPE owner = find_id_owner(*id);
-    log_debug("%s: find_id_owner(%u): %u", __func__, *id, owner);
+    log_debug("find_id_owner(%u): %u", *id, owner);
 
     size_t msg_size = get_ipc_msg_size(sizeof(owner));
     struct libos_ipc_msg* msg = __alloca(msg_size);

--- a/libos/src/ipc/libos_ipc_vmid.c
+++ b/libos/src/ipc/libos_ipc_vmid.c
@@ -27,7 +27,7 @@ int ipc_get_new_vmid(IDTYPE* vmid) {
     }
     init_ipc_msg(msg, IPC_MSG_GET_NEW_VMID, msg_size);
 
-    log_debug("%s: sending a request", __func__);
+    log_debug("sending a request");
 
     void* resp = NULL;
     int ret = ipc_send_msg_and_get_response(g_process_ipc_ids.leader_vmid, msg, &resp);
@@ -37,7 +37,7 @@ int ipc_get_new_vmid(IDTYPE* vmid) {
 
     *vmid = *(IDTYPE*)resp;
     ret = 0;
-    log_debug("%s: got a response: %u", __func__, *vmid);
+    log_debug("got a response: %u", *vmid);
 
 out:
     free(resp);
@@ -49,7 +49,7 @@ int ipc_get_new_vmid_callback(IDTYPE src, void* data, uint64_t seq) {
     __UNUSED(data);
     IDTYPE vmid = get_next_vmid();
 
-    log_debug("%s: %u", __func__, vmid);
+    log_debug("vmid: %u", vmid);
 
     size_t msg_size = get_ipc_msg_size(sizeof(vmid));
     struct libos_ipc_msg* msg = __alloca(msg_size);

--- a/libos/src/libos_debug.c
+++ b/libos/src/libos_debug.c
@@ -91,7 +91,7 @@ void remove_r_debug(void* addr) {
         goto out;
     }
 
-    log_debug("%s: removing %s at %p", __func__, m->l_name, addr);
+    log_debug("removing %s at %p", m->l_name, addr);
     LISTP_DEL(m, &g_link_map_list, list);
     PalDebugMapRemove(addr);
     free(m);
@@ -105,20 +105,20 @@ void append_r_debug(const char* uri, void* addr) {
 
     struct gdb_link_map* new = malloc(sizeof(struct gdb_link_map));
     if (!new) {
-        log_warning("%s: couldn't allocate map", __func__);
+        log_warning("couldn't allocate map");
         goto out;
     }
 
     char* new_uri = strdup(uri);
     if (!new_uri) {
-        log_warning("%s: couldn't allocate uri", __func__);
+        log_warning("couldn't allocate uri");
         goto out;
     }
 
     new->l_addr = addr;
     new->l_name = new_uri;
 
-    log_debug("%s: adding %s at %p", __func__, uri, addr);
+    log_debug("adding %s at %p", uri, addr);
     LISTP_ADD_TAIL(new, &g_link_map_list, list);
     PalDebugMapAdd(uri, addr);
 

--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -16,7 +16,7 @@ int create_pollable_event(struct libos_pollable_event* event) {
     int ret = create_pipe(/*name=*/NULL, uri, sizeof(uri), &srv_handle,
                           /*use_vmid_for_name=*/false);
     if (ret < 0) {
-        log_error("%s: create_pipe failed: %s", __func__, unix_strerror(ret));
+        log_error("create_pipe failed: %s", unix_strerror(ret));
         return ret;
     }
 
@@ -26,7 +26,7 @@ int create_pollable_event(struct libos_pollable_event* event) {
                             PAL_OPTION_NONBLOCK, &write_handle);
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
-        log_error("%s: PalStreamOpen failed: %s", __func__, pal_strerror(ret));
+        log_error("PalStreamOpen failed: %s", pal_strerror(ret));
         ret = pal_to_unix_errno(ret);
         goto out;
     }
@@ -36,7 +36,7 @@ int create_pollable_event(struct libos_pollable_event* event) {
         ret = PalStreamWaitForClient(srv_handle, &read_handle, PAL_OPTION_NONBLOCK);
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
-        log_error("%s: PalStreamWaitForClient failed: %s", __func__, pal_strerror(ret));
+        log_error("PalStreamWaitForClient failed: %s", pal_strerror(ret));
         PalObjectClose(write_handle);
         ret = pal_to_unix_errno(ret);
         goto out;

--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -138,22 +138,22 @@ static int read_loadcmd(const elf_phdr_t* ph, struct loadcmd* c) {
 
     if (ph->p_align > 1) {
         if (!IS_POWER_OF_2(ph->p_align)) {
-            log_debug("%s: ELF load command alignment value is not a power of 2", __func__);
+            log_debug("ELF load command alignment value is not a power of 2");
             return -EINVAL;
         }
         if (!IS_ALIGNED_POW2(ph->p_vaddr - ph->p_offset, ph->p_align)) {
-            log_debug("%s: ELF load command address/offset not properly aligned", __func__);
+            log_debug("ELF load command address/offset not properly aligned");
             return -EINVAL;
         }
     }
 
     if (!IS_ALLOC_ALIGNED(ph->p_vaddr - ph->p_offset)) {
-        log_debug("%s: ELF load command address/offset not page-aligned", __func__);
+        log_debug("ELF load command address/offset not page-aligned");
         return -EINVAL;
     }
 
     if (ph->p_filesz > ph->p_memsz) {
-        log_debug("%s: file size larger than memory size", __func__);
+        log_debug("file size larger than memory size");
         return -EINVAL;
     }
 
@@ -190,7 +190,7 @@ static int read_all_loadcmds(const elf_phdr_t* phdr, size_t phnum, size_t* n_loa
     }
 
     if ((*loadcmds = malloc(n * sizeof(**loadcmds))) == NULL) {
-        log_debug("%s: failed to allocate memory", __func__);
+        log_debug("failed to allocate memory");
         return -ENOMEM;
     }
 
@@ -199,7 +199,7 @@ static int read_all_loadcmds(const elf_phdr_t* phdr, size_t phnum, size_t* n_loa
     for (ph = phdr; ph < &phdr[phnum]; ph++) {
         if (ph->p_type == PT_LOAD) {
             if (ph_prev && !(ph_prev->p_vaddr < ph->p_vaddr)) {
-                log_debug("%s: PT_LOAD segments are not in ascending order", __func__);
+                log_debug("PT_LOAD segments are not in ascending order");
                 ret = -EINVAL;
                 goto err;
             }
@@ -259,13 +259,13 @@ static int execute_loadcmd(const struct loadcmd* c, elf_addr_t base_diff,
 
         if ((ret = bkeep_mmap_fixed(map_start, map_size, c->prot, map_flags, file, c->map_off,
                                     /*comment=*/NULL)) < 0) {
-            log_debug("%s: failed to bookkeep address of segment", __func__);
+            log_debug("failed to bookkeep address of segment");
             return ret;
         }
 
         if ((ret = file->fs->fs_ops->mmap(file, map_start, map_size, c->prot, map_flags,
                                           c->map_off)) < 0) {
-            log_debug("%s: failed to map segment: %s", __func__, unix_strerror(ret));
+            log_debug("failed to map segment: %s", unix_strerror(ret));
             return ret;
         }
     }
@@ -280,7 +280,7 @@ static int execute_loadcmd(const struct loadcmd* c, elf_addr_t base_diff,
         if ((c->prot & PROT_WRITE) == 0) {
             if ((ret = PalVirtualMemoryProtect(last_page_start, ALLOC_ALIGNMENT,
                                                pal_prot | PAL_PROT_WRITE) < 0)) {
-                log_debug("%s: cannot change memory protections", __func__);
+                log_debug("cannot change memory protections");
                 return pal_to_unix_errno(ret);
             }
         }
@@ -289,7 +289,7 @@ static int execute_loadcmd(const struct loadcmd* c, elf_addr_t base_diff,
 
         if ((c->prot & PROT_WRITE) == 0) {
             if ((ret = PalVirtualMemoryProtect(last_page_start, ALLOC_ALIGNMENT, pal_prot) < 0)) {
-                log_debug("%s: cannot change memory protections", __func__);
+                log_debug("cannot change memory protections");
                 return pal_to_unix_errno(ret);
             }
         }
@@ -304,12 +304,12 @@ static int execute_loadcmd(const struct loadcmd* c, elf_addr_t base_diff,
 
         if ((ret = bkeep_mmap_fixed(zero_page_start, zero_page_size, c->prot, zero_map_flags,
                                     /*file=*/NULL, /*offset=*/0, /*comment=*/NULL)) < 0) {
-            log_debug("%s: cannot bookkeep address of zero-fill pages", __func__);
+            log_debug("cannot bookkeep address of zero-fill pages");
             return ret;
         }
 
         if ((ret = PalVirtualMemoryAlloc(zero_page_start, zero_page_size, zero_pal_prot)) < 0) {
-            log_debug("%s: cannot map zero-fill pages", __func__);
+            log_debug("cannot map zero-fill pages");
             return pal_to_unix_errno(ret);
         }
     }
@@ -894,11 +894,11 @@ static int find_interp(const char* interp_name, struct libos_dentry** out_dent) 
         size_t path_len = strlen(*path);
         char* interp_path = alloc_concat3(*path, path_len, "/", 1, filename, filename_len);
         if (!interp_path) {
-            log_warning("%s: couldn't allocate path: %s/%s", __func__, *path, filename);
+            log_warning("couldn't allocate path: %s/%s", *path, filename);
             return -ENOMEM;
         }
 
-        log_debug("%s: searching for interpreter: %s", __func__, interp_path);
+        log_debug("searching for interpreter: %s", interp_path);
         struct libos_dentry* dent;
         int ret = path_lookupat(/*start=*/NULL, interp_path, LOOKUP_FOLLOW, &dent);
         if (ret == 0) {

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -381,8 +381,7 @@ again:
             int tmp_ret = PalStreamAttributesQueryByHandle(pal_handle, &attr);
             if (tmp_ret < 0) {
                 unlock(&handle->lock);
-                log_error("%s: nonblocking restore: failed to get handle attrs: %s", __func__,
-                          pal_strerror(tmp_ret));
+                log_error("nonblocking restore: failed to get handle attrs: %s", pal_strerror(tmp_ret));
                 PalProcessExit(1);
             }
             assert(attr.nonblocking);
@@ -390,8 +389,7 @@ again:
             tmp_ret = PalStreamAttributesSetByHandle(pal_handle, &attr);
             if (tmp_ret < 0) {
                 unlock(&handle->lock);
-                log_error("%s: nonblocking restore: failed to set handle attrs: %s", __func__,
-                          pal_strerror(tmp_ret));
+                log_error("nonblocking restore: failed to set handle attrs: %s", pal_strerror(tmp_ret));
                 PalProcessExit(1);
             }
         }

--- a/libos/src/sys/libos_epoll.c
+++ b/libos/src/sys/libos_epoll.c
@@ -137,7 +137,7 @@ void interrupt_epolls(struct libos_handle* handle) {
         items = malloc(items_count * sizeof(*items));
         if (!items) {
             unlock(&handle->lock);
-            log_error("%s: failed to allocate memory for the epoll items array", __func__);
+            log_error("failed to allocate memory for the epoll items array");
             /* No way to handle this cleanly. */
             PalProcessExit(1);
         }

--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -90,7 +90,7 @@ long libos_syscall_socket(int family, int type, int protocol) {
         case AF_INET6:
             break;
         default:
-            log_warning("%s: unsupported socket domain %d", __func__, family);
+            log_warning("unsupported socket domain %d", family);
             return -EAFNOSUPPORT;
     }
 
@@ -107,7 +107,7 @@ long libos_syscall_socket(int family, int type, int protocol) {
         case SOCK_DGRAM:
             break;
         default:
-            log_warning("%s: unsupported socket type %d", __func__, type);
+            log_warning("unsupported socket type %d", type);
             return -EPROTONOSUPPORT;
     }
 
@@ -138,7 +138,7 @@ long libos_syscall_socketpair(int family, int type, int protocol, int* sv) {
 
     type &= SOCK_TYPE_MASK;
     if (type != SOCK_STREAM) {
-        log_warning("%s: unsupported socket type %d", __func__, type);
+        log_warning("unsupported socket type %d", type);
         return -EPROTONOSUPPORT;
     }
 
@@ -625,11 +625,11 @@ ssize_t do_sendmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_le
 
     if (flags & MSG_MORE) {
         if (sock->type != SOCK_STREAM) {
-            log_warning("%s: MSG_MORE on non-TCP sockets is not supported", __func__);
+            log_warning("MSG_MORE on non-TCP sockets is not supported");
             return -EOPNOTSUPP;
         }
         if (FIRST_TIME())
-            log_debug("%s: MSG_MORE on TCP sockets is ignored", __func__);
+            log_debug("MSG_MORE on TCP sockets is ignored");
     }
 
     lock(&sock->lock);
@@ -668,7 +668,7 @@ out:
             .si_code = SI_USER,
         };
         if (kill_current_proc(&info) < 0) {
-            log_error("%s: failed to deliver a signal", __func__);
+            log_error("failed to deliver a signal");
         }
     }
     if (ret == -EINTR) {
@@ -826,7 +826,7 @@ ssize_t do_recvmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_le
 
     if (*flags & MSG_PEEK) {
         if (sock->type != SOCK_STREAM) {
-            log_warning("%s: MSG_PEEK on non stream sockets is not supported", __func__);
+            log_warning("MSG_PEEK on non stream sockets is not supported");
             ret = -EOPNOTSUPP;
             goto out;
         }

--- a/libos/src/utils/log.c
+++ b/libos/src/utils/log.c
@@ -81,9 +81,13 @@ static int buf_write_all(const char* str, size_t size, void* arg) {
     return 0;
 }
 
-void libos_log(int level, const char* fmt, ...) {
+void libos_log(int level, const char* file, const char* func, uint64_t line, const char* fmt, ...) {
     if (level <= g_log_level) {
         struct print_buf buf = INIT_PRINT_BUF(buf_write_all);
+
+        if (LOG_LEVEL_DEBUG <= g_log_level) {
+            buf_printf(&buf, "(%s:%lu:%s) ", file, line, func);
+        }
 
         buf_puts(&buf, libos_get_tcb()->log_prefix);
         buf_puts(&buf, log_level_to_prefix[level]);

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -240,10 +240,10 @@ int _PalAttestationQuote(const void* user_report_data, size_t user_report_data_s
                          size_t* quote_size);
 int _PalGetSpecialKey(const char* name, void* key, size_t* key_size);
 
-#define INIT_FAIL(msg, ...)                                                         \
-    do {                                                                            \
-        log_error("PAL failed at %s:%d: " msg, __FILE__, __LINE__, ##__VA_ARGS__);  \
-        _PalProcessExit(1);                                                         \
+#define INIT_FAIL(msg, ...)                                                              \
+    do {                                                                                 \
+        log_error("PAL failed " msg, ##__VA_ARGS__);                                     \
+        _PalProcessExit(1);                                                              \
     } while (0)
 
 #define INIT_FAIL_MANIFEST(reason)                                      \
@@ -301,7 +301,8 @@ int _PalDebugLog(const void* buf, size_t size);
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
-void pal_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+void pal_log(int level, const char* file, const char* func, uint64_t line,
+             const char* fmt, ...) __attribute__((format(printf, 5, 6)));
 
 #define PAL_LOG_DEFAULT_LEVEL  LOG_LEVEL_ERROR
 #define PAL_LOG_DEFAULT_FD     2

--- a/pal/regression/pal_regression.h
+++ b/pal/regression/pal_regression.h
@@ -7,7 +7,6 @@
 #include "pal_error.h"
 
 void __attribute__((format(printf, 1, 2))) pal_printf(const char* fmt, ...);
-void __attribute__((format(printf, 2, 3))) _log(int level, const char* fmt, ...);
 
 #define CHECK(x) ({                                                     \
     __typeof__(x) _x = (x);                                             \

--- a/pal/regression/utils.c
+++ b/pal/regression/utils.c
@@ -27,9 +27,10 @@ void pal_printf(const char* fmt, ...) {
 /* The below two functions are used by stack protector's __stack_chk_fail(), _FORTIFY_SOURCE's
  * *_chk() functions and by assert.h's assert() defined in the common library. Thus they might be
  * called by any execution context, including these PAL tests. */
-void _log(int level, const char* fmt, ...) {
+void _log(int level, const char* file, const char* func, uint64_t line, const char* fmt, ...) {
     (void)level; /* PAL regression always prints log messages */
     va_list ap;
+    pal_printf(fmt, "(%s:%lu:%s) ", file, line, func);
     va_start(ap, fmt);
     log_vprintf(fmt, ap, /*append_newline=*/true);
     va_end(ap);

--- a/pal/src/host/linux-common/proc_maps.c
+++ b/pal/src/host/linux-common/proc_maps.c
@@ -96,7 +96,7 @@ static int parse_proc_maps_callback(const char* line, void* arg, bool* out_stop)
 
     struct proc_maps_range r;
     if (parse_proc_maps_line(line, &r) < 0) {
-        log_warning("%s: failed to parse /proc/[pid]/maps line \"%s\"", __func__, line);
+        log_warning("failed to parse /proc/[pid]/maps line \"%s\"", line);
         return -EINVAL;
     }
     return data->orig_callback(&r, data->arg);

--- a/pal/src/host/linux-sgx/enclave_edmm.c
+++ b/pal/src/host/linux-sgx/enclave_edmm.c
@@ -44,8 +44,7 @@ int sgx_edmm_add_pages(uint64_t addr, size_t count, uint64_t prot) {
                                                 | SGX_SECINFO_FLAGS_R | SGX_SECINFO_FLAGS_W
                                                 | SGX_SECINFO_FLAGS_PENDING);
         if (ret < 0) {
-            log_error("%s: failed to accept page at address %#lx: %d", __func__,
-                      addr + i * PAGE_SIZE, ret);
+            log_error("failed to accept page at address %#lx: %d", addr + i * PAGE_SIZE, ret);
             /* Since these errors do not happen in legitimate cases and restoring already accepted
              * pages would be cumbersome, we just kill the whole process. */
             die_or_inf_loop();
@@ -61,7 +60,7 @@ int sgx_edmm_add_pages(uint64_t addr, size_t count, uint64_t prot) {
     if (~prot & (SGX_SECINFO_FLAGS_R | SGX_SECINFO_FLAGS_W)) {
         ret = ocall_edmm_restrict_pages_perm(addr, count, prot);
         if (ret < 0) {
-            log_error("%s: failed to restrict pages permissions at %#lx-%#lx: %s", __func__, addr,
+            log_error("failed to restrict pages permissions at %#lx-%#lx: %s", addr,
                       addr + count * PAGE_SIZE, unix_strerror(ret));
             /* Since these errors do not happen in legitimate cases and restoring already allocated
              * pages would be cumbersome, we just kill the whole process. */
@@ -72,7 +71,7 @@ int sgx_edmm_add_pages(uint64_t addr, size_t count, uint64_t prot) {
                               (SGX_PAGE_TYPE_REG << SGX_SECINFO_FLAGS_TYPE_SHIFT)
                               | SGX_SECINFO_FLAGS_PR | prot);
             if (ret < 0) {
-                log_error("%s: failed to accept restricted pages permissions at %#lx: %d", __func__,
+                log_error("failed to accept restricted pages permissions at %#lx: %d",
                           addr + i * PAGE_SIZE, ret);
                 /* Since these errors do not happen in legitimate cases and restoring already
                  * allocated pages would be cumbersome, we just kill the whole process. */
@@ -94,8 +93,8 @@ int sgx_edmm_remove_pages(uint64_t addr, size_t count) {
         ret = sgx_eaccept(addr + i * PAGE_SIZE, (SGX_PAGE_TYPE_TRIM << SGX_SECINFO_FLAGS_TYPE_SHIFT)
                                                 | SGX_SECINFO_FLAGS_MODIFIED);
         if (ret < 0) {
-            log_error("%s: failed to accept page removal at address %#lx: %d", __func__,
-                      addr + i * PAGE_SIZE, ret);
+            log_error("failed to accept page removal at address %#lx: %d", addr + i * PAGE_SIZE,
+                      ret);
             /* Since these errors do not happen in legitimate cases and restoring already accepted
              * pages would be cumbersome, we just kill the whole process. */
             die_or_inf_loop();
@@ -104,8 +103,8 @@ int sgx_edmm_remove_pages(uint64_t addr, size_t count) {
 
     ret = ocall_edmm_remove_pages(addr, count);
     if (ret < 0) {
-        log_error("%s: failed to remove pages at %#lx-%#lx: %s", __func__, addr,
-                  addr + count * PAGE_SIZE, unix_strerror(ret));
+        log_error("failed to remove pages at %#lx-%#lx: %s", addr, addr + count * PAGE_SIZE,
+                  unix_strerror(ret));
         /* Since these errors do not happen in legitimate cases and restoring already accepted pages
          * would be cumbersome, we just kill the whole process. */
         die_or_inf_loop();
@@ -126,7 +125,7 @@ int sgx_edmm_set_page_permissions(uint64_t addr, size_t count, uint64_t prot) {
 
     int ret = ocall_edmm_restrict_pages_perm(addr, count, prot);
     if (ret < 0) {
-        log_error("%s: failed to restrict pages permissions at %#lx-%#lx: %s", __func__, addr,
+        log_error("failed to restrict pages permissions at %#lx-%#lx: %s", addr,
                   addr + count * PAGE_SIZE, unix_strerror(ret));
         /* Since these errors do not happen in legitimate cases and restoring old permissions would
          * be cumbersome, we just kill the whole process. */
@@ -137,7 +136,7 @@ int sgx_edmm_set_page_permissions(uint64_t addr, size_t count, uint64_t prot) {
         ret = sgx_eaccept(addr + i * PAGE_SIZE, (SGX_PAGE_TYPE_REG << SGX_SECINFO_FLAGS_TYPE_SHIFT)
                                                 | SGX_SECINFO_FLAGS_PR | prot);
         if (ret < 0) {
-            log_error("%s: failed to accept restricted pages permissions at %#lx: %d", __func__,
+            log_error("failed to accept restricted pages permissions at %#lx: %d",
                       addr + i * PAGE_SIZE, ret);
             /* Since these errors do not happen in legitimate cases and restoring old permissions
              * would be cumbersome, we just kill the whole process. */

--- a/pal/src/host/linux-sgx/host_framework.c
+++ b/pal/src/host/linux-sgx/host_framework.c
@@ -392,7 +392,7 @@ int edmm_restrict_pages_perm(uint64_t addr, size_t count, uint64_t prot) {
             if (ret == -EBUSY || ret == -EAGAIN || ret == -EINTR) {
                 continue;
             }
-            log_error("%s: SGX_IOC_ENCLAVE_RESTRICT_PERMISSIONS failed (%llu) %s", __func__,
+            log_error("SGX_IOC_ENCLAVE_RESTRICT_PERMISSIONS failed (%llu) %s",
                       (unsigned long long)params.result, unix_strerror(ret));
             return ret;
         }
@@ -418,7 +418,7 @@ int edmm_modify_pages_type(uint64_t addr, size_t count, uint64_t type) {
             if (ret == -EBUSY || ret == -EAGAIN || ret == -EINTR) {
                 continue;
             }
-            log_error("%s: SGX_IOC_ENCLAVE_MODIFY_TYPES failed: (%llu) %s", __func__,
+            log_error("SGX_IOC_ENCLAVE_MODIFY_TYPES failed: (%llu) %s",
                       (unsigned long long)params.result, unix_strerror(ret));
             return ret;
         }

--- a/pal/src/host/linux-sgx/host_log.h
+++ b/pal/src/host/linux-sgx/host_log.h
@@ -17,4 +17,5 @@ int host_log_init(const char* path);
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
-void pal_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+void pal_log(int level, const char* file, const char* func, uint64_t line,
+             const char* fmt, ...) __attribute__((format(printf, 5, 6)));

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -329,7 +329,7 @@ static long sgx_ocall_bind(void* args) {
                    sizeof(ocall_bind_args->new_port));
             break;
         default:
-            log_error("%s: unknown address family: %d", __func__, addr.ss_family);
+            log_error("unknown address family: %d", addr.ss_family);
             DO_SYSCALL(exit_group, 1);
             die_or_inf_loop();
     }

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -353,7 +353,7 @@ static int file_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64
         ret = sgx_edmm_set_page_permissions((uint64_t)addr, size / PAGE_SIZE,
                                             PAL_TO_SGX_PROT(prot));
         if (ret < 0) {
-            log_error("%s: failed to remove W bit from pages permissions at %p-%p", __func__,
+            log_error("failed to remove W bit from pages permissions at %p-%p",
                       (char*)addr, (char*)addr + size);
             goto out;
         }
@@ -366,8 +366,8 @@ out:
         if (g_pal_linuxsgx_state.edmm_enabled) {
             int tmp_ret = sgx_edmm_remove_pages((uint64_t)addr, size / PAGE_SIZE);
             if (tmp_ret < 0) {
-                log_error("%s (ret: %d): removing previously allocated pages failed: %s",
-                          __func__, ret, unix_strerror(tmp_ret));
+                log_error("removing previously allocated pages failed: %s (%d)",
+                          pal_strerror(tmp_ret), ret);
                 die_or_inf_loop();
             }
         } else {

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -140,8 +140,7 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
     if (!handle) {
         int ret = ocall_close(fd);
         if (ret < 0) {
-            log_error("%s:%d closing socket fd failed: %s", __func__, __LINE__,
-                      unix_strerror(ret));
+            log_error("closing socket fd failed: %s", unix_strerror(ret));
         }
         return -PAL_ERROR_NOMEM;
     }
@@ -153,8 +152,7 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
 static int close(PAL_HANDLE handle) {
     int ret = ocall_close(handle->sock.fd);
     if (ret < 0) {
-        log_error("%s:%d closing socket fd failed: %s", __func__, __LINE__,
-                  unix_strerror(ret));
+        log_error("closing socket fd failed: %s", unix_strerror(ret));
         /* We cannot do anything about it anyway... */
     }
     return 0;
@@ -224,8 +222,7 @@ static int tcp_accept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDL
     if (!client) {
         int ret = ocall_close(fd);
         if (ret < 0) {
-            log_error("%s:%d closing socket fd failed: %s", __func__, __LINE__,
-                      unix_strerror(ret));
+            log_error("closing socket fd failed: %s", unix_strerror(ret));
         }
         return -PAL_ERROR_NOMEM;
     }

--- a/pal/src/host/linux/pal_sockets.c
+++ b/pal/src/host/linux/pal_sockets.c
@@ -44,7 +44,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
         int len = sizeof(val);
         int ret = DO_SYSCALL(getsockopt, fd, SOL_SOCKET, SO_RCVBUF, &val, &len);
         if (ret < 0) {
-            log_error("%s: getsockopt SO_RCVBUF failed: %s", __func__, unix_strerror(ret));
+            log_error("getsockopt SO_RCVBUF failed: %s", unix_strerror(ret));
             free(handle);
             return NULL;
         }
@@ -58,7 +58,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
         int len = sizeof(val);
         int ret = DO_SYSCALL(getsockopt, fd, SOL_SOCKET, SO_SNDBUF, &val, &len);
         if (ret < 0) {
-            log_error("%s: getsockopt SO_SNDBUF failed: %s", __func__, unix_strerror(ret));
+            log_error("getsockopt SO_SNDBUF failed: %s", unix_strerror(ret));
             free(handle);
             return NULL;
         }
@@ -131,7 +131,7 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
     if (!handle) {
         int ret = DO_SYSCALL(close, fd);
         if (ret < 0) {
-            log_error("%s:%d closing socket fd failed: %s", __func__, __LINE__, unix_strerror(ret));
+            log_error("closing socket fd failed: %s", unix_strerror(ret));
         }
         return -PAL_ERROR_NOMEM;
     }
@@ -143,7 +143,7 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
 static int close(PAL_HANDLE handle) {
     int ret = DO_SYSCALL(close, handle->sock.fd);
     if (ret < 0) {
-        log_error("%s: closing socket fd failed: %s", __func__, unix_strerror(ret));
+        log_error("closing socket fd failed: %s", unix_strerror(ret));
         /* We cannot do anything about it anyway... */
     }
     return 0;
@@ -233,7 +233,7 @@ static int tcp_accept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDL
     if (!client) {
         int ret = DO_SYSCALL(close, fd);
         if (ret < 0) {
-            log_error("%s:%d closing socket fd failed: %s", __func__, __LINE__, unix_strerror(ret));
+            log_error("closing socket fd failed: %s", unix_strerror(ret));
         }
         return -PAL_ERROR_NOMEM;
     }

--- a/pal/src/pal_memory.c
+++ b/pal/src/pal_memory.c
@@ -285,8 +285,7 @@ static int initial_mem_free(uintptr_t addr, size_t size) {
     }
     ret = _PalVirtualMemoryFree((void*)addr, size);
     if (ret < 0) {
-        log_error("%s: failed to free initial PAL internal memory: %s", __func__,
-                  pal_strerror(ret));
+        log_error("failed to free initial PAL internal memory: %s", pal_strerror(ret));
         _PalProcessExit(1);
     }
     return 0;
@@ -299,8 +298,7 @@ int pal_internal_memory_bkeep(size_t size, uintptr_t* out_addr) {
 
     int ret = g_mem_bkeep_alloc_upcall(size, out_addr);
     if (ret < 0) {
-        log_warning("%s: failed to bookkeep PAL internal memory: %s", __func__,
-                    unix_strerror(ret));
+        log_warning("failed to bookkeep PAL internal memory: %s", unix_strerror(ret));
         return -PAL_ERROR_NOMEM;
     }
     return 0;
@@ -318,12 +316,11 @@ int pal_internal_memory_alloc(size_t size, void** out_addr) {
     ret = _PalVirtualMemoryAlloc((void*)addr, size, PAL_PROT_READ | PAL_PROT_WRITE);
     if (ret < 0) {
         if (!g_mem_bkeep_alloc_upcall) {
-            log_error("%s: failed to allocate initial PAL internal memory: %s", __func__,
-                      pal_strerror(ret));
+            log_error("failed to allocate initial PAL internal memory: %s", pal_strerror(ret));
             _PalProcessExit(1);
         }
 
-        log_warning("%s: failed to allocate PAL internal memory: %s", __func__, pal_strerror(ret));
+        log_warning("failed to allocate PAL internal memory: %s", pal_strerror(ret));
         ret = g_mem_bkeep_free_upcall(addr, size);
         if (ret < 0) {
             BUG();
@@ -344,12 +341,12 @@ int pal_internal_memory_free(void* addr, size_t size) {
 
     int ret = _PalVirtualMemoryFree(addr, size);
     if (ret < 0) {
-        log_warning("%s: failed to free PAL internal memory: %s", __func__, pal_strerror(ret));
+        log_warning("failed to free PAL internal memory: %s", pal_strerror(ret));
         return ret;
     }
     ret = g_mem_bkeep_free_upcall((uintptr_t)addr, size);
     if (ret < 0) {
-        log_error("%s: failed to release PAL internal memory: %s", __func__, unix_strerror(ret));
+        log_error("failed to release PAL internal memory: %s", unix_strerror(ret));
         _PalProcessExit(1);
     }
     return 0;

--- a/pal/src/printf.c
+++ b/pal/src/printf.c
@@ -12,17 +12,21 @@ static int buf_write_all(const char* str, size_t size, void* arg) {
     return 0;
 }
 
-static void log_vprintf(const char* prefix, const char* fmt, va_list ap) {
+static void log_vprintf(const char* prefix, const char* file, const char* func, uint64_t line,
+                        const char* fmt, va_list ap) {
     struct print_buf buf = INIT_PRINT_BUF(buf_write_all);
 
+    if (LOG_LEVEL_DEBUG <= g_pal_public_state.log_level)
+        buf_printf(&buf, "(%s:%lu:%s) ", file, line, func);
     if (prefix)
         buf_puts(&buf, prefix);
+
     buf_vprintf(&buf, fmt, ap);
     buf_printf(&buf, "\n");
     buf_flush(&buf);
 }
 
-void pal_log(int level, const char* fmt, ...) {
+void pal_log(int level, const char* file, const char* func, uint64_t line, const char* fmt, ...) {
     if (level <= g_pal_public_state.log_level) {
         va_list ap;
         va_start(ap, fmt);
@@ -42,7 +46,7 @@ void pal_log(int level, const char* fmt, ...) {
             case LOG_LEVEL_TRACE:   prefix = "trace: "; break;
         }
 
-        log_vprintf(prefix, fmt, ap);
+        log_vprintf(prefix, file, func, line, fmt, ap);
         va_end(ap);
     }
 }

--- a/pal/src/slab.c
+++ b/pal/src/slab.c
@@ -55,7 +55,7 @@ static inline void system_mem_free(void* addr, size_t size) {
 
     int ret = pal_internal_memory_free(addr, size);
     if (ret < 0) {
-        log_error("%s:%d freeing memory failed: %s", __FILE__, __LINE__, pal_strerror(ret));
+        log_error("freeing memory failed: %s", pal_strerror(ret));
         _PalProcessExit(1);
     }
 }

--- a/tools/sgx/common/util.c
+++ b/tools/sgx/common/util.c
@@ -239,8 +239,11 @@ int parse_hex(const char* hex, void* buffer, size_t buffer_size, const char* mas
 }
 
 /* _log() and abort() are needed for our <assert.h>; see also: common/include/callbacks.h */
-void _log(int level, const char* fmt, ...) {
+void _log(int level, const char* file, const char* func, uint64_t line, const char* fmt, ...) {
     (void)level;
+    (void)file;
+    (void)line;
+    (void)func;
     va_list ap;
     va_start(ap, fmt);
     vdprintf(g_stderr_fd, fmt, ap);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

In many places, Gramine developers add information about files, line number, and function manually.
This isn't structured in any way.
Instead, I propose to add this information always if the debug level is set.

Logs after this change:
```
(libos/src/ipc/libos_ipc_pid.c:329:ipc_release_id_range_callback) [P1:libos] debug: release_id_range(2..2)
(libos/src/sys/libos_exit.c:179:libos_syscall_exit_group) [P1:T1:a.out] debug: ---- exit_group (returning 0)
(libos/src/fs/libos_fs_lock.c:651:posix_lock_clear_pid) [P1:T1:a.out] debug: clearing POSIX locks for pid 1
(libos/src/sync/libos_sync_client.c:331:shutdown_sync_client) [P1:T1:a.out] debug: sync client shutdown: closing handles
(libos/src/sync/libos_sync_client.c:346:shutdown_sync_client) [P1:T1:a.out] debug: sync client shutdown: waiting for confirmation
(libos/src/sync/libos_sync_client.c:359:shutdown_sync_client) [P1:T1:a.out] debug: sync client shutdown: finished
(libos/src/ipc/libos_ipc_worker.c:284:ipc_worker_main) [P1:libos] debug: IPC worker: exiting worker thread
(libos/src/sys/libos_exit.c:58:libos_clean_and_exit) [P1:T1:a.out] debug: process 1 exited with status 0
```

This is a simple approach where we take the whole __FILE__, which is quite verbose. Maybe instead of the full path we just want to print the filename?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1040)
<!-- Reviewable:end -->
