### PR TITLE
[Pal/Linux-SGX] EDMM hybrid allocation

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -483,6 +483,20 @@ before enclave creation (because it involves more enclave exits and syscalls).
 .. note::
    Support for EDMM first appeared in Linux 6.0.
 
+EDMM Hybrid allocation (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.edmm_heap_prealloc_size = "[SIZE]"
+    (default: "0")
+
+When ``sgx.edmm_enable`` is enabled, users can precisely set the amount of heap
+to pre-allocate by setting the ``sgx.edmm_heap_prealloc_size``. For
+example, when size is set to "64M" Gramine will pre-allocate top 64M of heap
+pages rather than allocating dynamically and thus the name "Hybrid allocation".
+This may help to balance out the cost between load time and run time.
+
 Enclave size
 ^^^^^^^^^^^^
 
@@ -824,8 +838,10 @@ predictable.
 Please note that using this option makes sense only when the :term:`EPC` is
 large enough to hold the whole heap area.
 
-This option is invalid (i.e. must be ``false``) if specified together with
-``sgx.edmm_enable``, as there are no heap pages to pre-fault.
+This option is invalid (i.e. must be ``false``) when only ``sgx.edmm_enable``is
+specified, as there are no heap pages to pre-fault. But if used together with
+``sgx.edmm_heap_prealloc_size``, then the pre-allocated heap size will be
+pre-faulted.
 
 Enabling per-thread and process-wide SGX stats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pal/src/host/linux-sgx/enclave_ecalls.c
+++ b/pal/src/host/linux-sgx/enclave_ecalls.c
@@ -101,6 +101,7 @@ void handle_ecall(long ecall_index, void* ecall_args, void* exit_target, void* e
                        COPY_UNTRUSTED_VALUE(&start_args->rpc_queue),
                        COPY_UNTRUSTED_VALUE(&start_args->dns_host_conf),
                        COPY_UNTRUSTED_VALUE(&start_args->edmm_enabled),
+                       COPY_UNTRUSTED_VALUE(&start_args->edmm_heap_prealloc_size),
                        COPY_UNTRUSTED_VALUE(&start_args->reserved_mem_ranges),
                        COPY_UNTRUSTED_VALUE(&start_args->reserved_mem_ranges_size));
     } else {

--- a/pal/src/host/linux-sgx/host_ecalls.c
+++ b/pal/src/host/linux-sgx/host_ecalls.c
@@ -9,8 +9,8 @@
 int ecall_enclave_start(char* libpal_uri, char* args, size_t args_size, char* env,
                         size_t env_size, int parent_stream_fd, sgx_target_info_t* qe_targetinfo,
                         struct pal_topo_info* topo_info, struct pal_dns_host_conf* dns_conf,
-                        bool edmm_enabled, void* reserved_mem_ranges,
-                        size_t reserved_mem_ranges_size) {
+                        bool edmm_enabled, size_t edmm_heap_prealloc_size,
+                        void* reserved_mem_ranges, size_t reserved_mem_ranges_size) {
     g_rpc_queue = NULL;
 
     if (g_pal_enclave.rpc_thread_num > 0) {
@@ -34,6 +34,7 @@ int ecall_enclave_start(char* libpal_uri, char* args, size_t args_size, char* en
         .topo_info                = topo_info,
         .dns_host_conf            = dns_conf,
         .edmm_enabled             = edmm_enabled,
+        .edmm_heap_prealloc_size  = edmm_heap_prealloc_size,
         .reserved_mem_ranges      = reserved_mem_ranges,
         .reserved_mem_ranges_size = reserved_mem_ranges_size,
         .rpc_queue                = g_rpc_queue,

--- a/pal/src/host/linux-sgx/host_ecalls.h
+++ b/pal/src/host/linux-sgx/host_ecalls.h
@@ -9,8 +9,8 @@
 int ecall_enclave_start(char* libpal_uri, char* args, size_t args_size, char* env, size_t env_size,
                         int parent_stream_fd, sgx_target_info_t* qe_targetinfo,
                         struct pal_topo_info* topo_info, struct pal_dns_host_conf* host_conf,
-                        bool edmm_enabled, void* reserved_mem_ranges,
-                        size_t reserved_mem_ranges_size);
+                        bool edmm_enabled, size_t edmm_heap_prealloc_size,
+                        void* reserved_mem_ranges, size_t reserved_mem_ranges_size);
 
 int ecall_thread_start(void);
 

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -47,6 +47,7 @@ struct pal_enclave {
     unsigned long rpc_thread_num;
     unsigned long ssa_frame_size;
     bool edmm_enabled;
+    size_t edmm_heap_prealloc_size;
     enum sgx_attestation_type attestation_type;
     char* libpal_uri; /* Path to the PAL binary */
 

--- a/pal/src/host/linux-sgx/pal_ecall_types.h
+++ b/pal/src/host/linux-sgx/pal_ecall_types.h
@@ -29,6 +29,7 @@ struct ecall_enclave_start {
     struct pal_topo_info*     topo_info;
     struct pal_dns_host_conf* dns_host_conf;
     unsigned char             edmm_enabled;
+    size_t                    edmm_heap_prealloc_size;
     void*                     reserved_mem_ranges;
     size_t                    reserved_mem_ranges_size;
 

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -34,6 +34,7 @@ extern struct pal_linuxsgx_state {
     /* enclave information */
     bool enclave_initialized;        /* thread creation ECALL is allowed only after this is set */
     bool edmm_enabled;
+    size_t edmm_heap_prealloc_size;
     sgx_target_info_t qe_targetinfo; /* received from untrusted host, use carefully */
     sgx_report_body_t enclave_info;  /* cached self-report result, trusted */
 
@@ -72,7 +73,8 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
                              size_t args_size, void* uptr_env, size_t env_size,
                              int parent_stream_fd, void* uptr_qe_targetinfo, void* uptr_topo_info,
                              void* uptr_rpc_queue, void* uptr_dns_conf, bool edmm_enabled,
-                             void* urts_reserved_mem_ranges, size_t urts_reserved_mem_ranges_size);
+                             size_t edmm_heap_prealloc_size, void* urts_reserved_mem_ranges,
+                             size_t urts_reserved_mem_ranges_size);
 void pal_start_thread(void);
 
 extern char __text_start, __text_end, __data_start, __data_end;

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -104,6 +104,7 @@ class Manifest:
         sgx.setdefault('require_amx', False)
         sgx.setdefault('require_exinfo', False)
         sgx.setdefault('enable_stats', False)
+        sgx.setdefault('edmm_heap_prealloc_size', '0')
 
         if not isinstance(sgx['trusted_files'], list):
             raise ValueError("Unsupported trusted files syntax, more info: " +

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -54,6 +54,10 @@ def rounddown(addr):
     return addr - addr % offs.PAGESIZE
 
 
+def is_aligned(val, alignment):
+    return (val % alignment == 0)
+
+
 def parse_size(value):
     scale = 1
     if value.endswith('K'):
@@ -277,9 +281,25 @@ def populate_memory_areas(attr, areas, enclave_base, enclave_heap_min):
 
     gen_area_content(attr, areas, enclave_base, enclave_heap_min)
 
-    # Enclaves with EDMM do not add "free" memory at startup.
+    # Enclaves with EDMM do not add "free" memory at startup but if heap is pre-allocated
+    # using manifest `sgx.edmm_heap_prealloc_size` add the "free" pre-allocated pages.
+    # PS: Assumption here is that we have a single heap region (called "free") that is beneath all
+    # other statically allocated memory areas(manifest, ssa, tls. tcs, stack, sig_stack, pal).
     if attr['edmm_enable']:
-        return areas
+        free_preallocated = []
+        if (attr['edmm_heap_prealloc_size'] > 0 and
+                last_populated_addr > enclave_heap_min):
+
+            flags = PAGEINFO_R | PAGEINFO_W | PAGEINFO_X | PAGEINFO_REG
+            start_addr = last_populated_addr - attr['edmm_heap_prealloc_size']
+            if start_addr < enclave_heap_min:
+                raise Exception(" sgx.edmm_heap_prealloc_size cannot be more than total heap size!")
+
+            free_preallocated.append(
+                MemoryArea('free', addr=start_addr, size=attr['edmm_heap_prealloc_size'],
+                           flags=flags, measure=False))
+
+        return areas + free_preallocated
 
     free_areas = []
     for area in areas:
@@ -438,6 +458,17 @@ def generate_measurement(enclave_base, attr, areas, verbose=False):
     return mrenclave.digest()
 
 
+def check_memory_area_holes(attr, areas, enclave_base):
+    last_populated_addr = enclave_base + attr['enclave_size']
+
+    for area in areas:
+        if last_populated_addr != area.addr + area.size:
+            return 1
+        last_populated_addr = area.addr
+
+    return 0
+
+
 def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
     with open(manifest_path, 'rb') as f: # pylint: disable=invalid-name
         manifest_data = f.read()
@@ -447,22 +478,32 @@ def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
     attr = {
         'enclave_size': parse_size(manifest_sgx['enclave_size']),
         'edmm_enable': manifest_sgx.get('edmm_enable', False),
+        'edmm_heap_prealloc_size': parse_size(manifest_sgx['edmm_heap_prealloc_size']),
         'max_threads': manifest_sgx.get('max_threads', manifest_sgx.get('thread_num')),
         'isv_prod_id': manifest_sgx['isvprodid'],
         'isv_svn': manifest_sgx['isvsvn'],
     }
     attr['flags'], attr['xfrms'], attr['misc_select'] = get_enclave_attributes(manifest_sgx)
 
+    if not attr['edmm_enable'] and attr['edmm_heap_prealloc_size'] > 0:
+        raise Exception("sgx.edmm_heap_prealloc_size should be used along with sgx.edmm_enable!")
+
+    if attr['edmm_heap_prealloc_size'] < 0 or  \
+       is_aligned(attr['edmm_heap_prealloc_size'], offs.PAGESIZE) == 0:
+        raise Exception("sgx.edmm_heap_prealloc_size: {0} should be greater than or equal to 0!"
+                        .format(attr['edmm_heap_prealloc_size']))
+
     if verbose:
         print('Attributes:')
-        print(f'    size:        {attr["enclave_size"]:#x}')
-        print(f'    edmm:        {attr["edmm_enable"]}')
-        print(f'    max_threads: {attr["max_threads"]}')
-        print(f'    isv_prod_id: {attr["isv_prod_id"]}')
-        print(f'    isv_svn:     {attr["isv_svn"]}')
-        print(f'    attr.flags:  {attr["flags"]:#x}')
-        print(f'    attr.xfrm:   {attr["xfrms"]:#x}')
-        print(f'    misc_select: {attr["misc_select"]:#x}')
+        print(f'    size:                    {attr["enclave_size"]:#x}')
+        print(f'    edmm:                    {attr["edmm_enable"]}')
+        print(f'    edmm_heap_prealloc_size: {attr["edmm_heap_prealloc_size"]:#x}')
+        print(f'    max_threads:             {attr["max_threads"]}')
+        print(f'    isv_prod_id:             {attr["isv_prod_id"]}')
+        print(f'    isv_svn:                 {attr["isv_svn"]}')
+        print(f'    attr.flags:              {attr["flags"]:#x}')
+        print(f'    attr.xfrm:               {attr["xfrms"]:#x}')
+        print(f'    misc_select:             {attr["misc_select"]:#x}')
 
         print('SGX remote attestation:')
         attestation_type = manifest_sgx.get('remote_attestation', 'none')
@@ -491,6 +532,11 @@ def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
         ] + memory_areas
 
     memory_areas = populate_memory_areas(attr, memory_areas, enclave_base, enclave_heap_min)
+
+    # Ensure no holes in the populated memory areas
+    memory_area_holes = check_memory_area_holes(attr, memory_areas, enclave_base)
+    if memory_area_holes:
+        raise Exception('Cannot have holes in memory areas!')
 
     # Generate measurement
     mrenclave = generate_measurement(enclave_base, attr, memory_areas, verbose=verbose)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

To reduce the enclave exits, pre-allocate minimal heap from top as required by application and allocate the remaining dynamically using EDMM. As part of this commit, introduced a new manifest option `sgx.edmm_heap_prealloc_size` to pre-allocate amount of heap required by the application.

Note: This change assumes there is a single heap region (also called "free") that is beneath all other statically allocated memory areas (manifest, ssa, tls. tcs, stack, sig_stack, pal).

Sample memory regions with `helloworld` program
000000000fffc000-0000000010000000 manifest
000000000ff7c000-000000000fffc000 ssa
000000000ff6c000-000000000ff7c000 tcs
000000000ff5c000-000000000ff6c000 tls
000000000ff1c000-000000000ff5c000 stack
000000000fedc000-000000000ff1c000 stack
000000000fe9c000-000000000fedc000 stack
000000000fe5c000-000000000fe9c000 stack
000000000fe1c000-000000000fe5c000 stack
000000000fddc000-000000000fe1c000 stack
000000000fd9c000-000000000fddc000 stack
000000000fd5c000-000000000fd9c000 stack
000000000fd1c000-000000000fd5c000 stack
000000000fcdc000-000000000fd1c000 stack
000000000fc9c000-000000000fcdc000 stack
000000000fc5c000-000000000fc9c000 stack
000000000fc1c000-000000000fc5c000 stack
000000000fbdc000-000000000fc1c000 stack
000000000fb9c000-000000000fbdc000 stack
000000000fb5c000-000000000fb9c000 stack
000000000fb4c000-000000000fb5c000 sig_stack
000000000fb3c000-000000000fb4c000 sig_stack
000000000fb2c000-000000000fb3c000 sig_stack
000000000fb1c000-000000000fb2c000 sig_stack
000000000fb0c000-000000000fb1c000 sig_stack
000000000fafc000-000000000fb0c000 sig_stack
000000000faec000-000000000fafc000 sig_stack
000000000fadc000-000000000faec000 sig_stack
000000000facc000-000000000fadc000 sig_stack
000000000fabc000-000000000facc000 sig_stack
000000000faac000-000000000fabc000 sig_stack
000000000fa9c000-000000000faac000 sig_stack
000000000fa8c000-000000000fa9c000 sig_stack
000000000fa7c000-000000000fa8c000 sig_stack
000000000fa6c000-000000000fa7c000 sig_stack
000000000fa5c000-000000000fa6c000 sig_stack
000000000f9f5000-000000000fa5c000 pal
0000000000010000-000000000f9f5000 free

Fixes #1221 

## How to test this PR? <!-- (if applicable) -->
Regular EDMM CI pipeline with  `sgx.edmm_heap_prealloc_size`. 
Note: Currently the default value for `sgx.edmm_heap_prealloc_size` is set to zero. Based on experiments, need to set this to a reasonable default.

