### PR TITLE
[tools/sgx] Install RA-TLS and SecretProv libs properly

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -39,7 +39,10 @@ ssl/server.crt: ssl/ca_config.conf
 
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
-CFLAGS += $(shell pkg-config --cflags mbedtls_gramine)
+CFLAGS += $(shell pkg-config --cflags mbedtls_gramine) \
+          $(shell pkg-config --cflags ra_tls_gramine)
+
+# no need for `pkg-config --libs ra_tls_gramine` because programs use dlopen
 LDFLAGS += -ldl -Wl,--enable-new-dtags $(shell pkg-config --libs mbedtls_gramine)
 
 server: src/server.c

--- a/CI-Examples/ra-tls-mbedtls/src/client.c
+++ b/CI-Examples/ra-tls-mbedtls/src/client.c
@@ -34,6 +34,8 @@
 #include "mbedtls/net_sockets.h"
 #include "mbedtls/ssl.h"
 
+#include "ra_tls.h"
+
 /* RA-TLS: on client, only need to register ra_tls_verify_callback_der() for cert verification */
 int (*ra_tls_verify_callback_der_f)(uint8_t* der_crt, size_t der_crt_size);
 

--- a/CI-Examples/ra-tls-mbedtls/src/server.c
+++ b/CI-Examples/ra-tls-mbedtls/src/server.c
@@ -31,9 +31,7 @@
 #include "mbedtls/ssl.h"
 #include "mbedtls/x509.h"
 
-/* RA-TLS: on server, only need ra_tls_create_key_and_crt_der() to create keypair and X.509 cert */
-int (*ra_tls_create_key_and_crt_der_f)(uint8_t** der_key, size_t* der_key_size, uint8_t** der_crt,
-                                       size_t* der_crt_size);
+#include "ra_tls.h"
 
 #define HTTP_RESPONSE                                    \
     "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n" \
