### PR TITLE
[LibOS] Print warning when running as root user

### DIFF
--- a/libos/src/bookkeep/libos_thread.c
+++ b/libos/src/bookkeep/libos_thread.c
@@ -178,6 +178,12 @@ static int init_main_thread(void) {
         return -EINVAL;
     }
 
+    if (uid_int64 == 0 || gid_int64 == 0) {
+        log_warning("Application starts as root (UID and/or GID are equal to 0). Running as root "
+                    "brings some risks. Consider specifying a non-root user in the manifest (use "
+                    "'loader.uid' and 'loader.gid' options).");
+    }
+
     cur_thread->uid = uid_int64;
     cur_thread->euid = uid_int64;
     cur_thread->suid = uid_int64;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It is considered a good practice to run as non-root user whenever possible. E.g., Docker recommends it in its "Best practices":
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

Kudos to @marcelamelara for pointing this out.

## How to test this PR? <!-- (if applicable) -->

Manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1158)
<!-- Reviewable:end -->
