### PR TITLE
[CI] Do not forward host `PATH` envvar into Docker container

### DIFF
--- a/.ci/lib/config-docker.jenkinsfile
+++ b/.ci/lib/config-docker.jenkinsfile
@@ -1,8 +1,7 @@
 env.PREFIX = env.WORKSPACE + '/usr'
 
-// don't mess with PATH before reading this: https://issues.jenkins.io/browse/JENKINS-49076
 env.DOCKER_ARGS_COMMON = """
-    --env=PATH=${env.PREFIX}/bin:${env.PATH}
+    --env=PREFIX=${env.PREFIX}
     --security-opt seccomp=${env.WORKSPACE}/scripts/docker_seccomp.json
 """
 env.DOCKER_ARGS_SGX = '''

--- a/.ci/lib/config.jenkinsfile
+++ b/.ci/lib/config.jenkinsfile
@@ -1,5 +1,7 @@
 env.MAKEOPTS = '-j8'
 
+env.PATH = env.PREFIX + '/bin:' + env.PATH
+
 python_platlib = sh(returnStdout: true, script: 'python3 scripts/get-python-platlib.py "$PREFIX"')
 env.PYTHONPATH = python_platlib + ':' + env.WORKSPACE + '/scripts'
 

--- a/.ci/lib/config.jenkinsfile
+++ b/.ci/lib/config.jenkinsfile
@@ -1,7 +1,5 @@
 env.MAKEOPTS = '-j8'
 
-env.PATH = env.PREFIX + '/bin:' + env.PATH
-
 python_platlib = sh(returnStdout: true, script: 'python3 scripts/get-python-platlib.py "$PREFIX"')
 env.PYTHONPATH = python_platlib + ':' + env.WORKSPACE + '/scripts'
 

--- a/.ci/lib/stage-build-nosgx.jenkinsfile
+++ b/.ci/lib/stage-build-nosgx.jenkinsfile
@@ -48,6 +48,8 @@ stage('build') {
     // available anyway.
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
+    env.PATH = env.PREFIX + '/bin:' + env.PATH
+
     // prevent cheating and testing from repo
     sh 'rm -rf build'
     sh 'git clean -Xf subprojects'

--- a/.ci/lib/stage-build-nosgx.jenkinsfile
+++ b/.ci/lib/stage-build-nosgx.jenkinsfile
@@ -49,6 +49,7 @@ stage('build') {
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
     env.PATH = env.PREFIX + '/bin:' + env.PATH
+    sh 'echo "---- HERE IS THE PATH: $PATH ----"'
 
     // prevent cheating and testing from repo
     sh 'rm -rf build'

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -40,9 +40,10 @@ stage('build') {
             ninja -vC build/
         '''
 
-        // install
+        // install (note that we need to set PATH so that Gramine signing tool can be found)
         sh '''
             ninja -vC build/ install
+            export PATH=$PREFIX/bin:$PATH
             gramine-sgx-gen-private-key
         '''
     } finally {

--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -69,6 +69,9 @@ stage('build') {
     // available anyway.
     env.PKG_CONFIG_PATH = libdir + '/pkgconfig'
 
+    env.PATH = env.PREFIX + '/bin:' + env.PATH
+    sh 'echo "---- HERE IS THE PATH: $PATH ----"'
+
     // prevent cheating and testing from repo
     sh 'rm -rf build'
     sh 'git clean -Xf subprojects'


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, our CI were overriding the Docker-image `PATH` with the Jenkins environment (host) `PATH`. If a Docker image is based on one OS distro (e.g. Ubuntu) and the host has another OS distro (e.g. Debian), then the `PATH` inside a Docker container could be unexpected. In particular, Ubuntu has `/sbin` in its PATH but Debian doesn't, and this led to failures of in-Docker scripts that want to use `/sbin` apps.

See #1032 for discussions.

## How to test this PR? <!-- (if applicable) -->

CI should succeed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1312)
<!-- Reviewable:end -->