@@ -81,7 +79,10 @@ int main(int argc, char** argv) {
     mbedtls_net_context client_fd;
     unsigned char buf[1024];
     const char* pers = "ssl_server";
+
     void* ra_tls_attest_lib;
+    int (*ra_tls_create_key_and_crt_der_f)(uint8_t** der_key, size_t* der_key_size, uint8_t** der_crt,
+                                           size_t* der_crt_size);
 
     uint8_t* der_key = NULL;
     uint8_t* der_crt = NULL;

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -48,13 +48,8 @@ ssl/server.crt: ssl/ca_config.conf
 
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
-# Use hard-coded GRAMINEDIR because we currently fail to provide secret prov headers in Gramine
-# installation. We also use `mbedtls_gramine` pkg-config because we don't have a secret prov one.
-# TODO: Create a pkg-config file for secretprov_gramine libs, and use it in below
-#       CFLAGS/LDFLAGS lines (via `pkg-config {--cflags|--libs} secretprov_gramine`).
-GRAMINEDIR ?= ../..
-CFLAGS += -Wall -std=c11 -I$(GRAMINEDIR)/tools/sgx/ra-tls
-LDFLAGS += -Wl,--enable-new-dtags $(shell pkg-config --libs mbedtls_gramine)
+CFLAGS += -Wall -std=c11 $(shell pkg-config --cflags secret_prov_gramine)
+LDFLAGS += -Wl,--enable-new-dtags $(shell pkg-config --libs secret_prov_gramine)
 
 %/server_epid: %/server.c
 	$(CC) $< $(CFLAGS) $(LDFLAGS) -lsecret_prov_verify_epid -pthread -o $@

--- a/debian/gramine.install
+++ b/debian/gramine.install
@@ -9,11 +9,19 @@ usr/lib/${DEB_HOST_MULTIARCH}/gramine/sgx/libpal.so
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/sgx/loader
 usr/lib/${DEB_HOST_MULTIARCH}/libmbed*_gramine.*
 usr/lib/${DEB_HOST_MULTIARCH}/libra_tls_attest.so*
+usr/lib/${DEB_HOST_MULTIARCH}/libra_tls_verify.a
 usr/lib/${DEB_HOST_MULTIARCH}/libsecret_prov_attest.so*
+usr/lib/${DEB_HOST_MULTIARCH}/libsecret_prov_verify.a
 usr/lib/${DEB_HOST_MULTIARCH}/libsgx_util.a*
 usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig/*.pc
+
 usr/include/gramine/mbedtls/*.h
 usr/include/gramine/psa/*.h
+usr/include/gramine/ra_tls.h
+usr/include/gramine/ra_tls_common.h
+usr/include/gramine/secret_prov.h
+usr/include/gramine/sgx_arch.h
+usr/include/gramine/sgx_attest.h
 
 # careful here not to install lib{ra_tls,secret_prov}_verify_*,
 # because that would cause file conflicts with gramine-ratls-* packages
@@ -41,6 +49,8 @@ usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/glibc/libutil.so*
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/glibc/libmbed*
 
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/glibc/libra_tls_attest.so*
+usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/glibc/libra_tls_verify.a
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/glibc/libsecret_prov_attest.so*
+usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/glibc/libsecret_prov_verify.a
 
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/runtime/musl/

--- a/gramine.spec
+++ b/gramine.spec
@@ -100,10 +100,15 @@ install -t %{buildroot}/%{_licensedir}/%{name} LICENSE*.txt
 %{_libdir}/%{name}/runtime/musl
 
 %{_libdir}/pkgconfig/mbedtls_%{name}.pc
+%{_libdir}/pkgconfig/ra_tls_%{name}.pc
+%{_libdir}/pkgconfig/secret_prov_%{name}.pc
+
 %{_libdir}/libmbed{crypto,tls,x509}_%{name}.{so*,a}
 
 %{_libdir}/libra_tls*.so*
+%{_libdir}/libra_tls_verify.a
 %{_libdir}/libsecret_prov*.so*
+%{_libdir}/libsecret_prov_verify.a
 %{_libdir}/libsgx_util.a
 
 %dir %{python3_sitearch}/%{name}libos
@@ -112,6 +117,7 @@ install -t %{buildroot}/%{_licensedir}/%{name} LICENSE*.txt
 %{python3_sitearch}/_%{name}libos_offsets.py
 %{python3_sitearch}/__pycache__
 
+%{_includedir}/gramine/*.h
 %{_includedir}/gramine/mbedtls/*.h
 %{_includedir}/gramine/psa/*.h
 

--- a/pal/src/host/linux-sgx/meson.build
+++ b/pal/src/host/linux-sgx/meson.build
@@ -19,6 +19,9 @@ sgx_inc = [
     ),
 ]
 
+# below headers are SGX-infrastructure generic and required by e.g. RA-TLS libs
+install_headers('sgx_arch.h', 'sgx_attest.h', subdir : 'gramine')
+
 cflags_pal_sgx = [
     cflags_pal_common,
     '-DHOST_TYPE=Linux-SGX',

--- a/tools/sgx/ra-tls/meson.build
+++ b/tools/sgx/ra-tls/meson.build
@@ -2,15 +2,25 @@
 # libraries. This is because they are loaded dynamically to users' software and we don't want our
 # patched mbedtls to collide with libraries the program already uses.
 
+pkgconfig = import('pkgconfig')
+
+install_headers('ra_tls.h', 'ra_tls_common.h', 'secret_prov.h', subdir : 'gramine')
+
 libra_tls_inc = include_directories('.')
 
-ra_tls_args = [
-    '-fvisibility=hidden',
+ra_tls_map = join_paths(meson.current_source_dir(), 'ra_tls.map')
+ra_tls_link_args = [
+    '-Wl,--version-script=@0@'.format(ra_tls_map),
+]
+
+secret_prov_map = join_paths(meson.current_source_dir(), 'secret_prov.map')
+secret_prov_link_args = [
+    '-Wl,--version-script=@0@'.format(secret_prov_map),
 ]
 
 libra_tls_attest = shared_library('ra_tls_attest',
     'ra_tls_attest.c',
-    c_args: ra_tls_args,
+    link_args: ra_tls_link_args,
     include_directories: pal_sgx_inc, # this is only for `sgx_arch.h` and `sgx_attest.h`
     dependencies: [
         mbedtls_static_dep,
@@ -23,12 +33,9 @@ meson.add_install_script('/bin/sh', '-c',
     '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
         get_option('libdir')))
 
-libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
-    'ra_tls_verify_epid.c',
+libra_tls_verify = static_library('ra_tls_verify',
     'ra_tls_verify_common.c',
-    'ra_tls.h',
 
-    c_args: ra_tls_args,
     include_directories: pal_sgx_inc,
     dependencies: [
         sgx_util_dep,
@@ -36,6 +43,28 @@ libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
     ],
     install: true,
     install_rpath: get_option('prefix') / get_option('libdir'),
+)
+meson.add_install_script('/bin/sh', '-c',
+    'ln -sf ../../../libra_tls_verify.a ' +
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
+        get_option('libdir')))
+
+libra_tls_verify_dep = declare_dependency(
+    link_with: libra_tls_verify,
+    include_directories: pal_sgx_inc,
+)
+
+libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
+    'ra_tls_verify_epid.c',
+
+    link_args: ra_tls_link_args,
+    dependencies: [
+        libra_tls_verify_dep.as_link_whole(),
+        mbedtls_static_dep,
+        sgx_util_dep,
+    ],
+    install: true,
+    install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libra_tls_verify_epid.so ' +
@@ -46,10 +75,8 @@ libsecret_prov_attest = shared_library('secret_prov_attest',
     'secret_prov_attest.c',
     'secret_prov_common.c',
     'ra_tls_attest.c',
-    'ra_tls.h',
-    'secret_prov.h',
 
-    c_args: ra_tls_args,
+    link_args: secret_prov_link_args,
     include_directories: pal_sgx_inc,
     dependencies: [
         mbedtls_static_dep,
@@ -63,20 +90,37 @@ meson.add_install_script('/bin/sh', '-c',
     '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
         get_option('libdir')))
 
-libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
-    'ra_tls_verify_epid.c',
-    'ra_tls_verify_common.c',
+libsecret_prov_verify = static_library('secret_prov_verify',
     'secret_prov_verify.c',
     'secret_prov_common.c',
-    'ra_tls.h',
-    'secret_prov.h',
 
-    c_args: ra_tls_args,
-    include_directories: pal_sgx_inc,
     dependencies: [
-        threads_dep,
-        sgx_util_dep,
+        libra_tls_verify_dep,
         mbedtls_static_dep,
+        sgx_util_dep,
+    ],
+    install: true,
+    install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
+)
+meson.add_install_script('/bin/sh', '-c',
+    'ln -sf ../../../libsecret_prov_verify.a ' +
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
+        get_option('libdir')))
+
+libsecret_prov_verify_dep = declare_dependency(
+    link_with: libsecret_prov_verify,
+    include_directories: pal_sgx_inc,
+)
+
+libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
+    'ra_tls_verify_epid.c',
+
+    link_args: secret_prov_link_args,
+    dependencies: [
+        libsecret_prov_verify_dep.as_link_whole(),
+        mbedtls_static_dep,
+        sgx_util_dep,
+        threads_dep,
     ],
     install: true,
     install_rpath: get_option('prefix') / get_option('libdir'),
@@ -89,15 +133,13 @@ meson.add_install_script('/bin/sh', '-c',
 if dcap
     libra_tls_verify_dcap = shared_library('ra_tls_verify_dcap',
         'ra_tls_verify_dcap.c',
-        'ra_tls_verify_common.c',
-        'ra_tls.h',
 
-        c_args: ra_tls_args,
-        include_directories: pal_sgx_inc,
+        link_args: ra_tls_link_args,
         dependencies: [
+            libra_tls_verify_dep.as_link_whole(),
+            mbedtls_static_dep,
             sgx_dcap_quoteverify_dep,
             sgx_util_dep,
-            mbedtls_static_dep,
         ],
         install: true,
         install_rpath: get_option('prefix') / get_option('libdir'),
@@ -110,15 +152,13 @@ if dcap
     libra_tls_verify_dcap_gramine = shared_library('ra_tls_verify_dcap_gramine',
         'ra_tls_verify_dcap.c',
         'ra_tls_verify_dcap_gramine.c',
-        'ra_tls_verify_common.c',
-        'ra_tls.h',
 
-        c_args: ra_tls_args,
-        include_directories: pal_sgx_inc,
+        link_args: ra_tls_link_args,
         dependencies: [
+            libra_tls_verify_dep.as_link_whole(),
+            mbedtls_static_dep,
             sgx_dcap_quoteverify_dep,
             sgx_util_dep,
-            mbedtls_static_dep,
         ],
         install: true,
         install_rpath: get_option('prefix') / get_option('libdir'),
@@ -130,19 +170,15 @@ if dcap
 
     libsecret_prov_verify_dcap = shared_library('secret_prov_verify_dcap',
         'ra_tls_verify_dcap.c',
-        'ra_tls_verify_common.c',
-        'secret_prov_verify.c',
-        'secret_prov_common.c',
-        'ra_tls.h',
-        'secret_prov.h',
 
-        c_args: ra_tls_args,
+        link_args: secret_prov_link_args,
         include_directories: pal_sgx_inc,
         dependencies: [
-            threads_dep,
+            libsecret_prov_verify_dep.as_link_whole(),
+            mbedtls_static_dep,
             sgx_dcap_quoteverify_dep,
             sgx_util_dep,
-            mbedtls_static_dep,
+            threads_dep,
         ],
         install: true,
         install_rpath: get_option('prefix') / get_option('libdir'),
@@ -152,3 +188,27 @@ if dcap
         '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
             get_option('libdir')))
 endif
+
+pkgconfig.generate(
+    name: 'ra_tls_gramine',
+    filebase: 'ra_tls_gramine',
+    description: 'RA-TLS (SGX Remote Attestation TLS library) for Gramine',
+    subdirs: 'gramine',
+    libraries: [
+        '-L${libdir}',
+        '-Wl,-rpath,${libdir}',
+        # RA-TLS consists of multiple independent libs, let user decide which to link
+    ],
+)
+
+pkgconfig.generate(
+    name: 'secret_prov_gramine',
+    filebase: 'secret_prov_gramine',
+    description: 'Secret Provisioning library for Gramine',
+    subdirs: 'gramine',
+    libraries: [
+        '-L${libdir}',
+        '-Wl,-rpath,${libdir}',
+        # Secret Prov consists of multiple independent libs, let user decide which to link
+    ],
+)

--- a/tools/sgx/ra-tls/ra_tls.map
+++ b/tools/sgx/ra-tls/ra_tls.map
@@ -1,0 +1,5 @@
+RA_TLS {
+    global: ra_tls_set_measurement_callback; ra_tls_verify_callback_der; ra_tls_create_key_and_crt_der;
+    local: *;
+};
+

--- a/tools/sgx/ra-tls/ra_tls_attest.c
+++ b/tools/sgx/ra-tls/ra_tls_attest.c
@@ -30,8 +30,7 @@
 #include <mbedtls/x509_crt.h>
 
 #include "ra_tls.h"
-#include "sgx_arch.h"
-#include "sgx_attest.h"
+#include "ra_tls_common.h"
 
 #define CERT_SUBJECT_NAME_VALUES  "CN=RATLS,O=GramineDevelopers,C=US"
 #define CERT_TIMESTAMP_NOT_BEFORE_DEFAULT "20010101000000"

--- a/tools/sgx/ra-tls/ra_tls_common.h
+++ b/tools/sgx/ra-tls/ra_tls_common.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Labs */
+
+/*
+ * Internal RA-TLS details, to be used by external RA-TLS implementations:
+ *   - external implementation must implement ra_tls_verify_callback(),
+ *   - external implementation can call all other funcs declared here.
+ *
+ * Note that external implementations must use static mbedTLS libraries (shipped together with
+ * Gramine).
+ */
+
+#pragma once
+
+#include <mbedtls/x509_crt.h>
+#include <stdint.h>
+
+#include "sgx_attest.h"
+
+#define SHA256_DIGEST_SIZE       32
+#define PUB_KEY_SIZE_MAX         128 /* enough for the only currently supported algo (ECDSA-384) */
+#define IAS_REQUEST_NONCE_LEN    32
+
+#define OID(N) \
+    { 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF8, 0x4D, 0x8A, 0x39, (N) }
+static const uint8_t g_quote_oid[] = OID(0x06);
+static const size_t g_quote_oid_size = sizeof(g_quote_oid);
+
+bool getenv_allow_outdated_tcb(void);
+bool getenv_allow_debug_enclave(void);
+int cmp_crt_pk_against_quote_report_data(mbedtls_x509_crt* crt, sgx_quote_t* quote);
+int extract_quote_and_verify_pubkey(mbedtls_x509_crt* crt, sgx_quote_t** out_quote,
+                                    size_t* out_quote_size);
+int verify_quote_body_against_envvar_measurements(const sgx_quote_body_t* quote_body);
+int ra_tls_create_key_and_crt(mbedtls_pk_context* key, mbedtls_x509_crt* crt);
+
+/* to be implemented by an RA-TLS implementation (e.g. talk to IAS for EPID implementation) */
+int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_t* flags);

