### PR TITLE
[PAL/Linux-SGX] Mitigate CVE-2022-21166 aka INTEL-SA-00615

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -590,8 +590,10 @@ more CPU cores and burning more CPU cycles. For example, a single-threaded
 Redis instance on Linux becomes 5-threaded on Gramine with Exitless. Thus,
 Exitless may negatively impact throughput but may improve latency.
 
-This feature is currently marked as insecure, because it reads untrusted memory
-in potentially insecure manner - susceptible to CVE-2022-21233 (INTEL-SA-00657).
+This feature is currently marked as insecure, because it reads and writes to
+untrusted memory in potentially insecure manner - susceptible to
+CVE-2022-21233 (INTEL-SA-00657) and CVE-2022-21166 (INTEL-SA-00615)
+respectively.
 
 Optional CPU features (AVX, AVX512, MPX, PKRU, AMX, EXINFO)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -164,7 +164,8 @@ Exitless feature
 ----------------
 
 Note this feature is currently insecure and not recommended for production
-usage (potentially susceptible to CVE-2022-21233 aka INTEL-SA-00657).
+usage (potentially susceptible to CVE-2022-21233 aka INTEL-SA-00657 and
+CVE-2022-21166 aka INTEL-SA-00615).
 
 Gramine supports the Exitless (or Switchless) feature – it trades off CPU cores
 for faster OCALL execution. More specifically, with Exitless, enclave threads do

--- a/pal/src/host/linux-sgx/enclave_api.h
+++ b/pal/src/host/linux-sgx/enclave_api.h
@@ -18,15 +18,21 @@ void sgx_reset_ustack(const void* old_ustack);
 
 void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size);
 bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize);
-bool sgx_copy_from_enclave(void* urts_ptr, const void* enclave_ptr, size_t size);
+void sgx_copy_from_enclave_verified(void* uptr, const void* ptr, size_t size);
+bool sgx_copy_from_enclave(void* uptr, const void* ptr, size_t size);
 void* sgx_import_array_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt);
 void* sgx_import_array2d_to_enclave(const void* uptr, size_t elem_size, size_t elem_cnt1,
                                     size_t elem_cnt2);
 
 #define COPY_UNTRUSTED_VALUE(untrusted_ptr) ({                          \
     __typeof__(*(untrusted_ptr)) val;                                   \
-    sgx_copy_to_enclave_verified(&val, (untrusted_ptr), sizeof(val));   \
+    sgx_copy_to_enclave_verified(&val, untrusted_ptr, sizeof(val));     \
     val;                                                                \
+})
+
+#define COPY_VALUE_TO_UNTRUSTED(untrusted_ptr, val) ({                            \
+    __typeof__(*(untrusted_ptr)) src_val = (val);                                 \
+    sgx_copy_from_enclave_verified(untrusted_ptr, &src_val, sizeof(src_val));     \
 })
 
 /*!

--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -120,7 +120,7 @@ void* sgx_copy_to_ustack(const void* ptr, size_t size) {
     }
     void* uptr = sgx_alloc_on_ustack(size);
     if (uptr) {
-        memcpy(uptr, ptr, size);
+        sgx_copy_from_enclave_verified(uptr, ptr, size);
     }
     return uptr;
 }
@@ -130,14 +130,25 @@ void sgx_reset_ustack(const void* old_ustack) {
     UPDATE_USTACK(old_ustack);
 }
 
-static void copy_u64s(void* dst, const void* untrusted_src, size_t count) {
-    assert((uintptr_t)untrusted_src % 8 == 0);
+static void copy_u64s(void* dst, const void* src, size_t count) {
     __asm__ volatile (
         "rep movsq\n"
-        : "+D"(dst), "+S"(untrusted_src), "+c"(count)
+        : "+D"(dst), "+S"(src), "+c"(count)
         :
         : "memory", "cc"
     );
+}
+
+static void copy_u64s_from_untrusted(void* dst, const void* untrusted_src, size_t count) {
+    assert((uintptr_t)untrusted_src % 8 == 0);
+
+    copy_u64s(dst, untrusted_src, count);
+}
+
+static void copy_u64s_to_untrusted(void* untrusted_dst, const void* src, size_t count) {
+    assert((uintptr_t)untrusted_dst % 8 == 0);
+
+    copy_u64s(untrusted_dst, src, count);
 }
 
 void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size) {
@@ -159,7 +170,7 @@ void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size) {
     if (prefix_misalignment) {
         /* Beginning of the copied range is misaligned. */
         char prefix_val[8] = { 0 };
