### PR TITLE
[PAL/Linux-SGX,Docs] Remove deprecated syntax for number of threads

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -972,12 +972,3 @@ Experimental sysfs topology support
     fs.experimental__enable_sysfs_topology = [true|false]
 
 This feature is now enabled by default and the option was removed.
-
-Number of threads (deprecated syntax)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.thread_num = [NUM]
-
-This name was ambiguous and was replaced with ``sgx.max_threads``.

--- a/libos/test/regression/multi_pthread_exitless.manifest.template
+++ b/libos/test/regression/multi_pthread_exitless.manifest.template
@@ -9,8 +9,7 @@ fs.mounts = [
 ]
 
 # app runs with 4 parallel threads + Gramine has couple internal threads
-# TODO: legacy `sgx.thread_num` name just for testing, deprecated in v1.4, remove in v1.5
-sgx.thread_num = 8
+sgx.max_threads = 8
 sgx.insecure__rpc_thread_num = 8
 
 sgx.debug = true

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -705,20 +705,9 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info,
     }
 
     if (thread_num_int64 < 0) {
-        /* TODO: sgx.thread_num is deprecated in v1.4, remove in v1.5 */
-        ret = toml_int_in(manifest_root, "sgx.thread_num", /*defaultval=*/-1, &thread_num_int64);
-        if (ret < 0) {
-            log_error("Cannot parse 'sgx.thread_num'");
-            ret = -EINVAL;
-            goto out;
-        }
-        if (thread_num_int64 < 0) {
-            log_error("'sgx.max_threads' not found in the manifest");
-            ret = -EINVAL;
-            goto out;
-        }
-        log_error("Detected deprecated syntax: 'sgx.thread_num'. Consider switching to "
-                  "'sgx.max_threads'.");
+        log_error("'sgx.max_threads' not found in the manifest");
+        ret = -EINVAL;
+        goto out;
     }
 
     if (!thread_num_int64) {

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -88,11 +88,7 @@ class Manifest:
 
         sgx = manifest.setdefault('sgx', {})
         sgx.setdefault('trusted_files', [])
-
-        # TODO: sgx.thread_num is deprecated in v1.4, simplify below logic in v1.5
-        if 'thread_num' not in sgx:
-            sgx.setdefault('max_threads', DEFAULT_THREAD_NUM)
-
+        sgx.setdefault('max_threads', DEFAULT_THREAD_NUM)
         sgx.setdefault('isvprodid', 0)
         sgx.setdefault('isvsvn', 0)
         sgx.setdefault('remote_attestation', "none")

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -447,7 +447,7 @@ def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
     attr = {
         'enclave_size': parse_size(manifest_sgx['enclave_size']),
         'edmm_enable': manifest_sgx.get('edmm_enable', False),
-        'max_threads': manifest_sgx.get('max_threads', manifest_sgx.get('thread_num')),
+        'max_threads': manifest_sgx['max_threads'],
         'isv_prod_id': manifest_sgx['isvprodid'],
         'isv_svn': manifest_sgx['isvsvn'],
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The syntax `sgx.thread_num = [NUM]` was deprecated in Gramine v1.4.

Now that the next version of Gramine will be v1.5, we can safely remove it.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1331)
<!-- Reviewable:end -->
