### PR TITLE
[Pal] Enhance device "dev:tty" checking

### DIFF
--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -74,6 +74,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
+            bool is_tty;
             bool nonblocking;
         } dev;
 

--- a/pal/src/host/linux/pal_devices.c
+++ b/pal/src/host/linux/pal_devices.c
@@ -38,6 +38,7 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
 
     if (!strcmp(uri, "tty")) {
         /* special case of "dev:tty" device which is the standard input + standard output */
+        hdl->dev.is_tty      = true;
         hdl->dev.nonblocking = false;
 
         if (access == PAL_ACCESS_RDONLY) {
@@ -53,6 +54,7 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
         }
     } else {
         /* other devices must be opened through the host */
+        hdl->dev.is_tty      = false;
         hdl->dev.nonblocking = !!(options & PAL_OPTION_NONBLOCK);
 
         ret = DO_SYSCALL(open, uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
@@ -115,9 +117,8 @@ static int dev_close(PAL_HANDLE handle) {
     if (handle->hdr.type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    /* currently we just assign `0`/`1` FDs without duplicating, so close is a no-op for them */
     int ret = 0;
-    if (handle->dev.fd != PAL_IDX_POISON && handle->dev.fd != 0 && handle->dev.fd != 1) {
+    if (handle->dev.fd != PAL_IDX_POISON && !handle->dev.is_tty) {
         ret = DO_SYSCALL(close, handle->dev.fd);
     }
     handle->dev.fd = PAL_IDX_POISON;
@@ -166,7 +167,7 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     if (handle->hdr.type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    if (handle->dev.fd == 0 || handle->dev.fd == 1) {
+    if (handle->dev.is_tty) {
         /* special case of "dev:tty" device which is the standard input + standard output */
         attr->share_flags  = 0;
         attr->pending_size = 0;
@@ -191,7 +192,7 @@ static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
     if (handle->hdr.type != PAL_TYPE_DEV)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->dev.fd == 0 || handle->dev.fd == 1))
+    if (!handle->dev.is_tty)
         return -PAL_ERROR_NOTSUPPORT;
 
     if (length != 0)

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -51,6 +51,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
+            bool is_tty;
             bool nonblocking;
         } dev;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
After `fork`, `fd` in Pal for stdin/stdout is not `0`/`1`. 
During `fork`, `PalSendHandle` uses syscall `sendmsg` to send internal file handle(including stdin and stdout) from parent to child, `SCM_RIGHTS` is specified to pass file descriptors directly.
https://github.com/gramineproject/gramine/blob/be3331f199bd0166a9d077764d0c3e2cbad17ce1/pal/src/host/linux/pal_streams.c#L210
https://github.com/gramineproject/gramine/blob/be3331f199bd0166a9d077764d0c3e2cbad17ce1/pal/src/host/linux/pal_streams.c#L285
The file descriptor numbers in the received message are reassigned.

A flag `is_tty` is added to mark the fd is tty. Use this flag instead of fd numbers to check tty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1096)
<!-- Reviewable:end -->