-        copy_u64s(prefix_val, (char*)uptr - prefix_misalignment, /*count=*/1);
+        copy_u64s_from_untrusted(prefix_val, (char*)uptr - prefix_misalignment, /*count=*/1);
 
         copy_len = MIN(sizeof(prefix_val) - prefix_misalignment, size);
         memcpy(ptr, prefix_val + prefix_misalignment, copy_len);
@@ -176,7 +187,7 @@ void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size) {
     size_t suffix_misalignment = size & 7;
     copy_len = size - suffix_misalignment;
     assert(copy_len % 8 == 0);
-    copy_u64s(ptr, uptr, copy_len / 8);
+    copy_u64s_from_untrusted(ptr, uptr, copy_len / 8);
     ptr = (char*)ptr + copy_len;
     uptr = (const char*)uptr + copy_len;
     size -= copy_len;
@@ -185,7 +196,7 @@ void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size) {
     if (suffix_misalignment) {
         /* End of the copied range is misaligned. */
         char suffix_val[8] = { 0 };
-        copy_u64s(suffix_val, uptr, /*count=*/1);
+        copy_u64s_from_untrusted(suffix_val, uptr, /*count=*/1);
         memcpy(ptr, suffix_val, suffix_misalignment);
     }
 }
@@ -201,12 +212,66 @@ bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usi
     return true;
 }
 
