### PR TITLE
Remove redundant `sgx.nonpie_binary` manifest option

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -20,7 +20,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.max_threads = 4
 

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -22,7 +22,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 sys.stack.size = "8M"
 sgx.enclave_size = "2048M"
 sgx.max_threads = 64

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -21,7 +21,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 sgx.enclave_size = "256M"
 sgx.max_threads = 3
 

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -25,7 +25,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 sgx.max_threads = 16
 
 # Memcached does not fail explicitly when enclave memory is exhausted. Instead, Memcached goes into

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -27,7 +27,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.max_threads = 4
 

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -34,7 +34,6 @@ sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 sgx.enclave_size = "1G"
 sgx.max_threads = 32
 

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -87,15 +87,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 # specifying '8' allows to run a maximum of 6 Redis threads which is enough.
 sgx.max_threads = 8
 
-# Redis executable is typically a PIE (Position Independent Executable) on most
-# modern OS distros (e.g., Ubuntu 18.04). However, on some OS distros (notably,
-# CentOS), Redis executable is built as non-PIE. We mark Redis as a non-PIE
-# binary unconditionally -- this makes it work on CentOS and doesn't hurt on
-# Ubuntu. (Note that non-SGX Gramine correctly distinguishes between PIE and
-# non-PIE binaries, but for SGX we need to prearrange enclave memory layout,
-# hence the below option.)
-sgx.nonpie_binary = true
-
 ############################# SGX: TRUSTED FILES ###############################
 
 # Specify all files used by Redis and its dependencies (including all libraries

--- a/CI-Examples/rust/rust-hyper-http-server.manifest.template
+++ b/CI-Examples/rust/rust-hyper-http-server.manifest.template
@@ -19,7 +19,6 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.nonpie_binary = true
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/Documentation/devel/onboarding.rst
+++ b/Documentation/devel/onboarding.rst
@@ -261,13 +261,11 @@ fine on native Linux but fails under Gramine::
      Try to identify the system call in Gramine that goes wrong (e.g., returns
      an error code whereas it was supposed to finish successfully).
 
-   - Analyze the manifest file carefully. If at least one of the binaries
-     spawned during app execution is non-PIE, then set ``sgx.nonpie_binary =
-     true``. If you suspect problems with environment variables, see if it works
-     with ``loader.insecure__use_host_env = true``. If you observe that memory
-     addresses change constantly and hinder your debugging, set
-     ``loader.insecure__disable_aslr = true``. But don't use the last two
-     options in production; use them only for debugging and analysis!
+   - Analyze the manifest file carefully. If you suspect problems with
+     environment variables, see if it works with ``loader.insecure__use_host_env
+     = true``. If you observe that memory addresses change constantly and hinder
+     your debugging, set ``loader.insecure__disable_aslr = true``. But don't use
+     these two options in production; use them only for debugging and analysis!
 
    - Analyze FS mount points (``fs.mounts``) in the manifest file carefully.
      Check for duplicate mount points -- remember that a duplicate mount point's

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -529,17 +529,6 @@ your system, such ``bash -c ls`` SGX workload will fail. Note this does not
 apply to the enclaves with :term:`EDMM` enabled, where memory is not reserved
 upfront and is allocated on demand.
 
-Non-PIE binaries
-^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.nonpie_binary = [true|false]
-    (Default: false)
-
-This setting tells Gramine whether to use a specially crafted memory layout,
-which is required to support non-relocatable binaries (non-PIE).
-
 Number of threads
 ^^^^^^^^^^^^^^^^^
 

