### PR TITLE
[LibOS] Add support for two new pseudo files in /proc dir

### DIFF
--- a/libos/include/libos_types.h
+++ b/libos/include/libos_types.h
@@ -162,6 +162,9 @@ typedef uint32_t IDTYPE;
 
 #define PID_MAX_LIMIT 4194304 /* Linux limit 2^22, this value is *one greater* than max PID */
 #define PID_MAX (PID_MAX_LIMIT - 1)
+/* The following values are taken from Linux v6.2 */
+#define PIPE_MAX_SIZE 1048576
+#define LEASE_BREAK_TIME_MAX 45
 
 typedef uint64_t HASHTYPE;
 

--- a/libos/test/fs/common.h
+++ b/libos/test/fs/common.h
@@ -26,7 +26,13 @@
         type __dummy;                               \
         __builtin_add_overflow((val), 0, &__dummy); \
     })
-
+#define CHECK(x) ({                                         \
+    __typeof__(x) _x = (x);                                 \
+    if (_x == -1) {                                         \
+        err(1, "error at %s (line %d): %m", #x, __LINE__);  \
+    }                                                       \
+    _x;                                                     \
+})
 noreturn void fatal_error(const char* fmt, ...);
 void setup(void);
 int open_input_fd(const char* path);

--- a/libos/test/fs/meson.build
+++ b/libos/test/fs/meson.build
@@ -42,6 +42,7 @@ tests = {
     },
     'open_close': {},
     'open_flags': {},
+    'proc_pseudo_files': {},
     'read_write': {},
     'seek_tell': {},
     'seek_tell_truncate': {},

--- a/libos/test/fs/proc_pseudo_files.c
+++ b/libos/test/fs/proc_pseudo_files.c
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Fortanix Inc
+ *                    Nirjhar Roy <nirjhar.roy@fortanix.com> */
+
+/* Test description: this test reads the contents of the pseudo file /proc/sys/fs/pipe-max-size and
+ * /proc/sys/fs/lease-break-time and then tries to match the read contents with the expected
+ * contents. */
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ucontext.h>
+
+#include "common.h"
+
+#define BUF_SZ 1024
+/* The following values are defined in gramine/libos/include/libos_types.h */
+#define PIPE_MAX_SIZE "1048576"
+#define LEASE_BREAK_TIME "45"
+
+int main(void) {
+    struct test_cases {
+        const char* path;
+        const char* expected_value;
+        size_t expected_length;
+    } tc [] = {
+        {
+            "/proc/sys/fs/pipe-max-size",
+            PIPE_MAX_SIZE,
+            strlen(PIPE_MAX_SIZE)
+        },
+        {
+            "/proc/sys/fs/lease-break-time",
+            LEASE_BREAK_TIME,
+            strlen(LEASE_BREAK_TIME)
+        },
+    };
+
+    char buf[BUF_SZ];
+    for (size_t i = 0; i < sizeof(tc)/sizeof(*tc); i++) {
+        memset(buf, 0, sizeof(buf));
+        int fd = open_input_fd(tc[i].path);
+        if (fd < 0)
+            errx(1,"opening file %s failed", tc[i].path);
+        read_fd(tc[i].path, fd, buf, tc[i].expected_length);
+        if (strcmp(tc[i].expected_value, buf)) {
+            errx(1,"Content mismatch for file = %s. Expected %s got %s", tc[i].path,
+                 tc[i].expected_value, buf);
+        }
+
+        struct stat sb;
+        CHECK(stat(tc[i].path, &sb));
+        if (!S_ISREG(sb.st_mode))
+            errx(1,"Unexpected type for file = %s. Expected S_ISREG", tc[i].path);
+        CHECK(close(fd));
+    }
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/fs/test_fs.py
+++ b/libos/test/fs/test_fs.py
@@ -343,3 +343,17 @@ class TC_01_Sync(RegressionTestCase):
     @unittest.skip('file handle sync is not supported yet')
     def test_003_multiple_writers_many_processes_and_threads(self):
         self._test_multiple_writers(20, 5, 5)
+
+class TC_02_Proc_Pseudo_Files(RegressionTestCase):
+    TEST_DIR = 'tmp'
+
+    def setUp(self):
+        shutil.rmtree(self.TEST_DIR, ignore_errors=True)
+        os.mkdir(self.TEST_DIR)
+
+    def tearDown(self):
+        shutil.rmtree(self.TEST_DIR)
+
+    def test_000_proc_pseudo_files(self):
+        stdout, stderr = self.run_binary(['proc_pseudo_files'])
+        self.assertIn('TEST OK', stdout)

--- a/libos/test/fs/tests.toml
+++ b/libos/test/fs/tests.toml
@@ -13,6 +13,7 @@ manifests = [
   "multiple_writers",
   "open_close",
   "open_flags",
+  "proc_pseudo_files",
   "read_write",
   "seek_tell",
   "seek_tell_truncate",


### PR DESCRIPTION
The files which are added are:
- /proc/sys/fs/pipe-max-size
- /proc/sys/fs/lease-break-time

The values are hard-coded and taken from Linux v6.2, see:
- https://elixir.bootlin.com/linux/v6.2/source/fs/pipe.c#L54
- https://elixir.bootlin.com/linux/v6.2/source/fs/locks.c#L93

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

