### PR TITLE
[LibOS] Don't allow removal of pseudo-files

### DIFF
--- a/libos/src/fs/libos_fs_pseudo.c
+++ b/libos/src/fs/libos_fs_pseudo.c
@@ -266,6 +266,11 @@ static int pseudo_hstat(struct libos_handle* handle, struct stat* buf) {
     return pseudo_istat(handle->dentry, handle->inode, buf);
 }
 
+static int pseudo_unlink(struct libos_dentry* dent) {
+    __UNUSED(dent);
+    return -EACCES;
+}
+
 static int pseudo_follow_link(struct libos_dentry* dent, char** out_target) {
     assert(locked(&g_dcache_lock));
     assert(dent->inode);
@@ -592,6 +597,7 @@ struct libos_d_ops pseudo_d_ops = {
     .lookup      = &pseudo_lookup,
     .readdir     = &pseudo_readdir,
     .stat        = &pseudo_stat,
+    .unlink      = &pseudo_unlink,
     .follow_link = &pseudo_follow_link,
     .icheckpoint = &pseudo_icheckpoint,
     .irestore    = &pseudo_irestore,

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1048,9 +1048,7 @@ class TC_40_FileSystem(RegressionTestCase):
             cpuinfo['flags'] = ''
 
         stdout, _ = self.run_binary(['proc_cpuinfo', cpuinfo['flags']])
-
-        # proc/cpuinfo Linux-based formatting
-        self.assertIn('cpuinfo test passed', stdout)
+        self.assertIn('TEST OK', stdout)
 
     def test_021_procstat(self):
         stdout, _ = self.run_binary(['proc_stat'])


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Pseudo-files under `/dev`, `/proc` and `/sys` should not be removable.

This was noticed by @mkow in #1249.

## How to test this PR? <!-- (if applicable) -->

Added a quick sub-test in one of the LibOS regression tests. Also you can try manually via e.g. Busybox example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1266)
<!-- Reviewable:end -->