--- a/tools/sgx/ra-tls/ra_tls_verify_common.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_common.c
@@ -5,10 +5,11 @@
  * \file
  *
  * This file contains the common code of verification callbacks for TLS libraries. All functions
- * here have hidden visibility (not accessible from outside the shared library).
+ * here are internal (not accessible from outside the shared library).
  */
 
 #define _GNU_SOURCE
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,8 +19,10 @@
 #include <mbedtls/x509_crt.h>
 
 #include "quote.h"
-#include "ra_tls.h"
 #include "util.h"
+
+#include "ra_tls.h"
+#include "ra_tls_common.h"
 
 verify_measurements_cb_t g_verify_measurements_cb = NULL;
 

--- a/tools/sgx/ra-tls/ra_tls_verify_dcap.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_dcap.c
@@ -26,10 +26,10 @@
 #include <mbedtls/x509_crt.h>
 
 #include "quote.h"
-#include "ra_tls.h"
-#include "sgx_arch.h"
-#include "sgx_attest.h"
 #include "util.h"
+
+#include "ra_tls.h"
+#include "ra_tls_common.h"
 
 extern verify_measurements_cb_t g_verify_measurements_cb;
 

--- a/tools/sgx/ra-tls/ra_tls_verify_epid.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_epid.c
@@ -24,10 +24,10 @@
 
 #include "ias.h"
 #include "quote.h"
