### PR TITLE
[LibOS] Emulate in/out instructions as if they generate SIGSEGV

### DIFF
--- a/common/include/arch/x86_64/cpu.h
+++ b/common/include/arch/x86_64/cpu.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdnoreturn.h>
 
@@ -52,6 +53,11 @@ enum extended_state_sub_leaf {
 #define CPU_BRAND_CNTD_LEAF              0x80000003
 #define CPU_BRAND_CNTD2_LEAF             0x80000004
 #define INVARIANT_TSC_LEAF               0x80000007
+
+bool is_x86_instr_legacy_prefix(uint8_t op);
+bool is_x86_instr_rex_prefix(uint8_t op);
+bool has_lock_prefix(uint8_t* rip);
+bool is_in_out(uint8_t* rip);
 
 static inline void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[static 4]) {
     __asm__("cpuid"

--- a/common/src/arch/x86_64/cpu.c
+++ b/common/src/arch/x86_64/cpu.c
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Fortanix Inc
+ *                    Nirjhar Roy <nirjhar.roy@fortanix.com>
+ */
+
+/* This file contains functions that check various features and flags specific to x86 */
+
+#include <stddef.h>
+
+#include "api.h"
+#include "cpu.h"
+
+#define INSTR_SIZE_MAX 15
+
+bool is_x86_instr_legacy_prefix(uint8_t op) {
+    /*
+     * Official source for this list is Intel SDM, Vol. 2, Chapter 2.1.1 "Instruction Prefixes".
+     * These prefixes are called "legacy" for x86-64 (64-bit mode) instructions, see Intel SDM,
+     * Vol. 2, Chapter 2.2.1 and Figure 2-3 "Prefix Ordering in 64-bit Mode".
+     */
+    switch (op) {
+        /* Group 1 */
+        case 0xf0: /* LOCK prefix */
+        case 0xf2: /* REPNE/REPNZ prefix */
+        case 0xf3: /* REP or REPE/REPZ prefix */
+        /* Group 2 */
+        case 0x2e: /* CS segment override; Branch not taken */
+        case 0x36: /* SS segment override */
+        case 0x3e: /* DS segment override; Branch taken */
+        case 0x26: /* ES segment override */
+        case 0x64: /* FS segment override */
+        case 0x65: /* GS segment override */
+        /* Group 3 */
+        case 0x66: /*  Operand-size override prefix */
+        /* Group 4 */
+        case 0x67: /* Address-size override prefix */
+            return true;
+    }
+    return false;
+}
+
+bool is_x86_instr_rex_prefix(uint8_t op) {
+    /*
+     * Optional REX prefix is located after all legacy prefixes (see above) and right before the
+     * opcode. REX prefix is 1 byte with bits [0100WRXB], from which follows that REX prefix can be
+     * any of 0x40-0x4f. For details, see Intel SDM, Vol. 2, Chapter 2.2.1 "REX Prefixes".
+     */
+    return 0x40 <= op && op <= 0x4f;
+}
+
+bool has_lock_prefix(uint8_t* rip) {
+    size_t idx = 0;
+    while (is_x86_instr_legacy_prefix(rip[idx]) && idx < INSTR_SIZE_MAX) {
+        if (rip[idx] == 0xf0)
+            return true;
+        idx++;
+    }
+    return false;
+}
+
+bool is_in_out(uint8_t* rip) {
+    /*
+     * x86-64 instructions may be at most 15 bytes in length and may have multiple instruction
+     * prefixes. See description in Intel SDM, Vol. 2, Chapter 2.1.1 "Instruction Prefixes".
+     */
+    size_t idx = 0;
+    while (is_x86_instr_legacy_prefix(rip[idx]) && idx < INSTR_SIZE_MAX)
+        idx++;
+
+    if (idx == INSTR_SIZE_MAX)
+        return false;
+
+    /* skip over the optional REX prefix */
+    if (is_x86_instr_rex_prefix(rip[idx]))
+        idx++;
+
+    if (idx == INSTR_SIZE_MAX)
+        return false;
+
+    switch (rip[idx]) {
+        /* INS opcodes */
+        case 0x6c:
+        case 0x6d:
+        /* OUTS opcodes */
+        case 0x6e:
+        case 0x6f:
+        /* IN immediate opcodes */
+        case 0xe4:
+        case 0xe5:
+        /* OUT immediate opcodes */
+        case 0xe6:
+        case 0xe7:
+        /* IN register opcodes */
+        case 0xec:
+        case 0xed:
+        /* OUT register opcodes */
+        case 0xee:
+        case 0xef:
+            return true;
+    }
+
+    return false;
+}

--- a/common/src/arch/x86_64/meson.build
+++ b/common/src/arch/x86_64/meson.build
@@ -2,7 +2,9 @@ common_src_arch_nasm = nasm_gen.process(
     'ct_memequal.nasm',
 )
 
-common_src_arch_c = files()
+common_src_arch_c = files(
+    'cpu.c',
+)
 
 common_src_arch = [
     common_src_arch_nasm,

--- a/libos/test/regression/in_out_instruction.c
+++ b/libos/test/regression/in_out_instruction.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Fortanix Inc
+ *                    Nirjhar Roy <nirjhar.roy@fortanix.com>
+ */
+
+/*
+ * Verify that IN/OUT/INS/OUTS instructions generate SIGSEGV (and not SIGILL).
+ *
+ * This test is important for SGX PAL: IN/OUT/INS/OUTS instructions result in a #UD fault when
+ * executed in SGX enclaves, but result in a #GP fault when executed by normal userspace code.
+ * Gramine is supposed to transform the #UD fault into a #GP fault, which ends up as a SIGSEGV in
+ * the application.
+ */
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ucontext.h>
+
+#include "common.h"
+
+#ifndef __x86_64__
+#error Unsupported architecture
+#endif
+
+#define EXPECTED_NUM_SIGSEGVS 2
+
+static int g_sigsegv_triggered = 0;
+
+uint8_t inb_func(uint16_t port) __attribute__((visibility("internal")));
+void outb_func(uint8_t value, uint16_t port) __attribute__((visibility("internal")));
+void inb_instruction_addr(void) __attribute__((visibility("internal")));
+void outb_instruction_addr(void) __attribute__((visibility("internal")));
+void ret(void) __attribute__((visibility("internal")));
+
+__asm__ (
+".pushsection .text\n"
+".type inb_func, @function\n"
+".type outb_func, @function\n"
+".type inb_instruction_addr, @function\n"
+".type outb_instruction_addr, @function\n"
+".type ret, @function\n"
+"inb_func:\n"
+    "mov %rdi, %rdx\n"
+"inb_instruction_addr:\n"
+    "inb %dx, %al\n"
+    "ret\n"
+"outb_func:\n"
+    "mov %rsi, %rdx\n"
+    "mov %rdi, %rax\n"
+"outb_instruction_addr:\n"
+    "outb %al, %dx\n"
+"ret:\n"
+    "ret\n"
+".popsection\n"
+);
+
+static void handler(int signum, siginfo_t* si, void* uc) {
+    if (signum != SIGSEGV) {
+        /* we registered a SIGSEGV handler but got another signal?! */
+        _Exit(1);
+    }
+
+    uint64_t rip = ((ucontext_t*)uc)->uc_mcontext.gregs[REG_RIP];
+    if (g_sigsegv_triggered == 0) {
+        /* must be a fault on inb instruction */
+        if (rip != (uint64_t)(inb_instruction_addr))
+            _Exit(1);
+    } else if (g_sigsegv_triggered == 1) {
+        /* must be a fault on outb instruction */
+        if (rip != (uint64_t)(outb_instruction_addr))
+            _Exit(1);
+    } else {
+        /* too many segfaults?! */
+        _Exit(1);
+    }
+
+    g_sigsegv_triggered++;
+
+    /* no need to fixup the context (other than RIP) as we only modified caller-saved RDX and RAX in
+     * inb_func() and outb_func() */
+    ((ucontext_t*)uc)->uc_mcontext.gregs[REG_RIP] = (uint64_t)ret;
+}
+
+int main(void) {
+    struct sigaction sa = {
+        .sa_sigaction = handler,
+        .sa_flags = SA_RESTART | SA_SIGINFO,
+    };
+    CHECK(sigaction(SIGSEGV, &sa, NULL));
+
+    uint8_t value = 0;
+    uint16_t port = 0x3F8;
+
+    inb_func(port);
+    outb_func(value, port);
+
+    if (g_sigsegv_triggered != EXPECTED_NUM_SIGSEGVS)
+        errx(1, "Expected %d SIGSEGVs, got %d", EXPECTED_NUM_SIGSEGVS, g_sigsegv_triggered);
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -167,6 +167,7 @@ if host_machine.cpu_family() == 'x86_64'
         'debug_regs_x86_64': {
             'c_args': '-g3',
         },
+        'in_out_instruction' : {},
         'rdtsc': {},
         'sighandler_divbyzero': {},
     }

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1572,3 +1572,9 @@ class TC_92_avx(RegressionTestCase):
     def test_000_avx(self):
         stdout, _ = self.run_binary(['avx'])
         self.assertIn('TEST OK', stdout)
+
+@unittest.skipUnless(ON_X86, 'x86-specific')
+class TC_93_In_Out(RegressionTestCase):
+    def test_000_in_out(self):
+        stdout, stderr = self.run_binary(['in_out_instruction'])
+        self.assertIn('TEST OK', stdout)

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -144,6 +144,7 @@ manifests = [
   "avx",
   "cpuid",
   "debug_regs_x86_64",
+  "in_out_instruction",
   "rdtsc",
   "bootstrap_cpp",
   "sighandler_divbyzero",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -144,6 +144,7 @@ manifests = [
   "avx",
   "cpuid",
   "debug_regs_x86_64",
+  "in_out_instruction",
   "rdtsc",
   "sighandler_divbyzero",
 ]


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) --> 
Fixes #1191 : ```in``` and ```out``` instructions cause ```SIGILL``` instead of ```SIGSEGV```. ```in``` and ```out``` instructions aren't allowed inside SGX enclaves and hence throws ```SIGILL``` but native behavior of user applications is that ```in``` / ```out``` instructions throw ```SIGSEGV```. ```lscpu``` is requires this fix and ```lscpu``` is sometimes used in tensorflow applications and that is why this was required.

https://c9x.me/x86/html/file_module_x86_id_139.html (for IN instruction)

https://c9x.me/x86/html/file_module_x86_id_222.html (for OUT instruction)

https://c9x.me/x86/html/file_module_x86_id_139.html

https://stackoverflow.com/questions/3215878/what-are-in-out-instructions-in-x86-used-for

 https://stackoverflow.com/questions/46642384/how-to-run-code-that-uses-x86-in-and-out-i-o-instructions

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. --> 
Fixes #1191

## How to test this PR? <!-- (if applicable) --> 
```cd libos/test/fs/ && gramine-test --sgx pytest  -v -k test_211_copy_lscpu_test``` --> Run this command from Gramine root repo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1192)
<!-- Reviewable:end -->
