### PR TITLE
[PAL/Linux-SGX] Enforce AES-NI, XSAVE and RDRAND

### DIFF
--- a/.ci/linux-direct-sanitizers.jenkinsfile
+++ b/.ci/linux-direct-sanitizers.jenkinsfile
@@ -1,4 +1,4 @@
-node('nonsgx_slave') {
+node('nonsgx_slave && aesni') {
     checkout scm
 
     load '.ci/lib/config-docker.jenkinsfile'

--- a/.ci/linux-direct-ubuntu18.04-gcc-debug.jenkinsfile
+++ b/.ci/linux-direct-ubuntu18.04-gcc-debug.jenkinsfile
@@ -1,4 +1,4 @@
-node('nonsgx_slave') {
+node('nonsgx_slave && aesni') {
     checkout scm
 
     load '.ci/lib/config-docker.jenkinsfile'

--- a/.ci/linux-direct-ubuntu18.04-gcc-release.jenkinsfile
+++ b/.ci/linux-direct-ubuntu18.04-gcc-release.jenkinsfile
@@ -1,4 +1,4 @@
-node('nonsgx_slave') {
+node('nonsgx_slave && aesni') {
     checkout scm
 
     load '.ci/lib/config-docker.jenkinsfile'

--- a/.ci/linux-direct-ubuntu20.04-gcc-debug.jenkinsfile
+++ b/.ci/linux-direct-ubuntu20.04-gcc-debug.jenkinsfile
@@ -1,4 +1,4 @@
-node('nonsgx_slave') {
+node('nonsgx_slave && aesni') {
     checkout scm
 
     load '.ci/lib/config-docker.jenkinsfile'

--- a/.ci/linux-direct-ubuntu20.04-gcc-release.jenkinsfile
+++ b/.ci/linux-direct-ubuntu20.04-gcc-release.jenkinsfile
@@ -1,4 +1,4 @@
-node('nonsgx_slave') {
+node('nonsgx_slave && aesni') {
     checkout scm
 
     load '.ci/lib/config-docker.jenkinsfile'

--- a/.ci/linux-sgx-edmm.jenkinsfile
+++ b/.ci/linux-sgx-edmm.jenkinsfile
@@ -1,4 +1,4 @@
-node('sgx-edmm') {
+node('sgx-edmm && aesni') {
     checkout scm
 
     env.AVX = '1'  // EDMM-capable machines in our CI always have AVX

--- a/.ci/linux-sgx-sanitizers.jenkinsfile
+++ b/.ci/linux-sgx-sanitizers.jenkinsfile
@@ -1,4 +1,4 @@
-node('sgx_slave_2.6') {
+node('sgx_slave_2.6 && aesni') {
     checkout scm
 
     env.SGX = '1'

--- a/.ci/linux-sgx-ubuntu18.04-gcc-release-apps.jenkinsfile
+++ b/.ci/linux-sgx-ubuntu18.04-gcc-release-apps.jenkinsfile
@@ -1,4 +1,4 @@
-node('sgx_slave_2.6') {
+node('sgx_slave_2.6 && aesni') {
     checkout scm
 
     env.SGX = '1'

--- a/.ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
+++ b/.ci/linux-sgx-ubuntu18.04-gcc-release.jenkinsfile
@@ -1,4 +1,4 @@
-node('sgx_slave_2.6') {
+node('sgx_slave_2.6 && aesni') {
     checkout scm
 
     env.SGX = '1'

--- a/.ci/linux-sgx-ubuntu20.04-gcc-release-apps.jenkinsfile
+++ b/.ci/linux-sgx-ubuntu20.04-gcc-release-apps.jenkinsfile
@@ -1,4 +1,4 @@
-node('sgx_slave_2.6') {
+node('sgx_slave_2.6 && aesni') {
     checkout scm
 
     env.SGX = '1'

--- a/.ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
+++ b/.ci/linux-sgx-ubuntu20.04-gcc-release.jenkinsfile
@@ -1,4 +1,4 @@
-node('sgx_slave_2.6') {
+node('sgx_slave_2.6 && aesni') {
     checkout scm
 
     env.SGX = '1'

--- a/common/include/arch/x86_64/cpu.h
+++ b/common/include/arch/x86_64/cpu.h
@@ -34,10 +34,24 @@ enum extended_state_sub_leaf {
     EXTENDED_STATE_SUBLEAF_EXTENSIONS = 1,
 };
 
-#define INTEL_SGX_LEAF 0x12 /* Intel SGX Capabilities: CPUID Leaf 12H */
-#define EXTENDED_STATE_LEAF 0xD /* Extended state (XSTATE): CPUID leaf 0DH */
+#define CPU_VENDOR_LEAF                         0x0
+#define FEATURE_FLAGS_LEAF                      0x1
+#define THERMAL_AND_POWER_INFO_LEAF             0x6
+#define EXTENDED_FEATURE_FLAGS_LEAF             0x7
+#define EXTENDED_STATE_LEAF                     0xD /* Extended state (XSTATE) */
+#define INTEL_SGX_LEAF                         0x12 /* Intel SGX Capabilities */
+#define TSC_FREQ_LEAF                          0x15
+#define PROC_FREQ_LEAF                         0x16
+#define AMX_TILE_INFO_LEAF                     0x1D
+#define AMX_TMUL_INFO_LEAF                     0x1E
+#define MAX_INPUT_EXT_VALUE_LEAF         0x80000000
+#define EXT_SIGNATURE_AND_FEATURES_LEAF  0x80000001
+#define CPU_BRAND_LEAF                   0x80000002
+#define CPU_BRAND_CNTD_LEAF              0x80000003
+#define CPU_BRAND_CNTD2_LEAF             0x80000004
+#define INVARIANT_TSC_LEAF               0x80000007
 
-static inline void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[]) {
+static inline void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[static 4]) {
     __asm__("cpuid"
             : "=a"(words[CPUID_WORD_EAX]),
               "=b"(words[CPUID_WORD_EBX]),

--- a/libos/src/arch/x86_64/libos_cpuid.c
+++ b/libos/src/arch/x86_64/libos_cpuid.c
@@ -294,25 +294,25 @@ int libos_get_cpu_flags(char** out_cpu_flags) {
         goto out_err;
     }
 
-    RETRIEVE_CPUID(0, 0);
+    RETRIEVE_CPUID(CPU_VENDOR_LEAF, 0);
     unsigned int max_supported_cpuid_leaf = words[CPUID_WORD_EAX];
 
     /* Intel-defined flags: level 0x1 */
-    RETRIEVE_CPUID(1, 0);
+    RETRIEVE_CPUID(FEATURE_FLAGS_LEAF, 0);
 
     EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_1_ecx, CPUID_WORD_ECX);
     EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_1_edx, CPUID_WORD_EDX);
 
     /* Thermal and Power Management Leaf: level 0x6 (eax) */
     if (max_supported_cpuid_leaf >= 6) {
-        RETRIEVE_CPUID(6, 0);
+        RETRIEVE_CPUID(THERMAL_AND_POWER_INFO_LEAF, 0);
 
         EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_6_eax, CPUID_WORD_EAX);
     }
 
     /* Additional Intel-defined flags: level 0x7 */
     if (max_supported_cpuid_leaf >= 7) {
-        RETRIEVE_CPUID(7, 0);
+        RETRIEVE_CPUID(EXTENDED_FEATURE_FLAGS_LEAF, 0);
 
         EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_7_0_ebx, CPUID_WORD_EBX);
         EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_7_0_ecx, CPUID_WORD_ECX);
@@ -320,25 +320,25 @@ int libos_get_cpu_flags(char** out_cpu_flags) {
 
         /* `words[CPUID_WORD_EAX]` holds the max supported subleaf */
         if (words[CPUID_WORD_EAX] >= 1) {
-            RETRIEVE_CPUID(7, 1);
+            RETRIEVE_CPUID(EXTENDED_FEATURE_FLAGS_LEAF, 1);
 
             EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_7_1_eax, CPUID_WORD_EAX);
         }
     }
 
     /* Extended state features: level 0xd */
-    if (max_supported_cpuid_leaf >= 0xd) {
-        RETRIEVE_CPUID(0xd, 1);
+    if (max_supported_cpuid_leaf >= EXTENDED_STATE_LEAF) {
+        RETRIEVE_CPUID(EXTENDED_STATE_LEAF, 1);
 
         EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_d_1_eax, CPUID_WORD_EAX);
     }
 
-    RETRIEVE_CPUID(0x80000000, 0);
+    RETRIEVE_CPUID(MAX_INPUT_EXT_VALUE_LEAF, 0);
     unsigned int max_supported_extended_cpuid_leaf = words[CPUID_WORD_EAX];
 
     /* Extended processor info and feature flags: level 0x80000001 */
-    if (max_supported_extended_cpuid_leaf >= 0x80000001) {
-        RETRIEVE_CPUID(0x80000001, 0);
+    if (max_supported_extended_cpuid_leaf >= EXT_SIGNATURE_AND_FEATURES_LEAF) {
+        RETRIEVE_CPUID(EXT_SIGNATURE_AND_FEATURES_LEAF, 0);
 
         EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_8000_0001_ecx, CPUID_WORD_ECX);
         EXTEND_CAP_FLAGS(g_cpu_flags_cpuid_8000_0001_edx, CPUID_WORD_EDX);

--- a/libos/test/regression/cpuid.c
+++ b/libos/test/regression/cpuid.c
@@ -37,6 +37,19 @@ static void cpuid(uint32_t leaf, uint32_t subleaf, struct regs* r) {
                      : "0"(leaf), "2"(subleaf));
 }
 
+static const char* bool_to_str(bool x) {
+    return x ? "true" : "false";
+}
+
+static void print_features_status(void) {
+    struct regs r = {0};
+
+    cpuid(/*leaf=*/1, /*ignored*/0, &r);
+    printf("AESNI support: %s\n", bool_to_str((r.ecx >> 25) & 1));
+    printf("XSAVE support: %s\n", bool_to_str((r.ecx >> 26) & 1));
+    printf("RDRAND support: %s\n", bool_to_str((r.ecx >> 30) & 1));
+}
+
 static void test_cpuid_leaf_0xd(void) {
     struct regs r = {0, };
 
@@ -153,6 +166,7 @@ static void test_cpuid_leaf_not_recognized(void) {
 }
 
 int main(int argc, char** argv, char** envp) {
+    print_features_status();
     test_cpuid_leaf_0xd();
     test_cpuid_leaf_reserved();
     test_cpuid_leaf_not_recognized();

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1321,6 +1321,9 @@ class TC_90_CpuidSGX(RegressionTestCase):
     def test_000_cpuid(self):
         stdout, _ = self.run_binary(['cpuid'])
         self.assertIn('CPUID test passed.', stdout)
+        self.assertIn('AESNI support: true', stdout)
+        self.assertIn('XSAVE support: true', stdout)
+        self.assertIn('RDRAND support: true', stdout)
 
 # note that `rdtsc` also correctly runs on non-SGX PAL, but non-SGX CPU may not have rdtscp
 @unittest.skipUnless(HAS_SGX,

--- a/pal/src/arch/x86_64/pal_cpuid.c
+++ b/pal/src/arch/x86_64/pal_cpuid.c
@@ -31,7 +31,7 @@ int _PalGetCPUInfo(struct pal_cpu_info* ci) {
     if (!vendor_id)
         return -PAL_ERROR_NOMEM;
 
-    _PalCpuIdRetrieve(0, 0, words);
+    _PalCpuIdRetrieve(CPU_VENDOR_LEAF, 0, words);
     FOUR_CHARS_VALUE(&vendor_id[0], words[CPUID_WORD_EBX]);
     FOUR_CHARS_VALUE(&vendor_id[4], words[CPUID_WORD_EDX]);
     FOUR_CHARS_VALUE(&vendor_id[8], words[CPUID_WORD_ECX]);
@@ -44,16 +44,16 @@ int _PalGetCPUInfo(struct pal_cpu_info* ci) {
         rv = -PAL_ERROR_NOMEM;
         goto out_err;
     }
-    _PalCpuIdRetrieve(0x80000002, 0, words);
+    _PalCpuIdRetrieve(CPU_BRAND_LEAF, 0, words);
     memcpy(&brand[ 0], words, sizeof(unsigned int) * CPUID_WORD_NUM);
-    _PalCpuIdRetrieve(0x80000003, 0, words);
+    _PalCpuIdRetrieve(CPU_BRAND_CNTD_LEAF, 0, words);
     memcpy(&brand[16], words, sizeof(unsigned int) * CPUID_WORD_NUM);
-    _PalCpuIdRetrieve(0x80000004, 0, words);
+    _PalCpuIdRetrieve(CPU_BRAND_CNTD2_LEAF, 0, words);
     memcpy(&brand[32], words, sizeof(unsigned int) * CPUID_WORD_NUM);
     brand[BRAND_SIZE - 1] = '\0';
     ci->cpu_brand = brand;
 
-    _PalCpuIdRetrieve(1, 0, words);
+    _PalCpuIdRetrieve(FEATURE_FLAGS_LEAF, 0, words);
     ci->cpu_family   = BIT_EXTRACT_LE(words[CPUID_WORD_EAX], 8, 12);
     ci->cpu_model    = BIT_EXTRACT_LE(words[CPUID_WORD_EAX], 4, 8);
     ci->cpu_stepping = BIT_EXTRACT_LE(words[CPUID_WORD_EAX], 0, 4);

--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -346,7 +346,7 @@ static void ocall_munmap_untrusted_cache(void* addr, size_t size, bool need_munm
     }
 }
 
-int ocall_cpuid(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
+int ocall_cpuid(unsigned int leaf, unsigned int subleaf, unsigned int values[static 4]) {
     int retval = 0;
     struct ocall_cpuid* ocall_cpuid_args;
 

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -18,7 +18,7 @@ int ocall_mmap_untrusted(void** addrptr, size_t size, int prot, int flags, int f
 
 int ocall_munmap_untrusted(const void* addr, size_t size);
 
-int ocall_cpuid(unsigned int leaf, unsigned int subleaf, unsigned int values[4]);
+int ocall_cpuid(unsigned int leaf, unsigned int subleaf, unsigned int values[static 4]);
 
 int ocall_open(const char* pathname, int flags, unsigned short mode);
 

--- a/pal/src/host/linux-sgx/host_framework.c
+++ b/pal/src/host/linux-sgx/host_framework.c
@@ -97,11 +97,11 @@ static int get_optional_sgx_features(uint64_t xfrm, uint64_t xfrm_mask, uint64_t
         } cpuid;
     } xfrm_flags[] = {
         /* for mapping of CPUID leaves to CPU features, see libos/src/arch/x86_64/libos_cpuid.c */
-        {SGX_XFRM_AVX,    { .leaf = 1, .subleaf = 0, .reg = CPUID_WORD_ECX, .bit = 28 }},
-        {SGX_XFRM_MPX,    { .leaf = 7, .subleaf = 0, .reg = CPUID_WORD_EBX, .bit = 14 }},
-        {SGX_XFRM_AVX512, { .leaf = 7, .subleaf = 0, .reg = CPUID_WORD_EBX, .bit = 16 }},
-        {SGX_XFRM_PKRU,   { .leaf = 7, .subleaf = 0, .reg = CPUID_WORD_ECX, .bit = 3 }},
-        {SGX_XFRM_AMX,    { .leaf = 7, .subleaf = 0, .reg = CPUID_WORD_EDX, .bit = 24 }},
+        {SGX_XFRM_AVX,    { .leaf = FEATURE_FLAGS_LEAF,          .subleaf = 0, .reg = CPUID_WORD_ECX, .bit = 28 }},
+        {SGX_XFRM_MPX,    { .leaf = EXTENDED_FEATURE_FLAGS_LEAF, .subleaf = 0, .reg = CPUID_WORD_EBX, .bit = 14 }},
+        {SGX_XFRM_AVX512, { .leaf = EXTENDED_FEATURE_FLAGS_LEAF, .subleaf = 0, .reg = CPUID_WORD_EBX, .bit = 16 }},
+        {SGX_XFRM_PKRU,   { .leaf = EXTENDED_FEATURE_FLAGS_LEAF, .subleaf = 0, .reg = CPUID_WORD_ECX, .bit = 3 }},
+        {SGX_XFRM_AMX,    { .leaf = EXTENDED_FEATURE_FLAGS_LEAF, .subleaf = 0, .reg = CPUID_WORD_EDX, .bit = 24 }},
     };
 
     *out_xfrm = xfrm;
@@ -150,7 +150,7 @@ int read_enclave_sigstruct(int sigfile, sgx_sigstruct_t* sig) {
 
 bool is_wrfsbase_supported(void) {
     uint32_t cpuinfo[4];
-    cpuid(7, 0, cpuinfo);
+    cpuid(EXTENDED_FEATURE_FLAGS_LEAF, 0, cpuinfo);
 
     if (!(cpuinfo[1] & 0x1)) {
         log_error(

--- a/pal/src/host/linux-sgx/pal_misc.c
+++ b/pal/src/host/linux-sgx/pal_misc.c
@@ -29,11 +29,6 @@
  */
 #define TSC_REFINE_INIT_TIMEOUT_USECS 50000
 
-#define CPU_VENDOR_LEAF             0x0
-#define EXTENDED_FEATURE_FLAGS_LEAF 0x7
-#define AMX_TILE_INFO_LEAF          0x1D
-#define AMX_TMUL_INFO_LEAF          0x1E
-
 uint64_t g_tsc_hz = 0; /* TSC frequency for fast and accurate time ("invariant TSC" HW feature) */
 static uint64_t g_start_tsc = 0;
 static uint64_t g_start_usec = 0;
@@ -186,7 +181,7 @@ static inline uint32_t extension_enabled(uint32_t xfrm, uint32_t bit_idx) {
  * store each extension's state. Use this to sanitize host's untrusted cpuid output. We also know
  * through xfrm what extensions are enabled inside the enclave.
  */
-static void sanitize_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) {
+static void sanitize_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[static 4]) {
     uint64_t xfrm = g_pal_linuxsgx_state.enclave_info.attributes.xfrm;
 
     if (leaf == CPU_VENDOR_LEAF) {
@@ -194,11 +189,21 @@ static void sanitize_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) 
         values[CPUID_WORD_EBX] = 0x756e6547; /* 'Genu' */
         values[CPUID_WORD_EDX] = 0x49656e69; /* 'ineI' */
         values[CPUID_WORD_ECX] = 0x6c65746e; /* 'ntel' */
+    } else if (leaf == FEATURE_FLAGS_LEAF) {
+        /* We have to enforce these feature bits, otherwise some crypto libraries (e.g. mbedtls)
+         * silently switch to side-channel-prone software implementations of crypto algorithms.
+         *
+         * On hosts which really don't support these, the untrusted PAL should emit an error and
+         * refuse to start.
+         */
+        values[CPUID_WORD_ECX] |= 1 << 25; // AESNI
+        values[CPUID_WORD_ECX] |= 1 << 26; // XSAVE (this one is for Gramine code, it relies on it)
+        values[CPUID_WORD_ECX] |= 1 << 30; // RDRAND
     } else if (leaf == EXTENDED_FEATURE_FLAGS_LEAF) {
         if (subleaf == 0x0) {
             values[CPUID_WORD_EAX] = g_extended_feature_flags_max_supported_sub_leaves;
-            values[CPUID_WORD_EBX] |= 1U << 0; /* SGX-enabled CPUs always support FSGSBASE */
-            values[CPUID_WORD_EBX] |= 1U << 2; /* SGX-enabled CPUs always report the SGX bit */
+            values[CPUID_WORD_EBX] |= 1U << 0; /* CPUs with SGX always support FSGSBASE */
+            values[CPUID_WORD_EBX] |= 1U << 2; /* CPUs with SGX always report the SGX bit */
         }
     } else if (leaf == EXTENDED_STATE_LEAF) {
         switch (subleaf) {
@@ -637,10 +642,6 @@ int _PalGetSpecialKey(const char* name, void* key, size_t* key_size) {
     return 0;
 }
 
-#define CPUID_LEAF_INVARIANT_TSC 0x80000007
-#define CPUID_LEAF_TSC_FREQ 0x15
-#define CPUID_LEAF_PROC_FREQ 0x16
-
 ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size) {
     int fd;
 
@@ -656,7 +657,7 @@ ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size) {
 
 bool is_tsc_usable(void) {
     uint32_t words[CPUID_WORD_NUM];
-    _PalCpuIdRetrieve(CPUID_LEAF_INVARIANT_TSC, 0, words);
+    _PalCpuIdRetrieve(INVARIANT_TSC_LEAF, 0, words);
     return words[CPUID_WORD_EDX] & 1 << 8;
 }
 
@@ -664,7 +665,7 @@ bool is_tsc_usable(void) {
 uint64_t get_tsc_hz(void) {
     uint32_t words[CPUID_WORD_NUM];
 
-    _PalCpuIdRetrieve(CPUID_LEAF_TSC_FREQ, 0, words);
+    _PalCpuIdRetrieve(TSC_FREQ_LEAF, 0, words);
     if (!words[CPUID_WORD_EAX] || !words[CPUID_WORD_EBX]) {
         /* TSC/core crystal clock ratio is not enumerated, can't use RDTSC for accurate time */
         return 0;
@@ -680,7 +681,7 @@ uint64_t get_tsc_hz(void) {
     /* some Intel CPUs do not report nominal frequency of crystal clock, let's calculate it
      * based on Processor Frequency Information Leaf (CPUID 16H); this leaf always exists if
      * TSC Frequency Leaf exists; logic is taken from Linux 5.11's arch/x86/kernel/tsc.c */
-    _PalCpuIdRetrieve(CPUID_LEAF_PROC_FREQ, 0, words);
+    _PalCpuIdRetrieve(PROC_FREQ_LEAF, 0, words);
     if (!words[CPUID_WORD_EAX]) {
         /* processor base frequency (in MHz) is not enumerated, can't calculate frequency */
         return 0;

--- a/pal/src/host/linux/arch/x86_64/pal_arch_misc.c
+++ b/pal/src/host/linux/arch/x86_64/pal_arch_misc.c
@@ -34,7 +34,7 @@ int _PalSegmentBaseSet(enum pal_segment_reg reg, uintptr_t addr) {
     }
 }
 
-int _PalCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[4]) {
+int _PalCpuIdRetrieve(uint32_t leaf, uint32_t subleaf, uint32_t values[static 4]) {
     cpuid(leaf, subleaf, values);
     return 0;
 }

--- a/pal/src/host/linux/pal_linux.h
+++ b/pal/src/host/linux/pal_linux.h
@@ -59,7 +59,7 @@ void fixup_socket_handle_after_deserialization(PAL_HANDLE handle);
 void init_child_process(int parent_stream_fd, PAL_HANDLE* parent, char** manifest_out,
                         uint64_t* instance_id);
 
-void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[]);
+void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[static 4]);
 int block_async_signals(bool block);
 void signal_setup(bool is_first_process, uintptr_t vdso_start, uintptr_t vdso_end);
 

--- a/subprojects/packagefiles/mbedtls/compile-curl.sh
+++ b/subprojects/packagefiles/mbedtls/compile-curl.sh
@@ -15,6 +15,7 @@ cp -ar "$VENDOR_SOURCE_DIR" "$PRIVATE_DIR"
 cp "$CURRENT_SOURCE_DIR"/include/mbedtls/*.h "$PRIVATE_DIR"/include/mbedtls/
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/gramine.patch
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/fcntl.patch
+patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/enforce-aes-ni.patch
 
 make -C "$PRIVATE_DIR" lib SUFFIX="''" install DESTDIR="$SUBPROJ_ROOT"/mbedtls-curl
 

--- a/subprojects/packagefiles/mbedtls/compile.sh
+++ b/subprojects/packagefiles/mbedtls/compile.sh
@@ -25,6 +25,7 @@ cp -ar "$VENDOR_SOURCE_DIR" "$PRIVATE_DIR"
 cp "$CURRENT_SOURCE_DIR"/include/mbedtls/*.h "$PRIVATE_DIR"/include/mbedtls/
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/gramine.patch
 patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/fcntl.patch
+patch -p1 --directory "$PRIVATE_DIR" <"$CURRENT_SOURCE_DIR"/enforce-aes-ni.patch
 
 make -C "$PRIVATE_DIR" lib "$@"
 

--- a/subprojects/packagefiles/mbedtls/enforce-aes-ni.patch
+++ b/subprojects/packagefiles/mbedtls/enforce-aes-ni.patch
@@ -1,0 +1,34 @@
+diff --git a/library/aes.c b/library/aes.c
+index 319d9bb67e89fa7a62ce3f2e14aa1552b7c91a12..2725b7bb8cfc5cd2f593050454a6d2b23866834d 100644
+--- a/library/aes.c
++++ b/library/aes.c
+@@ -543,6 +543,8 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
+ #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
+         return( mbedtls_aesni_setkey_enc( (unsigned char *) RK, key, keybits ) );
++    else
++        return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
+ #endif
+ 
+     for( i = 0; i < ( keybits >> 5 ); i++ )
+@@ -654,6 +656,11 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
+                            (const unsigned char *) ( cty.buf + cty.rk_offset ), ctx->nr );
+         goto exit;
+     }
++    else
++    {
++        ret = MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED;
++        goto exit;
++    }
+ #endif
+ 
+     SK = cty.buf + cty.rk_offset + cty.nr * 4;
+@@ -947,6 +954,8 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
+ #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
+     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
+         return( mbedtls_aesni_crypt_ecb( ctx, mode, input, output ) );
++    else
++        return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
+ #endif
+ 
+ #if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

*This PR fixes a security issue*

These CPU features are required for correct and secure use of Gramine:
- XSAVE is used internally by Gramine,
- AES-NI and RDRAND are required, otherwise some crypto libraries (e.g. mbedtls) silently switch to side-channel-prone software implementations of crypto algorithms.

This PR ensures that we always have them enabled and report as such to the application running under Linux-SGX PAL. Additionally, it patches the mbedtls version we ship to refuse to ever use non-AES-NI (i.e. vulnerable) AES implementation.

Kudos to Corentin Lauverjat from Mithril Security for reporting the bug!

p.s. We don't have to fix `/proc/cpuinfo`, as it already gets the flags from CPUID. See: https://github.com/gramineproject/gramine/blob/1aab0f79729f0c8a4852150a985be527991a06bc/libos/src/arch/x86_64/libos_cpuid.c#L285

Fixes #1014.

## How to test this PR? <!-- (if applicable) -->

Try faking CPUID results in `sgx_ocall_cpuid()`, then the same with disabled sanitization to check if the patched mbedtls fails (as it should now).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1125)
<!-- Reviewable:end -->