-#include "ra_tls.h"
-#include "sgx_arch.h"
-#include "sgx_attest.h"
 #include "util.h"
+
+#include "ra_tls.h"
+#include "ra_tls_common.h"
 
 extern verify_measurements_cb_t g_verify_measurements_cb;
 

--- a/tools/sgx/ra-tls/secret_prov.h
+++ b/tools/sgx/ra-tls/secret_prov.h
@@ -1,5 +1,14 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
-/* Copyright (C) 2020 Intel Labs */
+/* Copyright (C) 2023 Intel Labs */
+
+/*
+ * Secret Prov user API:
+ *   - secret_provision_start() and secret_provision_get() for attester (SGX enclave, also called
+ *     "client") side,
+ *   - secret_provision_start_server() for verifier (also called "server") side,
+ *   - secret_provision_write(), secret_provision_read() and secret_provision_close() for both
+ *     sides.
+ */
 
 #pragma once
 
@@ -44,7 +53,6 @@ typedef int (*secret_provision_cb_t)(struct ra_tls_ctx* ctx);
  *
  * This function always writes all \p size bytes on success (partial writes are not possible).
  */
-__attribute__ ((visibility("default")))
 int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t size);
 
 /*!
@@ -62,7 +70,6 @@ int secret_provision_write(struct ra_tls_ctx* ctx, const uint8_t* buf, size_t si
  *
  * This function always reads all \p size bytes on success (partial reads are not possible).
  */
