### PR TITLE
[Docs] Edit build and install docs for upcoming 1.4 release

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -24,27 +24,18 @@ VM instances. The description below uses a *DCsv3 VM* running Ubuntu
 Install Gramine
 ^^^^^^^^^^^^^^^
 
-On Ubuntu 20.04::
+On Ubuntu 20.04 LTS and 18.04 LTS::
 
    sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ focal main' | sudo tee /etc/apt/sources.list.d/gramine.list
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ $(lsb_release -sc) main" \
+   | sudo tee /etc/apt/sources.list.d/gramine.list
 
-   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+   sudo curl -fsSLo /usr/share/keyrings/intel-sgx-deb.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.asc] https://download.01.org/intel-sgx/sgx_repo/ubuntu $(lsb_release -sc) main" \
+   | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 
    sudo apt-get update
    sudo apt-get install gramine
-
-On Ubuntu 18.04::
-
-   sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ bionic main' | sudo tee /etc/apt/sources.list.d/gramine.list
-
-   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-
-   sudo apt-get update
-   sudo apt-get install gramine-dcap
 
 Prepare a signing key
 ^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -169,7 +169,7 @@ Python
    python3`` shebang, Gramine would not be able to locate system-wide-installed
    Python packages.
 
-   Since Gramine currently supports only Debian/Ubuntu and CentOS/RHEL/Fedora
+   Since Gramine currently supports only Debian/Ubuntu and RHEL/AlmaLinux/Fedora
    distros, the shebang must always be ``#!/usr/bin/python3``.
 
 Meson

--- a/Documentation/devel/packaging.rst
+++ b/Documentation/devel/packaging.rst
@@ -2,13 +2,14 @@ Packaging and distributing
 ==========================
 
 Gramine project aims to support two most recent releases of the long-lived
-distributions (e.g. Debian, Ubuntu LTS, [the CentOS replacement that will
-hopefully emerge soon], ...).
+distributions (e.g. Debian, Ubuntu LTS, AlmaLinux and other CentOS replacements,
+...).
 
 Currently officially supported distributions:
 
-- Ubuntu (20.04 LTS, 18.04 LTS).
-- RHEL-8-like distributions (like AlmaLinux 8, CentOS 8, Rocky Linux 8, ...).
+- Ubuntu (22.04 LTS, 20.04 LTS, 18.04 LTS);
+- RHEL-8-like distributions (like AlmaLinux 8, Rocky Linux 8, ...);
+- experimentally, RHEL-9-like distros (packages are not fully validated).
 
 Exceptions
 ----------

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -10,9 +10,8 @@ Gramine without SGX has no special requirements.
 
 Gramine with SGX support requires several features from your system:
 
-- the FSGSBASE feature of recent processors must be enabled in the Linux kernel;
-- the Intel SGX driver must be built in the Linux kernel;
-- Intel SGX SDK/PSW and (optionally) Intel DCAP must be installed.
+- Linux kernel version at least 5.11 (with SGX driver enabled);
+- Intel SGX PSW and (optionally) Intel DCAP must be installed and configured.
 
 If your system doesn't meet these requirements, please refer to more detailed
 descriptions in :doc:`devel/building`.
@@ -24,52 +23,50 @@ package (see below).
 Install Gramine
 ---------------
 
-On Ubuntu 22.04 and Debian 11::
+Debian 11
+^^^^^^^^^
+
+::
 
    sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' | sudo tee /etc/apt/sources.list.d/gramine.list
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ $(lsb_release -sc) main" \
+   | sudo tee /etc/apt/sources.list.d/gramine.list
 
-   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+   sudo curl -fsSLo /usr/share/keyrings/intel-sgx-deb.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.asc] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main" \
+   | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 
    sudo apt-get update
+   sudo apt-get install gramine
 
-   sudo apt-get install gramine      # for 5.11+ upstream, in-kernel driver
-   sudo apt-get install gramine-oot  # for out-of-tree SDK driver
-   sudo apt-get install gramine-dcap # for out-of-tree DCAP driver
+Ubuntu 22.04 LTS, 20.04 LTS or 18.04 LTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Ubuntu 20.04::
+::
 
    sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ focal main' | sudo tee /etc/apt/sources.list.d/gramine.list
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ $(lsb_release -sc) main" \
+   | sudo tee /etc/apt/sources.list.d/gramine.list
 
