### PR TITLE
[debian] Create a virtual package for gramine-dcap

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,10 @@ Recommends:
  gramine-ratls-epid,
 Conflicts:
  gramine-oot,
- gramine-dcap,
+Replaces:
+ gramine-dcap (<< 1.4),
+Breaks:
+ gramine-dcap (<< 1.4),
 
 Package: gramine-ratls-dcap
 Architecture: amd64
@@ -63,3 +66,10 @@ Description: EPID-based Remote Attestation TLS (RA-TLS) library for Gramine
 Depends:
  gramine (= ${binary:Version}),
 # TODO: libc6
+
+Package: gramine-dcap
+Depends:
+ gramine (= ${binary:Version}),
+Architecture: all
+Description: transitional package
+Section: oldlibs


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

In this commit, we define a virtual package for gramine-dcap. The goal of it is to smoothly transit users from the `gramine-dcap` to Gramine package.

## Useful links:
* https://wiki.debian.org/RenamingPackages
* https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces
* https://rpmdeb.com/devops-articles/how-to-create-local-debian-repository/

## How to test this PR? <!-- (if applicable) -->
Tested upgrade from 1.3.1 to 1.4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1162)
<!-- Reviewable:end -->
