### PR TITLE
[tests] Re-enable test for writing to `/dev/stdout`

### DIFF
--- a/libos/test/regression/devfs.c
+++ b/libos/test/regression/devfs.c
@@ -110,9 +110,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-#if 0
-    /* `/dev/stdout` is a link to `/proc/self/fd/1`; Gramine currently fails, see #1387 */
-
     printf("===== Write to /dev/stdout\n");
     f = fopen("/dev/stdout", "w");
     if (!f) {
@@ -133,7 +130,6 @@ int main(int argc, char** argv) {
         perror("fclose /dev/stdout");
         return 1;
     }
-#endif
 
     puts("TEST OK!");
     return 0;

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1017,6 +1017,7 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/dev/stdout', stdout)
         self.assertIn('/dev/stderr', stdout)
         self.assertIn('Four bytes from /dev/urandom', stdout)
+        self.assertIn('Hello World written to stdout!', stdout)
         self.assertIn('TEST OK', stdout)
 
     def test_002_device_passthrough(self):


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This was fixed after the pseudo filesystem refactoring so that we can re-enable the test now.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1282)
<!-- Reviewable:end -->
