### PR TITLE
[PAL] Remove unused `__attribute_*` macros

### DIFF
--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -285,15 +285,6 @@ void* malloc_copy(const void* mem, size_t size);
 void* calloc(size_t num, size_t size);
 void free(void* mem);
 
-#ifdef __GNUC__
-#define __attribute_hidden        __attribute__((visibility("hidden")))
-#define __attribute_always_inline __attribute__((always_inline))
-#define __attribute_unused        __attribute__((unused))
-#define __attribute_noinline      __attribute__((noinline))
-#else
-#error Unsupported compiler
-#endif
-
 int _PalInitDebugStream(const char* path);
 int _PalDebugLog(const void* buf, size_t size);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Found this Graphene-era unused stuff while working on https://github.com/gramineproject/gramine/issues/1352

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1353)
<!-- Reviewable:end -->
