### PR TITLE
Fix a bunch of syscall arguments checking

### DIFF
--- a/libos/src/sys/libos_getcwd.c
+++ b/libos/src/sys/libos_getcwd.c
@@ -88,6 +88,10 @@ long libos_syscall_fchdir(int fd) {
 
     struct libos_dentry* dent = hdl->dentry;
 
+    if (!dent) {
+        log_debug("FD=%d has no path in the filesystem", fd);
+        return -ENOTDIR;
+    }
     if (!dent->inode || dent->inode->type != S_IFDIR) {
         char* path = NULL;
         dentry_abs_path(dent, &path, /*size=*/NULL);

--- a/libos/src/sys/libos_open.c
+++ b/libos/src/sys/libos_open.c
@@ -106,6 +106,11 @@ long libos_syscall_openat(int dfd, const char* filename, int flags, int mode) {
              | O_LARGEFILE | O_NOATIME | O_NOCTTY | O_NOFOLLOW | O_NONBLOCK | O_PATH | O_SYNC
              | O_TMPFILE | O_TRUNC;
 
+    if (   (flags & O_ACCMODE) != O_RDONLY
+        && (flags & O_ACCMODE) != O_WRONLY
+        && (flags & O_ACCMODE) != O_RDWR)
+        return -EINVAL;
+
     /* TODO: fail explicitly on valid but unsupported flags. */
 
     if (flags & O_PATH) {

--- a/libos/src/sys/libos_sched.c
+++ b/libos/src/sys/libos_sched.c
@@ -49,7 +49,10 @@ long libos_syscall_getpriority(int which, int who) {
 
 /* dummy implementation: ignore user-supplied param and return success */
 long libos_syscall_sched_setparam(pid_t pid, struct __kernel_sched_param* param) {
-    if (pid < 0 || param == NULL)
+    if (!is_user_memory_readable(param, sizeof(*param)))
+        return -EFAULT;
+
+    if (pid < 0)
         return -EINVAL;
 
     return 0;
@@ -57,7 +60,10 @@ long libos_syscall_sched_setparam(pid_t pid, struct __kernel_sched_param* param)
 
 /* dummy implementation: always return sched_priority of 0 (implies non-real-time sched policy) */
 long libos_syscall_sched_getparam(pid_t pid, struct __kernel_sched_param* param) {
-    if (pid < 0 || param == NULL)
+    if (!is_user_memory_writable(param, sizeof(*param)))
+        return -EFAULT;
+
+    if (pid < 0)
         return -EINVAL;
 
     param->__sched_priority = 0;
@@ -68,7 +74,10 @@ long libos_syscall_sched_getparam(pid_t pid, struct __kernel_sched_param* param)
 long libos_syscall_sched_setscheduler(pid_t pid, int policy, struct __kernel_sched_param* param) {
     policy &= ~SCHED_RESET_ON_FORK; /* ignore reset-on-fork flag */
 
-    if (pid < 0 || param == NULL)
+    if (!is_user_memory_readable(param, sizeof(*param)))
+        return -EFAULT;
+
+    if (pid < 0)
         return -EINVAL;
 
     /* fail on unrecognized policies */

--- a/libos/src/sys/libos_wait.c
+++ b/libos/src/sys/libos_wait.c
@@ -105,17 +105,20 @@ static long do_waitid(int which, pid_t id, siginfo_t* infop, int options) {
     }
 
     if (options & WSTOPPED) {
-        log_warning("Ignoring unsupported WSTOPPED flag to wait4");
+        log_warning("Ignoring unsupported WSTOPPED flag to waitid/wait4");
         options &= ~WSTOPPED;
     }
     if (options & WCONTINUED) {
-        log_warning("Ignoring unsupported WCONTINUED flag to wait4");
+        log_warning("Ignoring unsupported WCONTINUED flag to waitid/wait4");
         options &= ~WCONTINUED;
     }
-    assert(options & WEXITED);
+    if (!(options & WEXITED)) {
+        log_error("Unsupported combination of flags passed to waitid/wait4");
+        return -EINVAL;
+    }
 
     if (options & __WNOTHREAD) {
-        log_warning("Ignoring unsupported __WNOTHREAD flag to wait4");
+        log_warning("Ignoring unsupported __WNOTHREAD flag to waitid/wait4");
         options &= ~__WNOTHREAD;
     }
 

--- a/libos/src/sys/libos_wrappers.c
+++ b/libos/src/sys/libos_wrappers.c
@@ -17,7 +17,10 @@
  * notably affects pipes. */
 
 long libos_syscall_readv(unsigned long fd, struct iovec* vec, unsigned long vlen) {
-    if (!is_user_memory_readable(vec, sizeof(*vec) * vlen))
+    size_t arr_size;
+    if (__builtin_mul_overflow(sizeof(*vec), vlen, &arr_size))
+        return -EINVAL;
+    if (!is_user_memory_readable(vec, arr_size))
         return -EINVAL;
 
     for (size_t i = 0; i < vlen; i++) {
@@ -82,7 +85,10 @@ out:
 }
 
 long libos_syscall_writev(unsigned long fd, struct iovec* vec, unsigned long vlen) {
-    if (!is_user_memory_readable(vec, sizeof(*vec) * vlen))
+    size_t arr_size;
+    if (__builtin_mul_overflow(sizeof(*vec), vlen, &arr_size))
+        return -EINVAL;
+    if (!is_user_memory_readable(vec, arr_size))
         return -EINVAL;
 
     for (size_t i = 0; i < vlen; i++) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR fixes a bunch of unrelated checks which were missing from various syscalls. These cases were found by Jaewon Hur using an adapted version of syzkaller, thanks!

Just for the record: none of these bugs is security related, because both sides of the emulated syscall interface are in the same security domain.

## How to test this PR? <!-- (if applicable) -->

See each commit for the specific case where it failed. No tests added to CI, as all of the cases were adversarial and shouldn't be possible in normal apps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1211)
<!-- Reviewable:end -->
