### PR TITLE
Drop 18.04, part 2: Use `MAP_FIXED_NOREPLACE` where possible

### DIFF
--- a/common/include/asan.h
+++ b/common/include/asan.h
@@ -29,7 +29,7 @@
  * - Make sure the program maps the shadow memory area at startup. This will be something like:
  *
  *       mmap((void*)ASAN_SHADOW_START, ASAN_SHADOW_LENGTH, PROT_READ | PROT_WRITE,
- *            MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED,
+ *            MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED_NOREPLACE,
  *            -1, 0);
  *
  * - Annotate all functions that shouldn't perform sanitized memory access with

--- a/libos/src/libos_parser.c
+++ b/libos/src/libos_parser.c
@@ -856,6 +856,11 @@ static void parse_mmap_flags(struct print_buf* buf, va_list* ap) {
         flags &= ~MAP_FIXED;
     }
 
+    if (flags & MAP_FIXED_NOREPLACE) {
+        buf_puts(buf, "|MAP_FIXED_NOREPLACE");
+        flags &= ~MAP_FIXED_NOREPLACE;
+    }
+
 #ifdef CONFIG_MMAP_ALLOW_UNINITIALIZED
     if (flags & MAP_UNINITIALIZED) {
         buf_puts(buf, "|MAP_UNINITIALIZED");

--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -194,7 +194,7 @@ int ocall_mmap_untrusted(void** addrptr, size_t size, int prot, int flags, int f
 
     void* requested_addr = *addrptr;
 
-    if (flags & MAP_FIXED) {
+    if (flags & MAP_FIXED || flags & MAP_FIXED_NOREPLACE) {
         if (!sgx_is_valid_untrusted_ptr(requested_addr, size, PAGE_SIZE)) {
             sgx_reset_ustack(old_ustack);
             return -EINVAL;
@@ -216,7 +216,8 @@ int ocall_mmap_untrusted(void** addrptr, size_t size, int prot, int flags, int f
 
     if (retval < 0) {
         if (retval != -EACCES && retval != -EAGAIN && retval != -EBADF && retval != -EINVAL &&
-                retval != -ENFILE && retval != -ENODEV && retval != -ENOMEM && retval != -EPERM) {
+                retval != -ENFILE && retval != -ENODEV && retval != -ENOMEM && retval != -EEXIST &&
+                retval != -EPERM) {
             retval = -EPERM;
         }
         sgx_reset_ustack(old_ustack);
@@ -224,7 +225,7 @@ int ocall_mmap_untrusted(void** addrptr, size_t size, int prot, int flags, int f
     }
 
     void* returned_addr = COPY_UNTRUSTED_VALUE(&ocall_mmap_args->addr);
-    if (flags & MAP_FIXED) {
+    if (flags & MAP_FIXED || flags & MAP_FIXED_NOREPLACE) {
         /* addrptr already contains the mmap'ed address, no need to update it */
         if (returned_addr != requested_addr) {
             sgx_reset_ustack(old_ustack);

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -139,7 +139,7 @@ static int file_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
 static int file_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,
                     uint64_t size) {
     int fd = handle->file.fd;
-    int flags = PAL_MEM_FLAGS_TO_LINUX(prot) | (addr ? MAP_FIXED : 0);
+    int flags = PAL_MEM_FLAGS_TO_LINUX(prot) | (addr ? MAP_FIXED_NOREPLACE : 0);
     int linux_prot = PAL_PROT_TO_LINUX(prot);
 
     /* The memory will always be allocated with flag MAP_PRIVATE. */

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -111,10 +111,10 @@ __attribute_no_stack_protector
 __attribute_no_sanitize_address
 static void setup_asan(void) {
     int prot = PROT_READ | PROT_WRITE;
-    int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED;
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED_NOREPLACE;
     void* addr = (void*)DO_SYSCALL(mmap, (void*)ASAN_SHADOW_START, ASAN_SHADOW_LENGTH, prot, flags,
                                    /*fd=*/-1, /*offset=*/0);
-    if (IS_PTR_ERR(addr)) {
+    if (IS_PTR_ERR(addr) || addr != (void*)ASAN_SHADOW_START) {
         /* We are super early in the init sequence, TCB is not yet set, we probably should not call
          * any logging functions. */
         DO_SYSCALL(exit_group, PAL_ERROR_NOMEM);

--- a/pal/src/host/linux/pal_memory.c
+++ b/pal/src/host/linux/pal_memory.c
@@ -34,12 +34,14 @@ int _PalVirtualMemoryAlloc(void* addr, size_t size, pal_prot_flags_t prot) {
     int flags = PAL_MEM_FLAGS_TO_LINUX(prot);
     int linux_prot = PAL_PROT_TO_LINUX(prot);
 
-    flags |= MAP_ANONYMOUS | MAP_FIXED;
-    addr = (void*)DO_SYSCALL(mmap, addr, size, linux_prot, flags, -1, 0);
+    flags |= MAP_ANONYMOUS | MAP_FIXED_NOREPLACE;
+    void* res_addr = (void*)DO_SYSCALL(mmap, addr, size, linux_prot, flags, -1, 0);
 
-    if (IS_PTR_ERR(addr)) {
-        return unix_to_pal_error(PTR_TO_ERR(addr));
+    if (IS_PTR_ERR(res_addr)) {
+        return unix_to_pal_error(PTR_TO_ERR(res_addr));
     }
+
+    assert(res_addr == addr);
 
     return 0;
 }
@@ -166,13 +168,14 @@ int init_memory_bookkeeping(void) {
 #endif
     /* Allocate a guard page above the stack. We do not support further stack auto growth. */
     void* ptr = (void*)(proc_maps_info.stack_top - PAGE_SIZE);
-    ptr = (void*)DO_SYSCALL(mmap, ptr, PAGE_SIZE, PROT_NONE,
-                            MAP_FIXED_NOREPLACE | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-    if (IS_PTR_ERR(ptr)) {
-        ret = PTR_TO_ERR(ptr);
+    void* mmap_ret = (void*)DO_SYSCALL(mmap, ptr, PAGE_SIZE, PROT_NONE,
+                                       MAP_FIXED_NOREPLACE | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (IS_PTR_ERR(mmap_ret)) {
+        ret = PTR_TO_ERR(mmap_ret);
         log_error("failed to map a stack guard page: %s", unix_strerror(ret));
         return unix_to_pal_error(ret);
     }
+    assert(mmap_ret == ptr);
     ret = pal_add_initial_range((uintptr_t)ptr, PAGE_SIZE, /*prot=*/0, "stack guard");
     if (ret < 0) {
         return ret;
@@ -191,12 +194,9 @@ int init_memory_bookkeeping(void) {
         ptr = (void*)DO_SYSCALL(mmap, start_addr, PAGE_SIZE, PROT_NONE,
                                 MAP_FIXED_NOREPLACE | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
         if (!IS_PTR_ERR(ptr)) {
+            assert(ptr == (void*)start_addr);
             DO_SYSCALL(munmap, ptr, g_pal_public_state.alloc_align);
-            /* Check returned pointer in case of older kernels, which do not support
-             * `MAP_FIXED_NOREPLACE`. */
-            if (ptr == (void*)start_addr) {
-                break;
-            }
+            break;
         } else if (PTR_TO_ERR(ptr) == -EEXIST) {
             break;
         }


### PR DESCRIPTION
## Description of the changes

This is a safer version of `MAP_FIXED` which fails instead of overwriting already allocated memory.

## How to test this PR?

Please review carefully, especially please check whether I missed something which could also be changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1374)
<!-- Reviewable:end -->