-__attribute__ ((visibility("default")))
 int secret_provision_read(struct ra_tls_ctx* ctx, uint8_t* buf, size_t size);
 
 /*!
@@ -81,7 +88,6 @@ int secret_provision_read(struct ra_tls_ctx* ctx, uint8_t* buf, size_t size);
  *
  * This function must not be called again even if it returned an error. \p ctx is always freed.
  */
-__attribute__ ((visibility("default")))
 int secret_provision_close(struct ra_tls_ctx* ctx);
 
 /*!
@@ -99,7 +105,6 @@ int secret_provision_close(struct ra_tls_ctx* ctx);
  * copy of the secret from memory. Content of \p out_secret is dynamically allocated and should be
  * released using `free(*out_secret)`.
  */
-__attribute__ ((visibility("default")))
 int secret_provision_get(struct ra_tls_ctx* ctx, uint8_t** out_secret, size_t* out_secret_size);
 
 /*!
@@ -126,7 +131,6 @@ int secret_provision_get(struct ra_tls_ctx* ctx, uint8_t** out_secret, size_t* o
  * The first secret can be retrieved via secret_provision_get(). The secret is destroyed together
  * with the session during secret_provision_close().
  */
-__attribute__ ((visibility("default")))
 int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
                            struct ra_tls_ctx** out_ctx);
 
