### PR TITLE
[Docs] Remove fosshost.org mention from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,11 +89,3 @@ Reporting security issues
 =========================
 
 Please report security issues to security@gramineproject.io.
-
-
-Acknowledgments
-===============
-
-Gramine Project benefits from generous help of `fosshost.org
-<https://fosshost.org>`__: they lend us a VPS, which we use as toolserver and
-package hosting.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

They stopped to operate recently and we had to move to our own hosting.

For more info see the announcement at https://fosshost.org/.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1130)
<!-- Reviewable:end -->
