### PR TITLE
[LibOS] Fix memory leak of `interp_path` string

### DIFF
--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -88,8 +88,8 @@ void* migrated_memory_end;
 
 const char* const* migrated_envp __attribute_migratable;
 
-/* `g_library_paths` is populated with LD_PRELOAD entries once during LibOS initialization and is
- * used in `__load_interp_object()` to search for ELF program interpreter in specific paths. Once
+/* `g_library_paths` is populated with LD_LIBRARY_PATH entries once during LibOS initialization and
+ * is used in `load_elf_interp()` to search for ELF program interpreter in specific paths. Once
  * allocated, its memory is never freed or updated. */
 char** g_library_paths = NULL;
 

--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -885,7 +885,7 @@ static int find_interp(const char* interp_name, struct libos_dentry** out_dent) 
     }
 
     const char* default_paths[] = {"/lib", "/lib64", NULL};
-    const char** paths          = g_library_paths ?: default_paths;
+    const char** paths = g_library_paths ?: default_paths;
 
     for (const char** path = paths; *path; path++) {
         size_t path_len = strlen(*path);
@@ -898,6 +898,7 @@ static int find_interp(const char* interp_name, struct libos_dentry** out_dent) 
         log_debug("searching for interpreter: %s", interp_path);
         struct libos_dentry* dent;
         int ret = path_lookupat(/*start=*/NULL, interp_path, LOOKUP_FOLLOW, &dent);
+        free(interp_path);
         if (ret == 0) {
             *out_dent = dent;
             return 0;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This memory leak was found by the Coverity tool. Also, we fix a couple nits around `g_library_paths`.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1389)
<!-- Reviewable:end -->
