### PR TITLE
[PAL] Remove unused `PalStreamUnmap()`

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -176,9 +176,6 @@ applications.
 .. doxygenfunction:: PalStreamMap
    :project: pal
 
-.. doxygenfunction:: PalStreamUnmap
-   :project: pal
-
 .. doxygenfunction:: PalStreamSetLength
    :project: pal
 

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -416,19 +416,11 @@ int PalStreamDelete(PAL_HANDLE handle, enum pal_delete_mode delete_mode);
  * \param size    Size of the requested mapping. Must be non-zero and properly aligned.
  *
  * \returns 0 on success, negative error code on failure.
+ *
+ * Use `PalVirtualMemoryFree` to unmap the file.
  */
 int PalStreamMap(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,
                  size_t size);
-
-/*!
- * \brief Unmap virtual memory that is backed by a file stream.
- *
- * \returns 0 on success, negative error code on failure.
- *
- * `addr` and `size` must be aligned at the allocation alignment.
- * `[addr; addr+size)` must be a continuous memory range without any holes.
- */
-int PalStreamUnmap(void* addr, size_t size);
 
 /*!
  * \brief Set the length of the file referenced by handle to `length`.

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -170,7 +170,6 @@ int _PalStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr);
 int _PalStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
 int _PalStreamMap(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,
                   uint64_t size);
-int _PalStreamUnmap(void* addr, uint64_t size);
 int64_t _PalStreamSetLength(PAL_HANDLE handle, uint64_t length);
 int _PalStreamFlush(PAL_HANDLE handle);
 int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo);

--- a/pal/regression/File.c
+++ b/pal/regression/File.c
@@ -75,9 +75,9 @@ int main(int argc, char** argv, char** envp) {
             memcpy(buffer2, mem1 + 200, 40);
             print_hex("Map Test 2 (200th - 240th): %s\n", buffer2, 40);
 
-            ret = PalStreamUnmap(mem1, PAGE_SIZE);
+            ret = PalVirtualMemoryFree(mem1, PAGE_SIZE);
             if (ret < 0) {
-                pal_printf("PalStreamUnmap failed\n");
+                pal_printf("PalVirtualMemoryFree failed\n");
                 return 1;
             }
             ret = mem_bkeep_free((uintptr_t)mem1, PAGE_SIZE);

--- a/pal/regression/Symbols.c
+++ b/pal/regression/Symbols.c
@@ -25,7 +25,6 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(PalStreamWrite);
     PRINT_SYMBOL(PalStreamDelete);
     PRINT_SYMBOL(PalStreamMap);
-    PRINT_SYMBOL(PalStreamUnmap);
     PRINT_SYMBOL(PalStreamSetLength);
     PRINT_SYMBOL(PalStreamFlush);
     PRINT_SYMBOL(PalSendHandle);

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -150,7 +150,6 @@ class TC_02_Symbols(RegressionTestCase):
         'PalStreamWrite',
         'PalStreamDelete',
         'PalStreamMap',
-        'PalStreamUnmap',
         'PalStreamSetLength',
         'PalStreamFlush',
         'PalSendHandle',

--- a/pal/src/host/linux-sgx/pal_streams.c
+++ b/pal/src/host/linux-sgx/pal_streams.c
@@ -34,24 +34,6 @@ struct hdl_header {
     size_t  data_size; /* total size of serialized PAL handle */
 };
 
-int _PalStreamUnmap(void* addr, uint64_t size) {
-    __UNUSED(addr);
-    __UNUSED(size);
-    assert(sgx_is_completely_within_enclave(addr, size));
-
-    if (g_pal_linuxsgx_state.edmm_enabled) {
-        int ret = sgx_edmm_remove_pages((uint64_t)addr, size / PAGE_SIZE);
-        if (ret < 0) {
-            return ret;
-        }
-    } else {
-#ifdef ASAN
-        asan_poison_region((uintptr_t)addr, size, ASAN_POISON_USER);
-#endif
-    }
-    return 0;
-}
-
 static ssize_t handle_serialize(PAL_HANDLE handle, void** data) {
     int ret;
     const void* field = NULL;

--- a/pal/src/host/linux/pal_streams.c
+++ b/pal/src/host/linux/pal_streams.c
@@ -37,18 +37,6 @@ int handle_set_cloexec(PAL_HANDLE handle, bool enable) {
     return 0;
 }
 
-/* _PalStreamUnmap for internal use. Unmap stream at certain memory address. The memory is unmapped
- *  as a whole.*/
-int _PalStreamUnmap(void* addr, uint64_t size) {
-    /* Just let the kernel tell us if the mapping isn't good. */
-    int ret = DO_SYSCALL(munmap, addr, size);
-
-    if (ret < 0)
-        return -PAL_ERROR_DENIED;
-
-    return 0;
-}
-
 int handle_serialize(PAL_HANDLE handle, void** data) {
     const void* field = NULL;
     size_t field_size = 0;

--- a/pal/src/host/skeleton/pal_streams.c
+++ b/pal/src/host/skeleton/pal_streams.c
@@ -10,10 +10,6 @@
 #include "pal_error.h"
 #include "pal_internal.h"
 
-int _PalStreamUnmap(void* addr, uint64_t size) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/pal/src/pal_streams.c
+++ b/pal/src/pal_streams.c
@@ -351,14 +351,6 @@ int PalStreamMap(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t 
     return _PalStreamMap(handle, addr, prot, offset, size);
 }
 
-int PalStreamUnmap(void* addr, size_t size) {
-    if (!addr || !IS_ALLOC_ALIGNED_PTR(addr) || !size || !IS_ALLOC_ALIGNED(size)) {
-        return -PAL_ERROR_INVAL;
-    }
-
-    return _PalStreamUnmap(addr, size);
-}
-
 /* _PalStreamSetLength for internal use. This function truncate the stream to certain length. This
  *  call might not be support for certain streams */
 int64_t _PalStreamSetLength(PAL_HANDLE handle, uint64_t length) {

--- a/pal/src/pal_symbols
+++ b/pal/src/pal_symbols
@@ -17,7 +17,6 @@ PalStreamOpen
 PalStreamRead
 PalStreamWrite
 PalStreamMap
-PalStreamUnmap
 PalStreamSetLength
 PalStreamFlush
 PalStreamDelete


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The whole codebase of Gramine actually uses `PalVirtualMemoryFree()` instead, so this API was completely unused and untested.

## How to test this PR? <!-- (if applicable) -->

No functional changes. CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1329)
<!-- Reviewable:end -->
