### PR TITLE
[PAL/Linux-SGX] Try old mmap flags if first mmap on SGX driver failed

### DIFF
--- a/pal/src/host/linux-sgx/host_framework.c
+++ b/pal/src/host/linux-sgx/host_framework.c
@@ -186,6 +186,14 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
     uint64_t addr = DO_SYSCALL(mmap, request_mmap_addr, request_mmap_size,
                                PROT_READ | PROT_WRITE | PROT_EXEC, MAP_FIXED | MAP_SHARED,
                                g_isgx_device, 0);
+    if (IS_PTR_ERR(addr) && PTR_TO_ERR(addr) == -EACCES) {
+        /* OOT DCAP driver (e.g. v1.33.2 found on MS Azure VMs with Ubuntu 18.04) requires
+         * different mmap flags */
+        /* TODO: remove this fallback after we drop Ubuntu 18.04 */
+        addr = DO_SYSCALL(mmap, request_mmap_addr, request_mmap_size,
+                          PROT_NONE, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    }
+
     if (IS_PTR_ERR(addr)) {
         int ret = PTR_TO_ERR(addr);
         if (ret == -EPERM) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit "[PAL/Linux-SGX] Add initial EDMM support (only regular pages)" simplified the initial mmap request to the SGX driver (to allocate EPC memory). However, this simplification broke the OOT DCAP driver v1.33.2, found on MS Azure VMs with Ubuntu 18.04: it fails with EACCES.

It turns out the OOT DCAP driver and the upstream driver are not 100% compatible because of this mmap. Hopefully we won't need to support the OOT DCAP driver for long, so this commit introduces a hack to revert to the old mmap flags on failure.

See https://github.com/gramineproject/gramine/pull/1054/files#diff-4e06cdb88e117895595e7b079d551cf389b3e0456635a9a8ca7d9da3552539bc -- this is the offender.

Without this PR, on a Ubuntu 18.04 system (MS Azure CC VM), I get the following error:
```
$ dmesg | grep -i sgx
[    5.407890] sgx: EPC section 0x30e0000000-0x4edfffffff
[    6.416713] sgx: intel_sgx: Intel SGX DCAP Driver v1.33.2

$ gramine/CI-Examples/helloworld$ gramine-sgx helloworld
error: Allocation of EPC memory failed: Permission denied (EACCES)
error: Creating enclave failed: Permission denied (EACCES)
error: load_enclave() failed with error: Permission denied (EACCES)
```

## How to test this PR? <!-- (if applicable) -->

Test on as many different machines as possible. In particular, Ms Azure CC VM with Ubuntu 18.04.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1145)
<!-- Reviewable:end -->
