### PR TITLE
[CI] Remove `leeroy` user and `/opt/intel` dir

### DIFF
--- a/.ci/debian11.dockerfile
+++ b/.ci/debian11.dockerfile
@@ -24,5 +24,4 @@ RUN mkdir /debian
 COPY debian/control /debian
 RUN apt-get update && apt-get -y build-dep -t bullseye-backports --no-install-recommends --no-install-suggests /
 
-# Define default command.
 CMD ["bash"]

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -1,6 +1,5 @@
 stage('build') {
     sh '''
-        cd /opt/intel
         git clone https://github.com/intel/linux-sgx-driver.git
         cd linux-sgx-driver
         git checkout 276c5c6a064d22358542f5e0aa96b1c0ace5d695
@@ -22,6 +21,9 @@ stage('build') {
 
     if (env.SGX_DRIVER == null) {
         env.SGX_DRIVER = 'oot'
+    }
+    if (env.SGX_DRIVER == 'oot') {
+        env.MESON_OPTIONS += ' -Dsgx_driver_include_path=' + env.WORKSPACE + '/linux-sgx-driver'
     }
 
     try {

--- a/.ci/lib/stage-clean-check.jenkinsfile
+++ b/.ci/lib/stage-clean-check.jenkinsfile
@@ -20,6 +20,9 @@ stage('clean-check') {
         # root, and keeps cache there
         rm -rf .pytest_cache
 
+        # We downloaded the OOT SGX driver during build stage
+        rm -rf linux-sgx-driver
+
         make -C libos/test/regression clean
         make -C libos/test/fs clean
 
@@ -69,6 +72,7 @@ stage('clean-check') {
      * Gramine source tree.
      */
     sh 'rm -rf "$PREFIX"'
+    sh 'rm -rf linux-sgx-driver'
     sh '''
         ./scripts/gitignore-test
     '''

--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -1,7 +1,5 @@
-# Start with 18.04
 FROM ubuntu:18.04
 
-# Add steps here to set up dependencies
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     autoconf \
     bc \
@@ -90,27 +88,4 @@ RUN python3 -m pip install -U \
     'meson>=0.56,<0.57' \
     'docutils>=0.17,<0.18'
 
-# Add the user UID:1001, GID:1001, home at /leeroy
-RUN groupadd -r leeroy -g 1001 && useradd -u 1001 -r -g leeroy -m -d /leeroy -c "Leeroy Jenkins" leeroy && \
-    chmod 755 /leeroy
-
-# Make sure /leeroy can be written by leeroy
-RUN chown 1001 /leeroy
-
-# Blow away any random state
-RUN rm -f /leeroy/.rnd
-
-# Make a directory for the intel driver
-RUN mkdir -p /opt/intel && chown 1001 /opt/intel
-
-# Set the working directory to leeroy home directory
-WORKDIR /leeroy
-
-# Specify the user to execute all commands below
-USER leeroy
-
-# Set environment variables.
-ENV HOME /leeroy
-
-# Define default command.
 CMD ["bash"]

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:20.04
 
-# Add steps here to set up dependencies
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     autoconf \
     bc \
@@ -102,29 +101,4 @@ RUN python3 -m pip install -U \
     'meson>=0.56,<0.57' \
     'docutils>=0.17,<0.18'
 
-# Add the user UID:1001, GID:1001, home at /leeroy
-RUN \
-    groupadd -r leeroy -g 1001 && \
-    useradd -u 1001 -r -g leeroy -m -d /leeroy -c "Leeroy Jenkins" leeroy && \
-    chmod 755 /leeroy
-
-# Make sure /leeroy can be written by leeroy
-RUN chown 1001 /leeroy
-
-# Blow away any random state
-RUN rm -f /leeroy/.rnd
-
-# Make a directory for the intel driver
-RUN mkdir -p /opt/intel && chown 1001 /opt/intel
-
-# Set the working directory to leeroy home directory
-WORKDIR /leeroy
-
-# Specify the user to execute all commands below
-USER leeroy
-
-# Set environment variables.
-ENV HOME /leeroy
-
-# Define default command.
 CMD ["bash"]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As discussed in some other PRs and offline, `leeroy` seems to be totally useless, and we don't need `/opt/intel` directory -- instead we can just use a relative dir.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1131)
<!-- Reviewable:end -->
