### PR TITLE
[LibOS] Increase max size of `/proc/[pid]/cmdline`

### DIFF
--- a/libos/include/libos_process.h
+++ b/libos/include/libos_process.h
@@ -13,7 +13,9 @@
 #include "list.h"
 #include "pal.h"
 
-#define CMDLINE_SIZE 4096
+/* Some Java applications (e.g. Apache Kafka) use ~6KB of command-line arguments. The current limit
+ * of 16KB should be enough even for such applications. */
+#define CMDLINE_SIZE (4096 * 4)
 
 DEFINE_LIST(libos_child_process);
 DEFINE_LISTP(libos_child_process);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously it was 4KB, which turns out to be not enough for Apache Kafka workloads (which is actually a `/bin/java` command line with many JAR files listed in the command line). We simply bump the limit to 16KB.

Please see discussions in https://github.com/gramineproject/gramine/discussions/1303.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1319)
<!-- Reviewable:end -->
