### PR TITLE
[PAL] Remove deprecated syntax for debug type

### DIFF
--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -262,16 +262,6 @@ static void configure_logging(void) {
     int ret = 0;
     int log_level = PAL_LOG_DEFAULT_LEVEL;
 
-    char* debug_type = NULL;
-    ret = toml_string_in(g_pal_public_state.manifest_root, "loader.debug_type", &debug_type);
-    if (ret < 0)
-        INIT_FAIL_MANIFEST("Cannot parse 'loader.debug_type'");
-    if (debug_type) {
-        free(debug_type);
-        INIT_FAIL_MANIFEST("'loader.debug_type' has been replaced by 'loader.log_level' and "
-                           "'loader.log_file'");
-    }
-
     char* log_level_str = NULL;
     ret = toml_string_in(g_pal_public_state.manifest_root, "loader.log_level", &log_level_str);
     if (ret < 0)


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
The syntax `loader.debug_type = "[none|inline|file]"` was deprecated in favor of `loader.log_level` and `loader.log_file` long before Gramine introduced a deprecation policy. Now that the next version of Gramine will be v1.5, we can safely remove it.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1342)
<!-- Reviewable:end -->
