### PR TITLE
[tools/sgx] Add gramine-ratls wrapper

### DIFF
--- a/.ci/lib/stage-clean-check.jenkinsfile
+++ b/.ci/lib/stage-clean-check.jenkinsfile
@@ -45,6 +45,7 @@ stage('clean-check') {
         make -C CI-Examples/sqlite distclean
         make -C CI-Examples/rust distclean
 
+        make -C CI-Examples/ra-tls-nginx clean
         make -C CI-Examples/ra-tls-mbedtls distclean
         make -C CI-Examples/ra-tls-secret-prov distclean
 

--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -152,4 +152,24 @@ stage('test-sgx') {
             fi
         '''
     }
+    timeout(time: 5, unit: 'MINUTES') {
+        sh '''
+            cd CI-Examples/ra-tls-nginx
+            if [ "${RA_TYPE}" = "epid" ]; then \
+                if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
+                then \
+                    make check RA_TYPE=epid RA_CLIENT_SPID=${ra_client_spid} \
+                        RA_TLS_EPID_API_KEY=${ra_client_key} RA_CLIENT_LINKABLE=0; \
+                else \
+                    echo "Failure: no ra_client_spid and/or ra_client_key!"; \
+                    exit 1; \
+                fi \
+            elif [ "${RA_TYPE}" = "dcap" ]; then \
+                make check; \
+            else \
+                echo "Invalid RA_TYPE env variable: ${RA_TYPE}"; \
+                exit 1; \
+            fi
+        '''
+    }
 }

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     nasm \
     net-tools \
     netcat-openbsd \
+    nginx \
     ninja-build \
     pkg-config \
     protobuf-c-compiler \

--- a/.ci/ubuntu22.04.dockerfile
+++ b/.ci/ubuntu22.04.dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     nasm \
     net-tools \
     netcat-openbsd \
+    nginx \
     ninja-build \
     pkg-config \
     protobuf-c-compiler \

--- a/CI-Examples/ra-tls-nginx/Makefile
+++ b/CI-Examples/ra-tls-nginx/Makefile
@@ -1,0 +1,42 @@
+RA_TYPE ?= dcap
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+ifeq ($(DEBUG),1)
+GRAMINE_LOG_LEVEL = debug
+else
+GRAMINE_LOG_LEVEL = error
+endif
+
+.PHONY: all
+all: nginx.manifest.sgx nginx.sig
+
+%.manifest: %.manifest.template
+	gramine-manifest \
+		-Dentrypoint=$$(command -v gramine-ratls) \
+		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
+		-Dra_type=$(RA_TYPE) \
+		-Dra_client_spid=$(RA_CLIENT_SPID) \
+		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
+		-Darch_libdir=$(ARCH_LIBDIR) \
+		$< > $@
+
+%.manifest.sgx %.sig: sgx-sign-%
+	@:
+
+.INTERMEDIATE: sgx-sign-%
+sgx-sign-%: %.manifest
+	gramine-sgx-sign \
+		--manifest $< \
+		--output $<.sgx
+
+.PHONY: check
+check: all
+	@./run.sh
+
+.PHONY: clean
+clean:
+	$(RM) -r \
+		*.manifest \
+		*.manifest.sgx \
+		*.sig \
+		*.token

--- a/CI-Examples/ra-tls-nginx/README.md
+++ b/CI-Examples/ra-tls-nginx/README.md
@@ -1,0 +1,36 @@
+# RA-TLS with Nginx
+
+**NOTE:** This example requires SGX. It does not work with `gramine-direct`.
+
+This example demonstrates how to attest a generic TLS server using RA-TLS. The
+certificate and key files are saved to a tmpfs system inside Gramine using
+`gramine-ratls` tool. Nginx is configured to use those files. This works because
+while tmpfs is not shared between Gramine processes, Nginx is execve()'d from
+`gramine-ratls`, so the tmpfs is kept intact.
+
+```sh
+make
+gramine-sgx nginx
+```
+
+Then in another terminal:
+```sh
+curl --insecure https://localhost:8000
+```
+
+In this simplified example, `--insecure` argument to curl means that curl will
+not check the TLS certificate. The `curl` command-line tool can't check it at
+all, because RA-TLS certificate is self-signed and does not chain to any WebPKI
+roots, so `curl` is currently unsuitable for production deployments. In
+production, another HTTPS client performing remote attestation should be used.
+
+See also `run.sh` script, which starts the enclave, performs a request, then
+kills it and reports the status.
+
+## EPID remote attestation
+
+If you use EPID attestation, add those arguments to `make` invocation above:
+
+```sh
+make RA_TYPE=epid RA_CLIENT_SPID=... RA_CLIENT_LINKABLE=[0|1]
+```

--- a/CI-Examples/ra-tls-nginx/html/index.html
+++ b/CI-Examples/ra-tls-nginx/html/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>hello, world</title>
+<h1>hello, world</h1>

--- a/CI-Examples/ra-tls-nginx/nginx.conf
+++ b/CI-Examples/ra-tls-nginx/nginx.conf
@@ -1,0 +1,26 @@
+error_log stderr warn;
+pid /tmp/nginx.pid;
+daemon off;
+
+events {}
+
+http {
+    sendfile off;
+    default_type application/octet-stream;
+    access_log off;
+    gzip on;
+
+    client_body_temp_path /tmp/nginx/body;
+    fastcgi_temp_path /tmp/nginx/fastcgi;
+    proxy_temp_path /tmp/nginx/proxy;
+    scgi_temp_path /tmp/nginx/scgi;
+    uwsgi_temp_path /tmp/nginx/uwsgi;
+
+    server {
+        listen 8000 ssl;
+
+        ssl_certificate /tmp/crt.pem;
+        ssl_certificate_key /tmp/key.pem;
+        root /srv/www/html;
+    }
+}

--- a/CI-Examples/ra-tls-nginx/nginx.manifest.template
+++ b/CI-Examples/ra-tls-nginx/nginx.manifest.template
@@ -1,0 +1,62 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+loader.argv = [
+    "gramine-ratls", "/tmp/crt.pem", "/tmp/key.pem", "--",
+    "/usr/sbin/nginx", "-p", "/etc/nginx", "-c", "nginx.conf",
+]
+libos.entrypoint = "/gramine-ratls"
+loader.log_level = "{{ log_level }}"
+
+loader.env.LD_LIBRARY_PATH = "/usr/local/lib:/usr{{ arch_libdir }}:{{ arch_libdir }}"
+
+loader.uid = 65534
+loader.gid = 65534
+
+fs.mounts = [
+    { path = "/gramine-ratls", uri = "file:{{ entrypoint }}" },
+    { path = "/usr/sbin", uri = "file:/usr/sbin" },
+
+    { path = "/etc/nginx/nginx.conf", uri = "file:nginx.conf" },
+    { path = "/srv/www/html", uri = "file:html/" },
+
+    { path = "/lib", uri = "file:/lib" },
+    { path = "/usr/lib", uri = "file:/usr/lib" },
+    { path = "/usr/local/lib", uri = "file:{{ gramine.runtimedir() }}" },
+
+    { path = "/tmp", type = "tmpfs" },
+
+    {#
+     # Temporary directories for nginx (cf. nginx.conf). Nginx can't mkdir() those directories,
+     # and we can't create them from the glue script either, because they wouldn't survive `fork()`.
+     # This is one way to create them.
+    -#}
+    { path = "/tmp/nginx/body", type = "tmpfs" },
+    { path = "/tmp/nginx/fastcgi", type = "tmpfs" },
+    { path = "/tmp/nginx/proxy", type = "tmpfs" },
+    { path = "/tmp/nginx/scgi", type = "tmpfs" },
+    { path = "/tmp/nginx/uwsgi", type = "tmpfs" },
+]
+
+sgx.remote_attestation = "{{ ra_type }}"
+{%- if ra_type == "epid" %}
+sgx.ra_client_spid = "{{ ra_client_spid }}"
+sgx.ra_client_linkable = {{ 'true' if ra_client_linkable else 'false' }}
+{%- endif %}
+
+sgx.edmm_enable = {{ "true" if env.get("EDMM", "0") | int > 0 else "false" }}
+sys.enable_sigterm_injection = true
+
+sgx.debug = true
+
+sgx.trusted_files = [
+    "file:{{ gramine.libos }}",
+    "file:{{ gramine.runtimedir() }}/",
+
+    "file:{{ entrypoint }}",
+    "file:/usr/sbin/nginx",
+
+    "file:html/",
+    "file:nginx.conf",
+
+    "file:/usr{{ arch_libdir }}/",
+    "file:{{ arch_libdir }}/",
+]

--- a/CI-Examples/ra-tls-nginx/run.sh
+++ b/CI-Examples/ra-tls-nginx/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+gramine-sgx nginx &
+pid=$!
+
+sleep 10
+
+test "$(curl --insecure -s https://localhost:8000/)" = "$(cat html/index.html)"
+ret=$?
+
+kill -9 $pid
+
+if test $ret -eq 0
+then
+    echo OK
+else
+    echo FAIL
+fi
+
+exit $ret

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -194,6 +194,7 @@ man_pages = [
     ('manpages/gramine', 'gramine-sgx', 'Gramine', [author], 1),
     ('manpages/gramine-argv-serializer', 'gramine-argv-serializer', 'Serialize command line arguments', [author], 1),
     ('manpages/gramine-manifest', 'gramine-manifest', 'Gramine manifest preprocessor', [author], 1),
+    ('manpages/gramine-ratls', 'gramine-ratls', 'RA-TLS wrapper', [author], 1),
     ('manpages/gramine-sgx-gen-private-key', 'gramine-sgx-gen-private-key', 'Gramine SGX key generator', [author], 1),
     ('manpages/gramine-sgx-get-token', 'gramine-sgx-get-token', 'Gramine SGX Token generator', [author], 1),
     ('manpages/gramine-sgx-ias-request', 'gramine-sgx-ias-request', 'Submit Intel Attestation Service request', [author], 1),

--- a/Documentation/manpages/gramine-ratls.rst
+++ b/Documentation/manpages/gramine-ratls.rst
@@ -1,0 +1,74 @@
+.. program:: gramine-ratls
+.. _gramine-ratls:
+
+==========================================
+:program:`gramine-ratls` -- RA-TLS wrapper
+==========================================
+
+Synopsis
+========
+
+:command:`gramine-ratls` [*OPTIONS*] <*CERTFILE*> <*KEYFILE*> [--] [*COMMAND* *ARGS* ...]
+
+Description
+===========
+
+:program:`gramine-ratls` generates X.509 certificate and matching private key
+using RA-TLS library. It saves those as files (by default PEM encoded, but see
+option :option:`-D`) under paths given as first two CLI arguments. If further
+arguments are passed, those are interpreted as a |~| command that is then
+executed using ``execvp()``.
+
+It is intended to launch standalone TLS (HTTPS) servers which require cert and
+key passed as files.
+
+Options
+=======
+
+.. option:: -D
+
+    Write the certificate and key in DER format.
+
+.. option:: -P
+
+    Write the certificate and key in PEM format. This is the default, but can be
+    used to override :option:`-D`.
+
+.. option:: -h
+
+    Show help and exit.
+
+Example
+=======
+
+This manifest will run :program:`gramine-ratls` and write the contents of
+certificate file to standard output using the :program:`cat` utility:
+
+.. code-block:: jinja
+
+    loader.entrypoint = "file:{{ gramine.libos }}"
+    loader.argv = [
+        "gramine-ratls", "/tmp/crt.der", "/tmp/key.der",
+        "cat", "/tmp/crt.der",
+    ]
+    libos.entrypoint = "/gramine-ratls"
+
+    loader.env.LD_LIBRARY_PATH = "/lib"
+
+    fs.mounts = [
+        { path = "/gramine-ratls", uri = "file:/usr/bin/gramine-ratls" },
+        { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+        { path = "/bin/cat", uri = "file:/bin/cat" },
+        { path = "/tmp", type = "tmpfs" },
+    ]
+
+    sgx.remote_attestation = "dcap"
+
+    sgx.debug = true
+
+    sgx.trusted_files = [
+        "file:{{ gramine.libos }}",
+        "file:/usr/bin/gramine-ratls",
+        "file:{{ gramine.runtimedir() }}/",
+        "file:/bin/cat",
+    ]

--- a/Documentation/manpages/index.rst
+++ b/Documentation/manpages/index.rst
@@ -5,15 +5,6 @@ The following man pages are available:
 
 .. toctree::
    :maxdepth: 1
+   :glob:
 
-   gramine
-   gramine-argv-serializer
-   gramine-manifest
-   gramine-sgx-gen-private-key
-   gramine-sgx-get-token
-   gramine-sgx-ias-request
-   gramine-sgx-ias-verify-report
-   gramine-sgx-quote-view
-   gramine-sgx-sign
-   gramine-sgx-sigstruct-view
-   is-sgx-available
+   *

--- a/debian/gramine.manpages
+++ b/debian/gramine.manpages
@@ -1,5 +1,6 @@
 Documentation/_build/man/gramine-direct.1
 Documentation/_build/man/gramine-manifest.1
+Documentation/_build/man/gramine-ratls.1
 Documentation/_build/man/gramine-sgx-get-token.1
 Documentation/_build/man/gramine-sgx-ias-request.1
 Documentation/_build/man/gramine-sgx-ias-verify-report.1

--- a/tools/sgx/ra-tls/gramine-ratls.c
+++ b/tools/sgx/ra-tls/gramine-ratls.c
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later
+ * Copyright (C) 2023 Intel Corporation
+ *                    Wojtek Porczyk <woju@invisiblethingslab.com>
+ */
+
+#include <fcntl.h>
+#include <getopt.h>
+#include <mbedtls/base64.h>
+#include <mbedtls/error.h>
+#include <mbedtls/pem.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "ra_tls.h"
+#include "util.h"
+
+char* progname = NULL;
+
+static void usage(void) {
+    fprintf(stderr, "usage: %s [-D|-P] CERTPATH KEYPATH [COMMAND ...]\n", progname);
+}
+
+static void help(void) {
+    usage();
+    fprintf(stderr,
+        "\n"
+        "options:\n"
+        "  -h  show this help and exit\n"
+        "  -D  use DER format\n"
+        "  -P  use PEM format (default)\n"
+    );
+}
+
+static int der_to_pem(const char* header, const char* footer, uint8_t* der, size_t der_size,
+                      uint8_t** pem, size_t* pem_size) {
+    size_t buf_size;
+    int ret;
+
+    if (!pem)
+        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
+
+    ret = mbedtls_pem_write_buffer(header, footer, der, der_size, /*buf=*/NULL, /*buf_len=*/0,
+                                   &buf_size);
+    if (!ret) {
+        /* shouldn't happen, but let's be sure not to return 0 and leave *pem uninitialized */
+        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
+    } else if (ret != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+        return ret;
+    }
+
+    *pem = malloc(buf_size);
+    if (!*pem)
+        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
+
+    return mbedtls_pem_write_buffer(header, footer, der, der_size, *pem, buf_size, pem_size);
+}
+
+int main(int argc, char* argv[]) {
+    uint8_t* key_der = NULL;
+    uint8_t* crt_der = NULL;
+    uint8_t* key_out = NULL;
+    uint8_t* crt_out = NULL;
+    size_t key_der_size;
+    size_t crt_der_size;
+    size_t key_out_size;
+    size_t crt_out_size;
+    bool want_pem = true;
+    int ret;
+
+    progname = argv[0];
+
+    while ((ret = getopt(argc, argv, "DPh")) != -1) {
+        switch (ret) {
+        case 'D':
+            want_pem = false;
+            break;
+        case 'P':
+            want_pem = true;
+            break;
+        case 'h':
+            help();
+            return 0;
+        default:
+            usage();
+            return 2;
+        }
+    }
+
+    argc -= optind;
+    argv += optind;
+
+    if (argc < 2) {
+        usage();
+        return 2;
+    }
+
+    ret = ra_tls_create_key_and_crt_der(&key_der, &key_der_size, &crt_der, &crt_der_size);
+    if (ret < 0) {
+        fprintf(stderr, "ra_tls_create_key_and_crt_der returned %d\n", ret);
+        goto err;
+    }
+
+    if (want_pem) {
+        /* keep this in sync with RA-TLS key type */
+        ret = der_to_pem("-----BEGIN EC PRIVATE KEY-----\n", "-----END EC PRIVATE KEY-----\n",
+                         key_der, key_der_size, &key_out, &key_out_size);
+        if (ret < 0)
+            goto err;
+        /* RA-TLS certificates are always self-signed, so we unconditionally add TRUSTED */
+        ret = der_to_pem("-----BEGIN TRUSTED CERTIFICATE-----\n",
+                         "-----END TRUSTED CERTIFICATE-----\n", crt_der, crt_der_size, &crt_out,
+                         &crt_out_size);
+        if (ret < 0)
+            goto err;
+    } else { /* don't want_pem */
+        key_out = key_der;
+        key_out_size = key_der_size;
+        key_der = NULL;
+        crt_out = crt_der;
+        crt_out_size = crt_der_size;
+        crt_der = NULL;
+    }
+
+    ret = write_file(argv[0], crt_out_size, crt_out);
+    if (ret < 0)
+        goto err;
+
+    ret = write_file(argv[1], key_out_size, key_out);
+    if (ret < 0)
+        goto err;
+
+    free(key_der);
+    free(crt_der);
+    free(key_out);
+    free(crt_out);
+
+    if (argc < 3) {
+        return 0;
+    }
+
+    execvp(argv[2], argv + 2);
+    perror("execvp");
+    return 1;
+
+err:
+    free(key_der);
+    free(crt_der);
+    free(key_out);
+    free(crt_out);
+    return 1;
+ }

--- a/tools/sgx/ra-tls/meson.build
+++ b/tools/sgx/ra-tls/meson.build
@@ -212,3 +212,13 @@ pkgconfig.generate(
         # Secret Prov consists of multiple independent libs, let user decide which to link
     ],
 )
+
+executable('gramine-ratls',
+    'gramine-ratls.c',
+    link_with: libra_tls_attest,
+    dependencies: [
+        sgx_util_dep,
+        mbedtls_static_dep,
+    ],
+    install: true,
+)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR adds `gramine-ratls` tool, which is (will be) useful when packaging HTTP(S) apps which do attestation using RA-TLS.

## How to test this PR? <!-- (if applicable) -->

Run this tool inside enclave, possibly start HTTPS server using generated keypair.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1382)
<!-- Reviewable:end -->
