### PR TITLE
[LibOS] Do not try to free unmapped memory on execve

### DIFF
--- a/libos/src/sys/libos_exec.c
+++ b/libos/src/sys/libos_exec.c
@@ -46,8 +46,10 @@ noreturn static void __libos_syscall_execve_rtld(void* new_argp, elf_auxv_t* new
         if (bkeep_munmap(vma->addr, vma->length, !!(vma->flags & VMA_INTERNAL), &tmp_vma) < 0) {
             BUG();
         }
-        if (PalVirtualMemoryFree(vma->addr, vma->length) < 0) {
-            BUG();
+        if (!(vma->flags & VMA_UNMAPPED)) {
+            if (PalVirtualMemoryFree(vma->addr, vma->length) < 0) {
+                BUG();
+            }
         }
         bkeep_remove_tmp_vma(tmp_vma);
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
It's legal according to `PalVirtualMemoryFree` semantics, but is pointless

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1076)
<!-- Reviewable:end -->
