### PR TITLE
[LibOS] Move Linux ABI headers to a separate directory (part 2)

### DIFF
--- a/libos/include/arch/x86_64/linux_abi/syscalls_nr_arch.h
+++ b/libos/include/arch/x86_64/linux_abi/syscalls_nr_arch.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <asm/unistd.h>
+
 /* TODO: This is required when building Gramine on systems with older headers. We should actually
  * have our own copy of headers of the kernel we emulate, not from the one which is used on the
  * build machine.

--- a/libos/include/libos_defs.h
+++ b/libos/include/libos_defs.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include "libos_syscalls.h"
-
-/* Names and values are taken from the Linux kernel. */
-#define ERESTARTSYS     512 /* Usual case - restart if SA_RESTART is set. */
-#define ERESTARTNOINTR  513 /* Always restart. */
-#define ERESTARTNOHAND  514 /* Restart if no signal handler. */
+#include "linux_abi/syscalls_nr_arch.h"
 
 /* Internal LibOS stack size: 7 pages + one guard page normally, 15 pages + one guard page when ASan
  * is enabled (stack sanitization causes functions to take up more space). */

--- a/libos/include/libos_flags_conv.h
+++ b/libos/include/libos_flags_conv.h
@@ -13,12 +13,10 @@
 
 #pragma once
 
