### PR TITLE
[mbedtls] Use `pkg-config --cflags mbedtls_gramine`

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -19,7 +19,7 @@ RA_CLIENT_LINKABLE ?= 0
 all: app epid  # by default, only build EPID because it doesn't rely on additional (DCAP) libs
 
 .PHONY: app
-app: ssl/server.crt mbedtls/.mbedtls_downloaded server.manifest.sgx server.sig server.token client
+app: ssl/server.crt server.manifest.sgx server.sig server.token client
 
 .PHONY: epid
 epid: client_epid.manifest.sgx client_epid.sig client_epid.token
@@ -37,44 +37,15 @@ ssl/server.crt: ssl/ca_config.conf
 	openssl req -new -key ssl/server.key -out ssl/server.csr -config ssl/ca_config.conf
 	openssl x509 -req -days 360 -in ssl/server.csr -CA ssl/ca.crt -CAkey ssl/ca.key -CAcreateserial -out ssl/server.crt
 
-############################# MBEDTLS DEPENDENCY ##############################
-
-# This download is done to get headers in include/, because we currently fail to provide the headers
-# (`pkg-config --cflags mbedtls_gramine` in the below CFLAGS line returns a non-existing directory).
-# TODO: install mbedtls_gramine headers during Gramine install, and use them in below CFLAGS line.
-
-MBEDTLS_VERSION ?= 3.3.0
-MBEDTLS_SRC ?= mbedtls-$(MBEDTLS_VERSION).tar.gz
-MBEDTLS_URI ?= \
-	https://github.com/ARMmbed/mbedtls/archive \
-	https://packages.gramineproject.io/distfiles
-MBEDTLS_HASH ?= a22ff38512697b9cd8472faa2ea2d35e320657f6d268def3a64765548b81c3ec
-
-ifeq ($(DEBUG),1)
-MBED_BUILD_TYPE=Debug
-else
-MBED_BUILD_TYPE=Release
-endif
-
-$(MBEDTLS_SRC):
-	../common_tools/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_HASH)
-
-.SECONDARY: mbedtls/.mbedtls_downloaded
-mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC)
-	tar --touch -xzf $(MBEDTLS_SRC)
-	mv mbedtls-mbedtls-$(MBEDTLS_VERSION) mbedtls
-	touch $@
-
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
-# TODO: use `$(shell pkg-config --cflags mbedtls_gramine)` instead of local mbedtls includes
-CFLAGS += -I./mbedtls/include
+CFLAGS += $(shell pkg-config --cflags mbedtls_gramine)
 LDFLAGS += -ldl -Wl,--enable-new-dtags $(shell pkg-config --libs mbedtls_gramine)
 
-server: src/server.c mbedtls/.mbedtls_downloaded
+server: src/server.c
 	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
 
-client: src/client.c mbedtls/.mbedtls_downloaded
+client: src/client.c
 	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
 
 ############################### SERVER MANIFEST ###############################
@@ -193,4 +164,4 @@ clean:
 
 .PHONY: distclean
 distclean: clean
-	$(RM) -r mbedtls/ *.tar.gz ssl/ca.* ssl/server.*
+	$(RM) -r ssl/ca.* ssl/server.*

--- a/debian/gramine.install
+++ b/debian/gramine.install
@@ -13,3 +13,5 @@ usr/lib/${DEB_HOST_MULTIARCH}/libra_tls_attest.so*
 usr/lib/${DEB_HOST_MULTIARCH}/libsecret_prov_attest.so*
 usr/lib/${DEB_HOST_MULTIARCH}/libsgx_util.a*
 usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig/*.pc
+usr/include/gramine/mbedtls/*.h
+usr/include/gramine/psa/*.h

--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -43,6 +43,7 @@ pkgconfig.generate(
     name: 'mbedtls_gramine',
     filebase: 'mbedtls_gramine',
     description: 'A version of mbedtls patched for Gramine',
+    subdirs: 'gramine',
     libraries: [
         '-L${libdir}',
         '-Wl,-rpath,${libdir}',
@@ -60,6 +61,11 @@ foreach output : mbedtls_libs_output
         '"$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/runtime/glibc/').format(
             output, get_option('libdir')))
 endforeach
+
+# We rely on the fact that for `mbedtls_gramine` package, we don't need any changes in the default
+# mbedTLS headers
+install_subdir('mbedtls-mbedtls-3.3.0/include/mbedtls', install_dir: get_option('includedir') / 'gramine')
+install_subdir('mbedtls-mbedtls-3.3.0/include/psa', install_dir: get_option('includedir') / 'gramine')
 
 mbedtls_pal_libs = custom_target('mbedtls_pal',
     command: [


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine didn't install the header files for the `mbedtls_gramine` package. This required e.g. the `ra-tls-mbedtls` example to download mbedTLS and use its headers. This PR copies the header files such that they can be accessed via pkg-config, and `ra-tls-mbedtls` example uses it now.

This PR is part of solving #1071.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1106)
<!-- Reviewable:end -->