@@ -159,7 +163,6 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
  *
  * This function is thread-safe and requires pthread library.
  */
-__attribute__ ((visibility("default")))
 int secret_provision_start_server(uint8_t* secret, size_t secret_size, const char* port,
                                   const char* cert_path, const char* key_path,
                                   verify_measurements_cb_t m_cb, secret_provision_cb_t f_cb);

--- a/tools/sgx/ra-tls/secret_prov.map
+++ b/tools/sgx/ra-tls/secret_prov.map
@@ -1,0 +1,4 @@
+SECRET_PROV {
+    global: secret_provision_write; secret_provision_read; secret_provision_close; secret_provision_get; secret_provision_start; secret_provision_start_server;
+    local: *;
+};

--- a/tools/sgx/ra-tls/secret_prov_attest.c
+++ b/tools/sgx/ra-tls/secret_prov_attest.c
@@ -16,6 +16,7 @@
 #define STDC_WANT_LIB_EXT1 1
 #define _XOPEN_SOURCE 700
 #include <arpa/inet.h>
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -30,6 +31,7 @@
 #include "mbedtls/ssl.h"
 
 #include "ra_tls.h"
+#include "ra_tls_common.h"
 #include "secret_prov.h"
 #include "secret_prov_common.h"
 #include "util.h"

--- a/tools/sgx/ra-tls/secret_prov_common.h
+++ b/tools/sgx/ra-tls/secret_prov_common.h
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
-/* Copyright (C) 2022 Intel Labs */
+/* Copyright (C) 2023 Intel Labs */
+
+/* Internal Secret Prov details, not intended for external use. */
 
 #pragma once
 

--- a/tools/sgx/ra-tls/secret_prov_verify.c
+++ b/tools/sgx/ra-tls/secret_prov_verify.c
@@ -15,6 +15,7 @@
 
 #define _XOPEN_SOURCE 700
 #include <arpa/inet.h>
+#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <pthread.h>
@@ -31,6 +32,7 @@
 #include "mbedtls/ssl.h"
 
 #include "ra_tls.h"
+#include "ra_tls_common.h"
 #include "secret_prov.h"
 #include "secret_prov_common.h"
 #include "util.h"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR splits RA-TLS and SecretProv libs in a more fine-grained manner, suitable for writing external plugins (e.g. with Microsoft Azure Attestation flows). This PR also installs corresponding header files and pkg-config files. Finally, this PR fixes a bug with too-many exported symbols from these libs.

For more context on this, see https://github.com/gramineproject/gramine/issues/1071.

Fixes #1182 (by making the `abort` symbol local)

## How to test this PR? <!-- (if applicable) -->

The examples `ra-tls-mbedtls` and `ra-tls-secret-prov` (run in CI) are updated to reflect these changes.

