### PR TITLE
[Docs] Mention `sgx.enclave_size` in EDMM enablement section

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -459,6 +459,10 @@ as RWX). Unfortunately it can negatively impact performance, as adding a page
 to the enclave at runtime is a more expensive operation than adding the page
 before enclave creation (because it involves more enclave exits and syscalls).
 
+Even when EDMM is enabled, it is still necessary to specify ``sgx.enclave_size``
+-- it specifies the *maximal* size that the enclave can grow to. In case of
+doubt, set this size to some large value like ``128G``.
+
 .. note::
    Support for EDMM first appeared in Linux 6.0.
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Many people have a feeling that when `sgx.edmm_enable = true`, they can remove `sgx.enclave_size`. Which is not true (the enclave size becomes the "maximum limit on the available enclave-memory space"). Let's make it more explicit in our documentation.

See #1174.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1178)
<!-- Reviewable:end -->
