### PR TITLE
[LibOS] Add support for `setsid()`/`getsid()`

### DIFF
--- a/libos/include/libos_process.h
+++ b/libos/include/libos_process.h
@@ -9,9 +9,12 @@
 #include "libos_fs.h"
 #include "libos_handle.h"
 #include "libos_lock.h"
+#include "libos_rwlock.h"
 #include "libos_types.h"
 #include "list.h"
 #include "pal.h"
+
+extern struct libos_rwlock g_process_id_lock;
 
 DEFINE_LIST(libos_child_process);
 DEFINE_LISTP(libos_child_process);
@@ -35,8 +38,11 @@ struct libos_process {
     IDTYPE pid;
     IDTYPE ppid;
 
-    /* This field should be accessed atomically, so no lock needed. */
+    /* Process Group ID. Protected by `g_process_id_lock`. */
     IDTYPE pgid;
+
+    /* Session ID. Protected by `g_process_id_lock`. */
+    IDTYPE sid;
 
     /* Currently all threads share filesystem information. For more info check `CLONE_FS` flag in
      * `clone.c`. Protected by `fs_lock`. */

--- a/libos/src/bookkeep/libos_thread.c
+++ b/libos/src/bookkeep/libos_thread.c
@@ -19,6 +19,7 @@
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_process.h"
+#include "libos_rwlock.h"
 #include "libos_signal.h"
 #include "libos_thread.h"
 #include "libos_vma.h"
@@ -148,7 +149,9 @@ static int init_main_thread(void) {
         return -ESRCH;
     }
     g_process.pid = cur_thread->tid;
-    __atomic_store_n(&g_process.pgid, g_process.pid, __ATOMIC_RELEASE);
+    rwlock_write_lock(&g_process_id_lock);
+    g_process.pgid = g_process.pid;
+    rwlock_write_unlock(&g_process_id_lock);
 
     int64_t uid_int64;
     ret = toml_int_in(g_manifest_root, "loader.uid", /*defaultval=*/0, &uid_int64);

--- a/libos/src/sys/libos_getpid.c
+++ b/libos/src/sys/libos_getpid.c
@@ -1,11 +1,13 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *                    Borys Popławski <borysp@invisiblethingslab.com>
+ *                    Kailun Qin <kailun.qin@intel.com>
  */
 
 #include "libos_lock.h"
 #include "libos_process.h"
+#include "libos_rwlock.h"
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_types.h"
@@ -37,23 +39,35 @@ long libos_syscall_setpgid(pid_t pid, pid_t pgid) {
     }
 
     if (!pid || g_process.pid == (IDTYPE)pid) {
-        __atomic_store_n(&g_process.pgid, (IDTYPE)pgid ?: g_process.pid, __ATOMIC_RELEASE);
+        /* TODO: Currently we do not support checking that:
+         * - the target process group to be joined (specified by `pgid`) must exist;
+         * - the process group of the joining process (specified by `pid`) and the target process
+         *   group to be joined must have the same session ID. */
+
+        rwlock_write_lock(&g_process_id_lock);
+        g_process.pgid = (IDTYPE)pgid ?: g_process.pid;
+        rwlock_write_unlock(&g_process_id_lock);
+
         /* TODO: inform parent about pgid change. */
         return 0;
     }
 
     /* TODO: Currently we do not support setting pgid of children processes. */
-    return -EINVAL;
+    return -ESRCH;
 }
 
 long libos_syscall_getpgid(pid_t pid) {
     if (!pid || g_process.pid == (IDTYPE)pid) {
-        return __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE);
+        rwlock_read_lock(&g_process_id_lock);
+        long ret = g_process.pgid;
+        rwlock_read_unlock(&g_process_id_lock);
+
+        return ret;
     }
 
     /* TODO: Currently we do not support getting pgid of other processes.
      * Implement child lookup once `libos_syscall_setpgid` sends info to the parent. */
