### PR TITLE
[LibOS] Keep main thread alive in case of non-main thread `execve()`

### DIFF
--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -20,6 +20,8 @@
 #include "list.h"
 #include "pal.h"
 
+extern bool g_execve_happenning;
+
 #define WAKE_QUEUE_TAIL ((void*)1)
 /* If next is NULL, then this node is not on any queue.
  * Otherwise it is a valid pointer to the next node or WAKE_QUEUE_TAIL. */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There is a corner case of a non-main thread performing `execve()`. Linux does the following: the main (leader) thread is terminated, and the non-main thread assumes its identity: https://elixir.bootlin.com/linux/v6.0/source/fs/exec.c#L1078

Before this PR, Gramine simply terminated the main thread. This led to the process being marked as a zombie (even though the non-main thread runs correctly and responds to signals). This in turn confused tools like `docker kill`, which couldn't find the Gramine process anymore. See for details #1265.

This PR fixes this corner case. Gramine can't do as Linux because there is no way to ask the host OS to "rewire" the identity of one thread to the other thread. Thus we introduce a workaround of keeping alive (but in a "parked" state) the main thread -- it sleeps infinitely.

In this case, the main thread and its associated resources (like the thread's LibOS stack) are not freed -- this leaks memory, but only once per process, as there is only one main thread per process, even after several execve invocations.

Fixes #1265.

## How to test this PR? <!-- (if applicable) -->

I don't know how to test it in our CI reliably. We already have the test `exec_same` which does `execve()` in the non-main thread.

Anyther way to test it manually is to build and run the program in #1265 -- it will show as `defunct` when doing `ps` or similar without this PR. With this PR, it shows correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1268)
<!-- Reviewable:end -->
