### PR TITLE
[PAL/Linux-SGX] Add "parse frequency from /proc/cpuinfo" fallback

### DIFF
--- a/common/include/arch/x86_64/cpu.h
+++ b/common/include/arch/x86_64/cpu.h
@@ -44,6 +44,8 @@ enum extended_state_sub_leaf {
 #define PROC_FREQ_LEAF                         0x16
 #define AMX_TILE_INFO_LEAF                     0x1D
 #define AMX_TMUL_INFO_LEAF                     0x1E
+#define HYPERVISOR_INFO_LEAF             0x40000000
+#define HYPERVISOR_TIME_LEAF             0x40000010
 #define MAX_INPUT_EXT_VALUE_LEAF         0x80000000
 #define EXT_SIGNATURE_AND_FEATURES_LEAF  0x80000001
 #define CPU_BRAND_LEAF                   0x80000002

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -101,8 +101,6 @@ void _PalExceptionHandler(unsigned int exit_info, sgx_cpu_context_t* uc,
  * its underlying type. */
 void _PalHandleExternalEvent(long event_, sgx_cpu_context_t* uc, PAL_XREGS_STATE* xregs_state);
 
-bool is_tsc_usable(void);
-uint64_t get_tsc_hz(void);
 void init_tsc(void);
 
 int init_cpuid(void);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some hypervisors (like Microsoft Hyper-V) currently do not expose CPUID leaves 0x15 and 0x16 (Core Crystal Clock/Process Frequency), and also do not expose  hypervisor-specific synthetic CPUID leaf 0x40000010 (Timing Information). In this case, if "Invariant TSC" feature is found in CPUID leaves, we know that TSC is stable and we need to find its frequency: we try to parse the "Processor Brand String" CPUID leaves and extract the CPU frequency from that string (assuming that TSC frequency is equal to this base CPU frequency).

For context see:
- https://github.com/gramineproject/gramine/issues/1009
- https://github.com/gramineproject/gramine/pull/1012 (prerequisite for this PR)
- https://github.com/gramineproject/gramine/pull/1154 (failed attempt)

## How to test this PR? <!-- (if applicable) -->

Manually, e.g. on MS Azure cloud.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1180)
<!-- Reviewable:end -->
