### PR TITLE
[tests] Add "execute" subtest to `memory` test

### DIFF
--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -351,7 +351,7 @@ class TC_20_SingleProcess(RegressionTestCase):
             except subprocess.CalledProcessError as e:
                 self.assertEqual(e.returncode, 1)
                 stderr = e.stderr.decode()
-                self.assertRegex(stderr, r'write to R mem at 0x[0-9a-f]+ unexpectedly succeeded')
+                self.assertRegex(stderr, r'exec on RW mem at 0x[0-9a-f]+ unexpectedly succeeded')
 
     def test_400_pipe(self):
         _, stderr = self.run_binary(['Pipe'])


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This increases test coverage for the EDMM SGX feature.

This is another approach instead of #1120: we just augment the already-existing PAL test `memory.c` instead of creating a new one.

~~Closes #1120.~~

## How to test this PR? <!-- (if applicable) -->

CI and manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1146)
<!-- Reviewable:end -->
