### PR TITLE
[PAL/Linux] Do not call `pal_strerror` before/during/failed PAL relocation

### DIFF
--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -530,7 +530,10 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
     /* Relocate PAL */
     ret = setup_pal_binary();
     if (ret < 0) {
-        log_error("Relocation of the PAL binary failed: %s", pal_strerror(ret));
+        /* PAL relocation failed, so we can't use functions which use PAL .rodata (like
+         * pal_strerror or unix_strerror) to report an error because these functions will return
+         * offset instead of actual address, which will cause a segfault. */
+        log_error("Relocation of the PAL binary failed: %d", ret);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -169,8 +169,12 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
 
     /* relocate PAL */
     ret = setup_pal_binary();
-    if (ret < 0)
-        INIT_FAIL("Relocation of the PAL binary failed: %s", pal_strerror(ret));
+    if (ret < 0) {
+        /* PAL relocation failed, so we can't use functions which use PAL .rodata (like
+         * pal_strerror or unix_strerror) to report an error because these functions will return
+         * offset instead of actual address, which will cause a segfault. */
+        INIT_FAIL("Relocation of the PAL binary failed: %d", ret);
+    }
 
     uint64_t start_time;
     ret = _PalSystemTimeQuery(&start_time);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We can't do that because the array which contains error strings might not be relocated yet. The error strings reside in .rodata segment. If we use `pal_strerror` and relocations are in use (default build), the function will return the offset instead of the real address. This will cause Gramine to segfault.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1317)
<!-- Reviewable:end -->
