### PR TITLE
Move the current restriction of pipes + UDSes from PAL layer to Libos layer

### DIFF
--- a/libos/include/libos_utils.h
+++ b/libos/include/libos_utils.h
@@ -49,9 +49,6 @@ void remove_r_debug(void* addr);
 void append_r_debug(const char* uri, void* addr);
 void clean_link_map_list(void);
 
-/* Get the IPC pipe uri associated with `vmid`. */
-int vmid_to_uri(IDTYPE vmid, char* uri, size_t uri_len);
-
 /* create unique files/pipes */
 int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vmid_for_name);
 

--- a/libos/src/ipc/libos_ipc.c
+++ b/libos/src/ipc/libos_ipc.c
@@ -95,6 +95,16 @@ static struct libos_ipc_connection* node2conn(struct avl_tree_node* node) {
     return container_of(node, struct libos_ipc_connection, node);
 }
 
+static int vmid_to_uri(IDTYPE vmid, char* uri, size_t uri_size) {
+    int ret = snprintf(uri, uri_size, URI_PREFIX_PIPE "%lu/%u", g_pal_public_state->instance_id,
+                       vmid);
+    if (ret < 0 || (size_t)ret >= uri_size) {
+        return -ERANGE;
+    }
+
+    return 0;
+}
+
 static int ipc_connect(IDTYPE dest, struct libos_ipc_connection** conn_ptr) {
     struct libos_ipc_connection dummy = { .vmid = dest };
     int ret = 0;

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -534,14 +534,6 @@ static int get_256b_random_hex_string(char* buf, size_t size) {
     return 0;
 }
 
-int vmid_to_uri(IDTYPE vmid, char* uri, size_t uri_len) {
-    int ret = snprintf(uri, uri_len, URI_PREFIX_PIPE "%u", vmid);
-    if (ret < 0 || (size_t)ret >= uri_len) {
-        return -ERANGE;
-    }
-    return 0;
-}
-
 int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vmid_for_name) {
     int ret;
     size_t len;
@@ -554,7 +546,8 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
 
     while (true) {
         if (use_vmid_for_name) {
-            len = snprintf(pipename, sizeof(pipename), "%u", g_process_ipc_ids.self_vmid);
+            len = snprintf(pipename, sizeof(pipename), "%lu/%u", g_pal_public_state->instance_id,
+                           g_process_ipc_ids.self_vmid);
             if (len >= sizeof(pipename))
                 return -ERANGE;
         } else {

--- a/pal/include/host/linux-common/linux_utils.h
+++ b/pal/include/host/linux-common/linux_utils.h
@@ -45,8 +45,7 @@ void time_get_now_plus_ns(struct timespec* ts, uint64_t addend_ns);
  * can be negative! */
 int64_t time_ns_diff_from_now(struct timespec* ts);
 
-int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
-                                 struct sockaddr_un* out_addr);
+int get_gramine_unix_socket_addr(const char* name, struct sockaddr_un* out_addr);
 
 int file_stat_type(struct stat* stat);
 

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -129,6 +129,7 @@ struct pal_dns_host_conf {
 /* Part of PAL state which is shared between all PALs and accessible (read-only) by the binary
  * started by PAL (usually our LibOS). */
 struct pal_public_state {
+    uint64_t instance_id;
     const char* host_type;
     const char* attestation_type; /* currently only for Linux-SGX */
 

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -28,7 +28,6 @@
  * PAL.
  */
 struct pal_common_state {
-    uint64_t instance_id;
     PAL_HANDLE parent_process;
     const char* raw_manifest_data;
 };

--- a/pal/src/host/linux-common/gramine_unix_socket_addr.c
+++ b/pal/src/host/linux-common/gramine_unix_socket_addr.c
@@ -8,8 +8,7 @@
 #include "api.h"
 #include "linux_utils.h"
 
-int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
-                                  struct sockaddr_un* out_addr) {
+int get_gramine_unix_socket_addr(const char* name, struct sockaddr_un* out_addr) {
     /* Apparently there is no way to get this define without including whole "sys/socket.h". */
     out_addr->sun_family = /*AF_UNIX*/1;
 
@@ -17,8 +16,7 @@ int get_gramine_unix_socket_addr(uint64_t instance_id, const char* name,
      * buffer (i.e. do *not* consider the rest of the buffer as null-terminated C string, but rather
      * a fixed length byte array). */
     memset(out_addr->sun_path, 0, sizeof(out_addr->sun_path));
-    int ret = snprintf(out_addr->sun_path + 1, sizeof(out_addr->sun_path) - 1, "/gramine/%lu/%s",
-                       instance_id, name);
+    int ret = snprintf(out_addr->sun_path + 1, sizeof(out_addr->sun_path) - 1, "/gramine/%s", name);
     if (ret < 0) {
         return ret;
     }

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -32,7 +32,7 @@ extern pid_t g_host_pid;
 
 struct pal_enclave {
     /* attributes */
-    bool is_first_process; // Initial process in Gramine namespace is special.
+    bool is_first_process; // Initial process in Gramine instance is special.
 
     char* application_path;
     char* raw_manifest_data;

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -1209,7 +1209,7 @@ int main(int argc, char* argv[], char* envp[]) {
         return -ENOMEM;
     }
 
-    // Are we the first in this Gramine's namespace?
+    // Are we the first in this Gramine's instance?
     bool first_process = !strcmp(argv[2], "init");
     if (!first_process && strcmp(argv[2], "child")) {
         print_usage_and_exit(argv[0]);

--- a/pal/src/host/linux-sgx/pal_pipes.c
+++ b/pal/src/host/linux-sgx/pal_pipes.c
@@ -108,9 +108,9 @@ static noreturn int thread_handshake_func(void* param) {
  *
  * \returns 0 on success, negative PAL error code otherwise.
  *
- * An abstract UNIX socket with name "/gramine/<instance_id>/<pipename>" is opened for listening. A
- * corresponding PAL handle with type `pipesrv` is created. This PAL handle typically serves only as
- * an intermediate step to connect two ends of the pipe (`pipecli` and `pipe`). As soon as the other
+ * An abstract UNIX socket with name "/gramine/<pipename>" is opened for listening. A corresponding
+ * PAL handle with type `pipesrv` is created. This PAL handle typically serves only as an
+ * intermediate step to connect two ends of the pipe (`pipecli` and `pipe`). As soon as the other
  * end of the pipe connects to this listening socket, a new accepted socket and the corresponding
  * PAL handle are created, and this `pipesrv` handle can be closed.
  */
@@ -118,7 +118,7 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, pal_stream_options_
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 
@@ -242,15 +242,15 @@ out_err:
  * \returns 0 on success, negative PAL error code otherwise.
  *
  * This function connects to the other end of the pipe, represented as an abstract UNIX socket
- * "/gramine/<instance_id>/<pipename>" opened for listening. When the connection succeeds, a new
- * `pipe` PAL handle is created with the corresponding underlying socket and is returned in
- * `handle`. The other end of the pipe is typically of type `pipecli`.
+ * "/gramine/<pipename>" opened for listening. When the connection succeeds, a new `pipe` PAL
+ * handle is created with the corresponding underlying socket and is returned in `handle`.
+ * The other end of the pipe is typically of type `pipecli`.
  */
 static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options_t options) {
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 

--- a/pal/src/host/linux-sgx/pal_process.c
+++ b/pal/src/host/linux-sgx/pal_process.c
@@ -87,7 +87,7 @@
  *       All Gramine enclaves with the same configuration (manifest) and same Gramine (LibOS, PAL)
  *       binaries should have the same measurement. During initialization, it's decided based on
  *       input from untrusted PAL, whether a particular enclave will become a leader of a new
- *       Gramine namespace, or will wait on a pipe for some parent enclave connection.
+ *       Gramine instance, or will wait on a pipe for some parent enclave connection.
  *
  * (4) The two parties who create the session key need to be the ones proven by the CPU
  *     (for preventing man-in-the-middle attacks).
@@ -171,7 +171,7 @@ int _PalProcessCreate(const char** args, uintptr_t (*reserved_mem_ranges)[2],
         goto failed;
 
     /* Send this Gramine instance ID. */
-    uint64_t instance_id = g_pal_common_state.instance_id;
+    uint64_t instance_id = g_pal_public_state.instance_id;
     ret = _PalStreamSecureWrite(child->process.ssl_ctx, (uint8_t*)&instance_id, sizeof(instance_id),
                                 /*is_blocking=*/!child->process.nonblocking);
     if (ret != sizeof(instance_id)) {

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -213,7 +213,7 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     if (ret < 0)
         INIT_FAIL("verify_hw_requirements() failed");
 
-    // Are we the first in this Gramine's namespace?
+    // Are we the first in this Gramine's instance?
     bool first_process = !strcmp(argv[2], "init");
     if (!first_process && strcmp(argv[2], "child")) {
         print_usage_and_exit(argv[0]);

--- a/pal/src/host/linux/pal_pipes.c
+++ b/pal/src/host/linux/pal_pipes.c
@@ -30,9 +30,9 @@
  *
  * \returns 0 on success, negative PAL error code otherwise.
  *
- * An abstract UNIX socket with name "/gramine/<instance_id>/<pipename>" is opened for listening. A
- * corresponding PAL handle with type `pipesrv` is created. This PAL handle typically serves only as
- * an intermediate step to connect two ends of the pipe (`pipecli` and `pipe`). As soon as the other
+ * An abstract UNIX socket with name "/gramine/<pipename>" is opened for listening. A corresponding
+ * PAL handle with type `pipesrv` is created. This PAL handle typically serves only as an
+ * intermediate step to connect two ends of the pipe (`pipecli` and `pipe`). As soon as the other
  * end of the pipe connects to this listening socket, a new accepted socket and the corresponding
  * PAL handle are created, and this `pipesrv` handle can be closed.
  */
@@ -40,7 +40,7 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, pal_stream_options_
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 
@@ -130,15 +130,15 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
  * \returns 0 on success, negative PAL error code otherwise.
  *
  * This function connects to the other end of the pipe, represented as an abstract UNIX socket
- * "/gramine/<instance_id>/<pipename>" opened for listening. When the connection succeeds, a new
- * `pipe` PAL handle is created with the corresponding underlying socket and is returned in
- * `handle`. The other end of the pipe is typically of type `pipecli`.
+ * "/gramine/<pipename>" opened for listening. When the connection succeeds, a new `pipe` PAL handle
+ * is created with the corresponding underlying socket and is returned in `handle`. The other end of
+ * the pipe is typically of type `pipecli`.
  */
 static int pipe_connect(PAL_HANDLE* handle, const char* name, pal_stream_options_t options) {
     int ret;
 
     struct sockaddr_un addr;
-    ret = get_gramine_unix_socket_addr(g_pal_common_state.instance_id, name, &addr);
+    ret = get_gramine_unix_socket_addr(name, &addr);
     if (ret < 0)
         return -PAL_ERROR_DENIED;
 

--- a/pal/src/host/linux/pal_process.c
+++ b/pal/src/host/linux/pal_process.c
@@ -144,7 +144,7 @@ int _PalProcessCreate(const char** args, uintptr_t (*reserved_mem_ranges)[2],
         goto out;
     }
 
-    proc_args->instance_id = g_pal_common_state.instance_id;
+    proc_args->instance_id = g_pal_public_state.instance_id;
     proc_args->memory_quota = g_pal_linux_state.memory_quota;
 
     char* data = (char*)(proc_args + 1);

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -385,7 +385,7 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
             INIT_FAIL("Could not generate random instance_id");
         }
     }
-    g_pal_common_state.instance_id = instance_id;
+    g_pal_public_state.instance_id = instance_id;
     g_pal_common_state.parent_process = parent_process;
 
     ssize_t ret;


### PR DESCRIPTION
    This commit moves the current restriction of pipes + UDSes (that they can connect
    to processes only within the same Gramine instances) from PAL layer to LibOS layer.

    As a side effect, this commit renames `instance_id` to a more appropriate
    `namespace_id` ("Gramine instance" was a term we used to describe a set of
    Gramine processes that can communicate with each other, but the better term
    for this is "namespace").


Signed-off-by: Ying Liu <ying2.liu@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR
<!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1170)
<!-- Reviewable:end -->
