### PR TITLE
[PAL,Docs] Remove deprecated syntax for experimental sysfs topo support

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -960,15 +960,3 @@ In addition, the application manifest must also contain ``sgx.debug = true``.
    independently.
 
 See :ref:`vtune-sgx-profiling` for more information.
-
-Deprecated options
-------------------
-
-Experimental sysfs topology support
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    fs.experimental__enable_sysfs_topology = [true|false]
-
-This feature is now enabled by default and the option was removed.

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -586,13 +586,6 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     }
     g_pal_public_state.mem_total = _PalMemoryQuota();
 
-    if (toml_key_exists(g_pal_public_state.manifest_root,
-                        "fs.experimental__enable_sysfs_topology")) {
-        // TODO: Deprecation started in v1.2, drop in 2 releases.
-        log_warning("fs.experimental__enable_sysfs_topology is deprecated and sysfs topology is "
-                    "enabled by default now.");
-    }
-
     ret = load_entrypoint(entrypoint_name);
     if (ret < 0)
         INIT_FAIL("Unable to load loader.entrypoint: %ld", ret);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The syntax `fs.experimental__enable_sysfs_topology = [true|false]` was deprecated in Gramine v1.2.

Now that the next version of Gramine will be v1.5, we can safely remove it.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1332)
<!-- Reviewable:end -->