--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -849,10 +849,7 @@ int load_elf_object(struct libos_handle* file, struct link_map** out_map) {
 
     struct link_map* map = map_elf_object(file, &ehdr);
     if (!map) {
-        log_error("Failed to map %s. This may be caused by the binary being non-PIE, in which "
-                  "case Gramine requires a specially-crafted memory layout. You can enable it "
-                  "by adding 'sgx.nonpie_binary = true' to the manifest.",
-                  fname);
+        log_error("Failed to map %s.", fname);
         return -EINVAL;
     }
 

--- a/libos/test/abi/x86_64/manifest.template
+++ b/libos/test/abi/x86_64/manifest.template
@@ -6,7 +6,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = 4

--- a/libos/test/abi/x86_64/stack_arg.manifest.template
+++ b/libos/test/abi/x86_64/stack_arg.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = 4

--- a/libos/test/abi/x86_64/stack_env.manifest.template
+++ b/libos/test/abi/x86_64/stack_env.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = 4

--- a/libos/test/fs/manifest.template
+++ b/libos/test/fs/manifest.template
@@ -20,7 +20,6 @@ fs.mounts = [
 
 fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = 16

--- a/libos/test/ltp/manifest.template
+++ b/libos/test/ltp/manifest.template
@@ -19,7 +19,6 @@ fs.mounts = [
 
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/argv_from_file.manifest.template
+++ b/libos/test/regression/argv_from_file.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/argv_from_manifest.manifest.template
+++ b/libos/test/regression/argv_from_manifest.manifest.template
@@ -18,7 +18,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/attestation.manifest.template
+++ b/libos/test/regression/attestation.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
 
 fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/attestation_deprecated_syntax.manifest.template
+++ b/libos/test/regression/attestation_deprecated_syntax.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
 
 sgx.insecure__protected_files_key = "ffeeddccbbaa99887766554433221100"
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/bootstrap_cpp.manifest.template
+++ b/libos/test/regression/bootstrap_cpp.manifest.template
@@ -14,7 +14,6 @@ fs.mounts = [
 ]
 
 sgx.max_threads = 8
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/debug_log_file.manifest.template
+++ b/libos/test/regression/debug_log_file.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/debug_log_inline.manifest.template
+++ b/libos/test/regression/debug_log_inline.manifest.template
@@ -12,7 +12,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/device_passthrough.manifest.template
+++ b/libos/test/regression/device_passthrough.manifest.template
@@ -9,7 +9,6 @@ fs.mounts = [
   { path = "/dev/host-zero", uri = "dev:/dev/zero" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/env_from_file.manifest.template
+++ b/libos/test/regression/env_from_file.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/env_from_host.manifest.template
+++ b/libos/test/regression/env_from_host.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/env_passthrough.manifest.template
+++ b/libos/test/regression/env_passthrough.manifest.template
@@ -16,7 +16,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/libos/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/file_check_policy_strict.manifest.template
+++ b/libos/test/regression/file_check_policy_strict.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/host_root_fs.manifest.template
+++ b/libos/test/regression/host_root_fs.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { type = "tmpfs", path = "/etc" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/hostname_extra_runtime_conf.manifest.template
+++ b/libos/test/regression/hostname_extra_runtime_conf.manifest.template
@@ -12,7 +12,6 @@ fs.mounts = [
 sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.debug = true
-sgx.nonpie_binary = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/libos/test/regression/init_fail.manifest.template
+++ b/libos/test/regression/init_fail.manifest.template
@@ -10,7 +10,6 @@ fs.mounts = [
   { path = "/test", uri = "file:I_DONT_EXIST" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/init_fail2.manifest.template
+++ b/libos/test/regression/init_fail2.manifest.template
@@ -10,7 +10,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/large_mmap.manifest.template
+++ b/libos/test/regression/large_mmap.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
 ]
 
 sgx.enclave_size = "8G"
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -22,7 +22,6 @@ fs.mounts = [
 ]
 
 sgx.max_threads = 16
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/multi_pthread.manifest.template
+++ b/libos/test/regression/multi_pthread.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
 # app runs with 4 parallel threads + Gramine has couple internal threads
 sgx.max_threads = 8
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enable_stats = true

--- a/libos/test/regression/multi_pthread_exitless.manifest.template
+++ b/libos/test/regression/multi_pthread_exitless.manifest.template
@@ -13,7 +13,6 @@ fs.mounts = [
 sgx.thread_num = 8
 sgx.insecure__rpc_thread_num = 8
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enable_stats = true

--- a/libos/test/regression/openmp.manifest.template
+++ b/libos/test/regression/openmp.manifest.template
@@ -23,7 +23,6 @@ fs.mounts = [
 ]
 
 sgx.max_threads = 32
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/shebang_test_script.manifest.template
+++ b/libos/test/regression/shebang_test_script.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
 ]
 
 sgx.max_threads = 16
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/sysfs_common.manifest.template
+++ b/libos/test/regression/sysfs_common.manifest.template
@@ -8,7 +8,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/toml_parsing.manifest.template
+++ b/libos/test/regression/toml_parsing.manifest.template
@@ -21,7 +21,6 @@ fs.mount.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 # the manifest option below added only so that this feature has any test coverage
 libos.check_invalid_pointers = false
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/uid_gid.manifest.template
+++ b/libos/test/regression/uid_gid.manifest.template
@@ -11,7 +11,6 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/Bootstrap6.manifest.template
+++ b/pal/regression/Bootstrap6.manifest.template
@@ -4,7 +4,6 @@ loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
 
 sgx.enclave_size = "8192M"
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/Bootstrap7.manifest.template
+++ b/pal/regression/Bootstrap7.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 
 sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/File.manifest.template
+++ b/pal/regression/File.manifest.template
@@ -1,7 +1,6 @@
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/Thread2.manifest.template
+++ b/pal/regression/Thread2.manifest.template
@@ -2,7 +2,6 @@ loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 
 sgx.max_threads = 2
 sgx.enable_stats = true
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/Thread2_exitless.manifest.template
+++ b/pal/regression/Thread2_exitless.manifest.template
@@ -5,7 +5,6 @@ loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 sgx.max_threads = 2
 sgx.insecure__rpc_thread_num = 2
 sgx.enable_stats = true
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/manifest.template
+++ b/pal/regression/manifest.template
@@ -5,8 +5,6 @@ loader.insecure__use_cmdline_argv = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
-sgx.nonpie_binary = true # all tests are currently non-PIE unless overridden
-
 sgx.allowed_files = [
   "file:test.txt", # for File2 test
   "file:to_send.tmp", # for PalSendHandle test

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -46,7 +46,6 @@ struct pal_enclave {
     unsigned long thread_num;
     unsigned long rpc_thread_num;
     unsigned long ssa_frame_size;
-    bool nonpie_binary;
     bool edmm_enabled;
     enum sgx_attestation_type attestation_type;
     char* libpal_uri; /* Path to the PAL binary */

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -103,7 +103,6 @@ class Manifest:
         sgx.setdefault('require_pkru', False)
         sgx.setdefault('require_amx', False)
         sgx.setdefault('require_exinfo', False)
-        sgx.setdefault('nonpie_binary', False)
         sgx.setdefault('enable_stats', False)
 
         if not isinstance(sgx['trusted_files'], list):

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -480,12 +480,8 @@ def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
     # Populate memory areas
     memory_areas = get_memory_areas(attr, libpal)
 
-    if manifest_sgx['nonpie_binary']:
-        enclave_base = offs.DEFAULT_ENCLAVE_BASE
-        enclave_heap_min = offs.MMAP_MIN_ADDR
-    else:
-        enclave_base = attr['enclave_size']
-        enclave_heap_min = enclave_base
+    enclave_base = offs.DEFAULT_ENCLAVE_BASE
+    enclave_heap_min = offs.MMAP_MIN_ADDR
 
     manifest_data += b'\0' # in-memory manifest needs NULL-termination
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It is now unclear why we needed this manifest option in the first place (probably to work around a bug in very old SGX drivers that prohibited mmapping the enclave space from address 0x0).

As a side effect, Gramine enclave base address is always 0x0.

TODOs (if this PR passes CI):
- [x] Same for `gsc` repo -- https://github.com/gramineproject/gsc/pull/133
- [x] Same for `examples` repo -- https://github.com/gramineproject/examples/pull/54
- [ ] Same for `contrib` repo -- only in "Curated Apps" there, so I'm not touching and letting @jkr0103 decide when and how to do this change

## How to test this PR? <!-- (if applicable) -->

CI is enough (our CI has all kinds of SGX drivers which was the original problem iiuc).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1187)
<!-- Reviewable:end -->
