### PR TITLE
Do `gramine-sgx-get-token` automatically

### DIFF
--- a/CI-Examples/bash/Makefile
+++ b/CI-Examples/bash/Makefile
@@ -9,7 +9,7 @@ endif
 .PHONY: all
 all: bash.manifest
 ifeq ($(SGX),1)
-all: bash.manifest.sgx bash.sig bash.token
+all: bash.manifest.sgx bash.sig
 endif
 
 bash.manifest: manifest.template
@@ -25,9 +25,6 @@ bash.manifest.sgx: bash.manifest
 		--output $@
 
 bash.sig: bash.manifest.sgx
-
-bash.token: bash.sig
-	gramine-sgx-get-token --output bash.token --sig bash.sig
 
 ifeq ($(SGX),)
 GRAMINE = gramine-direct

--- a/CI-Examples/blender/Makefile
+++ b/CI-Examples/blender/Makefile
@@ -26,7 +26,7 @@ endif
 .PHONY: all
 all: $(BLENDER_DIR)/blender blender.manifest | $(DATA_DIR)/images
 ifeq ($(SGX),1)
-all: blender.manifest.sgx blender.sig blender.token
+all: blender.manifest.sgx blender.sig
 endif
 
 $(BLENDER_DIR)/blender:
@@ -57,9 +57,6 @@ sgx_outputs: $(BLENDER_DIR)/blender blender.manifest | $(RUN_DIR)
 	gramine-sgx-sign \
 		--output blender.manifest.sgx \
 		--manifest blender.manifest
-
-blender.token: blender.sig
-	gramine-sgx-get-token --output $@ --sig $<
 
 $(DATA_DIR)/images:
 	mkdir -p $@

--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -20,7 +20,7 @@ RA_CLIENT_LINKABLE ?= 0
 .PHONY: all
 all: busybox busybox.manifest
 ifeq ($(SGX),1)
-all: busybox.manifest.sgx busybox.sig busybox.token
+all: busybox.manifest.sgx busybox.sig
 endif
 
 $(SRCDIR)/Makefile:
@@ -58,10 +58,6 @@ sgx_sign: busybox.manifest busybox
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-busybox.token: busybox.sig
-	gramine-sgx-get-token \
-		--output $@ --sig $<
 
 # Copy Busybox binary to our root directory for simplicity.
 busybox: $(SRCDIR)/busybox

--- a/CI-Examples/helloworld/Makefile
+++ b/CI-Examples/helloworld/Makefile
@@ -11,7 +11,7 @@ endif
 .PHONY: all
 all: helloworld helloworld.manifest
 ifeq ($(SGX),1)
-all: helloworld.manifest.sgx helloworld.sig helloworld.token
+all: helloworld.manifest.sgx helloworld.sig
 endif
 
 helloworld: helloworld.o
@@ -44,10 +44,6 @@ sgx_sign: helloworld.manifest helloworld
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-helloworld.token: helloworld.sig
-	gramine-sgx-get-token \
-		--output $@ --sig $<
 
 ifeq ($(SGX),)
 GRAMINE = gramine-direct

--- a/CI-Examples/lighttpd/Makefile
+++ b/CI-Examples/lighttpd/Makefile
@@ -25,7 +25,7 @@ CONF_FILES = lighttpd-server.conf lighttpd.conf
 .PHONY: all
 all: $(INSTALL_DIR)/sbin/lighttpd lighttpd.manifest $(CONF_FILES) testdata
 ifeq ($(SGX),1)
-all: lighttpd.manifest.sgx lighttpd.sig lighttpd.token
+all: lighttpd.manifest.sgx lighttpd.sig
 endif
 
 $(INSTALL_DIR)/sbin/lighttpd: $(LIGHTTPD_SRC)/configure
@@ -61,9 +61,6 @@ sgx_sign: lighttpd.manifest $(INSTALL_DIR)/sbin/lighttpd
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-lighttpd.token: lighttpd.sig
-	gramine-sgx-get-token --output $@ --sig $^
 
 # lighttpd configuration and test data
 lighttpd-server.conf:

