### PR TITLE
[LibOS] Drop leftovers of old macro

### DIFF
--- a/libos/src/fs/libos_dcache.c
+++ b/libos/src/fs/libos_dcache.c
@@ -472,8 +472,6 @@ static void dump_dentry(struct libos_dentry* dent, unsigned int level) {
     }
 }
 
-#undef DUMP_FLAG
-
 void dump_dcache(struct libos_dentry* dent) {
     lock(&g_dcache_lock);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It was removed in 29f127542a4d81a8b461f05a4b36344d89bed3fa.

## How to test this PR? <!-- (if applicable) -->

Build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1240)
<!-- Reviewable:end -->
