### PR TITLE
[common] Fix POSIX locking on encrypted file in child process

### DIFF
--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -777,6 +777,8 @@ static bool ipf_init_new_file(pf_context_t* pf, const char* path) {
     memcpy(pf->encrypted_part_plain.path, path, strlen(path) + 1);
 
     pf->need_writing = true;
+    if (!ipf_internal_flush(pf))
+        return false;
 
     return true;
 }

--- a/libos/test/regression/fcntl_lock.c
+++ b/libos/test/regression/fcntl_lock.c
@@ -21,7 +21,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define TEST_DIR "tmp/"
 #define TEST_FILE "tmp/lock_file"
 
 static int g_fd;

--- a/libos/test/regression/fcntl_lock_child_only.c
+++ b/libos/test/regression/fcntl_lock_child_only.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation */
+
+/*
+ * Test for a corner case of POSIX locks (`fcntl(F_SETLK/F_SETLKW/F_GETLK`): the child process
+ * acquires the lock on the encrypted file that was not processed yet by the master process. In this
+ * case, the child sends an IPC request to the master process (since all POSIX locks' operations are
+ * centrally processed in the master process). The master process must lookup the file first, and
+ * only if the lookup is successful, grant the POSIX-lock request to the child.
+ *
+ * There was a bug in Gramine when the above scenario on encrypted files failed, because encrypted
+ * files were *not* updated on the hard disk upon creation (the file was created but its metadata
+ * wasn't flushed), which confused the master process, and POSIX lock operations failed.
+ */
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#define TEST_FILE "tmp_enc/lock_file"
+
+int main(void) {
+    pid_t pid = CHECK(fork());
+
+    if (pid == 0) {
+        int fd = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+
+        struct flock fl = {
+            .l_type = F_WRLCK,
+            .l_whence = SEEK_SET,
+            .l_start = 0,
+            .l_len = 0,
+        };
+        CHECK(fcntl(fd, F_SETLK, &fl));
+
+        fl.l_type = F_UNLCK;
+        CHECK(fcntl(fd, F_SETLK, &fl));
+
+        CHECK(close(fd));
+        exit(0);
+    }
+
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        errx(1, "child died with status: %#x", status);
+    }
+
+    CHECK(unlink(TEST_FILE));
+
+    printf("TEST OK\n");
+    return 0;
+}