-bool sgx_copy_from_enclave(void* urts_ptr, const void* enclave_ptr, size_t size) {
-    if (!sgx_is_valid_untrusted_ptr(urts_ptr, size, /*alignment=*/1)
-            || !sgx_is_completely_within_enclave(enclave_ptr, size)) {
+void sgx_copy_from_enclave_verified(void* uptr, const void* ptr, size_t size) {
+    assert(sgx_is_completely_within_enclave(ptr, size));
+    assert(sgx_is_valid_untrusted_ptr(uptr, size, /*alignment=*/1));
+
+    if (size == 0) {
+        return;
+    }
+
+    /*
+     * This should be simple `memcpy(uptr, ptr, size)`, but CVE-2022-21166 (INTEL-SA-00615).
+     * To mitigate this issue, all writes to untrusted memory from within the enclave must be done
+     * in 8-byte chunks aligned to 8-bytes boundary. Since x64 allocates memory in pages of
+     * (at least) 0x1000 in size, we can safely 8-align the pointer down and the size up.
+     */
+    size_t copy_len;
+    size_t prefix_misalignment = (uintptr_t)uptr & 7;
+    if (prefix_misalignment) {
+        /* Beginning of the range to copy is misaligned. */
+        char prefix_val[8] = { 0 };
+        copy_len = MIN(sizeof(prefix_val) - prefix_misalignment, size);
+
+        copy_u64s_from_untrusted(prefix_val, (char*)uptr - prefix_misalignment, /*count=*/1);
+        memcpy(prefix_val + prefix_misalignment, ptr, copy_len);
+        copy_u64s_to_untrusted((char*)uptr - prefix_misalignment, prefix_val, /*count=*/1);
+        uptr = (char*)uptr + copy_len;
+        ptr = (const char*)ptr + copy_len;
+        size -= copy_len;
+
+        if (size == 0) {
+            return;
+        }
+    }
+    assert((uintptr_t)uptr % 8 == 0);
+
+    size_t suffix_misalignment = size & 7;
+    copy_len = size - suffix_misalignment;
+    assert(copy_len % 8 == 0);
+    copy_u64s_to_untrusted(uptr, ptr, copy_len / 8);
+    uptr = (char*)uptr + copy_len;
+    ptr = (const char*)ptr + copy_len;
+    size -= copy_len;
+
+    assert(size == suffix_misalignment);
+    if (suffix_misalignment) {
+        /* End of the range to copy is misaligned. */
+        char suffix_val[8] = { 0 };
+
+        copy_u64s_from_untrusted(suffix_val, uptr, /*count=*/1);
+        memcpy(suffix_val, ptr, suffix_misalignment);
+        copy_u64s_to_untrusted(uptr, suffix_val, 1);
+    }
+}
+
+bool sgx_copy_from_enclave(void* uptr, const void* ptr, size_t size) {
+    if (!sgx_is_valid_untrusted_ptr(uptr, size, /*alignment=*/1)
+            || !sgx_is_completely_within_enclave(ptr, size)) {
         return false;
     }
-    memcpy(urts_ptr, enclave_ptr, size);
+
+    sgx_copy_from_enclave_verified(uptr, ptr, size);
     return true;
 }
 

--- a/pal/src/host/linux-sgx/pal_events.c
+++ b/pal/src/host/linux-sgx/pal_events.c
@@ -20,9 +20,13 @@
 static uintptr_t g_untrusted_page_next_entry = 0;
 static spinlock_t g_untrusted_page_lock = INIT_SPINLOCK_UNLOCKED;
 
-static int alloc_untrusted_futex_word(uint32_t** out_addr) {
+/* Allocate 8-byte ints instead of classic 4-byte ints for the futex word. This is to mitigate
+ * CVE-2022-21166 (INTEL-SA-00615) which requires all writes to untrusted memory from within the
+ * enclave to be done in 8-byte chunks aligned to 8-bytes boundary. Since the 8-byte ints returned
+ * are guaranteed to be 8-byte aligned, we don't need to care about the alignment later. */
+static int alloc_untrusted_futex_word(uint64_t** out_addr) {
     spinlock_lock(&g_untrusted_page_lock);
-    static_assert(PAGE_SIZE % sizeof(uint32_t) == 0, "required by the check below");
+    static_assert(PAGE_SIZE % sizeof(uint64_t) == 0, "required by the check below");
     if (g_untrusted_page_next_entry % PAGE_SIZE == 0) {
         void* untrusted_page;
         int ret = ocall_mmap_untrusted(&untrusted_page, PAGE_SIZE, PROT_READ | PROT_WRITE,
@@ -44,25 +48,27 @@ static int alloc_untrusted_futex_word(uint32_t** out_addr) {
     }
 
     uintptr_t addr = g_untrusted_page_next_entry;
-    g_untrusted_page_next_entry += sizeof(uint32_t);
+    g_untrusted_page_next_entry += sizeof(uint64_t);
 #ifdef ASAN
-    /* ASAN requires 8-byte aligned addresses, so we need to pad. */
-    g_untrusted_page_next_entry += sizeof(uint32_t);
-    asan_unpoison_region(addr, 2 * sizeof(uint32_t));
+    /* TODO: uncomment the following code once the painful mitigation for CVE-2022-21166
+     * (INTEL-SA-00615) can be removed in the future. This is a reminder that ASAN requires 8-byte
+     * aligned addresses, so we need to pad it using classic 4-byte ints for the futex word. */
+    /* g_untrusted_page_next_entry += sizeof(uint32_t); */
+    asan_unpoison_region(addr, sizeof(uint64_t));
 #endif
 
     /* This counter is only used to decide when to free the page - untrusted host can do this anyway
      * at any point, so we can keep the counter in untrusted memory. */
     uint64_t* untrusted_users_counter_ptr = (uint64_t*)ALIGN_DOWN(addr, PAGE_SIZE);
     uint64_t users_counter = COPY_UNTRUSTED_VALUE(untrusted_users_counter_ptr);
-    WRITE_ONCE(*untrusted_users_counter_ptr, users_counter + 1);
+    COPY_VALUE_TO_UNTRUSTED(untrusted_users_counter_ptr, users_counter + 1);
     spinlock_unlock(&g_untrusted_page_lock);
 
-    *out_addr = (uint32_t*)addr;
+    *out_addr = (uint64_t*)addr;
     return 0;
 }
 
-static void free_untrusted_futex_word(uint32_t* addr) {
+static void free_untrusted_futex_word(uint64_t* addr) {
     uint64_t* untrusted_users_counter_ptr = (uint64_t*)ALIGN_DOWN((uintptr_t)addr, PAGE_SIZE);
 
     void* addr_to_munmap = NULL;
@@ -76,10 +82,10 @@ static void free_untrusted_futex_word(uint32_t* addr) {
         }
     } else {
         assert(users_counter);
-        WRITE_ONCE(*untrusted_users_counter_ptr, users_counter - 1);
+        COPY_VALUE_TO_UNTRUSTED(untrusted_users_counter_ptr, users_counter - 1);
     }
 #ifdef ASAN
-    asan_poison_region((uintptr_t)addr, 2 * sizeof(uint32_t), ASAN_POISON_HEAP_LEFT_REDZONE);
+    asan_poison_region((uintptr_t)addr, sizeof(uint64_t), ASAN_POISON_HEAP_LEFT_REDZONE);
 #endif
     spinlock_unlock(&g_untrusted_page_lock);
 
@@ -131,7 +137,12 @@ void _PalEventSet(PAL_HANDLE handle) {
     if (need_wake) {
         int ret = 0;
         do {
-            ret = ocall_futex(handle->event.signaled_untrusted, FUTEX_WAKE,
+            /* We use 8-byte ints instead of classic 4-byte ints for futexes. This is to mitigate
+             * CVE-2022-21166 (INTEL-SA-00615) which requires all writes to untrusted memory from
+             * within the enclave to be done in 8-byte chunks aligned to 8-bytes boundary. We hence
+             * cast this 8-byte int of the futex word to a 4-byte int here to be compatible with
+             * futex() syscall signature. */
+            ret = ocall_futex((uint32_t*)handle->event.signaled_untrusted, FUTEX_WAKE,
                               handle->event.auto_clear ? 1 : INT_MAX, /*timeout=*/NULL);
         } while (ret == -EINTR);
         /* This `FUTEX_WAKE` cannot really fail. Negative return value would mean malicious host,
@@ -172,7 +183,13 @@ int _PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
         }
         spinlock_unlock(&handle->event.lock);
 
-        int ret = ocall_futex(handle->event.signaled_untrusted, FUTEX_WAIT, 0, timeout_us);
+        /* We use 8-byte ints instead of classic 4-byte ints for futexes. This is to mitigate
+         * CVE-2022-21166 (INTEL-SA-00615) which requires all writes to untrusted memory from within
+         * the enclave to be done in 8-byte chunks aligned to 8-bytes boundary. We hence cast this
+         * 8-byte int of the futex word to a 4-byte int here to be compatible with futex() syscall
+         * signature. */
+        int ret = ocall_futex((uint32_t*)handle->event.signaled_untrusted, FUTEX_WAIT, 0,
+                              timeout_us);
         if (ret < 0 && ret != -EAGAIN) {
             if (added_to_count) {
                 spinlock_lock(&handle->event.lock);

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -133,8 +133,12 @@ typedef struct {
             bool signaled;
             bool auto_clear;
             /* Access to the *content* of this field should be atomic, because it's used as futex
-             * word on the untrusted host. */
-            uint32_t* signaled_untrusted;
+             * word on the untrusted host. We use 8-byte ints instead of classic 4-byte ints for
+             * this futex word. This is to mitigate CVE-2022-21166 (INTEL-SA-00615) which requires
+             * all writes to untrusted memory from within the enclave to be done in 8-byte chunks
+             * aligned to 8-bytes boundary. We can safely typecast this 8-byte int to a 4-byte futex
+             * word because Intel SGX implies a little-endian CPU. */
+            uint64_t* signaled_untrusted;
         } event;
     };
 }* PAL_HANDLE;


### PR DESCRIPTION
A malicious OS could map MMIO memory into the untrusted memory space of an enclave application (which can be used for e.g. parameter passing to/from ECALLs and OCALLs, or any external buffers that an enclave might use to communicate with its application). Then when the enclave writes to this memory, it could unintentionally propagate the stale (secret) data in its core fill buffers into the uncore, where it could later be extracted by malicious software.

Naturally aligned 8-byte writes are not affected by this vulnerability, so as SW mitigation, this commit makes all untrusted memory writes 8-byte wide and naturally aligned.

There is a side effect introduced to the Exitless (aka RPC-threads aka Switchless) feature by the fix of CVE-2022-21233 aka INTEL-SA-00657, which marks the feature as insecure and didn't fix it due to its complex usage of the untrusted memory. We assume the same for this fix.

Fixes https://github.com/gramineproject/gramine/issues/1235.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1237)
<!-- Reviewable:end -->
