### PR TITLE
[LibOS] Expose SGX sealing keys under `/dev/attestation/keys/`

### DIFF
--- a/libos/src/fs/dev/attestation.c
+++ b/libos/src/fs/dev/attestation.c
@@ -406,6 +406,17 @@ static int init_sgx_attestation(struct pseudo_node* attestation) {
     target_info->perm = PSEUDO_PERM_FILE_RW;
     target_info->str.save = &target_info_save;
 
+    /* dummy retrieval of SGX sealing keys, so that they appear under /dev/attestation/keys/ */
+    const char* sealing_key_names[2] = { "_sgx_mrenclave", "_sgx_mrsigner" };
+    for (size_t i = 0; i < 2; i++) {
+        struct libos_encrypted_files_key* key;
+        int ret = get_or_create_encrypted_files_key(sealing_key_names[i], &key);
+        if (ret < 0) {
+            log_error("Cannot initialize SGX sealing key `%s`", sealing_key_names[i]);
+            return ret;
+        }
+    }
+
     if (!strcmp(g_pal_public_state->attestation_type, "none")) {
         log_debug("host is Linux-SGX and remote attestation type is 'none', skipping "
                   "/dev/attestation/quote file");

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -324,7 +324,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('TEST OK', stdout, 'test failed: {}'.format(cmd))
 
     def test_230_keys(self):
-        stdout, _ = self.run_binary(['keys'])
+        if HAS_SGX:
+            stdout, _ = self.run_binary(['keys', 'sgx'])
+        else:
+            stdout, _ = self.run_binary(['keys'])
         self.assertIn('TEST OK', stdout)
 
     def test_300_shared_object(self):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine has two SGX sealing keys, named `_sgx_mrenclave` and `_sgx_mrsigner`. Previously, these keys could be used in the manifest file's `fs.mounts = [ key_name = "..." ]` syntax, but these keys were not exposed as `/dev/attestation/keys/{_sgx_mrenclave,_sgx_mrsigner}`.

This PR fixes this small bug.

## How to test this PR? <!-- (if applicable) -->

A `keys` regression test was augmented to check these files.

Also, one can manually check these files via Busybox:
```sh
cd CI-Examples/busybox/
make SGX=1
gramine-sgx busybox sh

# running Busybox terminal inside SGX enclave now

$ ls /dev/attestation/keys
_sgx_mrenclave
_sgx_mrsigner

$ hexdump /dev/attestation/keys/_sgx_mrenclave
0000000 2718 40a7 0719 0eeb 9c5d 860e 02e7 5edf
0000010

$ hexdump /dev/attestation/keys/_sgx_mrsigner
0000000 0372 de63 b52b feb7 24a5 c452 5b04 c815
0000010

$ hexdump /dev/attestation/keys/_sgx_dummy
hexdump: /dev/attestation/keys/_sgx_dummy: No such file or directory
```