### PR TITLE
[PAL/Linux-SGX,Docs] Remove deprecated bool syntax for `sgx.remote_attestation`

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -973,19 +973,6 @@ Experimental sysfs topology support
 
 This feature is now enabled by default and the option was removed.
 
-Attestation and quotes (deprecated syntax)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.remote_attestation = [true|false]
-
-This syntax specified whether to enable SGX remote attestation. The boolean
-value has been replaced with the string value. The ``none`` value in the new
-syntax corresponds to the ``false`` boolean value in the deprecated syntax. The
-explicit ``epid`` and ``dcap`` values in the new syntax replace the ambiguous
-``true`` boolean value in the deprecated syntax.
-
 Number of threads (deprecated syntax)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
The syntax `sgx.remote_attestation = [true|false]` was deprecated in Gramine v1.3.

Now that the next version of Gramine will be v1.5, we can safely remove it.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1333)
<!-- Reviewable:end -->
