### PR TITLE
[LibOS] Use rwlock in libos handle map

### DIFF
--- a/libos/include/arch/x86_64/gramine_entry_api.h
+++ b/libos/include/arch/x86_64/gramine_entry_api.h
@@ -29,6 +29,9 @@ jmpq *%gs:GRAMINE_SYSCALL_OFFSET
 
 #else /* !__ASSEMBLER__ */
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #define GRAMINE_STR(x)  #x
 #define GRAMINE_XSTR(x) GRAMINE_STR(x)
 
@@ -47,6 +50,15 @@ __asm__(
 enum {
     GRAMINE_CALL_REGISTER_LIBRARY = 1,
     GRAMINE_CALL_RUN_TEST,
+    /* For RW locks test. GRAMINE_CALL_RUN_TEST is not suitable for it, because we need full control
+     * over locks from multiple threads. Additionally, this test is non-trivial in size, so it
+     * doesn't seem right to always compile it into our LibOS. */
+    GRAMINE_CALL_RWLOCK_CREATE,
+    GRAMINE_CALL_RWLOCK_DESTROY,
+    GRAMINE_CALL_RWLOCK_READ_LOCK,
+    GRAMINE_CALL_RWLOCK_READ_UNLOCK,
+    GRAMINE_CALL_RWLOCK_WRITE_LOCK,
+    GRAMINE_CALL_RWLOCK_WRITE_UNLOCK,
 };
 
 /* Magic syscall number for Gramine custom calls */
@@ -68,6 +80,30 @@ static inline int gramine_register_library(const char* name, unsigned long load_
 
 static inline int gramine_run_test(const char* test_name) {
     return gramine_call(GRAMINE_CALL_RUN_TEST, (unsigned long)test_name, 0);
+}
+
+static inline bool gramine_rwlock_create(void** out_lock) {
+    return gramine_call(GRAMINE_CALL_RWLOCK_CREATE, (unsigned long)out_lock, 0);
+}
+
+static inline void gramine_rwlock_destroy(void* lock) {
+    gramine_call(GRAMINE_CALL_RWLOCK_DESTROY, (unsigned long)lock, 0);
+}
+
+static inline void gramine_rwlock_read_lock(void* lock) {
+    gramine_call(GRAMINE_CALL_RWLOCK_READ_LOCK, (unsigned long)lock, 0);
+}
+
+static inline void gramine_rwlock_read_unlock(void* lock) {
+    gramine_call(GRAMINE_CALL_RWLOCK_READ_UNLOCK, (unsigned long)lock, 0);
+}
+
+static inline void gramine_rwlock_write_lock(void* lock) {
+    gramine_call(GRAMINE_CALL_RWLOCK_WRITE_LOCK, (unsigned long)lock, 0);
+}
+
+static inline void gramine_rwlock_write_unlock(void* lock){
+    gramine_call(GRAMINE_CALL_RWLOCK_WRITE_UNLOCK, (unsigned long)lock, 0);
 }
 
 #endif /* __ASSEMBLER__ */

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -16,6 +16,7 @@
 #include "libos_lock.h"
 #include "libos_pollable_event.h"
 #include "libos_refcount.h"
+#include "libos_rwlock.h"
 #include "libos_sync.h"
 #include "libos_types.h"
 #include "linux_abi/limits.h"
@@ -223,7 +224,7 @@ struct libos_handle_map {
 
     /* refrence count and lock */
     refcount_t ref_count;
-    struct libos_lock lock;
+    struct libos_rwlock lock;
 
     /* An array of file descriptor belong to this mapping */
     struct libos_fd_handle** map;
@@ -251,8 +252,6 @@ int set_new_fd_handle_by_fd(uint32_t fd, struct libos_handle* hdl, int fd_flags,
                             struct libos_handle_map* map);
 int set_new_fd_handle_above_fd(uint32_t fd, struct libos_handle* hdl, int fd_flags,
                                struct libos_handle_map* map);
-struct libos_handle* __detach_fd_handle(struct libos_fd_handle* fd, int* flags,
-                                        struct libos_handle_map* map);
 struct libos_handle* detach_fd_handle(uint32_t fd, int* flags, struct libos_handle_map* map);
 void detach_all_fds(void);
 void close_cloexec_handles(struct libos_handle_map* map);
@@ -261,8 +260,6 @@ void close_cloexec_handles(struct libos_handle_map* map);
 int dup_handle_map(struct libos_handle_map** new_map, struct libos_handle_map* old_map);
 void get_handle_map(struct libos_handle_map* map);
 void put_handle_map(struct libos_handle_map* map);
-int walk_handle_map(int (*callback)(struct libos_fd_handle*, struct libos_handle_map*),
-                    struct libos_handle_map* map);
 
 int init_handle(void);
 int init_std_handles(void);

--- a/libos/include/libos_rwlock.h
+++ b/libos/include/libos_rwlock.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+
+/*
+ * Readers-writer lock implementation.
+ * Inspired by https://eli.thegreenplace.net/2019/implementing-reader-writer-locks/.
+ *
+ * High level description:
+ * The most important part is the `state` variable, which tracks the number of active readers. It
+ * also indicates whether a writer is active (waiting for the lock or already has it). Each reader
+ * increments this variable on lock and decrements on unlock. A writer decrements it by a large
+ * value (bigger than the maximal number of readers) on write lock, which also hints any incoming
+ * readers that a writer is pending (so they must wait for the writer to finish).
+ * Rest of the variables is used to signal waiting readers when the writer is finished and
+ * the waiting writer when all the readers have released the lock.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "libos_lock.h"
+
+struct libos_rwlock {
+    /*
+     * State of the lock:
+     * = 0 - unlocked
+     * < 0 - write locked or writer waiting for the lock
+     * > 0 - read locked
+     *
+     * All accesses are acquire/release atomics, which also synchronize readers with writers.
+     */
+    int64_t state;
+    /* Number of readers having the lock after writer tried to acquire it. */
+    int64_t departing_readers;
+    /* Semaphore for writer to wait on. */
+    PAL_HANDLE writer_wait;
+    /* Semaphore for readers to wait on. */
+    PAL_HANDLE readers_wait;
+    /* Number of readers waiting on `readers_wait` after writer releases the lock. */
+    size_t waiting_readers;
+    /* Mutex to prevent multiple writers. */
+    struct libos_lock writers_lock;
+};
+
+/* This number must be greater than the maximal number of readers or writer starvation might
+ * happen. */
+#define WRITER_WEIGHT (1ul << 60)
+
+bool rwlock_create(struct libos_rwlock* l);
+void rwlock_destroy(struct libos_rwlock* l);
+
+void rwlock_read_lock_slow_path(struct libos_rwlock* l);
+void rwlock_read_unlock_slow_path(struct libos_rwlock* l);
+
+static inline void rwlock_read_lock(struct libos_rwlock* l) {
+    int64_t state = __atomic_fetch_add(&l->state, 1, __ATOMIC_ACQUIRE);
+    if (state < 0) {
+        rwlock_read_lock_slow_path(l);
+    }
+}
+
+static inline void rwlock_read_unlock(struct libos_rwlock* l) {
+    int64_t state = __atomic_sub_fetch(&l->state, 1, __ATOMIC_RELEASE);
+    if (state < 0) {
+        rwlock_read_unlock_slow_path(l);
+    }
+}
+
+void rwlock_write_lock(struct libos_rwlock* l);
+void rwlock_write_unlock(struct libos_rwlock* l);
+
+#ifdef DEBUG
+/*
+ * These two functions are not complete and might return false positives, but there are no false
+ * negatives. Creating a fully complete check (working in all cases) is very hard or even impossible
+ * with the current implementation, so this should be good enough.
+ */
+static inline bool rwlock_is_read_locked(struct libos_rwlock* l) {
+    return __atomic_load_n(&l->state, __ATOMIC_RELAXED) != 0;
+}
+
+static inline bool rwlock_is_write_locked(struct libos_rwlock* l) {
+    return locked(&l->writers_lock) && __atomic_load_n(&l->state, __ATOMIC_RELAXED) < 0;
+}
+#endif // DEBUG

--- a/libos/src/fs/proc/thread.c
+++ b/libos/src/fs/proc/thread.c
@@ -236,15 +236,15 @@ bool proc_thread_fd_name_exists(struct libos_dentry* parent, const char* name) {
 
     struct libos_handle_map* handle_map = get_thread_handle_map(NULL);
     assert(handle_map);
-    lock(&handle_map->lock);
+    rwlock_read_lock(&handle_map->lock);
 
     if (fd > handle_map->fd_top || handle_map->map[fd] == NULL ||
             handle_map->map[fd]->handle == NULL) {
-        unlock(&handle_map->lock);
+        rwlock_read_unlock(&handle_map->lock);
         return false;
     }
 
-    unlock(&handle_map->lock);
+    rwlock_read_unlock(&handle_map->lock);
     return true;
 }
 
@@ -253,7 +253,7 @@ int proc_thread_fd_list_names(struct libos_dentry* parent, readdir_callback_t ca
 
     struct libos_handle_map* handle_map = get_thread_handle_map(NULL);
     assert(handle_map);
-    lock(&handle_map->lock);
+    rwlock_read_lock(&handle_map->lock);
 
     int ret = 0;
     for (uint32_t i = 0; i <= handle_map->fd_top; i++)
@@ -264,7 +264,7 @@ int proc_thread_fd_list_names(struct libos_dentry* parent, readdir_callback_t ca
                 break;
         }
 
-    unlock(&handle_map->lock);
+    rwlock_read_unlock(&handle_map->lock);
     return ret;
 }
 
@@ -297,11 +297,11 @@ int proc_thread_fd_follow_link(struct libos_dentry* dent, char** out_target) {
 
     struct libos_handle_map* handle_map = get_thread_handle_map(NULL);
     assert(handle_map);
-    lock(&handle_map->lock);
+    rwlock_read_lock(&handle_map->lock);
 
     if (fd > handle_map->fd_top || handle_map->map[fd] == NULL ||
             handle_map->map[fd]->handle == NULL) {
-        unlock(&handle_map->lock);
+        rwlock_read_unlock(&handle_map->lock);
         return -ENOENT;
     }
 
@@ -317,7 +317,7 @@ int proc_thread_fd_follow_link(struct libos_dentry* dent, char** out_target) {
         ret = *out_target ? 0 : -ENOMEM;
     }
 
-    unlock(&handle_map->lock);
+    rwlock_read_unlock(&handle_map->lock);
 
     return ret;
 }

--- a/libos/src/libos_rwlock.c
+++ b/libos/src/libos_rwlock.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2022 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+
+#include "libos_rwlock.h"
+#include "pal.h"
+
+bool rwlock_create(struct libos_rwlock* l) {
+    l->state = 0;
+    l->departing_readers = 0;
+    if (PalEventCreate(&l->readers_wait, /*init_signaled=*/false, /*auto_clear=*/false) < 0) {
+        return false;
+    }
+    if (PalEventCreate(&l->writer_wait, /*init_signaled=*/false, /*auto_clear=*/true) < 0) {
+        PalObjectClose(l->readers_wait);
+        return false;
+    }
+    l->waiting_readers = 0;
+    if (!create_lock(&l->writers_lock)) {
+        PalObjectClose(l->readers_wait);
+        PalObjectClose(l->writer_wait);
+        return false;
+    }
+    return true;
+}
+
+void rwlock_destroy(struct libos_rwlock* l) {
+    assert(__atomic_load_n(&l->state, __ATOMIC_ACQUIRE) == 0);
+    assert(l->departing_readers == 0);
+    assert(l->waiting_readers == 0);
+
+    PalObjectClose(l->readers_wait);
+    PalObjectClose(l->writer_wait);
+    destroy_lock(&l->writers_lock);
+}
+
+void rwlock_read_lock_slow_path(struct libos_rwlock* l) {
+    while (PalEventWait(l->readers_wait, /*timeout=*/NULL) < 0)
+        /* nop */;
+    size_t waiting_readers = __atomic_sub_fetch(&l->waiting_readers, 1, __ATOMIC_RELAXED);
+    if (waiting_readers == 0) {
+        PalEventSet(l->writer_wait);
+    }
+    /* This prevents code hoisting. */
+    (void)__atomic_load_n(&l->state, __ATOMIC_ACQUIRE);
+}
+
+void rwlock_read_unlock_slow_path(struct libos_rwlock* l) {
+    int64_t departing = __atomic_sub_fetch(&l->departing_readers, 1, __ATOMIC_RELAXED);
+    if (departing == 0) {
+        /* Last reader, wake up writer. */
+        PalEventSet(l->writer_wait);
+    }
+}
+
+void rwlock_write_lock(struct libos_rwlock* l) {
+    lock(&l->writers_lock);
+
+    int64_t state = __atomic_fetch_sub(&l->state, WRITER_WEIGHT, __ATOMIC_ACQUIRE);
+    if (state > 0) {
+        int64_t departing = __atomic_add_fetch(&l->departing_readers, state, __ATOMIC_RELAXED);
+        if (departing != 0) {
+            assert(departing > 0);
+            while (PalEventWait(l->writer_wait, /*timeout=*/NULL) < 0)
+                /* nop */;
+        }
+        /* This prevents code hoisting. */
+        (void)__atomic_load_n(&l->state, __ATOMIC_ACQUIRE);
+    }
+}
+
+void rwlock_write_unlock(struct libos_rwlock* l) {
+    int64_t state = __atomic_add_fetch(&l->state, WRITER_WEIGHT, __ATOMIC_RELEASE);
+    assert(state >= 0);
+
+    if (state) {
+        __atomic_store_n(&l->waiting_readers, state, __ATOMIC_RELAXED);
+
+        /* Wake up readers. */
+        PalEventSet(l->readers_wait);
+
+        /* Wait for all waiting readers to actually wake up... */
+        while (PalEventWait(l->writer_wait, /*timeout=*/NULL) < 0)
+            /* nop */;
+
+        /* ...and unset the event. */
+        PalEventClear(l->readers_wait);
+    }
+
+    unlock(&l->writers_lock);
+}

--- a/libos/src/meson.build
+++ b/libos/src/meson.build
@@ -63,6 +63,7 @@ libos_sources = files(
     'libos_parser.c',
     'libos_pollable_event.c',
     'libos_rtld.c',
+    'libos_rwlock.c',
     'libos_syscalls.c',
     'libos_utils.c',
     'net/ip.c',

--- a/libos/src/sys/libos_fcntl.c
+++ b/libos/src/sys/libos_fcntl.c
@@ -164,10 +164,10 @@ long libos_syscall_fcntl(int fd, int cmd, unsigned long arg) {
 
         /* F_SETFD (int) */
         case F_SETFD:
-            lock(&handle_map->lock);
+            rwlock_write_lock(&handle_map->lock);
             if (HANDLE_ALLOCATED(handle_map->map[fd]))
                 handle_map->map[fd]->flags = arg & FD_CLOEXEC;
-            unlock(&handle_map->lock);
+            rwlock_write_unlock(&handle_map->lock);
             ret = 0;
             break;
 

--- a/libos/src/sys/libos_ioctl.c
+++ b/libos/src/sys/libos_ioctl.c
@@ -61,24 +61,24 @@ long libos_syscall_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
             ret = set_handle_nonblocking(hdl, !!nonblocking_on);
             break;
         case FIONCLEX:
-            lock(&handle_map->lock);
+            rwlock_write_lock(&handle_map->lock);
             if (HANDLE_ALLOCATED(handle_map->map[fd])) {
                 handle_map->map[fd]->flags &= ~FD_CLOEXEC;
                 ret = 0;
             } else {
                 ret = -EBADF;
             }
-            unlock(&handle_map->lock);
+            rwlock_write_unlock(&handle_map->lock);
             break;
         case FIOCLEX:
-            lock(&handle_map->lock);
+            rwlock_write_lock(&handle_map->lock);
             if (HANDLE_ALLOCATED(handle_map->map[fd])) {
                 handle_map->map[fd]->flags |= FD_CLOEXEC;
                 ret = 0;
             } else {
                 ret = -EBADF;
             }
-            unlock(&handle_map->lock);
+            rwlock_write_unlock(&handle_map->lock);
             break;
         case FIOASYNC:
             ret = install_async_event(hdl->pal_handle, 0, &signal_io, NULL);

--- a/libos/src/sys/libos_poll.c
+++ b/libos/src/sys/libos_poll.c
@@ -82,7 +82,7 @@ static long do_poll(struct pollfd* fds, size_t fds_len, uint64_t* timeout_us) {
     size_t ret_events_count = 0;
     struct libos_handle_map* map = get_cur_thread()->handle_map;
 
-    lock(&map->lock);
+    rwlock_read_lock(&map->lock);
 
     /*
      * After each iteration of this loop either:
@@ -124,7 +124,7 @@ static long do_poll(struct pollfd* fds, size_t fds_len, uint64_t* timeout_us) {
             }
 
             if (ret < 0) {
-                unlock(&map->lock);
+                rwlock_read_unlock(&map->lock);
                 goto out;
             }
 
@@ -166,7 +166,7 @@ static long do_poll(struct pollfd* fds, size_t fds_len, uint64_t* timeout_us) {
         pal_handles[i] = pal_handle;
     }
 
-    unlock(&map->lock);
+    rwlock_read_unlock(&map->lock);
 
     uint64_t tmp_timeout_us = 0;
     if (ret_events_count) {

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -93,8 +93,13 @@ tests = {
     'rename_unlink': {},
     'run_test': {
         'include_directories': include_directories(
-            # for `libos_entry_api.h`
-            '../../include',
+            # for `gramine_entry_api.h`
+            '../../include/arch' / host_machine.cpu_family(),
+        ),
+    },
+    'rwlock': {
+        'include_directories': include_directories(
+            # for `gramine_entry_api.h`
             '../../include/arch' / host_machine.cpu_family(),
         ),
     },

--- a/libos/test/regression/rwlock.c
+++ b/libos/test/regression/rwlock.c
@@ -1,0 +1,190 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+ */
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <threads.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "gramine_entry_api.h"
+
+#define CHECK_IF_TRUE(x) CHECK((x) ? 0 : -1)
+
+/* Large enough to make naive modifications non-atomic on x64. */
+struct shared_state {
+    uint64_t a, b; // first fibonacci sequence
+    uint64_t c, d; // second fibonacci sequence (one step ahead of the first)
+};
+
+struct reader_args {
+    void* lock;
+    struct shared_state* m;
+    size_t total_iterations;
+};
+
+struct writer_args {
+    void* lock;
+    struct shared_state* m;
+    size_t iterations;
+    size_t writers_delay_us;
+};
+
+/* Keeps its own fibonacci sequence and synchronizes it with the shared ones. */
+static void reader(void* lock, struct shared_state* m, size_t total_iterations) {
+    uint64_t a = 0, b = 1;
+    size_t current_it = 0;
+    while (current_it < total_iterations) {
+        gramine_rwlock_read_lock(lock);
+        CHECK_IF_TRUE(m->b == m->c);
+        CHECK_IF_TRUE(m->a + m->b == m->d);
+        while (b != m->d) {
+            /* Advance local sequence to the global state */
+            uint64_t sum = a + b;
+            a = b;
+            b = sum;
+            current_it++;
+            CHECK_IF_TRUE(current_it <= total_iterations);
+        }
+        gramine_rwlock_read_unlock(lock);
+    }
+}
+
+static int reader_(void* args_) {
+    const struct reader_args* args = (const struct reader_args*)args_;
+    reader(args->lock, args->m, args->total_iterations);
+    return 0;
+}
+
+static void writer(void* lock, struct shared_state* m, size_t iterations, size_t writers_delay_us) {
+    for (size_t i = 0; i < iterations; i++) {
+        gramine_rwlock_write_lock(lock);
+        /* Computing fibonacci this exact way doesn't make much sense, but we need some workload
+         * to be executed for testing. */
+        m->b += m->a;
+        m->a = m->b - m->a;
+        thrd_yield();
+        m->d += m->c;
+        m->c = m->d - m->c;
+        gramine_rwlock_write_unlock(lock);
+
+        CHECK(usleep(writers_delay_us));
+    }
+}
+
+static int writer_(void* args_) {
+    const struct writer_args* args = (const struct writer_args*)args_;
+    writer(args->lock, args->m, args->iterations, args->writers_delay_us);
+    return 0;
+}
+
+static void run_test(size_t iterations, size_t readers_num, size_t writers_num,
+                     size_t writers_delay_us) {
+    struct shared_state m = {1, 0, 0, 1};
+    void* lock;
+    if (!gramine_rwlock_create(&lock))
+        errx(1, "gramine_rwlock_create failed");
+
+    thrd_t* threads = calloc(sizeof(*threads), readers_num + writers_num);
+    if (!threads)
+        errx(1, "calloc failed");
+
+    struct reader_args reader_args = {
+        .lock = lock,
+        .m = &m,
+        .total_iterations = iterations * writers_num,
+    };
+    struct writer_args writer_args = {
+        .lock = lock,
+        .m = &m,
+        .iterations = iterations,
+        .writers_delay_us = writers_delay_us,
+    };
+
+    /* Spawn readers */
+    for (size_t i = 0; i < readers_num; i++) {
+        int ret = thrd_create(&threads[i], reader_, &reader_args);
+        if (ret != thrd_success)
+            errx(1, "thrd_create failed with ret = %d", ret);
+    }
+    /* Spawn writers */
+    for (size_t i = readers_num; i < readers_num + writers_num; i++) {
+        int ret = thrd_create(&threads[i], writer_, &writer_args);
+        if (ret != thrd_success)
+            errx(1, "thrd_create failed with ret = %d", ret);
+    }
+
+    /* Wait for all */
+    for (size_t i = 0; i < readers_num + writers_num; i++) {
+        int ret = thrd_join(threads[i], NULL);
+        if (ret != thrd_success)
+            errx(1, "thrd_join failed with ret = %d", ret);
+    }
+    gramine_rwlock_destroy(lock);
+    free(threads);
+}
+
+struct run_test_args {
+    size_t iterations;
+    size_t readers_num;
+    size_t writers_num;
+    size_t writers_delay_us;
+};
+
+static int run_test_(void* args_) {
+    const struct run_test_args* args = (const struct run_test_args*)args_;
+    run_test(args->iterations, args->readers_num, args->writers_num, args->writers_delay_us);
+    return 0;
+}
+
+static size_t str_to_size_t(const char* str) {
+    errno = 0;
+    size_t res = strtoul(str, /*str_end=*/NULL, 10);
+    CHECK_IF_TRUE(errno == 0);
+    return res;
+}
+
+int main(int argc, char* argv[]) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+
+    if (argc != 6)
+        errx(2, "Usage: %s <instances> <iterations> <readers_num> <writers_num> <writers_delay_us>\n", argv[0]);
+
+    size_t instances_num = str_to_size_t(argv[1]);
+    size_t iterations = str_to_size_t(argv[2]);
+    size_t readers_num = str_to_size_t(argv[3]);
+    size_t writers_num = str_to_size_t(argv[4]);
+    size_t writers_delay_us = str_to_size_t(argv[5]);
+
+    thrd_t* threads = calloc(sizeof(*threads), instances_num);
+    if (!threads)
+        errx(1, "calloc failed");
+
+    struct run_test_args run_test_args = {
+        .iterations = iterations,
+        .readers_num = readers_num,
+        .writers_num = writers_num,
+        .writers_delay_us = writers_delay_us,
+    };
+
+    for (size_t i = 0; i < instances_num; i++) {
+        int ret = thrd_create(&threads[i], run_test_, &run_test_args);
+        if (ret != thrd_success)
+            errx(1, "thrd_create failed with ret = %d", ret);
+    }
+
+    for (size_t i = 0; i < instances_num; i++) {
+        int ret = thrd_join(threads[i], NULL);
+        if (ret != thrd_success)
+            errx(1, "thrd_join failed with ret = %d", ret);
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/rwlock.manifest.template
+++ b/libos/test/regression/rwlock.manifest.template
@@ -1,0 +1,20 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.insecure__use_cmdline_argv = true
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.max_threads = 200
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -28,8 +28,18 @@ CPUINFO_TEST_FLAGS = [
 class TC_00_Unittests(RegressionTestCase):
     def test_000_spinlock(self):
         stdout, _ = self.run_binary(['spinlock'], timeout=20)
-
         self.assertIn('Test successful!', stdout)
+
+    def test_001_rwlock(self):
+        # You may need to adjust sgx.max_threads in the manifest when changing these
+        instances = 5
+        iterations = 100
+        readers_num = 10
+        writers_num = 3
+        writers_delay_us = 100
+        stdout, _ = self.run_binary(['rwlock', str(instances), str(iterations), str(readers_num),
+                                     str(writers_num), str(writers_delay_us)], timeout=45)
+        self.assertIn('TEST OK', stdout)
 
     def test_010_gramine_run_test(self):
         stdout, _ = self.run_binary(['run_test', 'pass'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -90,6 +90,7 @@ manifests = [
   "readdir",
   "rename_unlink",
   "run_test",
+  "rwlock",
   "sched",
   "sched_set_get_affinity",
   "sealed_file",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -92,6 +92,7 @@ manifests = [
   "readdir",
   "rename_unlink",
   "run_test",
+  "rwlock",
   "sched",
   "sched_set_get_affinity",
   "sealed_file",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Map of LibOS handles is mainly read, so using rwlocks should give some performance advantage.

## How to test this PR? <!-- (if applicable) -->
CI.
I couldn't come up with a good and simple test for the locks themselves. Also we have no way of running "unit tests" in LibOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1109)
<!-- Reviewable:end -->