--- a/CI-Examples/memcached/Makefile
+++ b/CI-Examples/memcached/Makefile
@@ -17,7 +17,7 @@ endif
 .PHONY: all
 all: memcached memcached.manifest
 ifeq ($(SGX),1)
-all: memcached.manifest.sgx memcached.sig memcached.token
+all: memcached.manifest.sgx memcached.sig
 endif
 
 $(SRCDIR)/configure:
@@ -46,10 +46,6 @@ sgx_sign: memcached.manifest memcached
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-memcached.token: memcached.sig
-	gramine-sgx-get-token \
-		--output memcached.token --sig memcached.sig
 
 # for simplicity, copy memcached executable into our root directory
 memcached: $(SRCDIR)/memcached

--- a/CI-Examples/nginx/Makefile
+++ b/CI-Examples/nginx/Makefile
@@ -23,7 +23,7 @@ endif
 .PHONY: all
 all: $(INSTALL_DIR)/sbin/nginx nginx.manifest config testdata ssldata nginx_args
 ifeq ($(SGX),1)
-all: nginx.manifest.sgx nginx.sig nginx.token
+all: nginx.manifest.sgx nginx.sig
 endif
 
 # Note that Gramine doesn't support eventfd() and PR_SET_DUMPABLE, so we manually
@@ -66,9 +66,6 @@ sgx_sign: nginx.manifest $(INSTALL_DIR)/sbin/nginx \
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-nginx.token: nginx.sig
-	gramine-sgx-get-token --output $@ --sig $<
 
 # Nginx configuration and test data
 .PHONY: config

--- a/CI-Examples/python/Makefile
+++ b/CI-Examples/python/Makefile
@@ -9,7 +9,7 @@ endif
 .PHONY: all
 all: python.manifest
 ifeq ($(SGX),1)
-all: python.manifest.sgx python.sig python.token
+all: python.manifest.sgx python.sig
 endif
 
 RA_TYPE ?= none
@@ -36,9 +36,6 @@ sgx_sign: python.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-python.token: python.sig
-	gramine-sgx-get-token --output $@ --sig $<
 
 .PHONY: check
 check: all

--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -19,13 +19,13 @@ RA_CLIENT_LINKABLE ?= 0
 all: app epid  # by default, only build EPID because it doesn't rely on additional (DCAP) libs
 
 .PHONY: app
-app: ssl/server.crt server.manifest.sgx server.sig server.token client
+app: ssl/server.crt server.manifest.sgx server.sig client
 
 .PHONY: epid
-epid: client_epid.manifest.sgx client_epid.sig client_epid.token
+epid: client_epid.manifest.sgx client_epid.sig
 
 .PHONY: dcap
-dcap: client_dcap.manifest.sgx client_dcap.sig client_dcap.token
+dcap: client_dcap.manifest.sgx client_dcap.sig
 
 ############################# SSL DATA DEPENDENCY #############################
 
@@ -70,9 +70,6 @@ sgx_sign_server: server.manifest server
 		--manifest $< \
 		--output $<.sgx
 
-server.token: server.sig
-	gramine-sgx-get-token --output $@ --sig $<
-
 ########################### CLIENT (DCAP) MANIFEST ############################
 
 client_dcap.manifest: client.manifest.template
@@ -90,9 +87,6 @@ sgx_sign_client_dcap: client_dcap.manifest client
 		--manifest $< \
 		--output $<.sgx
 
-client_dcap.token: client_dcap.sig
-	gramine-sgx-get-token --output $@ --sig $<
-
 ########################### CLIENT (EPID) MANIFEST ############################
 
 client_epid.manifest: client.manifest.template
@@ -109,9 +103,6 @@ sgx_sign_client_epid: client_epid.manifest client
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-client_epid.token: client_epid.sig
-	gramine-sgx-get-token --output $@ --sig $<
 
 ############################### SGX CHECKS FOR CI #############################
 

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -24,9 +24,9 @@ all: app epid  # by default, only build EPID because it doesn't rely on addition
 .PHONY: app
 app: \
      ssl/server.crt \
