### PR TITLE
[tests] Fix compiler optimization in RW lock test

### DIFF
--- a/libos/test/regression/rwlock.c
+++ b/libos/test/regression/rwlock.c
@@ -86,25 +86,26 @@ static int writer_(void* args_) {
 static void run_test(size_t iterations, size_t readers_num, size_t writers_num,
                      size_t writers_delay_us) {
     struct shared_state m = {1, 0, 0, 1};
-    void* lock;
-    if (!gramine_rwlock_create(&lock))
-        errx(1, "gramine_rwlock_create failed");
-
-    thrd_t* threads = calloc(sizeof(*threads), readers_num + writers_num);
-    if (!threads)
-        errx(1, "calloc failed");
-
     struct reader_args reader_args = {
-        .lock = lock,
         .m = &m,
         .total_iterations = iterations * writers_num,
     };
     struct writer_args writer_args = {
-        .lock = lock,
         .m = &m,
         .iterations = iterations,
         .writers_delay_us = writers_delay_us,
     };
+
+    void* lock;
+    if (!gramine_rwlock_create(&lock))
+        errx(1, "gramine_rwlock_create failed");
+
+    reader_args.lock = lock;
+    writer_args.lock = lock;
+
+    thrd_t* threads = calloc(sizeof(*threads), readers_num + writers_num);
+    if (!threads)
+        errx(1, "calloc failed");
 
     /* Spawn readers */
     for (size_t i = 0; i < readers_num; i++) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
The issue was found on GCC >= 11 with `-O3` optimization level where the compiler generated the test binary unexpectedly.

Fixes https://github.com/gramineproject/gramine/issues/1352.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Manual testing since we don't have a Ubuntu22.04 CI pipeline (w/ GCC >= 11) setup yet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1351)
<!-- Reviewable:end -->
