### PR TITLE
[CI-Examples] Update nginx version to 1.22.0

### DIFF
--- a/CI-Examples/nginx/Makefile
+++ b/CI-Examples/nginx/Makefile
@@ -3,8 +3,8 @@ THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 INSTALL_DIR ?= $(THIS_DIR)install
-NGINX_SRC ?= $(THIS_DIR)nginx-1.16.1
-NGINX_SHA256 ?= f11c2a6dd1d3515736f0324857957db2de98be862461b5a542a3ac6188dbe32b
+NGINX_SRC ?= $(THIS_DIR)nginx-1.22.0
+NGINX_SHA256 ?= b33d569a6f11a01433a57ce17e83935e953ad4dc77cdd4d40f896c88ac26eb53
 
 NGINX_MIRRORS ?= \
     http://nginx.org/download \


### PR DESCRIPTION
Nginx version 1.16.1 is not compatible with openssl version available for Ubuntu 22.04. Nginx make kept failing with deprecated errors.
So, in order to enable Nginx for Ubuntu 22.04 also, we need to upgrade nginx version.

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1047)
<!-- Reviewable:end -->
