### PR TITLE
[Pal] Drop usage of an undocumented glibc macros

### DIFF
--- a/pal/include/elf/elf.h
+++ b/pal/include/elf/elf.h
@@ -23,8 +23,6 @@
 #include <features.h>
 #include <stdint.h>
 
-__BEGIN_DECLS
-
 /* Standard ELF types.  */
 
 #define __ELF_NATIVE_CLASS 64
@@ -2661,5 +2659,3 @@ typedef ElfW(Rela)   elf_rela_t;
 typedef ElfW(Sym)    elf_sym_t;
 typedef ElfW(Word)   elf_word_t;
 typedef ElfW(Xword)  elf_xword_t;
-
-__END_DECLS


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`__BEGIN_DECLS` and `__END_DECLS` seem to be undocumented and glibc-specific, and we accidentally left them in a header copied from glibc. This prevented building Gramine on non-glibc-based OSes.

## How to test this PR? <!-- (if applicable) -->

Try building e.g. on Alpine Linux.