### PR TITLE
[Docs] CONTRIBUTING.rst: Update the list of maintainers

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -254,22 +254,32 @@ For more information on how to run the ltp tests, please refer to
 :file:`libos/test/ltp/README.rst`.
 
 
-Management Team
-===============
+Management Team (Maintainers)
+=============================
 
-The current members of the management team are:
+The currently active members of the management team are:
 
 * Michał Kowalczyk (Invisible Things Lab/Intel)
 * Dmitrii Kuvaiskii (Intel)
-* Paweł Marczewski (Invisible Things Lab/Intel)
 * Borys Popławski (Invisible Things Lab/Intel)
+* Wojtek Porczyk (Invisible Things Lab/Intel)
 * Don Porter (UNC)
 * Chia-Che Tsai (Texas A&M University)
-* Rafał Wojdyła (Invisible Things Lab/Golem)
 * Mona Vij (Intel)
-* Isaku Yamahata (Intel)
 
-The procedure for adding and removing maintainers
+The past (inactive) members of the management team are:
+
+* Paweł Marczewski
+* Rafał Wojdyła
+* Isaku Yamahata
+
+The active members have the review and voting rights. The past (inactive)
+members have only the review rights.
+
+The active members are also the TSC voting members as described in the Technical
+Charter for Gramine project.
+
+The Procedure for Adding and Removing Maintainers
 -------------------------------------------------
 
 + Joining: # of PRs submitted & merged + # of PRs reviewed + # of issues closed
@@ -277,5 +287,5 @@ The procedure for adding and removing maintainers
   and thorough reviews count.
 + Leaving: a member may be removed if not active or notoriously breaking rules
   from this document.
-+ Additionally, at least 60% (rounded up) of current members have to agree to
-  make any change to the team membership.
++ Additionally, at least 60% (rounded up) of currently active members have to
+  agree to make any change to the team membership.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As discussed in the Gramine core meeting, we'd like to:
- split the list of maintainers into active and inactive,
- amend the rules slightly so that only active maintainers vote,
- add @woju as the active maintainer.

## How to test this PR? <!-- (if applicable) -->

We need to agree and vote on these changes. The comments/reviews in this PR will serve as the voting procedure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1095)
<!-- Reviewable:end -->
