### PR TITLE
[Docs] Work around the bug of urllib3 and OpenSSL incompatibility

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,14 @@
 version: 2
+
+# The recent version of urllib3 (v2.0) only supports OpenSSL 1.1.1+. However, the ReadTheDocs
+# engine that we use for generating our web documentation by default uses older OpenSSL. The
+# workaround is to pin a specific OS distro and Python version.
+# See also https://github.com/readthedocs/readthedocs.org/issues/10290.
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.11"
+
 python:
     install:
         - requirements: Documentation/requirements.txt


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The recent version of urllib3 (v2.0) only supports OpenSSL 1.1.1+. However, the ReadTheDocs engine that we use for generating our web documentation by default uses older OpenSSL. The workaround is to pin a specific OS distro and Python version.

For the context:
- https://github.com/urllib3/urllib3/issues/2168
- https://github.com/readthedocs/readthedocs.org/issues/10290
- https://github.com/readthedocs/readthedocs-docker-images/issues/194

## How to test this PR? <!-- (if applicable) -->

Check RTD logs. (I will do it manually.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1335)
<!-- Reviewable:end -->
