### PR TITLE
[PAL/Linux-SGX] Verify OCALL-obtained time against last RDTSC time

### DIFF
--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -1789,7 +1789,7 @@ int ocall_gettime(uint64_t* microsec_ptr) {
                 break;
             }
         }
-        *microsec_ptr = microsec;
+        *microsec_ptr = MAX(microsec, expected_microsec);
     }
 
     sgx_reset_ustack(old_ustack);

--- a/pal/src/host/linux-sgx/pal_misc.c
+++ b/pal/src/host/linux-sgx/pal_misc.c
@@ -43,7 +43,6 @@ void init_tsc(void) {
     }
 }
 
-/* TODO: result comes from the untrusted host, introduce some schielding */
 int _PalSystemTimeQuery(uint64_t* out_usec) {
     int ret;
 
@@ -62,6 +61,8 @@ int _PalSystemTimeQuery(uint64_t* out_usec) {
     } while (read_seqretry(&g_tsc_lock, seq));
 
     uint64_t usec = 0;
+    /* Last seen RDTSC-calculated time value. This guards against time rewinding. */
+    static uint64_t last_usec = 0;
     if (start_tsc > 0 && start_usec > 0) {
         /* baseline TSC/usec pair was initialized, can calculate time via RDTSC (but should be
          * careful with integer overflow during calculations) */
@@ -74,13 +75,21 @@ int _PalSystemTimeQuery(uint64_t* out_usec) {
                 usec = start_usec + diff_usec;
                 if (usec < start_usec)
                     return -PAL_ERROR_OVERFLOW;
+
+                /* It's simply `last_usec = max(last_usec, usec)`, but executed atomically. */
+                uint64_t expected_usec = __atomic_load_n(&last_usec, __ATOMIC_ACQUIRE);
+                while (expected_usec < usec) {
+                    if (__atomic_compare_exchange_n(&last_usec, &expected_usec, usec,
+                                                    /*weak=*/true, __ATOMIC_RELEASE,
+                                                    __ATOMIC_ACQUIRE)) {
+                        break;
+                    }
+                }
+
+                *out_usec = MAX(usec, expected_usec);
+                return 0;
             }
         }
-    }
-
-    if (usec) {
-        *out_usec = usec;
-        return 0;
     }
 
     /* if we are here, either the baseline TSC/usec pair was not yet initialized or too much time
@@ -90,6 +99,14 @@ int _PalSystemTimeQuery(uint64_t* out_usec) {
     if (ret < 0)
         return -PAL_ERROR_DENIED;
     uint64_t tsc_cyc2 = get_tsc();
+
+    uint64_t last_recorded_rdtsc = __atomic_load_n(&last_usec, __ATOMIC_ACQUIRE);
+    if (usec < last_recorded_rdtsc) {
+        /* new OCALL-obtained timestamp (`usec`) is "back in time" than the last recorded timestamp
+         * from RDTSC (`last_recorded_rdtsc`); this can happen if the actual host time drifted
+         * backwards compared to the RDTSC time. */
+         usec = last_recorded_rdtsc;
+    }
 
     /* we need to match the OCALL-obtained timestamp (`usec`) with the RDTSC-obtained number of
      * cycles (`tsc_cyc`); since OCALL is a time-consuming operation, we estimate `tsc_cyc` as a


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously, Gramine did not verify the read-from-Linux-host timestamp against the last RDTSC time. So it is possible periodically that the previous timestamp (calculated via RDTSC) is greater than the current timestamp (read from Linux host via OCALLs), which can lead to the intermittent failure of LTP test `gettimeofday02` on some configurations with indication that "time is going backwards". This could be even security-relevant since the app running inside the enclave may behave unexpectedly if time teleports back.

This commit adds a sanity adjustment which guarantees no rewinding time is applied when the OCALL-obtained timestamp is "back in time" than the last recorded RDTSC timestamp.

Fixes https://github.com/gramineproject/gramine/issues/82.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI + LTP tests on specific configs mentioned in the original issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1276)
<!-- Reviewable:end -->