-    return -EINVAL;
+    return -ESRCH;
 }
 
 long libos_syscall_getpgrp(void) {
@@ -61,12 +75,39 @@ long libos_syscall_getpgrp(void) {
 }
 
 long libos_syscall_setsid(void) {
-    /* TODO: currently we do not support session management. */
-    return -ENOSYS;
+    rwlock_write_lock(&g_process_id_lock);
+
+    IDTYPE current_pid = g_process.pid;
+    IDTYPE current_pgid = g_process.pgid;
+
+    /* Fail if the calling process is already a process group leader. */
+    if (current_pid == current_pgid) {
+        rwlock_write_unlock(&g_process_id_lock);
+        return -EPERM;
+    }
+
+    /* TODO: Currently we do not fail if a process group ID already exists that equals the session
+     * ID to be set (which is made the same as the process ID of the calling process). */
+
+    /* The calling process is the leader of the new session and the process group leader of the new
+     * process group. */
+    g_process.sid = current_pid;
+    g_process.pgid = current_pid;
+
+    rwlock_write_unlock(&g_process_id_lock);
+
+    return current_pid;
 }
 
 long libos_syscall_getsid(pid_t pid) {
-    /* TODO: currently we do not support session management. */
-    __UNUSED(pid);
-    return -ENOSYS;
+    if (!pid || g_process.pid == (IDTYPE)pid) {
+        rwlock_read_lock(&g_process_id_lock);
+        long ret = g_process.sid;
+        rwlock_read_unlock(&g_process_id_lock);
+
+        return ret;
+    }
+
+    /* TODO: Currently we do not support getting sid of other processes. */
+    return -ESRCH;
 }

--- a/libos/src/sys/libos_ioctl.c
+++ b/libos/src/sys/libos_ioctl.c
@@ -8,6 +8,7 @@
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_process.h"
+#include "libos_rwlock.h"
 #include "libos_signal.h"
 #include "libos_table.h"
 #include "linux_abi/errors.h"
@@ -69,7 +70,9 @@ long libos_syscall_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
                 ret = -EFAULT;
                 break;
             }
-            *(int*)arg = __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE);
+            rwlock_read_lock(&g_process_id_lock);
+            *(int*)arg = g_process.pgid;
+            rwlock_read_unlock(&g_process_id_lock);
             ret = 0;
             break;
         case FIONBIO:

--- a/libos/src/sys/libos_sigaction.c
+++ b/libos/src/sys/libos_sigaction.c
@@ -15,6 +15,7 @@
 #include "libos_ipc.h"
 #include "libos_lock.h"
 #include "libos_process.h"
