### PR TITLE
[LibOS,CI-Examples] Always expose SGX local attestation files

### DIFF
--- a/CI-Examples/python/Makefile
+++ b/CI-Examples/python/Makefile
@@ -48,6 +48,7 @@ check: all
 	@grep -q "Success 3/4" TEST_STDOUT
 	@grep -q "Success 4/4" TEST_STDOUT
 ifeq ($(SGX),1)
+	@grep -q "Success SGX report" TEST_STDOUT
 	@grep -q "Success SGX quote" TEST_STDOUT
 endif
 

--- a/CI-Examples/python/README.md
+++ b/CI-Examples/python/README.md
@@ -52,6 +52,7 @@ Here's an example of running Python scripts under Gramine:
 gramine-sgx ./python scripts/helloworld.py
 gramine-sgx ./python scripts/test-numpy.py
 gramine-sgx ./python scripts/test-scipy.py
+gramine-sgx ./python scripts/sgx-report.py
 gramine-sgx ./python scripts/sgx-quote.py
 ```
 

--- a/CI-Examples/python/run-tests.sh
+++ b/CI-Examples/python/run-tests.sh
@@ -44,6 +44,10 @@ rm OUTPUT
 # === SGX quote ===
 if test -n "$SGX"
 then
+    $GRAMINE ./python scripts/sgx-report.py > OUTPUT
+    grep -q "Generated SGX report" OUTPUT && echo "[ Success SGX report ]"
+    rm OUTPUT
+
     $GRAMINE ./python scripts/sgx-quote.py > OUTPUT
     grep -q "Extracted SGX quote" OUTPUT && echo "[ Success SGX quote ]"
     rm OUTPUT

--- a/CI-Examples/python/scripts/sgx-quote.py
+++ b/CI-Examples/python/scripts/sgx-quote.py
@@ -3,11 +3,8 @@
 import os
 import sys
 
-def tohex(b):
-    return ''.join(format(x, '02x') for x in b)
-
-if not os.path.exists("/dev/attestation/user_report_data"):
-    print("Cannot find `/dev/attestation/user_report_data`; "
+if not os.path.exists("/dev/attestation/quote"):
+    print("Cannot find `/dev/attestation/quote`; "
           "are you running under SGX, with remote attestation enabled?")
     sys.exit(1)
 

--- a/CI-Examples/python/scripts/sgx-report.py
+++ b/CI-Examples/python/scripts/sgx-report.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+if not os.path.exists("/dev/attestation/report"):
+    print("Cannot find `/dev/attestation/report`; are you running under SGX?")
+    sys.exit(1)
+
+with open("/dev/attestation/my_target_info", "rb") as f:
+    my_target_info = f.read()
+
+with open("/dev/attestation/target_info", "wb") as f:
+    f.write(my_target_info)
+
+with open("/dev/attestation/user_report_data", "wb") as f:
+    f.write(b'\0'*64)
+
+with open("/dev/attestation/report", "rb") as f:
+    report = f.read()
+
+print(f"Generated SGX report with size = {len(report)} and the following fields:")
+print(f"  ATTRIBUTES.FLAGS: {report[48:56].hex()}  [ Debug bit: {report[48] & 2 > 0} ]")
+print(f"  ATTRIBUTES.XFRM:  {report[56:64].hex()}")
+print(f"  MRENCLAVE:        {report[64:96].hex()}")
+print(f"  MRSIGNER:         {report[128:160].hex()}")
+print(f"  ISVPRODID:        {report[256:258].hex()}")
+print(f"  ISVSVN:           {report[258:260].hex()}")
+print(f"  REPORTDATA:       {report[320:352].hex()}")
+print(f"                    {report[352:384].hex()}")


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, SGX local attestation files like `user_report_data` and `report` were exposed only if `sgx.remote_attestation` type was "epid" or "dcap". This is incorrect -- local attestation can be done completely independent of the remote-attestation scheme.

This PR always exposes all `/dev/attestation/` pseudo-files now, except for `quote` which is only exposed when `sgx.remote_attestation` is set.

See https://github.com/gramineproject/gramine/discussions/1055

## How to test this PR? <!-- (if applicable) -->

A Python example for SGX reports is added and tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1057)
<!-- Reviewable:end -->
