### PR TITLE
[tests] Define ACCESSPERMS, if not present

### DIFF
--- a/libos/test/fs/common.h
+++ b/libos/test/fs/common.h
@@ -27,6 +27,10 @@
         __builtin_add_overflow((val), 0, &__dummy); \
     })
 
+#ifndef ACCESSPERMS
+#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+
 noreturn void fatal_error(const char* fmt, ...);
 void setup(void);
 int open_input_fd(const char* path);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The ACCESSPERMS macro seems to be glibc specific, for example, it is not defined in the musl libc on Alpine Linux.
This macro is used by the `chmod_stat` test (`libos/test/fs/chmod_stat.c`).

## Links

* https://codebrowser.dev/glibc/glibc/io/sys/stat.h.html#_M/ACCESSPERMS
* https://git.musl-libc.org/cgit/musl/tree/include

## How to test this PR? <!-- (if applicable) -->

CI and build on Alpine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1370)
<!-- Reviewable:end -->
