### PR TITLE
[tools/sgx,meson,packaging] Bug fixes for RA-TLS plugins

### DIFF
--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     jq \
     libapr1-dev \
     libaprutil1-dev \
-    libcjson-dev \
     libelf-dev \
     libevent-dev \
     libexpat1 \

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Build-Depends: debhelper-compat (= 13),
  bison,
  jq,
  gawk,
- libcjson-dev (>= 1.7),
  libcurl4-openssl-dev (>= 7.58),
  libprotobuf-c-dev,
  libsgx-dcap-quote-verify-dev,
@@ -34,7 +33,6 @@ Package: gramine
 Architecture: amd64
 Description: A lightweight usermode guest OS designed to run a single Linux application
 Depends:
- libcjson1 (>= 1.7),
  libcurl4 (>= 7.58),
  libprotobuf-c1,
  python3,

--- a/gramine.spec
+++ b/gramine.spec
@@ -12,7 +12,6 @@ BuildArch: x86_64
 Source0: %{name}-%{version}.tar.gz
 
 BuildRequires: bison
-BuildRequires: cjson-devel
 BuildRequires: gcc
 BuildRequires: gcc-c++
 BuildRequires: jq
@@ -28,7 +27,6 @@ BuildRequires: python3-devel
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
 
-Requires: cjson
 Requires: python3-click
 Requires: python3-cryptography
 Requires: python3-jinja2

--- a/meson.build
+++ b/meson.build
@@ -252,16 +252,7 @@ if sgx
 
     libcurl_dep = curl_proj.get_variable('curl_minimal_dep')
 
-    cjson_dep = dependency('cjson', required: false)
-    if not cjson_dep.found()
-        # on Debian < 11 .pc file is not installed and dependency() fails, so we fallback to
-        # cc.find_library()
-        cjson_dep = cc.find_library('cjson', required: false)
-    endif
-    if not cjson_dep.found()
-        # Ubuntu 18.04 does not have cjson at all
-        cjson_dep = cjson_proj.get_variable('cjson_dep')
-    endif
+    cjson_dep = cjson_proj.get_variable('cjson_dep')
 
     protobuf_dep = dependency('libprotobuf-c')
 

--- a/subprojects/packagefiles/cJSON/meson.build
+++ b/subprojects/packagefiles/cJSON/meson.build
@@ -3,5 +3,4 @@ project('cJSON', 'c')
 cjson_dep = declare_dependency(
     sources: files('cJSON.c', 'cJSON.h'),
     include_directories: include_directories('.'),
-    compile_args: ['-DHAVE_INTERNAL_CJSON'],
 )

--- a/tools/sgx/common/ias.c
+++ b/tools/sgx/common/ias.c
@@ -20,12 +20,7 @@
 #include <string.h>
 #include <strings.h>
 
-#ifdef HAVE_INTERNAL_CJSON
-/* here we -I the cJSON's repo root, which directly contains the header */
 #include <cJSON.h>
-#else
-#include <cjson/cJSON.h>
-#endif
 
 #include "util.h"
 

--- a/tools/sgx/ra-tls/ra_tls_common.h
+++ b/tools/sgx/ra-tls/ra_tls_common.h
@@ -28,6 +28,8 @@ static const size_t g_quote_oid_size = sizeof(g_quote_oid);
 
 bool getenv_allow_outdated_tcb(void);
 bool getenv_allow_debug_enclave(void);
+int find_oid_in_cert_extensions(const uint8_t* exts, size_t exts_size, const uint8_t* oid,
+                                size_t oid_size, uint8_t** out_val, size_t* out_size);
 int cmp_crt_pk_against_quote_report_data(mbedtls_x509_crt* crt, sgx_quote_t* quote);
 int extract_quote_and_verify_pubkey(mbedtls_x509_crt* crt, sgx_quote_t** out_quote,
                                     size_t* out_quote_size);

--- a/tools/sgx/ra-tls/ra_tls_verify_common.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_common.c
@@ -109,8 +109,8 @@ bool getenv_allow_debug_enclave(void) {
 
 /*! searches for specific \p oid among \p exts and returns pointer to its value in \p out_val;
  *  tailored for SGX quotes with size strictly from 128 to 65535 bytes (fails on other sizes) */
-static int find_oid(const uint8_t* exts, size_t exts_size, const uint8_t* oid, size_t oid_size,
-                    uint8_t** out_val, size_t* out_size) {
+int find_oid_in_cert_extensions(const uint8_t* exts, size_t exts_size, const uint8_t* oid,
+                                size_t oid_size, uint8_t** out_val, size_t* out_size) {
     /* TODO: searching with memmem is not robust (what if some extension contains exactly these
      *       chars?), but mbedTLS has nothing generic enough for our purposes; this is still
      *       secure because this func is used for extracting the SGX quote which is verified
@@ -213,8 +213,8 @@ int extract_quote_and_verify_pubkey(mbedtls_x509_crt* crt, sgx_quote_t** out_quo
                                     size_t* out_quote_size) {
     sgx_quote_t* quote;
     size_t quote_size;
-    int ret = find_oid(crt->v3_ext.p, crt->v3_ext.len, g_quote_oid, g_quote_oid_size,
-                       (uint8_t**)&quote, &quote_size);
+    int ret = find_oid_in_cert_extensions(crt->v3_ext.p, crt->v3_ext.len, g_quote_oid,
+                                          g_quote_oid_size, (uint8_t**)&quote, &quote_size);
     if (ret < 0)
         return ret;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR is a result of me porting MAA from in-core-Gramine (#652) to being a plugin in [contrib repo](https://github.com/gramineproject/contrib).

The previous PR (#1114) created the basis for writing such plugins. However, I missed a couple bugs that prevent me from enabling MAA as a plugin. This PR fixes all bugs that I found:

- [tools/sgx] Expose `find_oid_in_cert_extensions()` in RA-TLS common API. Previously, function `find_oid()` was hidden in RA-TLS. However, some plugins (e.g. Microsoft Azure Attestation) would benefit from this function. So let's expose it and give a more specific name.

- ~~[meson] Install curl's headers and static lib as part of Gramine. Gramine uses a specially built minimized static version of curl. This version should be available for plugins of Gramine (in particular, RA-TLS plugins).~~

- [meson,packaging,CI] Do not use system-installed cJSON lib. cJSON installed on the system from OS distros only has a shared-library version and no static-library version. Recently, Gramine's RA-TLS libraries are linked against dependencies (such as cJSON) statically. Thus, we cannot use system-installed cJSON lib, instead we should always use the meson subproject.

## How to test this PR? <!-- (if applicable) -->

CI is enough. I also have a local plugin for MAA that requires this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1218)
<!-- Reviewable:end -->
