### PR TITLE
[Pal/Linux-SGX] sgx_gdb: Fix `ptrace(PTRACE_PEEKDATA)` invocation

### DIFF
--- a/pal/src/host/linux-common/debug_map.c
+++ b/pal/src/host/linux-common/debug_map.c
@@ -298,10 +298,10 @@ int debug_describe_location(uintptr_t addr, char* buf, size_t buf_size) {
     ret = find_in_symbol_map(name, offset, buf, buf_size);
     if (ret < 0) {
         /* parsing symbol map failed, display just name and offset */
-        snprintf(buf, buf_size, "%s+0x%lx", basename, offset);
+        snprintf(buf, buf_size, "%s+0x%lx (addr = 0x%lx)", basename, offset, addr);
     } else {
         size_t len = strlen(buf);
-        snprintf(&buf[len], buf_size - len, ", %s+0x%lx", basename, offset);
+        snprintf(&buf[len], buf_size - len, ", %s+0x%lx (addr = 0x%lx)", basename, offset, addr);
     }
 
     free(name);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine's GDB plugin used `ptrace(PTRACE_PEEKDATA, pid)` to detect all TIDs of enclave threads. This way of invocation (with a PID of a process instead of a stopped-tracee thread TID) led to sporadic errors of ptrace syscall with `-ESRCH`. Ptrace can return this error code when the specified tracee (the main thread) is not currently stopped. Because this invocation could happen from child threads, this error happened when debugging multi-threaded workloads.

The fix is to always use `ptrace(PTRACE_PEEKDATA, tid)` where TID is the currently ptrace-stopped tracee thread.

Also, this PR has a small commit to print the absolute address (RIP value) in debug messages. This turned out helpful in my debugging.

Fixes #1375.

## How to test this PR? <!-- (if applicable) -->

CI is enough. Also manually check the scenarios in https://github.com/gramineproject/gramine/issues/1375.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1377)
<!-- Reviewable:end -->
