### PR TITLE
[python] Remove commented out lines from template before passing to render with jinja

### DIFF
--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -131,7 +131,7 @@ class Manifest:
         self._manifest[key] = val
 
     @classmethod
-    def from_template(cls, template, variables=None):
+    def from_template(cls, in_template, variables=None):
         """Render template into Manifest.
 
         Creates a manifest from the jinja template given as string. Optional variables may be given
@@ -145,6 +145,16 @@ class Manifest:
         Returns:
             Manifest: instance created from rendered template.
         """
+        template = ''
+        for line in in_template.splitlines():
+            if line.lstrip().startswith('#'):
+                line = line.replace(line, '')
+            else:
+                line = line + '\n'
+            template = template + line
+
+        template = template.replace('\n\n','\n')
+
         return cls(_env.from_string(template).render(**(variables or {})))
 
     @classmethod


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
If you have a manifest template that has lines that require defines/variables to be passed as arguments to gramine-manifest, but commented out, gramine-manifest command fails during jinja render because the variables are applied even for the commented-out lines first before passing on to toml.

For example, if you don't have `-Dpythondistpath=...` as part of gramine-manifest command, having the following lines in the manifest template will make gramine-manifest fail:
```

# fs.mount.pydistpath.type = "chroot"
    # fs.mount.pydistpath.path = "{{ pythondistpath }}"
 # fs.mount.pydistpath.uri = "file:{{ pythondistpath }}"

```
This PR fixes it by removing the commented out lines before passing to render with jinja

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
 Fixes #1380 

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1381)
<!-- Reviewable:end -->
