### PR TITLE
[LibOS,PAL] Reduce lock contention caused by malloc() in poll

### DIFF
--- a/pal/src/host/linux/pal_object.c
+++ b/pal/src/host/linux/pal_object.c
@@ -12,15 +12,29 @@
 #include "pal_internal.h"
 #include "pal_linux_error.h"
 
+/* To avoid expensive malloc/free (due to locking), use stack if the required space is small
+ * enough. */
+#define NFDS_LIMIT_TO_USE_STACK 16
+
 int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_t* events,
                           pal_wait_flags_t* ret_events, uint64_t* timeout_us) {
     int ret;
     uint64_t remaining_time_us = timeout_us ? *timeout_us : 0;
 
-    struct pollfd* fds = calloc(count, sizeof(*fds));
-    if (!fds) {
-        return -PAL_ERROR_NOMEM;
+    struct pollfd* fds = NULL;
+    bool allocate_on_stack = count <= NFDS_LIMIT_TO_USE_STACK;
+
+    if (allocate_on_stack) {
+        static_assert(sizeof(*fds) * NFDS_LIMIT_TO_USE_STACK <= 128,
+                      "Would use too much space on stack, reduce the limit");
+        fds = __builtin_alloca(count * sizeof(*fds));
+    } else {
+        fds = malloc(count * sizeof(*fds));
+        if (!fds) {
+            return -PAL_ERROR_NOMEM;
+        }
     }
+    memset(fds, 0, count * sizeof(*fds));
 
     for (size_t i = 0; i < count; i++) {
         PAL_HANDLE handle = handle_array[i];
@@ -98,6 +112,8 @@ out:
     if (timeout_us) {
         *timeout_us = remaining_time_us;
     }
-    free(fds);
+    if (!allocate_on_stack) {
+        free(fds);
+    }
     return ret;
 }


### PR DESCRIPTION
## Description of the changes
Current implementation of poll syscall uses multiple malloc and free. When the number of threads calling poll is high, the lock contention limits the application performance. This PR tries to use stack space when the space being allocated is small, and reduces such lock contention.

## How to test this PR?
Run the MySQL example on one server and use Sysbench to test it from another. When the number of threads in Sysbench is set to 128, the result TPS is >50% better than the original code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1051)
<!-- Reviewable:end -->
