### PR TITLE
[Docs] Additional info for `sgx-profling` for long running applications

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -853,8 +853,8 @@ SGX profiling
     (Default: "none")
 
 This syntax specifies whether to enable SGX profiling. Gramine must be compiled
-with ``DEBUG=1`` or ``DEBUGOPT=1`` for this option to work (the latter is
-advised).
+with ``--buildtype=debug`` or ``--buildtype=debugoptimized`` for this option to
+work (the latter is advised).
 
 If this option is set to ``main``, the main process will collect IP samples and
 save them as ``sgx-perf.data``. If it is set to ``all``, all processes will
@@ -923,9 +923,9 @@ SGX profiling with Intel VTune Profiler
     (Default: false)
 
 This syntax specifies whether to enable SGX profiling with Intel VTune Profiler.
-Gramine must be compiled with ``DEBUG=1`` or ``DEBUGOPT=1`` for this option to
-work (the latter is advised). In addition, the application manifest must also
-contain ``sgx.debug = true``.
+Gramine must be compiled with ``--buildtype=debug`` or
+``--buildtype=debugoptimized`` for this option to work (the latter is advised).
+In addition, the application manifest must also contain ``sgx.debug = true``.
 
 .. note::
    The manifest options ``sgx.vtune_profile`` and ``sgx.profile.*`` can work

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -561,6 +561,9 @@ use it:
    (optimizations enabled) makes Gramine performance more similar to release
    build.
 
+#. Profiling the code inside the SGX enclave can be done on debug enclave.
+   Add ``sgx.debug = true`` to manifest to specify debug enclave.
+
 #. Add ``sgx.profile.enable = "main"`` to manifest (to collect data for the main
    process), or ``sgx.profile.enable = "all"`` (to collect data for all
    processes).
@@ -572,6 +575,12 @@ use it:
    multiple files will be written).
 
 #. Run ``perf report -i <data file>`` (see :ref:`perf` above).
+
+Some applications might run for long time or run always (e.g. redis) generating
+huge perf data. In such cases, user may want to exit the application in between
+of execution. Hard killing the application will mess up perf data. Instead add
+``sys.enable_sigterm_injection = true`` in application manifest file and
+terminate application using command ``kill <pid>``.
 
 *Note*: The accuracy of this tool is unclear (though we had positive experiences
 using the tool so far). The SGX profiling works by measuring the value of


### PR DESCRIPTION
SGX profiling document misses information for profling long runing or always running processes. This PR add some info. Also updated the old gramine build options.

## How to test this PR? <!-- (if applicable) -->
Compile Gramine with `-Dsgx=enabled --buildtype=debugoptimized.`

1. `sgx.debug = true` is already added, also add below manifest options to `redis-server.manifest.template` file:
```
    sgx.profile.enable = "main"
    sgx.profile.with_stack = true
```

2. Build and run `redis-server`:
```
cd CI-Examples/redis/
make SGX=1
gramine-sgx redis-server &
```
3. Find PID for `redis-server` process and terminate it using command `kill <pid>`
4. Should be able to open sgx perf report using below command:
`perf report --no-children -i sgx-perf.data`