-   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-
-   sudo apt-get update
-
-   sudo apt-get install gramine      # for 5.11+ upstream, in-kernel driver
-   sudo apt-get install gramine-oot  # for out-of-tree SDK driver
-   sudo apt-get install gramine-dcap # for out-of-tree DCAP driver
-
-On Ubuntu 18.04::
-
-   sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
-   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ bionic main' | sudo tee /etc/apt/sources.list.d/gramine.list
-
-   curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+   sudo curl -fsSLo /usr/share/keyrings/intel-sgx-deb.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.asc] https://download.01.org/intel-sgx/sgx_repo/ubuntu $(lsb_release -sc) main" \
+   | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 
    sudo apt-get update
+   sudo apt-get install gramine
 
-   sudo apt-get install gramine      # for 5.11+ upstream, in-kernel driver
-   sudo apt-get install gramine-oot  # for out-of-tree SDK driver
-   sudo apt-get install gramine-dcap # for out-of-tree DCAP driver
+RHEL-like distributions version 8 (and experimentally also version 9)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On RHEL-8-like distribution (like AlmaLinux 8, CentOS 8, Rocky Linux 8, ...)::
+(like AlmaLinux, Rocky Linux, ...)
 
-   sudo curl -fsSLo /etc/yum.repos.d/gramine.repo https://packages.gramineproject.io/rpm/gramine.repo
-   sudo dnf install gramine          # only the default, distro-provided kernel is supported
+1. Install EPEL repository as described here:
+   https://docs.fedoraproject.org/en-US/epel/
+
+2. Install Gramine::
+
+      sudo curl -fsSLo /etc/yum.repos.d/gramine.repo https://packages.gramineproject.io/rpm/gramine.repo
+      sudo dnf install gramine
 
 Prepare a signing key
 ---------------------
@@ -97,7 +94,7 @@ we want to build and run the HelloWorld example. To build the HelloWorld
 application, we need the ``gcc`` compiler and the ``make`` build system::
 
    sudo apt-get install gcc make  # for Ubuntu distribution
-   sudo dnf install gcc make      # for RHEL-8-like distribution
+   sudo dnf install gcc make      # for RHEL-like distribution
 
 Go to the HelloWorld example directory::
 
@@ -125,12 +122,12 @@ understand manifest options and features of Gramine.
 Additional sample configurations for applications enabled in Gramine can be
 found in a separate repository https://github.com/gramineproject/examples.
 
-Please note that these sample applications are tested on Ubuntu 18.04 and 20.04.
-Most of these applications are also known to run correctly on
-Fedora/RHEL/CentOS, but with caveats. One caveat is that Makefiles should be
-invoked with ``ARCH_LIBDIR=/lib64 make``. Another caveat is that applications
-that rely on specific versions/builds of Glibc may break (our GCC example is
-known to work only on Ubuntu).
+Please note that these sample applications are tested on Ubuntu. Most of these
+applications are also known to run correctly on Fedora/RHEL/AlmaLinux/Rocky
+Linux, but with caveats. One caveat is that Makefiles should be invoked with
+``ARCH_LIBDIR=/lib64 make``. Another caveat is that applications that rely on
+specific versions/builds of Glibc may break (our GCC example is known to work
+only on Ubuntu).
 
 glibc vs musl
 -------------


### PR DESCRIPTION
I'd prefer this PR be merged after #1102, because although it's unrelated, I think the discussion if we support RHEL 9 et.al. should be concluded before we agree on the exact language about installing on RHEL and derivatives. Regardless of that section's intro text, the CLI commands will be the same.

## How to test this PR? <!-- (if applicable) -->

Just before release there will be packages available in `unstable-` repositories. I'll change this text when this happens. Then you should go though all the new install instructions, but for our repos prefix the names with `unstable-` (like, instead of `https://packages.gramineproject.io jammy`, write `https://packages.gramineproject.io unstable-jammy`) and see if they work. Obviously the packages from stable repos won't be available until after the release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1136)
<!-- Reviewable:end -->
