### PR TITLE
Enable unix domain socket between two different gramine instances

### DIFF
--- a/libos/src/ipc/libos_ipc.c
+++ b/libos/src/ipc/libos_ipc.c
@@ -113,12 +113,19 @@ static int ipc_connect(IDTYPE dest, struct libos_ipc_connection** conn_ptr) {
         }
 
         char uri[PIPE_URI_SIZE];
+        char  uri_new[PIPE_URI_SIZE];
         if (vmid_to_uri(dest, uri, sizeof(uri)) < 0) {
             log_error("buffer for IPC pipe URI too small");
             BUG();
         }
+
+        uint64_t len = snprintf(uri_new, sizeof(uri_new), "%s/%lu", uri, g_pal_public_state->instance_id);
+        if (len >= sizeof(uri_new)) {
+                return -ERANGE;
+        }
+
         do {
-            ret = PalStreamOpen(uri, PAL_ACCESS_RDONLY, /*share_flags=*/0, PAL_CREATE_IGNORED,
+            ret = PalStreamOpen(uri_new, PAL_ACCESS_RDONLY, /*share_flags=*/0, PAL_CREATE_IGNORED,
                                 /*options=*/0, &conn->handle);
         } while (ret == -PAL_ERROR_INTERRUPTED);
         if (ret < 0) {

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -554,7 +554,7 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
 
     while (true) {
         if (use_vmid_for_name) {
-            len = snprintf(pipename, sizeof(pipename), "%u", g_process_ipc_ids.self_vmid);
+            len = snprintf(pipename, sizeof(pipename), "%u/%lu",  g_process_ipc_ids.self_vmid, g_pal_public_state->instance_id);
             if (len >= sizeof(pipename))
                 return -ERANGE;
         } else {

--- a/pal/include/host/linux-common/linux_utils.h
+++ b/pal/include/host/linux-common/linux_utils.h
@@ -45,8 +45,7 @@ void time_get_now_plus_ns(struct timespec* ts, uint64_t addend_ns);
  * can be negative! */
 int64_t time_ns_diff_from_now(struct timespec* ts);
 
-int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
-                                 struct sockaddr_un* out_addr);
+int get_gramine_unix_socket_addr(const char* name, struct sockaddr_un* out_addr);
 
 int file_stat_type(struct stat* stat);
 

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -174,6 +174,7 @@ struct pal_public_state {
 
     bool extra_runtime_domain_names_conf;
     struct pal_dns_host_conf dns_host;
+    uint64_t instance_id;
 };
 
 /* We cannot mark this as returning a pointer to `const` object, because LibOS can

--- a/pal/src/host/linux-common/gramine_unix_socket_addr.c
+++ b/pal/src/host/linux-common/gramine_unix_socket_addr.c
@@ -8,7 +8,7 @@
 #include "api.h"
 #include "linux_utils.h"
 
-int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
+int get_gramine_unix_socket_addr(const char* name,
                                   struct sockaddr_un* out_addr) {
     /* Apparently there is no way to get this define without including whole "sys/socket.h". */
     out_addr->sun_family = /*AF_UNIX*/1;
@@ -17,8 +17,7 @@ int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
      * buffer (i.e. do *not* consider the rest of the buffer as null-terminated C string, but rather
      * a fixed length byte array). */
     memset(out_addr->sun_path, 0, sizeof(out_addr->sun_path));
-    int ret = snprintf(out_addr->sun_path + 1, sizeof(out_addr->sun_path) - 1, "/gramine/%lu/%s",
-                       instance_id, name);
+    int ret = snprintf(out_addr->sun_path + 1, sizeof(out_addr->sun_path) - 1, "/gramine/%s", name);
     if (ret < 0) {
         return ret;
     }

--- a/pal/src/host/linux-sgx/pal_pipes.c
+++ b/pal/src/host/linux-sgx/pal_pipes.c
@@ -118,7 +118,7 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, pal_stream_options_
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 
@@ -250,7 +250,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 

--- a/pal/src/host/linux/pal_pipes.c
+++ b/pal/src/host/linux/pal_pipes.c
@@ -40,7 +40,7 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, pal_stream_options_
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 
@@ -138,7 +138,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -387,6 +387,7 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     }
     g_pal_common_state.instance_id = instance_id;
     g_pal_common_state.parent_process = parent_process;
+    g_pal_public_state.instance_id = instance_id;
 
     ssize_t ret;
 


### PR DESCRIPTION
Currently gramine only supports unix domain socket between child/parent within the same gramine instance. Some cloud use cases need unix domain socket between two different gramine instances. Add this support based on customers' requirement.

Signed-off-by: Ying Liu <ying2.liu@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
<!--
    Currently gramine only supports unix domain socket between child/parent within
    the same gramine instance. Some cloud use cases need unix domain socket between
    two different gramine instances. Add this support based on customers' requirement.
     -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
- 
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1132)
<!-- Reviewable:end -->
[uds_test.zip](https://github.com/gramineproject/gramine/files/10453853/uds_test.zip)
