### PR TITLE
[LibOS] fix ASLR calculation

### DIFF
--- a/libos/src/bookkeep/libos_vma.c
+++ b/libos/src/bookkeep/libos_vma.c
@@ -632,16 +632,14 @@ int init_vma(void) {
                                - g_pal_public_state->memory_address_start) / 6 * 5;
         /* We do address space randomization only if we have at least ASLR_BITS to randomize. */
         if (gap_max_size / ALLOC_ALIGNMENT >= (1ul << ASLR_BITS)) {
-            size_t gap = 0;
+            size_t rnd = 0;
 
-            int ret = PalRandomBitsRead(&gap, sizeof(gap));
+            int ret = PalRandomBitsRead(&rnd, sizeof(rnd));
             if (ret < 0) {
                 return pal_to_unix_errno(ret);
             }
-
-            /* Resulting distribution is not ideal, but it should not be an issue here. */
-            gap = ALLOC_ALIGN_DOWN(gap % gap_max_size);
-            g_aslr_addr_top = (char*)g_aslr_addr_top - gap;
+            rnd = (rnd & ((1UL << ASLR_BITS) - 1)) * ALLOC_ALIGNMENT;
+            g_aslr_addr_top = (char*)g_aslr_addr_top - rnd;
 
             log_debug("ASLR top address adjusted to %p", g_aslr_addr_top);
         } else {


### PR DESCRIPTION
## Description of the changes 
In current code, `g_aslr_addr_top` is calculated by `memory_address_end` minus `gap`, which is from 0 to 5/6 of max memory space . Workload that `mmap` more than half of max memory space fails randomly because neither `memory_address_end` to `g_aslr_addr_top` or  `g_aslr_addr_top` to `memory_address_end` can hold the memory space.
https://github.com/gramineproject/gramine/blob/be3331f199bd0166a9d077764d0c3e2cbad17ce1/libos/src/bookkeep/libos_vma.c#L630-L632
 However `gap` in Linux kernel is used to hold stack (https://elixir.bootlin.com/linux/v6.1/source/arch/x86/mm/mmap.c#L85). and `rnd` is used to randomize address, which is calculated according to `mmap_rnd_bits` (https://elixir.bootlin.com/linux/v6.1/source/arch/x86/mm/mmap.c#L74)
It's default 28 for 64bit OS and 8 for 32bit OS. It means that 1/(2^(64-28-12)) and 1/(2^(32-8-12)) of max memory space 2^64 and 2^32.
```
$ sudo cat /proc/sys/vm/mmap_rnd_bits
28
```
In enclave, `sgx.enclave_size` is max memory space and it's usually GB grade, so 1/3 of max memory space is fair.

This PR fixes `g_aslr_addr_top` calculation by 1/3 of max memory space to fix random failure of workload  with  `mmap` half of max memory space.

## How to test this PR? 
existing tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1087)
<!-- Reviewable:end -->
