### PR TITLE
[CI-Examples] Increase server wait time to 300

### DIFF
--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -44,7 +44,7 @@ stage('test-sgx') {
             cd CI-Examples/memcached
             make ${MAKEOPTS}
             make SGX=1 start-gramine-server &
-            ../../scripts/wait_for_server 60 127.0.0.1 11211
+            ../../scripts/wait_for_server 300 127.0.0.1 11211
             # memcslap populates server but doesn't report errors, use
             # memcached-tool for this (must return two lines of stats)
             memcslap --servers=127.0.0.1 --concurrency=8
@@ -64,7 +64,7 @@ stage('test-sgx') {
             cd CI-Examples/redis
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
-            ../../scripts/wait_for_server 60 127.0.0.1 6379
+            ../../scripts/wait_for_server 300 127.0.0.1 6379
             ./src/src/redis-benchmark
         '''
     }
@@ -73,7 +73,7 @@ stage('test-sgx') {
             cd CI-Examples/lighttpd
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
-            ../../scripts/wait_for_server 60 127.0.0.1 8003
+            ../../scripts/wait_for_server 300 127.0.0.1 8003
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8003
         '''
     }
@@ -82,7 +82,7 @@ stage('test-sgx') {
             cd CI-Examples/nginx
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
-            ../../scripts/wait_for_server 60 127.0.0.1 8002
+            ../../scripts/wait_for_server 300 127.0.0.1 8002
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:8002
         '''
     }
@@ -91,7 +91,7 @@ stage('test-sgx') {
             cd CI-Examples/rust
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-gramine-server &
-            ../../scripts/wait_for_server 60 127.0.0.1 3000
+            ../../scripts/wait_for_server 300 127.0.0.1 3000
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:3000
         '''
     }

--- a/CI-Examples/python/run-tests.sh
+++ b/CI-Examples/python/run-tests.sh
@@ -18,7 +18,7 @@ rm OUTPUT
 # === web server and client (on port 8005) ===
 echo -e "\n\nRunning HTTP server dummy-web-server.py in the background:"
 $GRAMINE ./python scripts/dummy-web-server.py 8005 & echo $! > server.PID
-../../scripts/wait_for_server 60 127.0.0.1 8005
+../../scripts/wait_for_server 300 127.0.0.1 8005
 
 echo -e "\n\nRunning HTTP client test-http.py:"
 $GRAMINE ./python scripts/test-http.py 127.0.0.1 8005 > OUTPUT1


### PR DESCRIPTION
Workloads take 2x-5x times to execute with EDMM than non-EDMM's, and thus require larger timeouts, hence increasing the wait time for server.

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1113)
<!-- Reviewable:end -->
