### PR TITLE
[LibOS,Pal] Add support of `ioctl(SIOCGIFCONF/SIOCGIFHWADDR)`

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -456,9 +456,10 @@ Allowed IOCTLs
       { request_code = [NUM], struct = "[identifier-of-ioctl-struct]" },
     ]
 
-By default, Gramine disables all device-backed IOCTLs. This syntax allows to
-explicitly allow a set of IOCTLs on devices (devices must be explicitly mounted
-via ``fs.mounts`` manifest syntax). Only IOCTLs with the ``request_code``
+By default, Gramine disables all device-backed and socket IOCTLs. This syntax
+allows to explicitly allow a set of IOCTLs on devices (devices must be
+explicitly mounted via ``fs.mounts`` manifest syntax) and sockets (e.g. for
+``SIOCGIFCONF`` and ``SIOCGIFHWADDR``). Only IOCTLs with the ``request_code``
 argument found among the manifest-listed IOCTLs are allowed to pass-through to
 the host. Each IOCTL entry may also contain a reference to an IOCTL struct in
 the ``struct`` field, in case the third IOCTL argument is intended to be

--- a/libos/src/fs/socket/fs.c
+++ b/libos/src/fs/socket/fs.c
@@ -167,8 +167,20 @@ static int ioctl(struct libos_handle* handle, unsigned int cmd, unsigned long ar
             }
             *(int*)arg = size;
             return 0;
-        default:
-            return -ENOTTY;
+
+        default:;
+            PAL_HANDLE pal_handle = __atomic_load_n(&handle->info.sock.pal_handle,
+                                                    __ATOMIC_ACQUIRE);
+            if (!pal_handle) {
+                return -ENOTCONN;
+            }
+            int cmd_ret;
+            ret = PalDeviceIoControl(pal_handle, cmd, arg, &cmd_ret);
+            if (ret < 0) {
+                return ret == -PAL_ERROR_NOTIMPLEMENTED ? -ENOTTY: pal_to_unix_errno(ret);
+            }
+            assert(ret == 0);
+            return cmd_ret;
     }
 }
 

--- a/libos/src/sys/libos_ioctl.c
+++ b/libos/src/sys/libos_ioctl.c
@@ -154,9 +154,15 @@ long libos_syscall_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
             ret = 0;
             break;
         }
-        default:
-            ret = -ENOSYS;
+        default: {
+            struct libos_fs* fs = hdl->fs;
+            if (!fs || !fs->fs_ops || !fs->fs_ops->ioctl) {
+                ret = -ENOTTY;
+                break;
+            }
+            ret = fs->fs_ops->ioctl(hdl, cmd, arg);
             break;
+        }
     }
 
 out:

--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -2218,9 +2218,12 @@ must-pass =
     5
     6
 
+# subtests 3-4,6-8: ioctl commands SIOCATMARK and SIOCGIFFLAGS not supported
 [sockioctl01]
 must-pass =
     1
+    2
+    5
 
 # no splice()
 [splice*]

--- a/libos/test/ltp/ltp_sgx.cfg
+++ b/libos/test/ltp/ltp_sgx.cfg
@@ -711,10 +711,6 @@ skip = yes
 [socketpair02]
 skip = yes
 
-[sockioctl01]
-timeout = 60
-skip = yes
-
 [stat01]
 skip = yes
 

--- a/libos/test/ltp/manifest.template
+++ b/libos/test/ltp/manifest.template
@@ -37,3 +37,16 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/librt.so.1",
   "file:{{ coreutils_libdir }}/libstdbuf.so",
 ]