+#include "libos_rwlock.h"
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_utils.h"
@@ -373,7 +374,9 @@ int do_kill_proc(IDTYPE sender, IDTYPE pid, int sig) {
 }
 
 int do_kill_pgroup(IDTYPE sender, IDTYPE pgid, int sig) {
-    IDTYPE current_pgid = __atomic_load_n(&g_process.pgid, __ATOMIC_ACQUIRE);
+    rwlock_read_lock(&g_process_id_lock);
+    IDTYPE current_pgid = g_process.pgid;
+    rwlock_read_unlock(&g_process_id_lock);
     if (!pgid) {
         pgid = current_pgid;
     }

--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -747,10 +747,6 @@ skip = yes
 [getrusage*]
 skip = yes
 
-# session management not supported
-[getsid*]
-skip = yes
-
 # Requires support for getsockopt(level=SOL_SOCKET, optname=SO_PEERCRED, ...)
 [getsockopt02]
 skip = yes
@@ -2070,6 +2066,10 @@ skip = yes
 [setrlimit06]
 skip = yes
 
+# The test expects failure in creating a new session whose session ID equals a process group ID that
+# already exists. This check on colluding IDs is however unsupported in Gramine. Note that the test
+# is also broken on Clang < 12 where Clang/LLVM handles infinite loops incorrectly. See
+# https://bugs.llvm.org/show_bug.cgi?id=965.
 [setsid01]
 skip = yes
 

--- a/libos/test/ltp/ltp_sgx.cfg
+++ b/libos/test/ltp/ltp_sgx.cfg
@@ -172,9 +172,6 @@ skip = yes
 [getrlimit02]
 skip = yes
 
-[getsid01]
-skip = yes
-
 [getsockname01]
 skip = yes
 

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -115,6 +115,7 @@ tests = {
     'shared_object': {
         'pie': true,
     },
+    'sid': {},
     'sigaction_per_process': {},
     'sigaltstack': {},
     'sighandler_reset': {},

--- a/libos/test/regression/sid.c
+++ b/libos/test/regression/sid.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Kailun Qin <kailun.qin@intel.com>
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+int main(int argc, const char** argv) {
+    /* The test is based on the assumption that it's started as the first member of the process
+     * group (i.e., the group leader); setsid() should then fail in the first place. */
+    errno = 0;
+    pid_t psid = setsid();
+    if (psid != -1 || errno != EPERM) {
+        errx(1, "Unexpected setsid error (expected: %d, actual: %d)", EPERM, errno);
+    }
+
+    psid = CHECK(getsid(0));
+    pid_t p = CHECK(fork());
+    if (p == 0) {
+        /* Child created via fork inherits its parent's session ID. */
+        pid_t sid = CHECK(getsid(0));
+        if (sid != psid) {
+            errx(1, "Child: unexpected child's sid (expected: %d, actual: %d)", psid, sid);
+        }
+
+        /* On setsid() success, the calling process is the leader of the new session (i.e., its
+         * session ID is made the same as its process ID). It also becomes the process group leader
+         * of a new process group in the session (i.e., its process group ID is made the same as its
+         * process ID). */
+        pid_t new_sid = CHECK(setsid());
+        if (CHECK(getsid(0)) == sid || CHECK(getsid(0)) != new_sid ||
+            new_sid != getpid() || CHECK(getpgid(0)) != new_sid) {
+            errx(1, "Child: setsid returned wrong value: %d (expected: %d)", new_sid, getpid());
+        }
+
+        p = CHECK(fork());
+        if (p == 0) {
+            sid = CHECK(getsid(0));
+
+            /* A forked child of the session leader should be able to create a new session. */
+            new_sid = CHECK(setsid());
+            if (CHECK(getsid(0)) == sid || CHECK(getsid(0)) != new_sid ||
+                new_sid != getpid() || CHECK(getpgid(0)) != new_sid) {
+                errx(1, "Grandchild: setsid returned wrong value: %d (expected: %d)", new_sid,
+                     getpid());
+            }
+            exit(0);
+        }
+
+        int status = 0;
+        CHECK(wait(&status));
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            errx(1, "Grandchild: died with status: %#x", status);
+        }
+
+        exit(0);
+    }
+
+    /* NOTE: in a "standard" usage of setsid() for daemonizing, the parent should be terminated to
+     * ensure the new process is an orphan (adopted by init) and also return control to the calling
+     * shell. Here we just wait for child termination for testing purposes. */
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        errx(1, "Child: died with status: %#x", status);
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -971,6 +971,10 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['hostname_extra_runtime_conf', socket.gethostname()])
         self.assertIn("TEST OK", stdout)
 
+    def test_130_sid(self):
+        stdout, _ = self.run_binary(['sid'])
+        self.assertIn("TEST OK", stdout)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -100,6 +100,7 @@ manifests = [
   "shared_object",
   "shadow_pseudo_fs",
   "shebang_test_script",
+  "sid",
   "sigaction_per_process",
   "sigaltstack",
   "sighandler_reset",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -101,6 +101,7 @@ manifests = [
   "send_handle",
   "shadow_pseudo_fs",
   "shared_object",
+  "sid",
   "sigaction_per_process",
   "sigaltstack",
   "sighandler_reset",


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously, session-management syscalls e.g., `setsid()`, `getsid()`, were not supported in Gramine. However, they are required for many workloads, particularly the ones that use JVM.

This commit adds basic support for session-management syscalls and enables the related tests. As a side effect of the introduction of `setsid()`, `pgid` and `sid` in struct `libos_process` are now both not suitable for atomic access so we introduced a new global lock and used it everywhere where we access `pgid` and `sid`.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Newly enabled LTP tests + unit tests

## Useful references
How session-management syscalls work:
* https://man7.org/linux/man-pages/man2/setsid.2.html
* https://man7.org/linux/man-pages/man2/getsid.2.html
* https://www.andy-pearce.com/blog/posts/2013/Aug/process-groups-and-sessions/
* https://biriukov.dev/docs/fd-pipe-session-terminal/3-process-groups-jobs-and-sessions/#sessions

Linux source code on:
* `setsid`: https://elixir.bootlin.com/linux/v6.2/source/kernel/sys.c#L1207
* `getsid`: https://elixir.bootlin.com/linux/v6.2/source/kernel/sys.c#L1168

One of the typical usage example of `setsid()` for daemonising:
https://github.com/pasce/daemon-skeleton-linux-c

Reasons why `attached_to_other_pg` is introduced:
* When the process group having forked of a child and then it attached itself to another process group and tries to setsid, it should fail w/ `EPERM`, see the example of `setsid01` in LTP: https://github.com/linux-test-project/ltp/blob/7015b2e2c6c16f97fcfed29510b3ef67da7e2ebb/testcases/kernel/syscalls/setsid/setsid01.c#L176-L191
* The underlying kernel logic: `setsid()` should fail if a process group id already exists that equals the proposed session id (https://elixir.bootlin.com/linux/v6.2/source/kernel/sys.c#L1222). This process group id is actually set on `setpgid()` when the specified `pgid` points to a different process group (https://elixir.bootlin.com/linux/v6.2/source/kernel/sys.c#L1116) via `change_pid()` -> `attach_pid()` (https://elixir.bootlin.com/linux/v6.2/source/kernel/pid.c#L334).
* This is not clearly stated in the man page, but can be found in kernel impl. and the associated LTP test case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1264)
<!-- Reviewable:end -->
