### PR TITLE
[PAL/Linux-SGX] Print error message if no EDMM support

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -459,6 +459,9 @@ as RWX). Unfortunately it can negatively impact performance, as adding a page
 to the enclave at runtime is a more expensive operation than adding the page
 before enclave creation (because it involves more enclave exits and syscalls).
 
+.. note::
+   Support for EDMM first appeared in Linux 6.0.
+
 Enclave size
 ^^^^^^^^^^^^
 

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -78,6 +78,7 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
 int edmm_restrict_pages_perm(uint64_t addr, size_t count, uint64_t prot);
 int edmm_modify_pages_type(uint64_t addr, size_t count, uint64_t type);
 int edmm_remove_pages(uint64_t addr, size_t count);
+int edmm_supported_by_driver(bool* out_supported);
 
 /*!
  * \brief Retrieve Quoting Enclave's sgx_target_info_t by talking to AESMD.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Fixes #1148

Some references:
- https://lore.kernel.org/lkml/6f8653a000c0fd670ea19337d1c744b28127be54.1644274683.git.reinette.chatre@intel.com/ (search for "Ensure kernel supports ...")
- https://lore.kernel.org/lkml/165721846417.15455.4074908162801839460.tip-bot2@tip-bot2/T/ (search for "sgx_ioc_sgx2_ready")
- https://patchwork.kernel.org/project/intel-sgx/patch/d787827dbfca6b3210ac3e432e3ac1202727e786.1616136308.git.kai.huang@intel.com/
- https://elixir.bootlin.com/linux/latest/source/arch/x86/kernel/cpu/sgx/ioctl.c#L1257
- Intel SDM, Table 3-8, CPUID leaf `0x12`.

## How to test this PR? <!-- (if applicable) -->

Manually on different machines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1149)
<!-- Reviewable:end -->