-#include <asm/fcntl.h>
-#include <linux/fcntl.h>
-#include <linux/mman.h>
-
 #include "api.h"
 #include "assert.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/memory.h"
 #include "pal.h"
 
 static inline pal_prot_flags_t LINUX_PROT_TO_PAL(int prot, int map_flags) {

--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <asm/stat.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -16,6 +15,8 @@
 #include "libos_refcount.h"
 #include "libos_types.h"
 #include "libos_utils.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/limits.h"
 #include "list.h"
 #include "pal.h"
 
@@ -459,14 +460,6 @@ struct libos_d_ops {
      */
     int (*irestore)(struct libos_inode* inode, void* data);
 };
-
-/*
- * Limits for path and filename length, as defined in Linux. Note that, same as Linux, PATH_MAX only
- * applies to paths processed by syscalls such as getcwd() - there is no limit on paths you can
- * open().
- */
-#define NAME_MAX 255   /* filename length, NOT including null terminator */
-#define PATH_MAX 4096  /* path size, including null terminator */
 
 struct libos_fs {
     /* Null-terminated, used in manifest and for uniquely identifying a filesystem. */

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <asm/fcntl.h>
-#include <asm/resource.h>
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -20,6 +18,7 @@
 #include "libos_refcount.h"
 #include "libos_sync.h"
 #include "libos_types.h"
+#include "linux_abi/limits.h"
 #include "linux_socket.h"
 #include "list.h"
 #include "pal.h"

--- a/libos/include/libos_table.h
+++ b/libos/include/libos_table.h
@@ -7,10 +7,6 @@
 
 #pragma once
 
-#if defined(__i386__) || defined(__x86_64__)
-#include <asm/ldt.h>
-#endif
-
 #include "libos_types.h"
 
 typedef void (*libos_syscall_t)(void);
@@ -206,21 +202,3 @@ long libos_syscall_getcpu(unsigned* cpu, unsigned* node, void* unused_cache);
 long libos_syscall_getrandom(char* buf, size_t count, unsigned int flags);
 long libos_syscall_mlock2(unsigned long start, size_t len, int flags);
 long libos_syscall_sysinfo(struct sysinfo* info);
-
-#define GRND_NONBLOCK 0x0001
-#define GRND_RANDOM   0x0002
-#define GRND_INSECURE 0x0004
-
-#ifndef MADV_FREE
-#define MADV_FREE 8
-#endif
-#ifdef __x86_64__
-#ifndef MADV_WIPEONFORK
-#define MADV_WIPEONFORK 18
-#endif
-#ifndef MADV_KEEPONFORK
-#define MADV_KEEPONFORK 19
-#endif
-#else /* __x86_64__ */
-#error "Unsupported platform"
-#endif

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <linux/futex.h>
-#include <linux/signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -17,6 +15,7 @@
 #include "libos_signal.h"
 #include "libos_tcb.h"
 #include "libos_types.h"
+#include "linux_abi/signals.h"
 #include "list.h"
 #include "pal.h"
 

--- a/libos/include/libos_types.h
+++ b/libos/include/libos_types.h
@@ -10,18 +10,16 @@
 #include "pal.h"
 
 // TODO: remove from here and include only where they are used.
-#include "linux_abi/types.h"
 #include "linux_abi/fs.h"
 #include "linux_abi/limits.h"
+#include "linux_abi/poll.h"
 #include "linux_abi/sched.h"
 #include "linux_abi/signals.h"
 #include "linux_abi/time.h"
+#include "linux_abi/types.h"
 
 typedef unsigned long int nfds_t;
 typedef unsigned long int nlink_t;
-
-#undef __CPU_SETSIZE
-#undef __NCPUBITS
 
 typedef Elf64_auxv_t elf_auxv_t;
 
@@ -44,8 +42,3 @@ struct libos_lock {
 
 /* maximum length of pipe/FIFO name (should be less than Linux sockaddr_un.sun_path = 108) */
 #define PIPE_URI_SIZE 96
-
-#ifndef EPOLLNVAL
-/* This is not defined in the older kernels e.g. the default kernel on Ubuntu 18.04. */
-#define EPOLLNVAL ((uint32_t)0x00000020)
-#endif

--- a/libos/include/libos_vma.h
+++ b/libos/include/libos_vma.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <linux/mman.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -17,6 +16,7 @@
 #include "libos_defs.h"
 #include "libos_handle.h"
 #include "libos_types.h"
+#include "linux_abi/memory.h"
 #include "pal.h"
 
 #define VMA_COMMENT_LEN 16
@@ -32,14 +32,6 @@ struct libos_vma_info {
     uint64_t file_offset;
     char comment[VMA_COMMENT_LEN];
 };
-
-/* MAP_FIXED_NOREPLACE and MAP_SHARED_VALIDATE are fairly new and might not be defined. */
-#ifndef MAP_FIXED_NOREPLACE
-#define MAP_FIXED_NOREPLACE 0x100000
-#endif // MAP_FIXED_NOREPLACE
-#ifndef MAP_SHARED_VALIDATE
-#define MAP_SHARED_VALIDATE 0x03
-#endif // MAP_SHARED_VALIDATE
 
 /* vma is kept for bookkeeping, but the memory is not actually allocated */
 #define VMA_UNMAPPED 0x10000000

--- a/libos/include/linux_abi/errors.h
+++ b/libos/include/linux_abi/errors.h
@@ -4,11 +4,11 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#include <asm/errno.h>
+
+#define ERESTARTSYS     512 /* Usual case - restart if SA_RESTART is set. */
+#define ERESTARTNOINTR  513 /* Always restart. */
+#define ERESTARTNOHAND  514 /* Restart if no signal handler. */

--- a/libos/include/linux_abi/fs.h
+++ b/libos/include/linux_abi/fs.h
@@ -7,6 +7,10 @@
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
+#include <asm/fcntl.h>
+#include <asm/stat.h>
+#include <linux/fadvise.h>
+#include <linux/fcntl.h>
 #include <stdint.h>
 
 struct linux_dirent64 {

--- a/libos/include/linux_abi/futex.h
+++ b/libos/include/linux_abi/futex.h
@@ -4,11 +4,7 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#include <linux/futex.h>

--- a/libos/include/linux_abi/ioctl.h
+++ b/libos/include/linux_abi/ioctl.h
@@ -4,11 +4,7 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#include <asm/ioctls.h>

--- a/libos/include/linux_abi/limits.h
+++ b/libos/include/linux_abi/limits.h
@@ -7,6 +7,8 @@
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
+#include <asm/resource.h>
+#include <linux/resource.h>
 #include <stdint.h>
 
 #include "linux_abi/time.h"
@@ -37,3 +39,11 @@ struct __kernel_rlimit {
 struct __kernel_rlimit64 {
     uint64_t rlim_cur, rlim_max;
 };
+
+/*
+ * Limits for path and filename length, as defined in Linux. Note that, same as Linux, PATH_MAX only
+ * applies to paths processed by syscalls such as getcwd() - there is no limit on paths you can
+ * open().
+ */
+#define NAME_MAX 255   /* filename length, NOT including null terminator */
+#define PATH_MAX 4096  /* path size, including null terminator */

--- a/libos/include/linux_abi/memory.h
+++ b/libos/include/linux_abi/memory.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+ */
+#pragma once
+
+/* Types and structures used by various Linux ABIs (e.g. syscalls). */
+/* These need to be binary-identical with the ones used by Linux. */
+
+#include <linux/mman.h>
+
+/* MAP_FIXED_NOREPLACE and MAP_SHARED_VALIDATE are fairly new and might not be defined. */
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif // MAP_FIXED_NOREPLACE
+#ifndef MAP_SHARED_VALIDATE
+#define MAP_SHARED_VALIDATE 0x03
+#endif // MAP_SHARED_VALIDATE
+
+#ifndef MADV_FREE
+#define MADV_FREE 8
+#endif
+#ifdef __x86_64__
+#ifndef MADV_WIPEONFORK
+#define MADV_WIPEONFORK 18
+#endif
+#ifndef MADV_KEEPONFORK
+#define MADV_KEEPONFORK 19
+#endif
+#else /* __x86_64__ */
+#error "Unsupported platform"
+#endif

--- a/libos/include/linux_abi/net.h
+++ b/libos/include/linux_abi/net.h
@@ -4,11 +4,8 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#include <linux/in.h>
+#include <linux/in6.h>

--- a/libos/include/linux_abi/poll.h
+++ b/libos/include/linux_abi/poll.h
@@ -4,11 +4,10 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#ifndef EPOLLNVAL
+/* This is not defined in the older kernels e.g. the default kernel on Ubuntu 18.04. */
+#define EPOLLNVAL ((uint32_t)0x00000020)
+#endif

--- a/libos/include/linux_abi/process.h
+++ b/libos/include/linux_abi/process.h
@@ -4,11 +4,9 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#include <asm/prctl.h>
+#include <linux/sched.h> // for CLONE_* stuff
+#include <linux/wait.h>

--- a/libos/include/linux_abi/random.h
+++ b/libos/include/linux_abi/random.h
@@ -4,11 +4,9 @@
  */
 #pragma once
 
-#include <linux/sched.h>
-
 /* Types and structures used by various Linux ABIs (e.g. syscalls). */
 /* These need to be binary-identical with the ones used by Linux. */
 
-struct __kernel_sched_param {
-    int __sched_priority;
-};
+#define GRND_NONBLOCK 0x0001
+#define GRND_RANDOM   0x0002
+#define GRND_INSECURE 0x0004

--- a/libos/include/linux_abi/signals.h
+++ b/libos/include/linux_abi/signals.h
@@ -9,7 +9,10 @@
 
 // TODO: remove all of these includes and make this header libc-independent.
 #include <asm/siginfo.h>
-#include <asm/signal.h>
+#include <stddef.h>  // FIXME(mkow): Without this we get:
+                     //     asm/signal.h:126:2: error: unknown type name ‘size_t’
+                     // It definitely shouldn't behave like this...
+#include <linux/signal.h>
 
 #include "linux_abi/signals_arch.h"
 

--- a/libos/include/linux_abi/time.h
+++ b/libos/include/linux_abi/time.h
@@ -11,6 +11,7 @@
 #include <linux/times.h>
 #include <linux/timex.h>
 #include <linux/utime.h>
+#include <linux/version.h>
 
 typedef __kernel_time_t time_t;
 

--- a/libos/src/arch/x86_64/libos_arch_prctl.c
+++ b/libos/src/arch/x86_64/libos_arch_prctl.c
@@ -5,11 +5,10 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include <asm/prctl.h>
-
 #include "libos_internal.h"
 #include "libos_table.h"
 #include "libos_tcb.h"
+#include "linux_abi/process.h"
 #include "pal.h"
 
 /* Linux v5.16 supports Intel AMX. To enable this feature, Linux added several XSTATE-related

--- a/libos/src/arch/x86_64/libos_table.c
+++ b/libos/src/arch/x86_64/libos_table.c
@@ -9,10 +9,9 @@
  * This file contains the system call table.
  */
 
-#include <asm/unistd.h>
-
 #include "libos_internal.h"
 #include "libos_table.h"
+#include "linux_abi/syscalls_nr_arch.h"
 
 libos_syscall_t libos_syscall_table[LIBOS_SYSCALL_BOUND] = {
     [__NR_read]                    = (libos_syscall_t)libos_syscall_read,

--- a/libos/src/bookkeep/libos_signal.c
+++ b/libos/src/bookkeep/libos_signal.c
@@ -8,9 +8,6 @@
  * This file contains code for handling signals and exceptions passed from PAL.
  */
 
-#include <stddef.h> /* needed by <linux/signal.h> for size_t */
-
-#include <asm/signal.h>
 #include <stdnoreturn.h>
 
 #include "cpu.h"
@@ -23,6 +20,8 @@
 #include "libos_types.h"
 #include "libos_utils.h"
 #include "libos_vma.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/signals.h"
 #include "pal.h"
 #include "toml_utils.h"
 

--- a/libos/src/bookkeep/libos_vma.c
+++ b/libos/src/bookkeep/libos_vma.c
@@ -5,8 +5,6 @@
 
 #include <stddef.h> /* needed by <linux/signal.h> for size_t */
 
-#include <linux/fcntl.h>
-#include <linux/mman.h>
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -23,6 +21,7 @@
 #include "libos_tcb.h"
 #include "libos_utils.h"
 #include "libos_vma.h"
+#include "linux_abi/memory.h"
 #include "spinlock.h"
 
 /* The amount of total memory usage, all accesses must be protected by `vma_tree_lock`. */

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -11,9 +11,7 @@
  * finished.
  */
 
-#include <asm/mman.h>
 #include <errno.h>
-#include <linux/fcntl.h>
 
 #include "libos_flags_conv.h"
 #include "libos_fs.h"
@@ -21,6 +19,8 @@
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_utils.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/memory.h"
 #include "pal.h"
 #include "perm.h"
 #include "stat.h"

--- a/libos/src/fs/libos_fs_lock.c
+++ b/libos/src/fs/libos_fs_lock.c
@@ -3,12 +3,11 @@
  *                    Paweł Marczewski <pawel@invisiblethingslab.com>
  */
 
-#include <linux/fcntl.h>
-
 #include "libos_fs.h"
 #include "libos_fs_lock.h"
 #include "libos_ipc.h"
 #include "libos_lock.h"
+#include "linux_abi/fs.h"
 
 /*
  * Global lock for the whole subsystem. Protects access to `g_fs_lock_list`, and also to dentry

--- a/libos/src/fs/libos_namei.c
+++ b/libos/src/fs/libos_namei.c
@@ -5,14 +5,13 @@
  * This file contains code for parsing a FS path and looking up in the directory cache.
  */
 
-#include <asm/fcntl.h>
-#include <linux/fcntl.h>
 #include <stdbool.h>
 
 #include "libos_fs.h"
 #include "libos_handle.h"
 #include "libos_lock.h"
 #include "libos_process.h"
+#include "linux_abi/fs.h"
 #include "perm.h"
 #include "stat.h"
 

--- a/libos/src/fs/pipe/fs.c
+++ b/libos/src/fs/pipe/fs.c
@@ -19,9 +19,6 @@
  * However, using FDs makes it easier to checkpoint a named pipe.
  */
 
-#include <asm/fcntl.h>
-#include <errno.h>
-
 #include "libos_fs.h"
 #include "libos_handle.h"
 #include "libos_internal.h"
@@ -29,6 +26,8 @@
 #include "libos_process.h"
 #include "libos_signal.h"
 #include "libos_thread.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/errors.h"
 #include "pal.h"
 #include "perm.h"
 #include "stat.h"

--- a/libos/src/fs/socket/fs.c
+++ b/libos/src/fs/socket/fs.c
@@ -3,13 +3,12 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include <asm/fcntl.h>
-#include <asm/ioctls.h>
-
 #include "api.h"
 #include "libos_fs.h"
 #include "libos_lock.h"
 #include "libos_socket.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/ioctl.h"
 #include "pal.h"
 #include "perm.h"
 #include "stat.h"

--- a/libos/src/libos_checkpoint.c
+++ b/libos/src/libos_checkpoint.c
@@ -5,7 +5,6 @@
  * This file contains implementation of checkpoint and restore.
  */
 
-#include <asm/mman.h>
 #include <stdarg.h>
 #include <stdint.h>
 
@@ -17,6 +16,7 @@
 #include "libos_thread.h"
 #include "libos_utils.h"
 #include "libos_vma.h"
+#include "linux_abi/memory.h"
 #include "list.h"
 #include "pal.h"
 

--- a/libos/src/libos_malloc.c
+++ b/libos/src/libos_malloc.c
@@ -9,13 +9,12 @@
  * ends up here (__system_alloc and __system_free).
  */
 
-#include <asm/mman.h>
-
 #include "asan.h"
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_utils.h"
 #include "libos_vma.h"
+#include "linux_abi/memory.h"
 #include "pal.h"
 
 static struct libos_lock slab_mgr_lock;

--- a/libos/src/libos_parser.c
+++ b/libos/src/libos_parser.c
@@ -5,25 +5,21 @@
  * This file contains code for parsing system call arguments for debug purpose.
  */
 
-#include <asm/fcntl.h>
-#include <asm/ioctls.h>
-#include <asm/mman.h>
-#include <asm/unistd.h>
-#include <linux/fcntl.h>
-#include <linux/futex.h>
-#include <linux/in.h>
-#include <linux/in6.h>
-#include <linux/sched.h>
-#include <linux/un.h>
-#include <linux/wait.h>
-
 #include "api.h"
 #include "libos_fs.h"
 #include "libos_internal.h"
-#include "libos_syscalls.h"
 #include "libos_table.h"
 #include "libos_types.h"
 #include "libos_vma.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/ioctl.h"
+#include "linux_abi/memory.h"
+#include "linux_abi/net.h"
+#include "linux_abi/process.h"
+#include "linux_abi/random.h"
+#include "linux_abi/sched.h"
+#include "linux_abi/signals.h"
+#include "linux_abi/syscalls_nr_arch.h"
 
 static void parse_open_flags(struct print_buf*, va_list*);
 static void parse_open_mode(struct print_buf*, va_list*);

--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -17,7 +17,6 @@
  * than glibc.
  */
 
-#include <asm/mman.h>
 #include <endian.h>
 #include <errno.h>
 
@@ -34,6 +33,7 @@
 #include "libos_vdso.h"
 #include "libos_vdso_arch.h"
 #include "libos_vma.h"
+#include "linux_abi/memory.h"
 
 #define INTERP_PATH_SIZE 256 /* Default shebang size */
 

--- a/libos/src/libos_syscalls.c
+++ b/libos/src/libos_syscalls.c
@@ -11,6 +11,7 @@
 #include "libos_table.h"
 #include "libos_tcb.h"
 #include "libos_thread.h"
+#include "linux_abi/errors.h"
 
 typedef arch_syscall_arg_t (*six_args_syscall_t)(arch_syscall_arg_t, arch_syscall_arg_t,
                                                  arch_syscall_arg_t, arch_syscall_arg_t,

--- a/libos/src/sys/libos_access.c
+++ b/libos/src/sys/libos_access.c
@@ -5,13 +5,12 @@
  * Implementation of system calls "access" and "faccessat".
  */
 
-#include <errno.h>
-#include <linux/fcntl.h>
-
 #include "libos_fs.h"
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/fs.h"
 
 long libos_syscall_access(const char* file, mode_t mode) {
     return libos_syscall_faccessat(AT_FDCWD, file, mode);

--- a/libos/src/sys/libos_clone.c
+++ b/libos/src/sys/libos_clone.c
@@ -4,9 +4,6 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include <errno.h>
-#include <linux/sched.h>
-
 #include "libos_checkpoint.h"
 #include "libos_fs.h"
 #include "libos_internal.h"
@@ -18,6 +15,9 @@
 #include "libos_vma.h"
 #include "pal.h"
 #include "toml_utils.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/process.h"
+#include "linux_abi/sched.h"
 
 struct libos_clone_args {
     PAL_HANDLE create_event;

--- a/libos/src/sys/libos_epoll.c
+++ b/libos/src/sys/libos_epoll.c
@@ -31,6 +31,7 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_types.h"
+#include "linux_abi/errors.h"
 #include "list.h"
 
 /* This bit is currently unoccupied in epoll events mask. */

--- a/libos/src/sys/libos_eventfd.c
+++ b/libos/src/sys/libos_eventfd.c
@@ -7,14 +7,13 @@
  * they must be explicitly allowed through the "sys.insecure__allow_eventfd" manifest key.
  */
 
-#include <asm/fcntl.h>
-
 #include "libos_fs.h"
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_table.h"
 #include "libos_utils.h"
 #include "linux_eventfd.h"
+#include "linux_abi/fs.h"
 #include "pal.h"
 #include "toml_utils.h"
 

--- a/libos/src/sys/libos_fcntl.c
+++ b/libos/src/sys/libos_fcntl.c
@@ -14,9 +14,6 @@
  * - F_SETOWN (file descriptor owner): dummy implementation
  */
 
-#include <errno.h>
-#include <linux/fcntl.h>
-
 #include "libos_fs.h"
 #include "libos_fs_lock.h"
 #include "libos_handle.h"
@@ -25,6 +22,8 @@
 #include "libos_process.h"
 #include "libos_table.h"
 #include "libos_thread.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/fs.h"
 
 #define FCNTL_SETFL_MASK (O_APPEND | O_DIRECT | O_NOATIME | O_NONBLOCK)
 

--- a/libos/src/sys/libos_file.c
+++ b/libos/src/sys/libos_file.c
@@ -6,15 +6,14 @@
  * "chmod", "fchmod", "fchmodat", "rename", "renameat" and "sendfile".
  */
 
-#include <errno.h>
-#include <linux/fcntl.h>
-
 #include "libos_fs.h"
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_process.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/fs.h"
 #include "perm.h"
 #include "stat.h"
 

--- a/libos/src/sys/libos_fork.c
+++ b/libos/src/sys/libos_fork.c
@@ -3,11 +3,9 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include <stddef.h> // without this header we are missing `size_t` definition in "signal.h" ...
-#include <linux/sched.h>
-#include <linux/signal.h>
-
 #include "libos_table.h"
+#include "linux_abi/process.h"
+#include "linux_abi/signals.h"
 
 long libos_syscall_fork(void) {
     return libos_syscall_clone(SIGCHLD, 0, NULL, NULL, 0);

--- a/libos/src/sys/libos_futex.c
+++ b/libos/src/sys/libos_futex.c
@@ -15,7 +15,6 @@
  * As a result we can distinguish futexes by their virtual address.
  */
 
-#include <linux/futex.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -28,6 +27,8 @@
 #include "libos_thread.h"
 #include "libos_types.h"
 #include "libos_utils.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/futex.h"
 #include "list.h"
 #include "pal.h"
 #include "spinlock.h"

--- a/libos/src/sys/libos_getrandom.c
+++ b/libos/src/sys/libos_getrandom.c
@@ -7,6 +7,8 @@
 
 #include "libos_internal.h"
 #include "libos_table.h"
+#include "linux_abi/random.h"
+#include "linux_abi/errors.h"
 
 long libos_syscall_getrandom(char* buf, size_t count, unsigned int flags) {
     if (flags & ~(GRND_NONBLOCK | GRND_RANDOM | GRND_INSECURE))

--- a/libos/src/sys/libos_getrlimit.c
+++ b/libos/src/sys/libos_getrlimit.c
@@ -5,9 +5,6 @@
  * Implementation of system calls "getrlimit", "setrlimit" and "sysinfo".
  */
 
-#include <asm/resource.h>
-#include <linux/sysinfo.h>
-
 #include "libos_checkpoint.h"
 #include "libos_internal.h"
 #include "libos_lock.h"
@@ -15,6 +12,7 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_vma.h"
+#include "linux_abi/limits.h"
 
 /*
  * TODO: implement actual limitation on each resource.
@@ -30,6 +28,8 @@
                                  the host limit). Ideally, we should have a PAL API which tells
                                  LibOS how many PAL handles it can use simultaneously. */
 #define MAX_MAX_FDS     65536
+#undef MLOCK_LIMIT /* Clashes with a macro from linux/resource.h. TODO: Remove after cleaning up
+                    * our headers. */
 #define MLOCK_LIMIT     (64 * 1024)
 #define MQ_BYTES_MAX    819200
 

--- a/libos/src/sys/libos_ioctl.c
+++ b/libos/src/sys/libos_ioctl.c
@@ -5,13 +5,13 @@
  * Implementation of system call "ioctl".
  */
 
-#include <asm/ioctls.h>
-
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_process.h"
 #include "libos_signal.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/ioctl.h"
 #include "pal.h"
 
 static void signal_io(IDTYPE caller, void* arg) {

--- a/libos/src/sys/libos_mlock.c
+++ b/libos/src/sys/libos_mlock.c
@@ -11,10 +11,9 @@
  * This (dummy) functionality is required by .NET workloads.
  */
 
-#include <asm/mman.h>
-
 #include "api.h"
 #include "libos_table.h"
+#include "linux_abi/memory.h"
 
 long libos_syscall_mlock(unsigned long start, size_t len) {
     if (!access_ok((void*)start, len)) {

--- a/libos/src/sys/libos_mmap.c
+++ b/libos/src/sys/libos_mmap.c
@@ -17,6 +17,7 @@
 #include "libos_internal.h"
 #include "libos_table.h"
 #include "libos_vma.h"
+#include "linux_abi/memory.h"
 #include "pal.h"
 #include "pal_error.h"
 

--- a/libos/src/sys/libos_open.c
+++ b/libos/src/sys/libos_open.c
@@ -8,10 +8,7 @@
 
 #define _POSIX_C_SOURCE 200809L  /* for SSIZE_MAX */
 
-#include <errno.h>
 #include <limits.h>
-#include <linux/fadvise.h>
-#include <linux/fcntl.h>
 #include <stdalign.h>
 
 #include "libos_fs.h"
@@ -20,6 +17,9 @@
 #include "libos_lock.h"
 #include "libos_process.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/fs.h"
+#include "linux_abi/memory.h"
 #include "stat.h"
 
 ssize_t do_handle_read(struct libos_handle* hdl, void* buf, size_t count) {

--- a/libos/src/sys/libos_pipe.c
+++ b/libos/src/sys/libos_pipe.c
@@ -5,9 +5,6 @@
  * Implementation of system calls "pipe", "pipe2", "mknod", and "mknodat".
  */
 
-#include <asm/fcntl.h>
-#include <errno.h>
-
 #include "libos_flags_conv.h"
 #include "libos_fs.h"
 #include "libos_handle.h"
@@ -16,6 +13,8 @@
 #include "libos_table.h"
 #include "libos_types.h"
 #include "libos_utils.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/fs.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "perm.h"

--- a/libos/src/sys/libos_poll.c
+++ b/libos/src/sys/libos_poll.c
@@ -15,6 +15,7 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_utils.h"
+#include "linux_abi/errors.h"
 #include "pal.h"
 
 typedef unsigned long __fd_mask;

--- a/libos/src/sys/libos_sched.c
+++ b/libos/src/sys/libos_sched.c
@@ -8,15 +8,14 @@
  * "getcpu".
  */
 
-#include <errno.h>
-#include <linux/resource.h>
-#include <linux/sched.h>
-
 #include "api.h"
 #include "libos_internal.h"
 #include "libos_lock.h"
 #include "libos_table.h"
 #include "libos_thread.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/limits.h"
+#include "linux_abi/sched.h"
 #include "pal.h"
 
 long libos_syscall_sched_yield(void) {

--- a/libos/src/sys/libos_sigaction.c
+++ b/libos/src/sys/libos_sigaction.c
@@ -9,12 +9,7 @@
  * and "tgkill".
  */
 
-#include <errno.h>
-#include <stddef.h>  // FIXME(mkow): Without this we get:
-                     //     asm/signal.h:126:2: error: unknown type name ‘size_t’
-                     // It definitely shouldn't behave like this...
 #include <limits.h>
-#include <linux/signal.h>
 
 #include "libos_internal.h"
 #include "libos_ipc.h"
@@ -23,6 +18,8 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_utils.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/signals.h"
 #include "pal.h"
 
 long libos_syscall_rt_sigaction(int signum, const struct __kernel_sigaction* act,

--- a/libos/src/sys/libos_sleep.c
+++ b/libos/src/sys/libos_sleep.c
@@ -10,6 +10,7 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_utils.h"
+#include "linux_abi/errors.h"
 #include "pal.h"
 
 long libos_syscall_pause(void) {

--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -12,6 +12,7 @@
 #include "libos_signal.h"
 #include "libos_socket.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
 
 /*
  * Sockets can be in 4 states: NEW, BOUND, LISTENING and CONNECTED.

--- a/libos/src/sys/libos_stat.c
+++ b/libos/src/sys/libos_stat.c
@@ -5,14 +5,14 @@
  * Implementation of system calls "stat", "lstat", "fstat" and "readlink".
  */
 
-#include <errno.h>
-#include <linux/fcntl.h>
 
 #include "libos_fs.h"
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_process.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/fs.h"
 #include "stat.h"
 
 static int do_stat(struct libos_dentry* dent, struct stat* stat) {

--- a/libos/src/sys/libos_wait.c
+++ b/libos/src/sys/libos_wait.c
@@ -3,10 +3,6 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include <stddef.h> /* needed by <linux/signal.h> for size_t */
-
-#include <linux/signal.h>
-#include <linux/wait.h>
 #include <stdbool.h>
 
 #include "api.h"
@@ -18,6 +14,9 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_types.h"
+#include "linux_abi/errors.h"
+#include "linux_abi/process.h"
+#include "linux_abi/signals.h"
 
 /* For wait4() return value */
 #define WCOREFLAG 0x80

--- a/libos/src/sys/libos_wrappers.c
+++ b/libos/src/sys/libos_wrappers.c
@@ -11,6 +11,7 @@
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_table.h"
+#include "linux_abi/errors.h"
 
 /* TODO: `readv` and `writev` syscalls below are not correctly atomic if the implementation does not
  * provide `.readv` and `.writev` callbacks and does not use file position (`hdl->pos`). This most

--- a/libos/src/vdso/arch/x86_64/vdso.c
+++ b/libos/src/vdso/arch/x86_64/vdso.c
@@ -6,8 +6,8 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include <asm/unistd.h>
-
+#include "linux_abi/time.h"
+#include "linux_abi/syscalls_nr_arch.h"
 #include "vdso.h"
 #include "vdso_syscall.h"
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is the continuation of https://github.com/gramineproject/gramine/pull/1275. Now LibOS doesn't include `<linux/*>` nor `<asm/*>`headers directly. The next steps will be dropping the `__kernel_` prefix (probably renaming to `linux_` or something like that) and removing host includes from `linux_abi/` in favor of imported definitions of everything.

## How to test this PR? <!-- (if applicable) -->

No functional changes intended.