### PR TITLE
Use python according to env

### DIFF
--- a/python/gramine-gen-depend
+++ b/python/gramine-gen-depend
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-manifest
+++ b/python/gramine-manifest
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-sgx-gen-private-key
+++ b/python/gramine-sgx-gen-private-key
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (c) 2021 Intel Corporation
 #                    Wojtek Porczyk <woju@invisiblethingslab.com>

--- a/python/gramine-sgx-get-token
+++ b/python/gramine-sgx-get-token
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-sgx-sign
+++ b/python/gramine-sgx-sign
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>

--- a/python/gramine-sgx-sigstruct-view
+++ b/python/gramine-sgx-sigstruct-view
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2023 Intel Corporation
 #                    Dmitrii Kuvaiskii <dmitrii.kuvaiskii@intel.com>

--- a/python/gramine-test
+++ b/python/gramine-test
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2021 Intel Corporation
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This pull request changes the shebang from `#!/usr/bin/python3` to `#!/usr/bin/env python3` in order to pick up the python executable that is configured on the host system where the python scripts are invoked.

### Motivation
For python scripts (`gramine-gen-depend`, `gramine-manifest`, etc) the `python` executable under `/usr/bin/` is picked up even though it may not be the "active" one as per the `PATH` or some other system configuration.

The motivation for this change came through attempting to build `gramine` from source, in a docker image based on [`python:3.10-bullseye`](https://github.com/docker-library/python/blob/8a8d6baac38dcd208f699ae2eb10f0893a764035/3.10/bullseye/Dockerfile) (debian) and running into issues with `graminelibos` or some dependencies such as `click` not being found. 

## How to test this PR? <!-- (if applicable) -->
One may run one of the python scripts, such as `gramine-sgx-gen-private-key`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1250)
<!-- Reviewable:end -->
