### PR TITLE
[LibOS] Don't allow inlining of `gramine_call()`

### DIFF
--- a/libos/include/arch/x86_64/gramine_entry_api.h
+++ b/libos/include/arch/x86_64/gramine_entry_api.h
@@ -64,7 +64,13 @@ enum {
 /* Magic syscall number for Gramine custom calls */
 #define GRAMINE_CUSTOM_SYSCALL_NR 0x100000
 
-static inline int gramine_call(int number, unsigned long arg1, unsigned long arg2) {
+/* It is important to *not* inline this function because in this case, an optimized application may
+ * end up with `jmpq *%gs:<gramine-syscall>` instruction in the middle of app-specific logic. This
+ * logic may involve XSAVE registers like XMM/YMM/etc. which are *not* required to be saved/restored
+ * across the `jmpq`. This is in contrast to the `call` instruction, which forces the compiler to
+ * save/restore XSAVE registers across `call` (according to the Sys-V x86-64 ABI). */
+__attribute__ ((noinline))
+static int gramine_call(int number, unsigned long arg1, unsigned long arg2) {
     int ret;
     __asm__ volatile(
         "GRAMINE_SYSCALL"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`gramine_call()` is a special-syscall function, mainly used to test Gramine-specific functionality from the app. Previously it was always inlined in the app. However, an optimized application may end up with `jmpq *%gs:<gramine-syscall>` instruction in the middle of app-specific logic. This logic may involve XSAVE registers like XMM/YMM/etc. which are *not* required to be saved/restored across the `jmpq`. This is in contrast to the `call` instruction, which forces the compiler to save/restore XSAVE registers across `call` (according to the Sys-V x86-64 ABI). So this commit disallows inlining, to produce the `call` instruction.

## How to test this PR? <!-- (if applicable) -->

I tested manually on Ubuntu 22.04 with GCC 11.3.0. There, the recently added `rwlock` failed. E.g. build Gramine in release mode and execute like this: `gramine-direct rwlock 1 100 1 1 100`.