### PR TITLE
[LibOS] Add `avx` regression test

### DIFF
--- a/.ci/linux-sgx-edmm.jenkinsfile
+++ b/.ci/linux-sgx-edmm.jenkinsfile
@@ -1,6 +1,7 @@
 node('sgx-edmm') {
     checkout scm
 
+    env.AVX = '1'  // EDMM-capable machines in our CI always have Intel AVX
     env.SGX = '1'
     env.SGX_DRIVER = 'upstream'
     env.EDMM = '1'

--- a/libos/test/regression/avx.c
+++ b/libos/test/regression/avx.c
@@ -1,0 +1,28 @@
+/*
+ * This tests that optional CPU features are enabled inside of Gramine.
+ *
+ * This is particularly important for Intel SGX: it has SIGSTRUCT.ATTRIBUTES.XFRM that prohibits
+ * using CPU features unless they are explicitly set (during Gramine startup and only if
+ * SIGSTRUCT.ATTRIBUTE_MASK.XFRM allows it).
+ */
+
+#include <immintrin.h>
+#include <stdalign.h>
+#include <stdio.h>
+
+int main(void) {
+    alignas(32) float floats[8] = {1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7};
+
+    __m256 avx_vector = _mm256_load_ps(&floats[0]);
+    avx_vector = _mm256_add_ps(avx_vector, avx_vector);
+    _mm256_store_ps(&floats[0], avx_vector);
+
+    puts("result: ");
+    for (size_t i = 0; i < sizeof(floats)/sizeof(floats[0]); i++) {
+        printf("%f ", floats[i]);
+    }
+    puts("");
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -134,6 +134,9 @@ tests = {
 
 if host_machine.cpu_family() == 'x86_64'
     tests += {
+        'avx': {
+            'c_args': '-mavx',
+        },
         'cpuid': {},
         'debug_regs_x86_64': {
             'c_args': '-g3',

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -7,6 +7,7 @@ import subprocess
 import unittest
 
 from graminelibos.regression import (
+    HAS_AVX,
     HAS_EDMM,
     HAS_SGX,
     ON_X86,
@@ -1327,4 +1328,11 @@ class TC_90_CpuidSGX(RegressionTestCase):
 class TC_91_RdtscSGX(RegressionTestCase):
     def test_000_rdtsc(self):
         stdout, _ = self.run_binary(['rdtsc'])
+        self.assertIn('TEST OK', stdout)
+
+@unittest.skipUnless(HAS_AVX,
+    'This test checks if SIGSTRUCT.ATTRIBUTES.XFRM enables optional CPU features in SGX.')
+class TC_92_avx(RegressionTestCase):
+    def test_000_avx(self):
+        stdout, _ = self.run_binary(['avx'])
         self.assertIn('TEST OK', stdout)

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -120,6 +120,7 @@ manifests = [
 [arch.x86_64]
 
 manifests = [
+  "avx",
   "cpuid",
   "debug_regs_x86_64",
   "rdtsc",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -121,6 +121,7 @@ manifests = [
 [arch.x86_64]
 
 manifests = [
+  "avx",
   "cpuid",
   "debug_regs_x86_64",
   "rdtsc",

--- a/python/graminelibos/regression.py
+++ b/python/graminelibos/regression.py
@@ -16,6 +16,7 @@ fspath = getattr(os, 'fspath', str) # pylint: disable=invalid-name
 
 # pylint: disable=subprocess-popen-preexec-fn,subprocess-run-check
 
+HAS_AVX = os.environ.get('AVX') == '1'
 HAS_EDMM = os.environ.get('EDMM') == '1'
 HAS_SGX = os.environ.get('SGX') == '1'
 ON_X86 = os.uname().machine in ['x86_64']


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The new test verifies that optional CPU features are enabled inside of Gramine.

This is particularly important for Intel SGX: it has `SIGSTRUCT.ATTRIBUTES.XFRM` that prohibits using CPU features unless they are explicitly set (during Gramine startup and only if `SIGSTRUCT.ATTRIBUTE_MASK.XFRM` allows it).

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1124)
<!-- Reviewable:end -->
