### PR TITLE
[LibOS] Use dynamic allocation for `libos_process.cmdline`

### DIFF
--- a/libos/include/libos_process.h
+++ b/libos/include/libos_process.h
@@ -13,8 +13,6 @@
 #include "list.h"
 #include "pal.h"
 
-#define CMDLINE_SIZE 4096
-
 DEFINE_LIST(libos_child_process);
 DEFINE_LISTP(libos_child_process);
 struct libos_child_process {
@@ -61,9 +59,9 @@ struct libos_process {
     struct libos_lock fs_lock;
 
     /* Complete command line for the process, as reported by /proc/[pid]/cmdline; currently filled
-     * once during initialization, using static buffer and restricted to CMDLINE_SIZE. This is
-     * enough for current workloads but see https://github.com/gramineproject/gramine/issues/79. */
-    char cmdline[CMDLINE_SIZE];
+     * once during initialization and not able to be modified.
+     * See https://github.com/gramineproject/gramine/issues/79. */
+    char* cmdline;
     size_t cmdline_size;
 };
 

--- a/libos/src/bookkeep/libos_process.c
+++ b/libos/src/bookkeep/libos_process.c
@@ -60,22 +60,29 @@ int init_process(void) {
 }
 
 int init_process_cmdline(const char* const* argv) {
+    size_t size = 0;
+
+    for (const char* const* a = argv; *a; a++) {
+        size += strlen(*a) + 1;
+    }
+
+    char* cmdline = calloc(1, size);
+    if (!cmdline) {
+        return -ENOMEM;
+    }
+
+    size = 0;
+    for (const char* const* a = argv; *a; a++) {
+        memcpy(cmdline + size, *a, strlen(*a));
+        size += strlen(*a) + 1;
+    }
+
+    g_process.cmdline = cmdline;
     /* The command line arguments passed are stored in /proc/self/cmdline as part of the proc fs.
      * They are not separated by space, but by NUL instead. So, it is essential to maintain the
      * cmdline_size also as a member here. */
-    g_process.cmdline_size = 0;
-    memset(g_process.cmdline, '\0', ARRAY_SIZE(g_process.cmdline));
-    size_t tmp_size = 0;
+    g_process.cmdline_size = size;
 
-    for (const char* const* a = argv; *a; a++) {
-        if (tmp_size + strlen(*a) + 1 > ARRAY_SIZE(g_process.cmdline))
-            return -ENOMEM;
-
-        memcpy(g_process.cmdline + tmp_size, *a, strlen(*a));
-        tmp_size += strlen(*a) + 1;
-    }
-
-    g_process.cmdline_size = tmp_size;
     return 0;
 }
 
@@ -237,7 +244,9 @@ BEGIN_CP_FUNC(process_description) {
     new_process->pgid = process->pgid;
 
     /* copy cmdline (used by /proc/[pid]/cmdline) from the current process */
-    memcpy(new_process->cmdline, g_process.cmdline, ARRAY_SIZE(g_process.cmdline));
+    char* new_cmdline = (char*)(base + ADD_CP_OFFSET(g_process.cmdline_size));
+    memcpy(new_cmdline, g_process.cmdline, g_process.cmdline_size);
+    new_process->cmdline = new_cmdline;
     new_process->cmdline_size = g_process.cmdline_size;
 
     DO_CP_MEMBER(dentry, process, new_process, root);
@@ -289,6 +298,7 @@ BEGIN_RS_FUNC(process_description) {
     CP_REBASE(process->root);
     CP_REBASE(process->cwd);
     CP_REBASE(process->exec);
+    CP_REBASE(process->cmdline);
 
     if (process->exec) {
         get_handle(process->exec);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously Gramine had a static buffer of one page (4KB) in size to hold cmdline, which turns out to be not enough for Apache Kafka workloads (which is actually a `/bin/java` command line with many JAR files listed in the command line).

This commit changes to use dynamic allocation for it and propagates on fork/clone.

Fixes https://github.com/gramineproject/gramine/discussions/1303.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
manual testing + CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1320)
<!-- Reviewable:end -->