-     secret_prov_minimal/client.manifest.sgx secret_prov_minimal/client.sig secret_prov_minimal/client.token \
-     secret_prov/client.manifest.sgx     secret_prov/client.sig     secret_prov/client.token \
-     secret_prov_pf/client.manifest.sgx  secret_prov_pf/client.sig  secret_prov_pf/client.token
+     secret_prov_minimal/client.manifest.sgx secret_prov_minimal/client.sig \
+     secret_prov/client.manifest.sgx     secret_prov/client.sig \
+     secret_prov_pf/client.manifest.sgx  secret_prov_pf/client.sig
 
 .PHONY: epid
 epid: ssl/server.crt secret_prov_minimal/server_epid secret_prov/server_epid secret_prov_pf/server_epid \
@@ -100,9 +100,6 @@ sgx_sign_secret_prov_minimal_client: secret_prov_minimal/client.manifest secret_
 		--manifest $(notdir $<) \
 		--output $(notdir $<.sgx)
 
-secret_prov_minimal/client.token: secret_prov_minimal/client.sig
-	gramine-sgx-get-token --output $@ --sig $<
-
 ############################### CLIENT MANIFEST ###############################
 
 secret_prov/client.manifest: secret_prov/client.manifest.template
@@ -125,9 +122,6 @@ sgx_sign_secret_prov_client: secret_prov/client.manifest secret_prov/client
 		--manifest $(notdir $<) \
 		--output $(notdir $<.sgx)
 
-secret_prov/client.token: secret_prov/client.sig
-	gramine-sgx-get-token --output $@ --sig $<
-
 ############################## PF CLIENT MANIFEST #############################
 
 secret_prov_pf/client.manifest: secret_prov_pf/client.manifest.template
@@ -149,9 +143,6 @@ sgx_sign_secret_prov_pf_client: secret_prov_pf/client.manifest secret_prov_pf/cl
 	gramine-sgx-sign \
 		--manifest $(notdir $<) \
 		--output $(notdir $<.sgx)
-
-secret_prov_pf/client.token: secret_prov_pf/client.sig
-	gramine-sgx-get-token --output $@ --sig $<
 
 ########################## PREPARE PROTECTED FILES ############################
 

--- a/CI-Examples/redis/Makefile
+++ b/CI-Examples/redis/Makefile
@@ -34,7 +34,7 @@ endif
 .PHONY: all
 all: redis-server redis-server.manifest
 ifeq ($(SGX),1)
-all: redis-server.manifest.sgx redis-server.sig redis-server.token
+all: redis-server.manifest.sgx redis-server.sig
 endif
 
 ############################## REDIS EXECUTABLE ###############################
@@ -78,13 +78,6 @@ redis-server.manifest: redis-server.manifest.template
 # procedure measures all Redis trusted files, adds the measurement to the
 # resulting manifest.sgx file (among other, less important SGX options) and
 # creates redis-server.sig (SIGSTRUCT object).
-#
-# Gramine-SGX requires EINITTOKEN and SIGSTRUCT objects (see SGX hardware ABI,
-# in particular EINIT instruction). The "gramine-sgx-get-token" script
-# generates EINITTOKEN based on a SIGSTRUCT and puts it in .token file. Note
-# that filenames must be the same as the manifest name (i.e., "redis-server").
-# EINITTOKEN must be generated on the machine where the application will run,
-# not where it was built.
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
 # see the helloworld example for details on this workaround.
@@ -96,9 +89,6 @@ sgx_outputs: redis-server.manifest $(SRCDIR)/src/redis-server
 	gramine-sgx-sign \
 		--manifest redis-server.manifest \
 		--output redis-server.manifest.sgx
-
-redis-server.token: redis-server.sig
-	gramine-sgx-get-token --output $@ --sig $<
 
 ########################### COPIES OF EXECUTABLES #############################
 

--- a/CI-Examples/rust/Makefile
+++ b/CI-Examples/rust/Makefile
@@ -5,7 +5,7 @@ SELF_EXE = target/release/rust-hyper-http-server
 .PHONY: all
 all: $(SELF_EXE) rust-hyper-http-server.manifest
 ifeq ($(SGX),1)
