### PR TITLE
[LibOS] Fix length calculation in `mprotect` with `PROT_GROWSDOWN`

### DIFF
--- a/libos/src/sys/libos_mmap.c
+++ b/libos/src/sys/libos_mmap.c
@@ -249,6 +249,8 @@ long libos_syscall_mprotect(void* addr, size_t length, int prot) {
     if (prot & PROT_GROWSDOWN) {
         struct libos_vma_info vma_info = {0};
         if (lookup_vma(addr, &vma_info) >= 0) {
+            assert(vma_info.addr <= addr);
+            length += addr - vma_info.addr;
             addr = vma_info.addr;
             if (vma_info.file) {
                 put_handle(vma_info.file);

--- a/libos/test/regression/mprotect_prot_growsdown.c
+++ b/libos/test/regression/mprotect_prot_growsdown.c
@@ -36,15 +36,17 @@ int main(void) {
         err(1, "mmap");
     }
 
-    if (mprotect(ptr + page_size, page_size, PROT_READ | PROT_WRITE | PROT_GROWSDOWN) < 0) {
+    if (mprotect(ptr + 2 * page_size, page_size, PROT_READ | PROT_WRITE | PROT_GROWSDOWN) < 0) {
         err(1, "mprotect");
     }
 
     *(volatile char*)ptr = 'a';
+    *(volatile char*)(ptr + page_size) = 'b';
+    *(volatile char*)(ptr + 2 * page_size) = 'c';
 
-    if (*(volatile char*)ptr != 'a') {
-        printf("Value was not written to memory!\n");
-        return 1;
+    if (*(volatile char*)ptr != 'a' || *(volatile char*)(ptr + page_size) != 'b'
+            || *(volatile char*)(ptr + 2 * page_size) != 'c') {
+        errx(1, "Value was not written to memory!");
     }
 
     puts("TEST OK");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
If `mprotect` is called with `PROT_GROWSDOWN` flag, it should apply the change to the whole mapping. Old code correctly adjusted beginning of the changed region in such case, but used original length.

## How to test this PR? <!-- (if applicable) -->
We had a test for this, but it was faulty... Fixed now

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1060)
<!-- Reviewable:end -->