+
+# below IOCTL is for socket ioctl tests (e.g. `sockioctl01`); note that there is no additional
+# sanitization of these IOCTLs but this is only for testing anyway
+sys.ioctl_structs.ifconf = [
+  # When ifc_req is NULL, direction of ifc_len is out. Otherwise, direction is in.
+  { size = 4, direction = "inout", name = "ifc_len" },  # ifc_len
+  { size = 4, direction = "none" },                     # padding
+  { ptr = [ { size = "ifc_len", direction = "in" } ] }, # ifc_req
+]
+
+sys.allowed_ioctls = [
+  { request_code = 0x8912, struct = "ifconf" }, # SIOCGIFCONF
+]

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -122,6 +122,7 @@ tests = {
     'sighandler_sigpipe': {},
     'signal_multithread': {},
     'sigprocmask_pending': {},
+    'socket_ioctl': {},
     'spinlock': {
         'include_directories': include_directories(
             # for `spinlock.h`

--- a/libos/test/regression/socket_ioctl.c
+++ b/libos/test/regression/socket_ioctl.c
@@ -1,0 +1,128 @@
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <malloc.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include "common.h"
+
+/*
+ * Sanitization example: introduce `ioctl()` wrappers to add sanitization of SIOCGIFCONF and
+ * SIOCGIFHWADDR requests used by the main program. (Well, SIOCGIFHWADDR doesn't require
+ * sanitization because its data structure has nothing that needs checks.)
+ *
+ * Note that on errors, these wrappers return -1 and set errno. This is to make these wrappers
+ * similar to libc functions, so that `main()` can use the `CHECK()` macro.
+ *
+ * Though another solution would be in the form of a shared LD_PRELOAD-ed library, we recommend
+ * against this in production deployments as it is very brittle.
+ *
+ * Partial protection is also endorsed by `sgx.ioctl_structs` descriptions in the corresponding
+ * manifest (e.g. SIOCGIFHWADDR's `ifreq::ifr_name` is copy-out-only and thus cannot be modified by
+ * the attacker on the way back from IOCTL).
+ */
+static int list_ipv4_interfaces(int sockfd, struct ifconf* ifc) {
+    /* memoize some fields for SIOCGIFCONF sanitization after the syscall */
+    assert(ifc);
+    int initial_ifc_len = ifc->ifc_len;
+    void* initial_ifc_req = ifc->ifc_req;
+
+    int ret = ioctl(sockfd, SIOCGIFCONF, ifc);
+    if (ret < 0)
+        return ret;
+
+    /* verify ifc_len (same checks for both ifc_req==NULL and ifc_req!=NULL cases) */
+    if (ifc->ifc_len < 0) {
+        fprintf(stderr, "SIOCGIFCONF() returned negative ifc_len");
+        goto fail;
+    }
+    if (ifc->ifc_len % sizeof(struct ifreq)) {
+        fprintf(stderr, "SIOCGIFCONF() returned non-aligned ifc_len");
+        goto fail;
+    }
+    if ((ifc->ifc_len / sizeof(struct ifreq)) > 1024) {
+        fprintf(stderr, "SIOCGIFCONF() returned too large ifc_len (limit is 1024 ifreq objs)");
+        goto fail;
+    }
+
+    if (!initial_ifc_req) {
+        /* SIOCGIFCONF must return the necessary buffer size for receiving all available addresses
+         * in ifc_len; ifc_req must be NULL */
+        if (ifc->ifc_req) {
+            fprintf(stderr, "SIOCGIFCONF(ifconf::ifc_req=NULL) returned ifc_req != NULL");
+            goto fail;
+        }
+    } else {
+        /* ifc_req contains a pointer to an array of ifreq structures to be filled with all
+         * currently active IPv4 interface addresses */
+        if (ifc->ifc_req != initial_ifc_req) {
+            fprintf(stderr, "SIOCGIFCONF(ifconf::ifc_req) returned modified ifc_req");
+            goto fail;
+        }
+        if (ifc->ifc_len > initial_ifc_len) {
+            fprintf(stderr, "SIOCGIFCONF(ifconf::ifc_req) returned ifc_len > initial");
+            goto fail;
+        }
+
+        /* verify each ifreq structure in the array */
+        struct ifreq* ifend = ifc->ifc_req + (ifc->ifc_len / sizeof(struct ifreq));
+        for (struct ifreq* ifr = ifc->ifc_req; ifr < ifend; ifr++) {
+            if (memchr(ifr->ifr_name, '\0', sizeof(ifr->ifr_name)) == NULL) {
+                fprintf(stderr, "SIOCGIFCONF(ifconf::ifc_req) returned ifc_req with bad ifr_name");
+                goto fail;
+            }
+        }
+    }
+
+    return 0;
+fail:
+    errno = EPERM;
+    return -1;
+}
+
+static int get_hwaddr(int sockfd, struct ifreq* ifreq) {
+    /* SIOCGIFHWADDR doesn't require sanitization: its data struct has nothing that needs checks */
+    return ioctl(sockfd, SIOCGIFHWADDR, ifreq);
+}
+
+int main(void) {
+    struct ifconf ifc;
+    int sockfd = CHECK(socket(AF_INET, SOCK_DGRAM, 0));
+
+    ifc.ifc_req = NULL;
+    CHECK(list_ipv4_interfaces(sockfd, &ifc));
+
+    ifc.ifc_req = (struct ifreq*)malloc(ifc.ifc_len);
+    if (ifc.ifc_req == NULL)
+        CHECK(-1);
+
+    CHECK(list_ipv4_interfaces(sockfd, &ifc));
+
+    struct ifreq* ifend = ifc.ifc_req + (ifc.ifc_len / sizeof(struct ifreq));
+    for (struct ifreq* ifr = ifc.ifc_req; ifr < ifend; ifr++) {
+        if (ifr->ifr_addr.sa_family == AF_INET) {
+            struct ifreq ifreq;
+            strncpy(ifreq.ifr_name, ifr->ifr_name, sizeof(ifreq.ifr_name) - 1);
+            ifreq.ifr_name[sizeof(ifreq.ifr_name) - 1] = '\0';
+
+            CHECK(get_hwaddr(sockfd, &ifreq));
+            printf("interface %s: inet %s ether %02x:%02x:%02x:%02x:%02x:%02x\n", ifreq.ifr_name,
+                    inet_ntoa(((struct sockaddr_in*)&ifr->ifr_addr)->sin_addr),
+                    (int)((unsigned char*)&ifreq.ifr_hwaddr.sa_data)[0],
+                    (int)((unsigned char*)&ifreq.ifr_hwaddr.sa_data)[1],
+                    (int)((unsigned char*)&ifreq.ifr_hwaddr.sa_data)[2],
+                    (int)((unsigned char*)&ifreq.ifr_hwaddr.sa_data)[3],
+                    (int)((unsigned char*)&ifreq.ifr_hwaddr.sa_data)[4],
+                    (int)((unsigned char*)&ifreq.ifr_hwaddr.sa_data)[5]);
+        }
+    }
+    free(ifc.ifc_req);
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/socket_ioctl.manifest.template
+++ b/libos/test/regression/socket_ioctl.manifest.template
@@ -1,0 +1,36 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.max_threads = 4
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]
+
+sys.ioctl_structs.ifconf = [
+  # When ifc_req is NULL, direction of ifc_len is out. Otherwise, direction is in.
+  { size = 4, direction = "inout", name = "ifc_len" },  # ifc_len
+  { size = 4, direction = "none" },                     # padding
+  { ptr = [ { size = "ifc_len", direction = "in" } ] }, # ifc_req
+]
+
+sys.ioctl_structs.ifreq = [
+  { size = 16, direction = "out" }, # ifr_name
+  { size = 24, direction = "in" },  # ifr_hwaddr
+]
+
+sys.allowed_ioctls = [
+  { request_code = 0x8912, struct = "ifconf" }, # SIOCGIFCONF
+  { request_code = 0x8927, struct = "ifreq" },  # SIOCGIFHWADDR
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1377,6 +1377,10 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['tcp_ipv6_v6only'], timeout=50)
         self.assertIn('test completed successfully', stdout)
 
+    def test_320_socket_ioctl(self):
+        stdout, _ = self.run_binary(['socket_ioctl'])
+        self.assertIn('TEST OK', stdout)
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX emulates CPUID.')
 class TC_90_CpuidSGX(RegressionTestCase):

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -107,6 +107,7 @@ manifests = [
   "sighandler_sigpipe",
   "signal_multithread",
   "sigprocmask_pending",
+  "socket_ioctl",
   "spinlock",
   "stat_invalid_args",
   "synthetic",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -108,6 +108,7 @@ manifests = [
   "sighandler_sigpipe",
   "signal_multithread",
   "sigprocmask_pending",
+  "socket_ioctl",
   "spinlock",
   "stat_invalid_args",
   "synthetic",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Add host ABI `PalSocketIoControl` to handle socket-specific `ioctl` operations. Currently only `SIOCGIFCONF` and `SIOCGIFHWADDR` commands are supported to enable workloads that request IP address of all network interfaces, for example, Pyspark.


In Linux-SGX Pal, `ocall_ioctl` is added and aligns with device-specific IOCTL support in #671.

## How to test this PR? <!-- (if applicable) -->

new regression test `socket_ioctl` and ltp test `sockioctl01`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1233)
<!-- Reviewable:end -->
