### PR TITLE
[LibOS] Add dummy ancillary data support for sockets

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -55,6 +55,8 @@ struct cmsghdr {
 #define CMSG_LEN(len)   (CMSG_ALIGN(sizeof(struct cmsghdr)) + (len))
 
 #define SCM_RIGHTS 1
+#define SCM_CREDENTIALS 2
+#define SCM_SECURITY 3
 
 #define AF_UNSPEC 0
 #define AF_UNIX 1
@@ -96,8 +98,13 @@ struct cmsghdr {
 #define SO_RCVTIMEO 20
 #define SO_SNDTIMEO 21
 #define SO_ACCEPTCONN 30
+#define SO_MARK 36
+#define SO_TIMESTAMPING_OLD 37
 #define SO_PROTOCOL 38
 #define SO_DOMAIN 39
+
+#define SO_TXTIME 61
+#define SCM_TXTIME SO_TXTIME
 
 /* TCP options. */
 #define TCP_NODELAY 1       /* Turn off Nagle's algorithm */

--- a/libos/include/libos_socket.h
+++ b/libos/include/libos_socket.h
@@ -80,6 +80,8 @@ struct libos_sock_ops {
      * \param      handle             A handle.
      * \param      iov                An array of buffers to write from.
      * \param      iov_len            The length of \p iov.
+     * \param      msg_control        An ancillary data buffer.
+     * \param      msg_controllen     The length of \p msg_control.
      * \param[out] out_size           On success contains the number of bytes sent.
      * \param      addr               An address to send to. May be NULL. It's up to
      *                                the implementation to decide what to do with it (which might
@@ -88,8 +90,9 @@ struct libos_sock_ops {
      * \param      force_nonblocking  If `true` this request should not block. Otherwise just use
      *                                whatever mode the handle is in.
      */
-    int (*send)(struct libos_handle* handle, struct iovec* iov, size_t iov_len, size_t* out_size,
-                void* addr, size_t addrlen, bool force_nonblocking);
+    int (*send)(struct libos_handle* handle, struct iovec* iov, size_t iov_len, void* msg_control,
+                size_t msg_controllen, size_t* out_size, void* addr, size_t addrlen,
+                bool force_nonblocking);
 
     /*!
      * \brief Receive continuous data into an array of buffers.
@@ -97,19 +100,23 @@ struct libos_sock_ops {
      * \param         handle             A handle.
      * \param         iov                An array of buffers to read to.
      * \param         iov_len            The length of \p iov.
+     * \param         msg_control        An ancillary data buffer to populate.
+     * \param[in,out] msg_controllen_ptr The length of \p msg_control. On success updated to the
+     *                                   actual length of the received ancillary data.
      * \param[out]    out_total_size     On success contains the number of bytes received (STREAM)
      *                                   or the datagram size (DGRAM), which might be bigger than
      *                                   the total size of buffers in \p iov array.
      * \param[out]    addr               On success contains the address data was received from. May
      *                                   be NULL.
-     * \param[in,out] addrlen            The length of \p addr. On success updated to the actual
+     * \param[in,out] addrlen_ptr        The length of \p addr. On success updated to the actual
      *                                   length of the address. Bigger than original value indicates
      *                                   that truncation has happened.
      * \param         force_nonblocking  If `true` this request should not block. Otherwise just use
      *                                   whatever mode the handle is in.
      */
-    int (*recv)(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
-                size_t* out_total_size, void* addr, size_t* addrlen, bool force_nonblocking);
+    int (*recv)(struct libos_handle* handle, struct iovec* iov, size_t iov_len, void* msg_control,
+                size_t* msg_controllen_ptr, size_t* out_total_size, void* addr, size_t* addrlen_ptr,
+                bool force_nonblocking);
 };
 
 struct libos_handle* get_new_socket_handle(int family, int type, int protocol,
@@ -118,7 +125,9 @@ struct libos_handle* get_new_socket_handle(int family, int type, int protocol,
 extern struct libos_sock_ops sock_unix_ops;
 extern struct libos_sock_ops sock_ip_ops;
 
-ssize_t do_recvmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len, void* addr,
-                   size_t* addrlen, unsigned int* flags);
-ssize_t do_sendmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len, void* addr,
-                   size_t addrlen, unsigned int flags);
+ssize_t do_recvmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
+                   void* msg_control, size_t* msg_controllen_ptr, void* addr, size_t* addrlen_ptr,
+                   unsigned int* flags);
+ssize_t do_sendmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
+                   void* msg_control, size_t msg_controllen, void* addr, size_t addrlen,
+                   unsigned int flags);

--- a/libos/src/fs/socket/fs.c
+++ b/libos/src/fs/socket/fs.c
@@ -36,7 +36,8 @@ static ssize_t read(struct libos_handle* handle, void* buf, size_t size, file_of
         .iov_len = size,
     };
     unsigned int flags = 0;
-    return do_recvmsg(handle, &iov, /*iov_len=*/1, /*addr=*/NULL, /*addrlen=*/NULL, &flags);
+    return do_recvmsg(handle, &iov, /*iov_len=*/1, /*msg_control=*/NULL,
+                      /*msg_controllen_ptr=*/NULL, /*addr=*/NULL, /*addrlen_ptr=*/NULL, &flags);
 }
 
 static ssize_t write(struct libos_handle* handle, const void* buf, size_t size, file_off_t* pos) {
@@ -45,20 +46,23 @@ static ssize_t write(struct libos_handle* handle, const void* buf, size_t size, 
         .iov_base = (void*)buf,
         .iov_len = size,
     };
-    return do_sendmsg(handle, &iov, /*iov_len=*/1, /*addr=*/NULL, /*addrlen=*/0, /*flags=*/0);
+    return do_sendmsg(handle, &iov, /*iov_len=*/1, /*msg_control=*/NULL, /*msg_controllen=*/0,
+                      /*addr=*/NULL, /*addrlen=*/0, /*flags=*/0);
 }
 
 static ssize_t readv(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
                      file_off_t* pos) {
     __UNUSED(pos);
     unsigned int flags = 0;
-    return do_recvmsg(handle, iov, iov_len, /*addr=*/NULL, /*addrlen=*/NULL, &flags);
+    return do_recvmsg(handle, iov, iov_len, /*msg_control=*/NULL, /*msg_controllen_ptr=*/NULL,
+                      /*addr=*/NULL, /*addrlen_ptr=*/NULL, &flags);
 }
 
 static ssize_t writev(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
                       file_off_t* pos) {
     __UNUSED(pos);
-    return do_sendmsg(handle, iov, iov_len, /*addr=*/NULL, /*addrlen=*/0, /*flags=*/0);
+    return do_sendmsg(handle, iov, iov_len, /*msg_control=*/NULL, /*msg_controllen=*/0,
+                      /*addr=*/NULL, /*addrlen=*/0, /*flags=*/0);
 }
 
 static int hstat(struct libos_handle* handle, struct stat* stat) {

--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -1661,22 +1661,11 @@ must-pass =
     4
     5
 
-# subtest 3: Linux ignores invalid address in recvmsg for stream sockets.
-# subtest 4: Requires MSG_ERRQUEUE support (LTP outputs: "skip MSG_ERRQUEUE test, it's supported
-#            from 3.17").
-# subtest 8: Ancillary data not supported.
-# subtest 9: Requires MSG_OOB support.
-# subtest 10: Requires MSG_ERRQUEUE support (LTP outputs: "skip MSG_ERRQUEUE test, it's supported
-#             from 3.17").
-# subtest 11: Ancillary data not supported.
-# subtest 12: Ancillary data not supported.
+# subtest 8 requires SCM_RIGHTS support (to send an FD from sender to receiver) and doesn't check
+# for errors (Gramine fails with -ENOSYS), leading to a hang on the receiver side because it tries
+# to receive something that was never sent.
 [recvmsg01]
-must-pass =
-    1
-    2
-    5
-    6
-    7
+skip = yes
 
 # MSG_PEEK with UDP sockets not supported currently.
 [recvmsg02]

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -124,6 +124,7 @@ tests = {
     'syscall': {},
     'syscall_restart': {},
     'sysfs_common': {},
+    'tcp_ancillary': {},
     'tcp_ipv6_v6only': {},
     'tcp_msg_peek': {},
     'udp': {},

--- a/libos/test/regression/tcp_ancillary.c
+++ b/libos/test/regression/tcp_ancillary.c
@@ -1,0 +1,186 @@
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef SCM_TXTIME
+#define SCM_TXTIME 61
+#endif
+
+#include "common.h"
+
+#define SRV_IP "127.0.0.1"
+#define PORT   11110
+
+#define MSG_SPACE (CMSG_SPACE(sizeof(int)) + CMSG_SPACE(sizeof(struct ucred)))
+
+static const char g_buffer[] = "Hello from server!";
+
+static void server(int pipefd) {
+    int s = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+
+    int enable = 1;
+    CHECK(setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)));
+
+    struct sockaddr_in sa = {
+        .sin_family = AF_INET,
+        .sin_port = htons(PORT),
+        .sin_addr.s_addr = htonl(INADDR_ANY),
+    };
+
+    CHECK(bind(s, (void*)&sa, sizeof(sa)));
+    CHECK(listen(s, 5));
+
+    char c = 0;
+    ssize_t x = CHECK(write(pipefd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        CHECK(-1);
+    }
+    CHECK(close(pipefd));
+
+    int client = CHECK(accept(s, NULL, NULL));
+
+    CHECK(close(s));
+
+    struct iovec iovec = {
+        .iov_base = (char*)g_buffer,
+        .iov_len = sizeof(g_buffer),
+    };
+
+    char control[MSG_SPACE] = {0};
+    struct msghdr msg = {
+        .msg_iov = &iovec,
+        .msg_iovlen = 1,
+        .msg_control = control,
+        .msg_controllen = sizeof(control),
+    };
+
+    /* below two ancillary data are dummies -- they should be ignored on TCP/IP */
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_CREDENTIALS;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(struct ucred));
+    struct ucred* cred = (struct ucred*)CMSG_DATA(cmsg);
+    cred->pid = getpid();
+    cred->uid = getuid();
+    cred->gid = getgid();
+
+    cmsg = CMSG_NXTHDR(&msg, cmsg);
+    if (!cmsg) {
+        /* make GCC happy (otherwise "potential null pointer dereference") */
+        errx(1, "no space for second cmsg");
+    }
+    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    int* fd = (int*)CMSG_DATA(cmsg);
+    *fd = STDOUT_FILENO;
+
+    x = CHECK(sendmsg(client, &msg, /*flags=*/0));
+    if (!x) {
+        /* technically impossible, but let's fail loudly if we ever hit this */
+        errx(1, "sendmsg returned zero");
+    }
+
+    /* set some dummy incorrect SCM_TXTIME in second ancillary data -- must result in EINVAL */
+    cmsg->cmsg_len = CMSG_LEN(sizeof(int)); /* wrong length */
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_TXTIME;
+    x = sendmsg(client, &msg, /*flags=*/0);
+    if (x != -1 && errno != EINVAL) {
+        errx(1, "sendmsg with invalid SCM_TXTTIME didn't fail with -EINVAL");
+    }
+
+    CHECK(close(client));
+}
+
+static void client(int pipefd) {
+    char c = 0;
+    ssize_t x = CHECK(read(pipefd, &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        CHECK(-1);
+    }
+    CHECK(close(pipefd));
+
+    int s = CHECK(socket(AF_INET, SOCK_STREAM, 0));
+
+    struct sockaddr_in sa = {
+        .sin_family = AF_INET,
+        .sin_port = htons(PORT),
+        .sin_addr = {
+            /* TODO: remove this once Ubuntu 18.04 is deprecated. */
+            .s_addr = 0,
+        },
+    };
+    if (inet_aton(SRV_IP, &sa.sin_addr) != 1) {
+        CHECK(-1);
+    }
+
+    CHECK(connect(s, (void*)&sa, sizeof(sa)));
+
+    while (1) {
+        /* Wait for the full data to arive. */
+        int v = 0;
+        CHECK(ioctl(s, FIONREAD, &v));
+        if ((unsigned int)v >= sizeof(g_buffer)) {
+            break;
+        }
+    }
+
+    char buf[sizeof(g_buffer) + 1] = { 0 };
+    struct iovec iovec = {
+        .iov_base = buf,
+        .iov_len = sizeof(buf),
+    };
+
+    char control[MSG_SPACE] = {0};
+    struct msghdr msg = {
+        .msg_iov = &iovec,
+        .msg_iovlen = 1,
+        .msg_control = control,
+        .msg_controllen = sizeof(control),
+    };
+
+    ssize_t count = recvmsg(s, &msg, /*flags=*/0);
+    if (count != sizeof(g_buffer)) {
+        errx(1, "recv returned less than available: %zd", count);
+    }
+    if (memcmp(buf, g_buffer, sizeof(g_buffer))) {
+        errx(1, "wrong data received: %s", buf);
+    }
+    if (msg.msg_controllen) {
+        errx(1, "unexpected ancillary data received (length = %zd)", msg.msg_controllen);
+    }
+
+    CHECK(close(s));
+}
+
+int main(int argc, char** argv) {
+    int pipefds[2];
+    CHECK(pipe(pipefds));
+
+    pid_t p = CHECK(fork());
+    if (p == 0) {
+        CHECK(close(pipefds[1]));
+        client(pipefds[0]);
+        return 0;
+    }
+
+    CHECK(close(pipefds[0]));
+    server(pipefds[1]);
+
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+        errx(1, "child wait status: %#x", status);
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1336,6 +1336,10 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['tcp_msg_peek'])
         self.assertIn('TEST OK', stdout)
 
+    def test_301_socket_tcp_ancillary(self):
+        stdout, _ = self.run_binary(['tcp_ancillary'])
+        self.assertIn('TEST OK', stdout)
+
     def test_310_socket_tcp_ipv6_v6only(self):
         stdout, _ = self.run_binary(['tcp_ipv6_v6only'], timeout=50)
         self.assertIn('test completed successfully', stdout)

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -109,6 +109,7 @@ manifests = [
   "syscall",
   "syscall_restart",
   "sysfs_common",
+  "tcp_ancillary",
   "tcp_ipv6_v6only",
   "tcp_msg_peek",
   "toml_parsing",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -110,6 +110,7 @@ manifests = [
   "syscall",
   "syscall_restart",
   "sysfs_common",
+  "tcp_ancillary",
   "tcp_ipv6_v6only",
   "tcp_msg_peek",
   "toml_parsing",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine returned `-ENOSYS` on `recvmsg()`/`sendmsg()` and similar syscalls if it detected the use of `struct msghdr` ancillary data (`msg_control` field). This PR is the first step in adding proper ancillary data support.

Currently no ancillary data type is truly supported:
- on `sendmsg()`:
  - unknown/unsupported types force an error,
  - SCM_RIGHTS/SCM_CREDENTIALS are ignored in TCP/UDP sockets;
- on `recvmsg()`: `msg_controllen` is set to zero to indicate there is no ancillary data added to the received network packet.

## How to test this PR? <!-- (if applicable) -->

I added a LibOS regression test + I disabled one misbehaving LTP test.

One can try this example: https://github.com/gramineproject/examples/pull/57. Without this PR, it doesn't work properly (see test 2 in the README there).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1210)
<!-- Reviewable:end -->
