### PR TITLE
[LibOS,PAL] Treat (e)poll error and hup events separately

### DIFF
--- a/libos/src/sys/libos_epoll.c
+++ b/libos/src/sys/libos_epoll.c
@@ -14,8 +14,8 @@
  *   using this flag,
  * - adding an epoll to another epoll instance is not supported, but should be implementable without
  *   design changes if need be,
- * - `EPOLLRDHUP` is not reported and `EPOLLHUP` is always reported together with `EPOLLERR` - this
- *   is current limitation of PAL API, which does not distinguish these conditions.
+ * - `EPOLLRDHUP` is always reported together with `EPOLLHUP` - this is current limitation of PAL
+ *   API, which does not distinguish these conditions.
  */
 
 #include <stdint.h>
@@ -658,8 +658,12 @@ static int do_epoll_wait(int epfd, struct epoll_event* events, int maxevents, in
 
             uint32_t this_item_events = 0;
             if (pal_ret_events[i] & PAL_WAIT_ERROR) {
-                /* XXX: unfortunately there is no way to distinguish these two. */
-                this_item_events |= EPOLLERR | EPOLLHUP;
+                this_item_events |= EPOLLERR;
+            }
+            if (pal_ret_events[i] & PAL_WAIT_HANG_UP) {
+                this_item_events |= EPOLLHUP;
+                /* add RDHUP event only if user requested for it to be reported */
+                this_item_events |= items[i]->events & EPOLLRDHUP;
             }
             if (pal_ret_events[i] & PAL_WAIT_READ) {
                 this_item_events |= items[i]->events & (EPOLLIN | EPOLLRDNORM);

--- a/libos/src/sys/libos_poll.c
+++ b/libos/src/sys/libos_poll.c
@@ -191,7 +191,12 @@ static long do_poll(struct pollfd* fds, size_t fds_len, uint64_t* timeout_us) {
 
         fds[i].revents = 0;
         if (ret_events[i] & PAL_WAIT_ERROR)
-            fds[i].revents |= POLLERR | POLLHUP;
+            fds[i].revents |= POLLERR;
+        if (ret_events[i] & PAL_WAIT_HANG_UP) {
+            fds[i].revents |= POLLHUP;
+            /* add RDHUP event only if user requested for it to be reported */
+            fds[i].revents |= fds[i].events & POLLRDHUP;
+        }
         if (ret_events[i] & PAL_WAIT_READ)
             fds[i].revents |= fds[i].events & (POLLIN | POLLRDNORM);
         if (ret_events[i] & PAL_WAIT_WRITE)

--- a/libos/test/regression/epoll_test.c
+++ b/libos/test/regression/epoll_test.c
@@ -1,9 +1,11 @@
 #define _GNU_SOURCE
+#include <arpa/inet.h>
 #include <err.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -11,6 +13,9 @@
 
 #define ERR(msg, args...) \
     errx(1, "%d: " msg, __LINE__, ##args)
+
+#define SRV_IP "127.0.0.1"
+#define PORT   11113
 
 static uint64_t wait_event(int epfd, struct epoll_event* possible_events,
                            size_t possible_events_len) {
@@ -147,12 +152,135 @@ static void test_epoll_empty(void) {
     CHECK(close(epfd));
 }
 
+static void server(int sockfd) {
+    int epfd = CHECK(epoll_create1(EPOLL_CLOEXEC));
+
+    int s = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+
+    int enable = 1;
+    CHECK(setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)));
+
+    struct sockaddr_in sa = {
+        .sin_family = AF_INET,
+        .sin_port = htons(PORT),
+        .sin_addr.s_addr = htonl(INADDR_ANY),
+    };
+
+    CHECK(bind(s, (void*)&sa, sizeof(sa)));
+    CHECK(listen(s, 5));
+
+    char c = 0;
+    ssize_t x = CHECK(write(sockfd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        ERR("write: %zd", x);
+    }
+
+    int client = CHECK(accept(s, NULL, NULL));
+
+    CHECK(close(s));
+
+    struct epoll_event event = {
+        .events = EPOLLIN | EPOLLRDHUP,
+        .data.fd = client,
+    };
+    CHECK(epoll_ctl(epfd, EPOLL_CTL_ADD, client, &event));
+
+    memset(&event, 0, sizeof(event));
+    int r = CHECK(epoll_wait(epfd, &event, 1, 0));
+    if (r != 0) {
+        ERR("epoll_wait returned: %d, events: %#x, fd: %d", r, event.events, event.data.fd);
+    }
+
+    x = CHECK(write(sockfd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        ERR("write: %zd", x);
+    }
+
+    x = CHECK(read(sockfd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        ERR("read: %zd", x);
+    }
+    CHECK(close(sockfd));
+
+    memset(&event, 0, sizeof(event));
+    r = CHECK(epoll_wait(epfd, &event, 1, 0));
+    /* `EPOLLRDHUP` is always reported together with `EPOLLHUP` in Gramine as its limitation. We
+     * thus ignore `EPOLLHUP` here (which is not reported natively) to make the test also work for
+     * native. */
+    if (r != 1 || (event.events & ~EPOLLHUP) != (EPOLLIN | EPOLLRDHUP) || event.data.fd != client) {
+        ERR("epoll_wait returned: %d, events: %#x, fd: %d", r, event.events, event.data.fd);
+    }
+
+    CHECK(close(client));
+    CHECK(close(epfd));
+}
+
+static void client(int sockfd) {
+    char c = 0;
+    ssize_t x = CHECK(read(sockfd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        ERR("read: %zd", x);
+    }
+
+    int s = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+
+    struct sockaddr_in sa = {
+        .sin_family = AF_INET,
+        .sin_port = htons(PORT),
+        .sin_addr = {
+            /* TODO: remove this once Ubuntu 18.04 is deprecated. */
+            .s_addr = 0,
+        },
+    };
+    if (inet_aton(SRV_IP, &sa.sin_addr) != 1) {
+        ERR("inet_aton failed");
+    }
+
+    CHECK(connect(s, (void*)&sa, sizeof(sa)));
+
+    x = CHECK(read(sockfd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        ERR("read: %zd", x);
+    }
+
+    CHECK(close(s));
+
+    x = CHECK(write(sockfd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        ERR("write: %zd", x);
+    }
+    CHECK(close(sockfd));
+}
+
+static void test_epoll_wait_rdhup(void) {
+    int sockfds[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockfds));
+
+    pid_t p = CHECK(fork());
+    if (p == 0) {
+        CHECK(close(sockfds[1]));
+        client(sockfds[0]);
+        exit(0);
+    }
+
+    CHECK(close(sockfds[0]));
+    server(sockfds[1]);
+
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+        errx(1, "child wait status: %#x", status);
+    }
+}
+
 int main(void) {
     test_epoll_empty();
 
     test_epoll_migration();
 
     test_epoll_oneshot();
+
+    test_epoll_wait_rdhup();
 
     puts("TEST OK");
     return 0;

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -806,9 +806,10 @@ void PalEventClear(PAL_HANDLE handle);
 int PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us);
 
 typedef uint32_t pal_wait_flags_t; /* bitfield */
-#define PAL_WAIT_READ   1
-#define PAL_WAIT_WRITE  2
-#define PAL_WAIT_ERROR  4 /*!< ignored in events */
+#define PAL_WAIT_READ     1
+#define PAL_WAIT_WRITE    2
+#define PAL_WAIT_ERROR    4
+#define PAL_WAIT_HANG_UP  8
 
 /*!
  * \brief Poll - wait for an event to happen on at least one handle.

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -149,5 +149,7 @@ typedef struct {
  * writable respectively. If none of these is set, then the handle has no host-level fd. */
 #define PAL_HANDLE_FD_READABLE  1
 #define PAL_HANDLE_FD_WRITABLE  2
-/* Set if an error was seen on this handle. Currently only set by `_PalStreamsWaitEvents`. */
+/* Set if an error was seen on this handle. */
 #define PAL_HANDLE_FD_ERROR     4
+/* Set if a hang-up was seen on this handle. */
+#define PAL_HANDLE_FD_HANG_UP   8

--- a/pal/src/host/linux-sgx/pal_object.c
+++ b/pal/src/host/linux-sgx/pal_object.c
@@ -46,6 +46,9 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
             if (events[i] & PAL_WAIT_WRITE) {
                 fdevents |= POLLOUT;
             }
+            /* Set `POLLRDHUP` unconditionally here, so that the host `ppoll()` always reports
+             * `POLLRDHUP` if it happened. */
+            fdevents |= POLLRDHUP;
             fds[i].fd = handle->generic.fd;
             fds[i].events = fdevents;
 
@@ -86,10 +89,18 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
             ret_events[i] |= PAL_WAIT_WRITE;
 
         /* FIXME: something is wrong here, it reads and writes to flags without any locks... */
-        if (fds[i].revents & (POLLHUP | POLLERR | POLLNVAL))
+
+        /* report error events on this FD */
+        if (fds[i].revents & (POLLERR | POLLNVAL))
             handle->flags |= PAL_HANDLE_FD_ERROR;
         if (handle->flags & PAL_HANDLE_FD_ERROR)
             ret_events[i] |= PAL_WAIT_ERROR;
+
+        /* report hang-up events on this FD */
+        if (fds[i].revents & (POLLHUP | POLLRDHUP))
+            handle->flags |= PAL_HANDLE_FD_HANG_UP;
+        if (handle->flags & PAL_HANDLE_FD_HANG_UP)
+            ret_events[i] |= PAL_WAIT_HANG_UP;
     }
 
     ret = 0;

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -112,8 +112,10 @@ typedef struct {
  * writable respectively. If none of these is set, then the handle has no host-level fd. */
 #define PAL_HANDLE_FD_READABLE  1
 #define PAL_HANDLE_FD_WRITABLE  2
-/* Set if an error was seen on this handle. Currently only set by `_PalStreamsWaitEvents`. */
+/* Set if an error was seen on this handle. */
 #define PAL_HANDLE_FD_ERROR     4
+/* Set if a hang-up was seen on this handle. */
+#define PAL_HANDLE_FD_HANG_UP   8
 
 int arch_do_rt_sigprocmask(int sig, int how);
 int arch_do_rt_sigaction(int sig, void* handler,

--- a/pal/src/host/linux/pal_object.c
+++ b/pal/src/host/linux/pal_object.c
@@ -48,6 +48,9 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
             if (events[i] & PAL_WAIT_WRITE) {
                 fdevents |= POLLOUT;
             }
+            /* Set `POLLRDHUP` unconditionally here, so that the host `ppoll()` always reports
+             * `POLLRDHUP` if it happened. */
+            fdevents |= POLLRDHUP;
             fds[i].fd = handle->generic.fd;
             fds[i].events = fdevents;
         } else {
@@ -100,10 +103,18 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
 
         /* FIXME: something is wrong here, it reads and writes to flags without any locks... */
         PAL_HANDLE handle = handle_array[i];
-        if (fds[i].revents & (POLLHUP | POLLERR | POLLNVAL))
+
+        /* report error events on this FD */
+        if (fds[i].revents & (POLLERR | POLLNVAL))
             handle->flags |= PAL_HANDLE_FD_ERROR;
         if (handle->flags & PAL_HANDLE_FD_ERROR)
             ret_events[i] |= PAL_WAIT_ERROR;
+
+        /* report hang-up events on this FD */
+        if (fds[i].revents & (POLLHUP | POLLRDHUP))
+            handle->flags |= PAL_HANDLE_FD_HANG_UP;
+        if (handle->flags & PAL_HANDLE_FD_HANG_UP)
+            ret_events[i] |= PAL_WAIT_HANG_UP;
     }
 
     ret = 0;


### PR DESCRIPTION
Previously, `(E)POLLRDHUP` was not handled and `(E)POLLHUP` was always reported together with `(E)POLLERR` due to the limitation of PAL API, which did not distinguish these conditions. This may cause some workloads to ignore the fact that the socket was closed by the peer and hence keep it in the `CLOSE-WAIT` state.

This commit:
* splits (e)poll error events from hup events.
* adds support for `(E)POLLRDHUP` but treats/reports it as `(E)POLLHUP`, i.e., not distinguishing these two states.

Fixes https://github.com/gramineproject/gramine/issues/1034.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1073)
<!-- Reviewable:end -->
