### PR TITLE
[Pal/Linux-SGX] Fix an error log when profile enabled

### DIFF
--- a/pal/src/host/linux-sgx/host_profile.c
+++ b/pal/src/host/linux-sgx/host_profile.c
@@ -316,7 +316,7 @@ void sgx_profile_report_elf(const char* filename, void* addr) {
     if (!strcmp(filename, ""))
         filename = get_main_exec_path();
 
-    if (!strcmp(filename, "linux-vdso.so.1"))
+    if (!strcmp(filename, "[vdso_libos]"))
         return;
 
     // Convert filename to absolute path - some tools (e.g. libunwind in 'perf report') refuse to


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
After enabling profile by `sgx.profile.enable = "main"` , we'll see the following error log
```
(libos_debug.c:121:append_r_debug) [P1:T1:helloworld] debug: adding file:[vdso_libos] at 0xf816d95000
(host_profile.c:327:sgx_profile_report_elf) error: sgx_profile_report_elf([vdso_libos]): realpath failed
```
It's also reported in https://github.com/gramineproject/gramine/issues/853#issuecomment-1225268770.

Dummy vdso filenames in LibOS and Pal do not match.
https://github.com/gramineproject/gramine/blob/73c8e93d6cfe17f1b9c95945f58b90e7485fc24c/libos/src/libos_rtld.c#L998

This PR corrects dummy vdso filename and fixes the error log. 

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Run a profile enabled workload and check the log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1285)
<!-- Reviewable:end -->
