### PR TITLE
[LTP] Add /usr/{{ arch_libdir }} to ltp manifest

### DIFF
--- a/libos/test/ltp/manifest.template
+++ b/libos/test/ltp/manifest.template
@@ -1,7 +1,7 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/lib64"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/lib64:/usr/{{ arch_libdir }}"
 loader.env.PATH = "/bin:/usr/bin:."
 loader.env.LD_PRELOAD = "{{ coreutils_libdir }}/libstdbuf.so"
 loader.env._STDBUF_O = "L"


### PR DESCRIPTION
Previously, Gramine exposed only arch_libdir for LD_LIBRARY_PATH, so if some library is present in /usr directory, Gramine was not looking under /usr.
This commit adds /usr/{{ arch_libdir }} to LD_LIBRARY_PATH so Gramine can also look there.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

