### PR TITLE
[CI] Expand timeout for blender example in CI

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -97,7 +97,7 @@ stage('test-direct') {
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:3000
         '''
     }
-    timeout(time: 5, unit: 'MINUTES') {
+    timeout(time: 10, unit: 'MINUTES') {
         sh '''
             cd CI-Examples/blender
             make ${MAKEOPTS} all

--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -95,7 +95,7 @@ stage('test-sgx') {
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh http://127.0.0.1:3000
         '''
     }
-    timeout(time: 5, unit: 'MINUTES') {
+    timeout(time: 10, unit: 'MINUTES') {
         sh '''
             cd CI-Examples/blender
             make ${MAKEOPTS}


### PR DESCRIPTION
## How to test this PR? <!-- (if applicable) -->

Liberally submit Jenkins-Debug-* pipelines in CI, none should time out on blender.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1117)
<!-- Reviewable:end -->
