### PR TITLE
[CI] Fix `git ls-files` command

### DIFF
--- a/scripts/gitignore-check-files
+++ b/scripts/gitignore-check-files
@@ -5,7 +5,7 @@ set -eu -o pipefail
 # Intended to be run before a build. Returns 1 (i.e. failure) if there's at
 # least one file that should be ignored.
 
-files="$(git ls-files -i --exclude-standard)"
+files="$(git ls-files -i -o --exclude-standard)"
 if [ -z "${files}" ]; then
     exit 0
 fi


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Starting from Git v2.32.0, `git ls-files -i` must be used with either `-o` or `-c` (this was a bug in Git, fixed in commit "ls-files: error out on -i unless -o or -c are specified").

See https://github.com/git/git/commit/b338e9f668737e08201c990450b8c3d744f63162 for details.

This was detected on my PR https://github.com/gramineproject/gramine/pull/1032 that uses Ubuntu 22.04 Docker, which has Git v2.34.

## How to test this PR? <!-- (if applicable) -->

https://github.com/gramineproject/gramine/pull/1032 fails without this trick.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1137)
<!-- Reviewable:end -->
