### PR TITLE
[tools/sgx,CI-Examples] Expose RA-TLS verification error details via callback args

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/src/client.c
+++ b/CI-Examples/ra-tls-mbedtls/src/client.c
@@ -36,8 +36,10 @@
 
 #include "ra_tls.h"
 
-/* RA-TLS: on client, only need to register ra_tls_verify_callback_der() for cert verification */
-int (*ra_tls_verify_callback_der_f)(uint8_t* der_crt, size_t der_crt_size);
+/* RA-TLS: on client, only need to register ra_tls_verify_callback_extended_der() for cert
+ * verification. */
+int (*ra_tls_verify_callback_extended_der_f)(uint8_t* der_crt, size_t der_crt_size,
+                                             struct ra_tls_verify_callback_results* results);
 
 /* RA-TLS: if specified in command-line options, use our own callback to verify SGX measurements */
 void (*ra_tls_set_measurement_callback_f)(int (*f_cb)(const char* mrenclave, const char* mrsigner,
@@ -108,8 +110,6 @@ static int my_verify_measurements(const char* mrenclave, const char* mrsigner,
 
 /* RA-TLS: mbedTLS-specific callback to verify the x509 certificate */
 static int my_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_t* flags) {
-    (void)data;
-
     if (depth != 0) {
         /* the cert chain in RA-TLS consists of single self-signed cert, so we expect depth 0 */
         return MBEDTLS_ERR_X509_INVALID_FORMAT;
@@ -120,7 +120,8 @@ static int my_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint
          * what mbedTLS thinks and ignore internal cert verification logic of mbedTLS */
         *flags = 0;
     }
-    return ra_tls_verify_callback_der_f(crt->raw.p, crt->raw.len);
+    return ra_tls_verify_callback_extended_der_f(crt->raw.p, crt->raw.len,
+                                                 (struct ra_tls_verify_callback_results*)data);
 }
 
 static bool getenv_client_inside_sgx() {
@@ -142,9 +143,10 @@ int main(int argc, char** argv) {
     bool in_sgx = getenv_client_inside_sgx();
 
     char* error;
-    void* ra_tls_verify_lib           = NULL;
-    ra_tls_verify_callback_der_f      = NULL;
+    void* ra_tls_verify_lib = NULL;
+    ra_tls_verify_callback_extended_der_f = NULL;
     ra_tls_set_measurement_callback_f = NULL;
+    struct ra_tls_verify_callback_results my_verify_callback_results = {0};
 
     mbedtls_entropy_context entropy;
     mbedtls_ctr_drbg_context ctr_drbg;
@@ -211,7 +213,8 @@ int main(int argc, char** argv) {
     }
 
     if (ra_tls_verify_lib) {
-        ra_tls_verify_callback_der_f = dlsym(ra_tls_verify_lib, "ra_tls_verify_callback_der");
+        ra_tls_verify_callback_extended_der_f = dlsym(ra_tls_verify_lib,
+                                                      "ra_tls_verify_callback_extended_der");
         if ((error = dlerror()) != NULL) {
             mbedtls_printf("%s\n", error);
             return 1;
@@ -343,7 +346,7 @@ int main(int argc, char** argv) {
     if (ra_tls_verify_lib) {
         /* use RA-TLS verification callback; this will overwrite CA chain set up above */
         mbedtls_printf("  . Installing RA-TLS callback ...");
-        mbedtls_ssl_conf_verify(&conf, &my_verify_callback, NULL);
+        mbedtls_ssl_conf_verify(&conf, &my_verify_callback, &my_verify_callback_results);
         mbedtls_printf(" ok\n");
     }
 
@@ -369,7 +372,27 @@ int main(int argc, char** argv) {
 
     while ((ret = mbedtls_ssl_handshake(&ssl)) != 0) {
         if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
-            mbedtls_printf(" failed\n  ! mbedtls_ssl_handshake returned -0x%x\n\n", -ret);
+            mbedtls_printf(" failed\n  ! mbedtls_ssl_handshake returned -0x%x\n", -ret);
+            mbedtls_printf("  ! ra_tls_verify_callback_results:\n"
+                           "    attestation_scheme=%d, err_loc=%d, \n",
+                           my_verify_callback_results.attestation_scheme,
+                           my_verify_callback_results.err_loc);
+            switch (my_verify_callback_results.attestation_scheme) {
+                case RA_TLS_ATTESTATION_SCHEME_EPID:
+                    mbedtls_printf("    epid.ias_enclave_quote_status=%s\n\n",
+                                   my_verify_callback_results.epid.ias_enclave_quote_status);
+                    break;
+                case RA_TLS_ATTESTATION_SCHEME_DCAP:
+                    mbedtls_printf("    dcap.func_verify_quote_result=0x%x, "
+                                   "dcap.quote_verification_result=0x%x\n\n",
+                                   my_verify_callback_results.dcap.func_verify_quote_result,
+                                   my_verify_callback_results.dcap.quote_verification_result);
+                    break;
+                default:
+                    mbedtls_printf("  ! unknown attestation scheme!\n\n");
+                    break;
+            }
+
             goto exit;
         }
     }
@@ -444,7 +467,6 @@ exit:
         mbedtls_printf("Last error was: %d - %s\n\n", ret, error_buf);
     }
 #endif
-
     if (ra_tls_verify_lib)
         dlclose(ra_tls_verify_lib);
 

--- a/tools/sgx/common/ias.c
+++ b/tools/sgx/common/ias.c
@@ -623,8 +623,8 @@ out:
 int ias_verify_report_extract_quote(const uint8_t* ias_report, size_t ias_report_size,
                                     uint8_t* ias_sig_b64, size_t ias_sig_b64_size,
                                     bool allow_outdated_tcb, const char* nonce,
-                                    const char* ias_pub_key_pem, uint8_t** out_quote,
-                                    size_t* out_quote_size) {
+                                    const char* ias_pub_key_pem, char (*enclave_quote_status)[128],
+                                    uint8_t** out_quote, size_t* out_quote_size) {
     mbedtls_pk_context ias_pub_key;
     int ret = -1;
     uint8_t* ias_sig = NULL;
@@ -724,6 +724,11 @@ int ias_verify_report_extract_quote(const uint8_t* ias_report, size_t ias_report
     if (node->type != cJSON_String) {
         ERROR("IAS report: quote status is not a string\n");
         goto out;
+    }
+
+    if (enclave_quote_status) {
+        strncpy(*enclave_quote_status, node->valuestring, sizeof(*enclave_quote_status));
+        (*enclave_quote_status)[sizeof(*enclave_quote_status) - 1] = '\0';
     }
 
     if (strcmp("OK", node->valuestring) == 0) {

--- a/tools/sgx/common/ias.h
+++ b/tools/sgx/common/ias.h
@@ -103,22 +103,26 @@ int ias_send_quote_get_report_raw(struct ias_context_t* context, const void* quo
  * \brief Verify IAS attestation report. Also extract the SGX quote contained in IAS report:
  *        allocate enough memory to hold the quote and pass it to the user.
  *
- * \param ias_report           IAS attestation verification report.
- * \param ias_report_size      Size of \p ias_report in bytes.
- * \param ias_sig_b64          IAS report signature (base64-encoded as returned by IAS).
- * \param ias_sig_b64_size     Size of \p ias_sig_b64 in bytes.
- * \param allow_outdated_tcb   Treat IAS status codes: GROUP_OUT_OF_DATE, CONFIGURATION_NEEDED,
- *                             SW_HARDENING_NEEDED, CONFIGURATION_AND_SW_HARDENING_NEEDED as OK.
- * \param nonce                (Optional) Nonce that's expected in the report.
- * \param ias_pub_key_pem      (Optional) IAS public RSA key (PEM format, NULL-terminated).
- *                             If not specified, a hardcoded Intel's key is used.
- * \param[out] out_quote       Buffer with quote. User is responsible for freeing it.
- * \param[out] out_quote_size  Size of \p out_quote in bytes.
+ * \param ias_report             IAS attestation verification report.
+ * \param ias_report_size        Size of \p ias_report in bytes.
+ * \param ias_sig_b64            IAS report signature (base64-encoded as returned by IAS).
+ * \param ias_sig_b64_size       Size of \p ias_sig_b64 in bytes.
+ * \param allow_outdated_tcb     Treat IAS status codes: GROUP_OUT_OF_DATE, CONFIGURATION_NEEDED,
+ *                               SW_HARDENING_NEEDED, CONFIGURATION_AND_SW_HARDENING_NEEDED as OK.
+ * \param nonce                  (Optional) Nonce that's expected in the report.
+ * \param ias_pub_key_pem        (Optional) IAS public RSA key (PEM format, NULL-terminated).
+ *                               If not specified, a hardcoded Intel's key is used.
+ * \param enclave_quote_status   (Optional) If non-NULL, this contains the returned
+ *                               `isvEnclaveQuoteStatus` string on enclave quote status verification
+ *                               failure. The string may be truncated to fit into 128 bytes
+ *                               (including the terminating NULL char).
+ * \param[out] out_quote         Buffer with quote. User is responsible for freeing it.
+ * \param[out] out_quote_size    Size of \p out_quote in bytes.
  *
  * \returns 0 on successful verification, negative value on error.
  */
 int ias_verify_report_extract_quote(const uint8_t* ias_report, size_t ias_report_size,
                                     uint8_t* ias_sig_b64, size_t ias_sig_b64_size,
                                     bool allow_outdated_tcb, const char* nonce,
-                                    const char* ias_pub_key_pem, uint8_t** out_quote,
-                                    size_t* out_quote_size);
+                                    const char* ias_pub_key_pem, char (*enclave_quote_status)[128],
+                                    uint8_t** out_quote, size_t* out_quote_size);

--- a/tools/sgx/ra-tls/ra_tls.map
+++ b/tools/sgx/ra-tls/ra_tls.map
@@ -1,5 +1,5 @@
 RA_TLS {
-    global: ra_tls_set_measurement_callback; ra_tls_verify_callback_der; ra_tls_create_key_and_crt_der;
+    global: ra_tls_set_measurement_callback; ra_tls_verify_callback_der; ra_tls_verify_callback_extended_der; ra_tls_create_key_and_crt_der;
     local: *;
 };
 

--- a/tools/sgx/ra-tls/ra_tls_verify_common.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_common.c
@@ -237,6 +237,13 @@ void ra_tls_set_measurement_callback(int (*f_cb)(const char* mrenclave, const ch
 }
 
 int ra_tls_verify_callback_der(uint8_t* der_crt, size_t der_crt_size) {
+    INFO("WARNING: The ra_tls_verify_callback_der() API is deprecated in favor of the "
+         "ra_tls_verify_callback_extended_der() version of API.\n");
+    return ra_tls_verify_callback_extended_der(der_crt, der_crt_size, /*unused results=*/NULL);
+}
+
+int ra_tls_verify_callback_extended_der(uint8_t* der_crt, size_t der_crt_size,
+                                        struct ra_tls_verify_callback_results* results) {
     int ret;
     mbedtls_x509_crt crt;
     mbedtls_x509_crt_init(&crt);
@@ -245,7 +252,12 @@ int ra_tls_verify_callback_der(uint8_t* der_crt, size_t der_crt_size) {
     if (ret < 0)
         goto out;
 
-    ret = ra_tls_verify_callback(/*unused data=*/NULL, &crt, /*depth=*/0, /*flags=*/NULL);
+    if (results) {
+        /* ensure that all the not-filled fields of callback results are always zeroized */
+        memset(results, 0, sizeof(*results));
+    }
+
+    ret = ra_tls_verify_callback(results, &crt, /*depth=*/0, /*flags=*/NULL);
     if (ret < 0)
         goto out;
 

--- a/tools/sgx/ra-tls/ra_tls_verify_dcap.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_dcap.c
@@ -96,12 +96,17 @@ static const char* sgx_ql_qv_result_to_str(sgx_ql_qv_result_t verification_resul
 }
 
 int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_t* flags) {
-    (void)data;
+    struct ra_tls_verify_callback_results* results = (struct ra_tls_verify_callback_results*)data;
 
     int ret;
 
     uint8_t* supplemental_data      = NULL;
     uint32_t supplemental_data_size = 0;
+
+    if (results) {
+        results->attestation_scheme = RA_TLS_ATTESTATION_SCHEME_DCAP;
+        results->err_loc = AT_INIT;
+    }
 
     if (depth != 0) {
         /* the cert chain in RA-TLS consists of single self-signed cert, so we expect depth 0 */
@@ -115,6 +120,9 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         *flags = 0;
     }
 
+    if (results)
+        results->err_loc = AT_EXTRACT_QUOTE;
+
     /* extract SGX quote from "quote" OID extension from crt */
     sgx_quote_t* quote;
     size_t quote_size;
@@ -123,6 +131,9 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         ERROR("extract_quote_and_verify_pubkey failed: %d\n", ret);
         goto out;
     }
+
+    if (results)
+        results->err_loc = AT_VERIFY_EXTERNAL;
 
     /* prepare user-supplied verification parameters "allow outdated TCB"/"allow debug enclave" */
     bool allow_outdated_tcb  = getenv_allow_outdated_tcb();
@@ -156,6 +167,10 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
                               current_time, &collateral_expiration_status, &verification_result,
                               /*p_qve_report_info=*/NULL, supplemental_data_size,
                               supplemental_data);
+    if (results) {
+        results->dcap.func_verify_quote_result = ret;
+        results->dcap.quote_verification_result = verification_result;
+    }
     if (ret) {
         ERROR("sgx_qv_verify_quote failed: %d\n", ret);
         ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
@@ -189,6 +204,9 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         goto out;
     }
 
+    if (results)
+        results->err_loc = AT_VERIFY_ENCLAVE_ATTRS;
+
     sgx_quote_body_t* quote_body = &quote->body;
 
     /* verify enclave attributes from the SGX quote body */
@@ -197,6 +215,9 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
         goto out;
     }
+
+    if (results)
+        results->err_loc = AT_VERIFY_ENCLAVE_MEASUREMENTS;
 
     /* verify other relevant enclave information from the SGX quote */
     if (g_verify_measurements_cb) {
@@ -214,6 +235,8 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         goto out;
     }
 
+    if (results)
+        results->err_loc = AT_NONE;
     ret = 0;
 out:
     free(supplemental_data);

--- a/tools/sgx/ra-tls/secret_prov_verify.c
+++ b/tools/sgx/ra-tls/secret_prov_verify.c
@@ -44,6 +44,7 @@ struct ra_tls_ctx {
 struct thread_info {
     mbedtls_net_context client_fd;
     mbedtls_ssl_config* conf;
+    struct ra_tls_verify_callback_results* cb_results;
     uint8_t* secret;
     size_t secret_size;
     secret_provision_cb_t f_cb;
@@ -74,6 +75,7 @@ int secret_provision_close(struct ra_tls_ctx* ctx) {
 static void* client_connection(void* data) {
     int ret;
     struct thread_info* ti = (struct thread_info*)data;
+    struct ra_tls_verify_callback_results results = {0};
 
     mbedtls_ssl_context ssl;
     mbedtls_ssl_init(&ssl);
@@ -91,10 +93,29 @@ static void* client_connection(void* data) {
          *        mbedTLS configuration and thread-safe RA-TLS in the future */
         pthread_mutex_lock(&g_handshake_lock);
         ret = mbedtls_ssl_handshake(&ssl);
+        memcpy(&results, ti->cb_results, sizeof(results));
         pthread_mutex_unlock(&g_handshake_lock);
     } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
     if (ret < 0) {
         ERROR("Secret Provisioning failed during mbedtls_ssl_handshake with error %d\n", ret);
+        ERROR("ra_tls_verify_callback_results:\n    attestation_scheme=%d, err_loc=%d, \n",
+              results.attestation_scheme, results.err_loc);
+        switch (results.attestation_scheme) {
+            case RA_TLS_ATTESTATION_SCHEME_EPID:
+                ERROR("    epid.ias_enclave_quote_status=%s\n",
+                      results.epid.ias_enclave_quote_status);
+                break;
+            case RA_TLS_ATTESTATION_SCHEME_DCAP:
+                ERROR("    dcap.func_verify_quote_result=0x%x, "
+                      "dcap.quote_verification_result=0x%x\n",
+                      results.dcap.func_verify_quote_result,
+                      results.dcap.quote_verification_result);
+                break;
+            default:
+                ERROR("    unknown attestation scheme!\n");
+                break;
+        }
+
         goto out;
     }
 
@@ -161,6 +182,7 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
                                   const char* cert_path, const char* key_path,
                                   verify_measurements_cb_t m_cb, secret_provision_cb_t f_cb) {
     int ret;
+    struct ra_tls_verify_callback_results results = {0};
 
     if (!secret || !secret_size || !cert_path || !key_path)
         return -EINVAL;
@@ -240,7 +262,7 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
     mbedtls_ssl_conf_ca_chain(&conf, &srvcert, NULL);
 
     ra_tls_set_measurement_callback(m_cb);
-    mbedtls_ssl_conf_verify(&conf, ra_tls_verify_callback, NULL);
+    mbedtls_ssl_conf_verify(&conf, ra_tls_verify_callback, &results);
 
     ret = mbedtls_ssl_conf_own_cert(&conf, &srvcert, &srvkey);
     if (ret < 0) {
@@ -266,6 +288,7 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
         /* client_fd is reused for multiple threads, so pass ownership of its copy to new thread */
         memcpy(&ti->client_fd, &client_fd, sizeof(client_fd));
         ti->conf        = &conf;
+        ti->cb_results  = &results;
         ti->secret      = secret;
         ti->secret_size = secret_size;
         ti->f_cb        = f_cb;

--- a/tools/sgx/verify-ias-report/verify_ias_report.c
+++ b/tools/sgx/verify-ias-report/verify_ias_report.c
@@ -167,13 +167,20 @@ int main(int argc, char* argv[]) {
 
     uint8_t* report_quote_body = NULL;
     size_t quote_body_size = 0;
+    char enclave_quote_status[128] = {0};
 
     /* IAS returns a truncated SGX quote without signature fields (only the SGX quote body) */
     ret = ias_verify_report_extract_quote(report, report_size, sig, sig_size,
                                           allow_outdated_tcb, nonce, ias_pubkey,
-                                          &report_quote_body, &quote_body_size);
-    if (ret < 0)
+                                          &enclave_quote_status, &report_quote_body,
+                                          &quote_body_size);
+    if (ret < 0) {
+        if (get_verbose()) {
+            ERROR("Failed to verify IAS attestation report or extract the SGX quote from it, "
+                  "enclave quote status: %s\n", enclave_quote_status);
+        }
         return ret;
+    }
 
     /* verify that obtained SGX quote (extracted from IAS report) has reasonable size */
     if (quote_body_size < sizeof(sgx_quote_body_t) || quote_body_size > SGX_QUOTE_MAX_SIZE) {


### PR DESCRIPTION
Previously, RA-TLS hid the details of errors in a dull and uninformative way. This was due to that `ra_tls_verify_callback()` is an mbedtls-adhering callback function, and we cannot simply return a non-mbedtls error code as a ret value.

This patch introduces `ra_tls_verify_callback_args` and a new RA-TLS API `ra_tls_verify_callback_extended_der()` to unhide the detailed error information (e.g. the original SGX-attestation-verification error code) from RA-TLS.

Resolves https://github.com/gramineproject/gramine/issues/1209.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1215)
<!-- Reviewable:end -->
