### PR TITLE
[PAL/Linux-SGX] sgx_gdb: return const string for `str_ptrace_request()`

### DIFF
--- a/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.c
+++ b/pal/src/host/linux-sgx/gdb_integration/sgx_gdb.c
@@ -52,7 +52,7 @@ static struct {
 } g_memdevs[32];
 
 #if DEBUG_GDB_PTRACE == 1
-static char* str_ptrace_request(gramine_ptrace_request request) {
+static const char* str_ptrace_request(gramine_ptrace_request request) {
     static char buf[50];
     int prev_errno;
 
@@ -95,7 +95,7 @@ static char* str_ptrace_request(gramine_ptrace_request request) {
     prev_errno = errno; /* snprintf can contaminate errno */
     snprintf(buf, sizeof(buf), "0x%x", request);
     errno = prev_errno;
-    return buf;
+    return (const char*)buf;
 }
 #endif
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

An implicit conversion from const-qualified pointer types to non-const-qualified ones in C can generate a compilation warning. This happened for `str_ptrace_request()` when `DEBUG_GDB_PTRACE` was enabled, where "return discards `const` qualifier from pointer target type".

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Manual testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1379)
<!-- Reviewable:end -->