-all: rust-hyper-http-server.manifest.sgx rust-hyper-http-server.sig rust-hyper-http-server.token
+all: rust-hyper-http-server.manifest.sgx rust-hyper-http-server.sig
 endif
 
 ifeq ($(DEBUG),1)
@@ -39,10 +39,6 @@ sgx_sign: rust-hyper-http-server.manifest $(SELF_EXE)
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-rust-hyper-http-server.token: rust-hyper-http-server.sig
-	gramine-sgx-get-token \
-		--output $@ --sig $<
 
 ifeq ($(SGX),)
 GRAMINE = gramine-direct

--- a/CI-Examples/sqlite/Makefile
+++ b/CI-Examples/sqlite/Makefile
@@ -9,7 +9,7 @@ endif
 .PHONY: all
 all: sqlite3.manifest
 ifeq ($(SGX),1)
-all: sqlite3.manifest.sgx sqlite3.sig sqlite3.token
+all: sqlite3.manifest.sgx sqlite3.sig
 endif
 
 sqlite3.manifest: manifest.template
@@ -29,9 +29,6 @@ sgx_sign: sqlite3.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
-
-sqlite3.token: sqlite3.sig
-	gramine-sgx-get-token --output sqlite3.token --sig sqlite3.sig
 
 ifeq ($(SGX),)
 GRAMINE = gramine-direct

--- a/Documentation/manpages/gramine-sgx-get-token.rst
+++ b/Documentation/manpages/gramine-sgx-get-token.rst
@@ -17,6 +17,9 @@ Description
 :program:`gramine-sgx-get-token` is used to generate the SGX token file for
 given SIGSTRUCT (".sig" file).
 
+Using this command is not necessary (it was previously), since the token is
+fetched automatically if needed during the first enclave start.
+
 Command line arguments
 ======================
 

--- a/Documentation/manpages/gramine.rst
+++ b/Documentation/manpages/gramine.rst
@@ -19,3 +19,12 @@ Description
 
 This is the main way to invoke Gramine. The first argument is the name of the
 application (that is, name of the manifest file *without* ``.manifest``).
+
+Environment variables
+=====================
+
+.. envvar:: GRAMINE_NO_AUTO_GET_TOKEN
+
+   If not empty, :command:`gramine-sgx` will not automatically generate
+   EINITTOKEN (for out-of-tree EPID driver), or its dummy counterpart (for
+   upstream and DCAP drivers).

--- a/tools/gramine.in
+++ b/tools/gramine.in
@@ -88,6 +88,18 @@ if [ ! -f "$PAL_CMD" ]; then
 	exit 1
 fi
 
+if [ "$SGX" == "1" ] \
+&& [ ! -e "$APPLICATION".token ] \
+&& [ -f "$APPLICATION".sig ] \
+&& [ -z "$GRAMINE_NO_AUTO_GET_TOKEN" ]
+then
+    @PREFIX@/@BINDIR@/gramine-sgx-get-token \
+        --output "$APPLICATION".token \
+        --sig "$APPLICATION".sig \
+    >&2
+fi
+
+
 CMD=("${ENVS[@]}")
 CMD+=("${PREFIX[@]}")
 CMD+=("$PAL_CMD" "$LIBPAL_PATH" init "$APPLICATION" "$@")

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,5 +1,7 @@
 conf = configuration_data()
 conf.set_quoted('IN_GIT', '')
+conf.set_quoted('PREFIX', prefix)
+conf.set_quoted('BINDIR', get_option('bindir'))
 
 if direct
     hostpalpath_direct = join_paths(prefix, pkglibdir, 'direct')


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There's no EINITTOKEN on upstream driver (nor DCAP), and most people use that driver (it is/will be the only packaged flavour). It's bad UX to require them to do `gramine-sgx-get-token` for nothing (like, 384 * `\0`).

This PR is the first of series of two. It changes UX (`gramine-sgx-get-token` gets called automatically), but doesn't change behaviour of loader (the `.token` file is still required).

## How to test this PR? <!-- (if applicable) -->

Run `gramine-sgx` without doing `gramine-sgx-get-token` first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1093)
<!-- Reviewable:end -->
