### PR TITLE
[LibOS,PAL] Support TCP_USER_TIMEOUT socket opt

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -99,11 +99,12 @@ struct cmsghdr {
 #define SO_DOMAIN 39
 
 /* TCP options. */
-#define TCP_NODELAY 1   /* Turn off Nagle's algorithm */
-#define TCP_CORK 3      /* Never send partially complete segments */
-#define TCP_KEEPIDLE 4  /* Start keeplives after this period */
-#define TCP_KEEPINTVL 5 /* Interval between keepalives */
-#define TCP_KEEPCNT 6   /* Number of keepalives before death */
+#define TCP_NODELAY 1       /* Turn off Nagle's algorithm */
+#define TCP_CORK 3          /* Never send partially complete segments */
+#define TCP_KEEPIDLE 4      /* Start keeplives after this period */
+#define TCP_KEEPINTVL 5     /* Interval between keepalives */
+#define TCP_KEEPCNT 6       /* Number of keepalives before death */
+#define TCP_USER_TIMEOUT 18 /* How long for loss retry before timeout */
 
 #define MAX_TCP_KEEPIDLE 32767
 #define MAX_TCP_KEEPINTVL 32767
@@ -112,6 +113,7 @@ struct cmsghdr {
 #define DEFAULT_TCP_KEEPIDLE (2 * 60 * 60) /* 2 hours */
 #define DEFAULT_TCP_KEEPINTVL 75           /* 75 seconds */
 #define DEFAULT_TCP_KEEPCNT 9              /* 9 keepalive probes */
+#define DEFAULT_TCP_USER_TIMEOUT 0         /* use system default */
 
 struct linger {
     int l_onoff;

--- a/libos/src/net/ip.c
+++ b/libos/src/net/ip.c
@@ -292,6 +292,12 @@ static int set_tcp_option(struct libos_handle* handle, int optname, void* optval
         case TCP_NODELAY:
             attr.socket.tcp_nodelay = value.i;
             break;
+        case TCP_USER_TIMEOUT:
+            if (value.i < 0) {
+                return -EINVAL;
+            }
+            attr.socket.tcp_user_timeout = value.i;
+            break;
         default:
             return -ENOPROTOOPT;
     }
@@ -536,6 +542,9 @@ static int get_tcp_option(struct libos_handle* handle, int optname, void* optval
             break;
         case TCP_NODELAY:
             val = attr.socket.tcp_nodelay;
+            break;
+        case TCP_USER_TIMEOUT:
+            val = attr.socket.tcp_user_timeout;
             break;
         default:
             return -ENOPROTOOPT;

--- a/libos/test/regression/getsockopt.c
+++ b/libos/test/regression/getsockopt.c
@@ -9,6 +9,7 @@
 #define DEFAULT_TCP_KEEPIDLE (120 * 60)
 #define DEFAULT_TCP_KEEPINTVL 75
 #define DEFAULT_TCP_KEEPCNT 9
+#define DEFAULT_TCP_USER_TIMEOUT 0
 
 int main(void) {
     socklen_t optlen; /* Option length */
@@ -53,6 +54,14 @@ int main(void) {
 
     if (optlen != sizeof(tcp_keepcnt) || tcp_keepcnt != DEFAULT_TCP_KEEPCNT) {
         errx(1, "getsockopt(IPPROTO_TCP, TCP_KEEPCNT) returned unexpected value");
+    }
+
+    int tcp_user_timeout;
+    optlen = sizeof(tcp_user_timeout);
+    CHECK(getsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &tcp_user_timeout, &optlen));
+
+    if (optlen != sizeof(tcp_user_timeout) || tcp_user_timeout != DEFAULT_TCP_USER_TIMEOUT) {
+        errx(1, "getsockopt(IPPROTO_TCP, TCP_USER_TIMEOUT) returned unexpected value");
     }
 
     puts("TEST OK");

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -478,6 +478,7 @@ typedef struct _PAL_STREAM_ATTR {
             bool keepalive;
             bool broadcast;
             bool tcp_cork;
+            uint32_t tcp_user_timeout;
             uint32_t tcp_keepidle;
             uint32_t tcp_keepintvl;
             uint8_t tcp_keepcnt;

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -101,6 +101,7 @@ typedef struct {
             bool keepalive;
             bool broadcast;
             bool tcp_cork;
+            uint32_t tcp_user_timeout;
             uint32_t tcp_keepidle;
             uint32_t tcp_keepintvl;
             uint8_t tcp_keepcnt;

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -86,6 +86,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.tcp_keepidle = DEFAULT_TCP_KEEPIDLE;
     handle->sock.tcp_keepintvl = DEFAULT_TCP_KEEPINTVL;
     handle->sock.tcp_keepcnt = DEFAULT_TCP_KEEPCNT;
+    handle->sock.tcp_user_timeout = DEFAULT_TCP_USER_TIMEOUT;
     handle->sock.tcp_nodelay = false;
     handle->sock.ipv6_v6only = false;
 
@@ -300,6 +301,7 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.tcp_keepintvl = handle->sock.tcp_keepintvl;
     attr->socket.tcp_keepcnt = handle->sock.tcp_keepcnt;
     attr->socket.tcp_nodelay = handle->sock.tcp_nodelay;
+    attr->socket.tcp_user_timeout = handle->sock.tcp_user_timeout;
     attr->socket.ipv6_v6only = handle->sock.ipv6_v6only;
 
     return 0;
@@ -479,6 +481,16 @@ static int attrsetbyhdl_tcp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
         }
         handle->sock.tcp_nodelay = attr->socket.tcp_nodelay;
+    }
+
+    if (attr->socket.tcp_user_timeout != handle->sock.tcp_user_timeout) {
+        assert(attr->socket.tcp_user_timeout <= INT_MAX);
+        int val = attr->socket.tcp_user_timeout;
+        int ret = ocall_setsockopt(handle->sock.fd, SOL_TCP, TCP_USER_TIMEOUT, &val, sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_user_timeout = attr->socket.tcp_user_timeout;
     }
 
     return 0;

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -78,6 +78,7 @@ typedef struct {
             bool broadcast;
             bool keepalive;
             bool tcp_cork;
+            uint32_t tcp_user_timeout;
             uint32_t tcp_keepidle;
             uint32_t tcp_keepintvl;
             uint8_t tcp_keepcnt;

--- a/pal/src/host/linux/pal_sockets.c
+++ b/pal/src/host/linux/pal_sockets.c
@@ -77,6 +77,7 @@ static PAL_HANDLE create_sock_handle(int fd, enum pal_socket_domain domain,
     handle->sock.tcp_keepidle = DEFAULT_TCP_KEEPIDLE;
     handle->sock.tcp_keepintvl = DEFAULT_TCP_KEEPINTVL;
     handle->sock.tcp_keepcnt = DEFAULT_TCP_KEEPCNT;
+    handle->sock.tcp_user_timeout = DEFAULT_TCP_USER_TIMEOUT;
     handle->sock.tcp_nodelay = false;
     handle->sock.ipv6_v6only = false;
 
@@ -332,6 +333,7 @@ static int attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.tcp_keepintvl = handle->sock.tcp_keepintvl;
     attr->socket.tcp_keepcnt = handle->sock.tcp_keepcnt;
     attr->socket.tcp_nodelay = handle->sock.tcp_nodelay;
+    attr->socket.tcp_user_timeout = handle->sock.tcp_user_timeout;
     attr->socket.ipv6_v6only = handle->sock.ipv6_v6only;
 
     return 0;
@@ -526,6 +528,17 @@ static int attrsetbyhdl_tcp(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
         }
         handle->sock.tcp_nodelay = attr->socket.tcp_nodelay;
+    }
+
+    if (attr->socket.tcp_user_timeout != handle->sock.tcp_user_timeout) {
+        assert(attr->socket.tcp_user_timeout <= INT_MAX);
+        int val = attr->socket.tcp_user_timeout;
+        int ret = DO_SYSCALL(setsockopt, handle->sock.fd, SOL_TCP, TCP_USER_TIMEOUT, &val,
+                             sizeof(val));
+        if (ret < 0) {
+            return unix_to_pal_error(ret);
+        }
+        handle->sock.tcp_user_timeout = attr->socket.tcp_user_timeout;
     }
 
     return 0;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine didn't support setting (via `setsockopt()`) or getting (via `getsockopt()`) `TCP_USER_TIMEOUT` socket option. This could lead to some applications failures (in particular, libpq) when they tried to get/set this socket option but found out it's unsupported.

This is requested by application devs that have to use `libpq` library. The offending code is here: https://github.com/postgres/postgres/blob/3d0c95bc8920f51f7d7685c622c9a75f59cf322f/src/backend/libpq/pqcomm.c#L1872-L1915

This PR is based on a prevoius similar PR: https://github.com/gramineproject/gramine/commit/bd977417363224906aba1d28ce14329ae37163c6

How Linux does it (very simply):
- https://elixir.bootlin.com/linux/latest/source/tools/include/uapi/linux/tcp.h#L108
- https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp.c#L3721
- https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp.c#L4240

Some man-page details:
- https://man7.org/linux/man-pages/man7/tcp.7.html (note that inside Linux, `TCP_USER_TIMEOUT` is simply an `int`)

## How to test this PR? <!-- (if applicable) -->

Added a quick test in CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1052)
<!-- Reviewable:end -->
