### PR TITLE
[docker] Drop deprecated/unstable directives

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,17 +1,17 @@
 FROM ubuntu:20.04
 
-RUN apt update
-RUN DEBIAN_FRONTEND=noninteractive apt install -y curl gnupg2 binutils
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl gnupg2 binutils
 
 RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
 RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ focal main' > /etc/apt/sources.list.d/gramine.list
 
-RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' > /etc/apt/sources.list.d/intel-sgx.list
+RUN curl -fsSLo /usr/share/keyrings/intel-sgx-deb.key https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
+RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.key] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' > /etc/apt/sources.list.d/intel-sgx.list
 
-RUN apt update
+RUN apt-get update
 
-RUN DEBIAN_FRONTEND=noninteractive apt install -y gramine \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gramine \
     sgx-aesm-service \
     libsgx-aesm-launch-plugin \
     libsgx-aesm-epid-plugin \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Replace usage of `apt` with `apt-get`. The `apt` tool doesn't have a stable CLI interface, and it's not recommended to use it in Dockerfile.

Replace deprecated `apt-key` with `signed-by`.

As we are here - drop the `packaging` directory, as other packaging scripts (like `debian`) don't use it.

## How to test this PR? <!-- (if applicable) -->

```
docker build .
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1181)
<!-- Reviewable:end -->
