### PR TITLE
[PAL/Linux] Log a message on `munmap()` returning `-ENOMEM`

### DIFF
--- a/pal/src/host/linux/pal_memory.c
+++ b/pal/src/host/linux/pal_memory.c
@@ -46,6 +46,11 @@ int _PalVirtualMemoryAlloc(void* addr, size_t size, pal_prot_flags_t prot) {
 
 int _PalVirtualMemoryFree(void* addr, size_t size) {
     int ret = DO_SYSCALL(munmap, addr, size);
+    if (ret == -ENOMEM && FIRST_TIME()) {
+        log_error("Host Linux returned -ENOMEM on munmap(); this may happen because process's "
+                  "maximum number of mappings is exceeded. Gramine cannot handle this case. "
+                  "You may want to increase the value in /proc/sys/vm/max_map_count.");
+    }
     return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Linux can return `-ENOMEM` if a request to `munmap()` will exceed the process's maximum number of mappings (this is possible in case of partial memory unmap, when Linux would have to create two mappings out of one). Gramine's LibOS is not ready for such failures, and also it is specific to the Linux PAL, so this commit simply makes this failure more visible and provides a hint for the user what can be done on the host.

Fixes #1327 (though not a real fix, more like a verbose failure).

## How to test this PR? <!-- (if applicable) -->

Manually test like described in https://github.com/gramineproject/gramine/issues/1327. This can be hit only on specific and memory-hungry workloads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1328)
<!-- Reviewable:end -->