--- a/libos/test/regression/fcntl_lock_child_only.manifest.template
+++ b/libos/test/regression/fcntl_lock_child_only.manifest.template
@@ -1,0 +1,22 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+
+  { type = "encrypted", path = "/tmp_enc/", uri = "file:tmp_enc/" },
+]
+
+fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
+
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -27,6 +27,7 @@ tests = {
     'exit': {},
     'exit_group': {},
     'fcntl_lock': {},
+    'fcntl_lock_child_only': {},
     'fdleak': {},
     'file_check_policy': {},
     'file_size': {},

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -943,6 +943,14 @@ class TC_30_Syscall(RegressionTestCase):
                 os.remove('tmp/lock_file')
         self.assertIn('TEST OK', stdout)
 
+    def test_111_fcntl_lock_child_only(self):
+        try:
+            stdout, _ = self.run_binary(['fcntl_lock_child_only'], timeout=60)
+        finally:
+            if os.path.exists('tmp_enc/lock_file'):
+                os.remove('tmp_enc/lock_file')
+        self.assertIn('TEST OK', stdout)
+
     def test_120_gethostname_default(self):
         # The generic manifest (manifest.template) doesn't use extra runtime conf.
         stdout, _ = self.run_binary(['hostname', 'localhost'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -30,6 +30,7 @@ manifests = [
   "exit",
   "exit_group",
   "fcntl_lock",
+  "fcntl_lock_child_only",
   "fdleak",
   "file_check_policy",
   "file_check_policy_allow_all_but_log",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -32,6 +32,7 @@ manifests = [
   "exit",
   "exit_group",
   "fcntl_lock",
+  "fcntl_lock_child_only",
   "fdleak",
   "file_check_policy",
   "file_check_policy_allow_all_but_log",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There was a bug in the corner case of POSIX locking: when the child process acquires a lock on an encrypted file that was not processed yet by the master process. In this case, the child sends an IPC request to the master process (since all POSIX locks' operations are centrally processed in the master process). The master process must lookup the file first, and only if the lookup is successful, grant the POSIX-lock request to the child.

The bug was: because encrypted files were *not* updated on the hard disk upon creation (the file was created but its metadata wasn't flushed), this confused the master process, and POSIX lock operations failed.

This PR fixes this bug by immediately flushing the metadata of each newly created encrypted file.

## How to test this PR? <!-- (if applicable) -->

A new test is added. CI is enough.

- An exerpt from the new regression test without the fix:
```
(libos_ipc.c:212:ipc_send_message_to_conn) [P2:T2:fcntl_lock_child_only] debug: Sending ipc message to 1
(libos_ipc.c:247:wait_for_response) [P2:T2:fcntl_lock_child_only] debug: Waiting for a response to 2
(libos_ipc_worker.c:193:receive_ipc_messages) [P1:libos] debug: IPC worker: received IPC message from 2: code=15 size=68 seq=2
(libos_fs_encrypted.c:141:cb_debug) [P1:libos] debug: ipf_open: handle: 0, path: 'tmp_enc/lock_file', real size: 0, mode: 0x3
(libos_fs_encrypted.c:41:cb_read) [P1:libos] warning: EOF
(libos_fs_encrypted.c:141:cb_debug) [P1:libos] debug: ipf_open: failed: -11
(libos_fs_encrypted.c:203:encrypted_file_internal_open) [P1:libos] warning: pf_open failed: Callback failed
(libos_fs_lock.c:514:posix_lock_set_from_ipc) [P1:libos] warning: posix_lock_set_from_ipc: error on dentry lookup for /tmp_enc/lock_file: -13
(libos_ipc.c:212:ipc_send_message_to_conn) [P1:libos] debug: Sending ipc message to 2
(libos_ipc_worker.c:193:receive_ipc_messages) [P2:libos] debug: IPC worker: received IPC message from 1: code=0 size=21 seq=2
(libos_ipc.c:331:ipc_response_callback) [P2:libos] debug: Got an IPC response from 1, seq: 2
(libos_ipc.c:254:wait_for_response) [P2:T2:fcntl_lock_child_only] debug: Waiting finished: Success (PAL_ERROR_SUCCESS)
(libos_parser.c:1609:buf_write_all) [P2:T2:fcntl_lock_child_only] trace: ---- fcntl(3, F_SETLK, 0x672c97001dc0) = -13
```

- An exerpt from the new regression test with the fix:
```
(libos_ipc.c:212:ipc_send_message_to_conn) [P2:T2:fcntl_lock_child_only] debug: Sending ipc message to 1
(libos_ipc.c:247:wait_for_response) [P2:T2:fcntl_lock_child_only] debug: Waiting for a response to 2
(libos_ipc_worker.c:193:receive_ipc_messages) [P1:libos] debug: IPC worker: received IPC message from 2: code=15 size=68 seq=2
(libos_fs_encrypted.c:141:cb_debug) [P1:libos] debug: ipf_open: handle: 0, path: 'tmp_enc/lock_file', real size: 4096, mode: 0x3
(libos_fs_encrypted.c:141:cb_debug) [P1:libos] debug: ipf_init_existing_file: data size 0
(libos_fs_encrypted.c:141:cb_debug) [P1:libos] debug: ipf_open: OK (data size 0)
(libos_fs_encrypted.c:141:cb_debug) [P1:libos] debug: ipf_internal_flush: no need to write
(libos_fs_lock.c:95:posix_lock_dump_write_all) [P1:libos] posix_lock: 2: w[0..end]
(libos_ipc.c:212:ipc_send_message_to_conn) [P1:libos] debug: Sending ipc message to 2
(libos_ipc_worker.c:193:receive_ipc_messages) [P2:libos] debug: IPC worker: received IPC message from 1: code=0 size=21 seq=2
(libos_ipc.c:331:ipc_response_callback) [P2:libos] debug: Got an IPC response from 1, seq: 2
(libos_ipc.c:254:wait_for_response) [P2:T2:fcntl_lock_child_only] debug: Waiting finished: Success (PAL_ERROR_SUCCESS)
(libos_parser.c:1609:buf_write_all) [P2:T2:fcntl_lock_child_only] trace: ---- fcntl(3, F_SETLK, 0x5177faa00dc0) = 0x0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1225)
<!-- Reviewable:end -->
