### PR TITLE
[LibOS] Fix NULL pointer dereference in pseudo fs

### DIFF
--- a/libos/src/fs/libos_fs_pseudo.c
+++ b/libos/src/fs/libos_fs_pseudo.c
@@ -44,8 +44,12 @@ static struct pseudo_node* pseudo_find(struct libos_dentry* dent) {
         return pseudo_find_root(dent->mount->uri);
     }
 
+    assert(dent->parent != NULL);
     assert(dent->parent->inode);
+
     struct pseudo_node* parent_node = dent->parent->inode->data;
+    if (parent_node == NULL)
+        return NULL;
 
     /* Look for a child node with matching name */
     assert(parent_node->type == PSEUDO_DIR);

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -66,6 +66,7 @@ tests = {
     'mprotect_prot_growsdown': {},
     'multi_pthread': {},
     'munmap': {},
+    'open_file': {},
     'open_opath': {},
     'openmp': {
         # NOTE: This will use `libgomp` in GCC and `libomp` in Clang.

--- a/libos/test/regression/open_file.c
+++ b/libos/test/regression/open_file.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "common.h"
+
+int main(int argc, const char** argv) {
+    if (argc != 2) {
+        fprintf(stderr, "This test requires a file to test");
+        return 1;
+    }
+
+    int fd = CHECK(open(argv[1], O_RDONLY));
+    CHECK(close(fd));
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/shadow_pseudo_fs.manifest.template
+++ b/libos/test/regression/shadow_pseudo_fs.manifest.template
@@ -1,0 +1,24 @@
+{% set entrypoint = "open_file" -%}
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.argv = [ "{{ entrypoint }}", "/proc/test/nested/dirs/exec" ]
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+
+  # Let's shadow some file in /proc as it is a pseudo fs.
+  { path = "/proc/test/nested/dirs/exec", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1070,6 +1070,10 @@ class TC_40_FileSystem(RegressionTestCase):
         # proc/stat Linux-based formatting
         self.assertIn('/proc/stat test passed', stdout)
 
+    def test_022_shadow_pseudo_fs(self):
+        stdout, _ = self.run_binary(['shadow_pseudo_fs'])
+        self.assertIn('TEST OK', stdout)
+
     def test_030_fdleak(self):
         # The fd limit is rather arbitrary, but must be in sync with numbers from the test.
         # Currently test opens 10 fds simultaneously, so 50 is a safe margin for any fds that

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -96,6 +96,7 @@ manifests = [
   "select",
   "send_handle",
   "shared_object",
+  "shadow_pseudo_fs",
   "shebang_test_script",
   "sigaction_per_process",
   "sigaltstack",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -97,6 +97,7 @@ manifests = [
   "sealed_file_mod",
   "select",
   "send_handle",
+  "shadow_pseudo_fs",
   "shared_object",
   "sigaction_per_process",
   "sigaltstack",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`inode` in `data` field keep a specific file system data. In the case of pseudo fs it is a `pseudo_node`. However, when a lookup is done, the `dentry` might not be fully initialized. During mount, we are doing a lookup using [do_path_lookupat](https://github.com/gramineproject/gramine/blob/634d0392c3acec724dad5a6af8e6305f166eca57/libos/src/fs/libos_namei.c#L266):
```c
   struct lookup lookup = {
        .flags = flags,
        .name = name,
        .has_slash = has_slash,
        .dent = dent,
        .link_depth = link_depth,
    };

    /* Main part of the algorithm. Repeatedly call `lookup_enter_dentry`, then `lookup_advance`,
     * until we have finished the path. */

    ret = lookup_enter_dentry(&lookup);
    if (ret < 0)
        goto err;
    while (*lookup.name != '\0') {
        ret = lookup_advance(&lookup);
        if (ret < 0)
            goto err;
        ret = lookup_enter_dentry(&lookup);
        if (ret < 0)
            goto err;
    }
```

For `/proc/net/route`, we first find a `/proc`, which is a pseudo FS. Next, we are doing a lookup for `/proc/net`, which doesn't exists. In this case, `lookup_advance` allocates a new `dentry` (`lookup_adbance` -> `lookup_dcache_or_create` -> `get_new_dentry`). The new `dentry` gets the same mount functions like the parent (`/proc` which is pseudo):
```c
struct libos_dentry* get_new_dentry(struct libos_mount* mount, struct libos_dentry* parent,                                                                                                    
                                    const char* name, size_t name_len) {                               
    ...
    if (mount) {                                                                                       
        get_mount(mount);                                                                              
        dent->mount = mount;                                                                           
    }                                                                                                  
```
And we do another lookup in `/proc/net` for the `route`. Now our `dentry` is `/proc/net`. Which has the same `lookup` function as `/proc` which is a lookup for a `pseudo file`. Now in lookup we use a `data` which is pseudo fs specific. However these data isn't copy while creating a new `dentry`. We ended up with `SEGFAULT`.
```c
static struct pseudo_node* pseudo_find(struct libos_dentry* dent) {                                 
    ...                                                                 
    assert(dent->parent->inode);                                                                       
                                                                                                       
    struct pseudo_node* parent_node = dent->parent->inode->data;                                       
```

The simplest solution is to check in `pseudo file` if the `data` is set. In this case we end up with a valid hierarchy:
```
[pseudo   2] 040555 dr-x        proc/ (pseudo "proc")                                                      
[ synth   2] 040555 dr-x          net/                                                                 
[ synth   2] 040555 dr-x M          route/                                                             
[chroot   1] 100444 -r--              route (chroot "file:/proc/net/route")                         
```
This was generated with `dentry_dump` function.

However we can consider other solutions as well:
- Test if we really need to do a recursive lookup if we haven't found the first node.
- Should we really copy a lookup function from a parent in this case?

Fixes #1101.

## How to test this PR? <!-- (if applicable) -->

The test is added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1238)
<!-- Reviewable:end -->
