### PR TITLE
[python,docs] Set `sgx.enclave_size` to 1TB on EDMM by default

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -459,6 +459,10 @@ as RWX). Unfortunately it can negatively impact performance, as adding a page
 to the enclave at runtime is a more expensive operation than adding the page
 before enclave creation (because it involves more enclave exits and syscalls).
 
+When this feature is enabled, it is not necessary to specify
+``sgx.enclave_size`` (Gramine will automatically set it to 1TB which should be
+enough for any application).
+
 .. note::
    Support for EDMM first appeared in Linux 6.0.
 
@@ -468,12 +472,13 @@ Enclave size
 ::
 
     sgx.enclave_size = "[SIZE]"
-    (default: "256M")
+    (default: "256M" without EDMM, "1024G" with EDMM)
 
 This syntax specifies the size of the enclave set during enclave creation time
 if :term:`EDMM` is not enabled (``sgx.edmm_enable = false``) or the maximal
 size that the enclave can grow to if :term:`EDMM` is enabled
 (``sgx.edmm_enable = true``).
+
 The PAL and library OS code/data count towards this size value, as well as the
 application memory itself: application's code, stack, heap, loaded application
 libraries, etc. The application cannot allocate memory that exceeds this limit.

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -17,7 +17,8 @@ import tomli_w
 
 from . import _env
 
-DEFAULT_ENCLAVE_SIZE = '256M'
+DEFAULT_ENCLAVE_SIZE_NO_EDMM = '256M'
+DEFAULT_ENCLAVE_SIZE_WITH_EDMM = '1024G'  # 1TB; note that DebugInfo is at 1TB and ASan at 1.5TB
 DEFAULT_THREAD_NUM = 4
 
 class ManifestError(Exception):
@@ -87,7 +88,6 @@ class Manifest:
 
         sgx = manifest.setdefault('sgx', {})
         sgx.setdefault('trusted_files', [])
-        sgx.setdefault('enclave_size', DEFAULT_ENCLAVE_SIZE)
 
         # TODO: sgx.thread_num is deprecated in v1.4, simplify below logic in v1.5
         if 'thread_num' not in sgx:
@@ -104,6 +104,12 @@ class Manifest:
         sgx.setdefault('require_amx', False)
         sgx.setdefault('require_exinfo', False)
         sgx.setdefault('enable_stats', False)
+        sgx.setdefault('edmm_enable', False)
+
+        if sgx['edmm_enable']:
+            sgx.setdefault('enclave_size', DEFAULT_ENCLAVE_SIZE_WITH_EDMM)
+        else:
+            sgx.setdefault('enclave_size', DEFAULT_ENCLAVE_SIZE_NO_EDMM)
 
         if not isinstance(sgx['trusted_files'], list):
             raise ValueError("Unsupported trusted files syntax, more info: " +


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See discussions in #1178 for context.

This PR builds on top of #1187.

## How to test this PR? <!-- (if applicable) -->

CI should be enough, but also try manually.