## Notes for reviewers

To aid the review process, let me show some logs how things look with this PR.

- Installed includes:
```
~/gramineproject/gramine/built/include$ tree
.
└── gramine
    ├── mbedtls
    │   ├── aes.h
    │   ├── ...
    ├── psa
    │   ├── crypto_builtin_composites.h
    │   ├── ...
    ├── ra_tls_common.h
    ├── ra_tls.h
    ├── secret_prov.h
    ├── sgx_arch.h
    └── sgx_attest.h
```

- Installed RA-TLS libs:
```
~/gramineproject/gramine/built/lib/x86_64-linux-gnu$ ls -1 libra_tls_*
libra_tls_attest.so
libra_tls_verify.a
libra_tls_verify_dcap_gramine.so
libra_tls_verify_dcap.so
libra_tls_verify_epid.so

~/gramineproject/gramine/built/lib/x86_64-linux-gnu$ nm --defined-only --extern-only libra_tls_*.so

libra_tls_attest.so:
0000000000000000 A RA_TLS
000000000000a183 T ra_tls_create_key_and_crt_der

libra_tls_verify_dcap_gramine.so:
0000000000000000 A RA_TLS
000000000000947c T ra_tls_set_measurement_callback
0000000000009499 T ra_tls_verify_callback_der

libra_tls_verify_dcap.so:
0000000000000000 A RA_TLS
00000000000093d7 T ra_tls_set_measurement_callback
00000000000093f4 T ra_tls_verify_callback_der

libra_tls_verify_epid.so:
0000000000000000 A RA_TLS
000000000000ce2f T ra_tls_set_measurement_callback
000000000000ce4c T ra_tls_verify_callback_der
```

- Installed SecretProv libs:
```
~/gramineproject/gramine/built/lib/x86_64-linux-gnu$ ls -1 libsecret_prov_*
libsecret_prov_attest.so
libsecret_prov_verify.a
libsecret_prov_verify_dcap.so
libsecret_prov_verify_epid.so

~/gramineproject/gramine/built/lib/x86_64-linux-gnu$ nm --defined-only --extern-only libsecret_prov_*.so

libsecret_prov_attest.so:
0000000000000000 A SECRET_PROV
000000000000accb T secret_provision_close
000000000000ab95 T secret_provision_get
000000000000ac7b T secret_provision_read
000000000000adb2 T secret_provision_start
000000000000ac2b T secret_provision_write

libsecret_prov_verify_dcap.so:
0000000000000000 A SECRET_PROV
000000000000b018 T secret_provision_close
000000000000afc8 T secret_provision_read
000000000000b454 T secret_provision_start_server
000000000000af78 T secret_provision_write

libsecret_prov_verify_epid.so:
0000000000000000 A SECRET_PROV
000000000000c7f0 T secret_provision_close
000000000000c7a0 T secret_provision_read
000000000000cc2c T secret_provision_start_server
000000000000c750 T secret_provision_write
```

- pkg-config files:
```
~/gramineproject/gramine/built/lib/x86_64-linux-gnu/pkgconfig$ cat ra_tls_gramine.pc
prefix=/home/dimakuv/gramineproject/gramine/built
includedir=${prefix}/include
libdir=${prefix}/lib/x86_64-linux-gnu

Name: ra_tls_gramine
Description: RA-TLS (SGX Remote Attestation TLS library) for Gramine
Version: 1.3.1post-UNRELEASED
Libs: -L${libdir} -Wl,-rpath,${libdir}
Cflags: -I${includedir}/gramine

~/gramineproject/gramine/built/lib/x86_64-linux-gnu/pkgconfig$ cat secret_prov_gramine.pc
prefix=/home/dimakuv/gramineproject/gramine/built
includedir=${prefix}/include
libdir=${prefix}/lib/x86_64-linux-gnu

Name: secret_prov_gramine
Description: Secret Provisioning library for Gramine
Version: 1.3.1post-UNRELEASED
Libs: -L${libdir} -Wl,-rpath,${libdir}
Cflags: -I${includedir}/gramine
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1114)
<!-- Reviewable:end -->
