### PR TITLE
[LibOS,PAL] Avoid using double error in error logs

### DIFF
--- a/libos/src/fs/libos_fs.c
+++ b/libos/src/fs/libos_fs.c
@@ -740,7 +740,7 @@ static int mount_fs_at_dentry(struct libos_mount_params* params, struct libos_de
     if (strcmp(params->type, "encrypted") != 0) {
         struct libos_dentry* root;
         if ((ret = path_lookupat(g_dentry_root, params->path, LOOKUP_NO_FOLLOW, &root))) {
-            log_warning("error looking up mount root %s: %d", params->path, ret);
+            log_warning("Failed to look up mount root %s: %d", params->path, ret);
             goto err;
         }
         assert(root == mount->root);
@@ -773,7 +773,7 @@ err:
     if (fs->fs_ops->unmount) {
         int ret_unmount = fs->fs_ops->unmount(mount_data);
         if (ret_unmount < 0) {
-            log_warning("error unmounting %s: %d", params->path, ret_unmount);
+            log_warning("Unmounting %s failed: %d", params->path, ret_unmount);
         }
     }
 
@@ -797,13 +797,13 @@ int mount_fs(struct libos_mount_params* params) {
         int lookup_flags = LOOKUP_NO_FOLLOW | LOOKUP_MAKE_SYNTHETIC;
         ret = path_lookupat(g_dentry_root, params->path, lookup_flags, &mount_point);
         if (ret < 0) {
-            log_error("error looking up mountpoint %s: %d", params->path, ret);
+            log_error("Looking up mountpoint %s failed: %d", params->path, ret);
             goto out;
         }
     }
 
     if ((ret = mount_fs_at_dentry(params, mount_point)) < 0) {
-        log_error("error mounting \"%s\" (%s) under %s: %d", params->uri, params->type,
+        log_error("Mounting \"%s\" (%s) under %s failed: %d", params->uri, params->type,
                   params->path, ret);
         goto out;
     }

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -361,7 +361,7 @@ static int read_environs(const char* const* envp) {
     do {                                                                    \
         int _err = CALL_INIT(func, ##__VA_ARGS__);                          \
         if (_err < 0) {                                                     \
-            log_error("Error during libos_init() in " #func " (%d)", _err); \
+            log_error("libos_init() failed in " #func " (%d)", _err);       \
             PalProcessExit(1);                                              \
         }                                                                   \
     } while (0)
@@ -383,7 +383,7 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     log_debug("Host: %s", g_pal_public_state->host_type);
 
     if (!IS_POWER_OF_2(ALLOC_ALIGNMENT)) {
-        log_error("Error during libos_init(): PAL allocation alignment not a power of 2");
+        log_error("PAL allocation alignment not a power of 2");
         PalProcessExit(1);
     }
 

--- a/pal/src/host/linux-sgx/host_profile.c
+++ b/pal/src/host/linux-sgx/host_profile.c
@@ -189,7 +189,7 @@ static void sample_simple(uint64_t rip) {
     spinlock_unlock(&g_perf_data_lock);
 
     if (ret < 0) {
-        log_error("error recording sample: %d", ret);
+        log_error("recording sample failed: %d", ret);
     }
 }
 
@@ -200,7 +200,7 @@ static void sample_stack(sgx_pal_gpr_t* gpr) {
     size_t stack_size;
     ret = debug_read(stack, (void*)gpr->rsp, sizeof(stack));
     if (ret < 0) {
-        log_error("error reading stack: %d", ret);
+        log_error("reading stack failed: %d", ret);
         return;
     }
     stack_size = ret;
@@ -212,7 +212,7 @@ static void sample_stack(sgx_pal_gpr_t* gpr) {
     spinlock_unlock(&g_perf_data_lock);
 
     if (ret < 0) {
-        log_error("error recording sample: %d", ret);
+        log_error("recording sample failed: %d", ret);
     }
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

When Gramine logs something, the log level tag is added at the beginning of the message. This commit rephrases logs in which the tag and first word of the message are exactly the same.
Thanks to that user won't see logs like:
```
error: error mounting "/re" under "/xxx"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1069)
<!-- Reviewable:end -->
