### PR TITLE
RFC: [PAL/Linux-SGX] Add encrypted-and-trusted files

### DIFF
--- a/libos/test/regression/encrypt_file.sh
+++ b/libos/test/regression/encrypt_file.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Usage:
+#
+#    encrypt_file file_to_encrypt file_encrypted
+#
+# Encrypts the file using `gramine-sgx-pf-crypt encrypt`.
+
+set -e
+
+SRC_FILE="$1"
+DEST_FILE="$2"
+
+# The hard-coded key must correspond to `fs.insecure__keys.default` in test manifests
+# (e.g. in `helloworld_enc.manifest.template`). Note that POSIX printf doesn't understand hex so we
+# must use octal.
+WRAPKEY_FILE=$(mktemp /tmp/gramine-wrap-key.XXXXXX)
+printf "\377\356\335\314\273\252\231\210" > ${WRAPKEY_FILE}
+printf "\167\146\125\104\63\42\21\0"     >> ${WRAPKEY_FILE}
+
+gramine-sgx-pf-crypt encrypt --input ${SRC_FILE} --output ${DEST_FILE} --wrap-key ${WRAPKEY_FILE}
+
+# Copy mode bits from input file; required to e.g. mark the output file as executable (Gramine
+# enforces the check for executable bit on entrypoint files).
+chmod --reference=${SRC_FILE} ${DEST_FILE}
+
+rm ${WRAPKEY_FILE}

--- a/libos/test/regression/helloworld_enc.manifest.template
+++ b/libos/test/regression/helloworld_enc.manifest.template
@@ -1,0 +1,20 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { type = "encrypted", path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}", key_name = "default" },
+]
+
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]
+
+fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"

--- a/libos/test/regression/helloworld_enc_fail.manifest.template
+++ b/libos/test/regression/helloworld_enc_fail.manifest.template
@@ -1,0 +1,26 @@
+{% set entrypoint = "helloworld_enc" -%}
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.log_level = "warning"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { type = "encrypted", path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}", key_name = "default" },
+]
+
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+
+  # dummy hash of the helloworld binary, to force a Gramine fail
+  { uri = "file:{{ binary_dir }}/{{ entrypoint }}", sha256 = "0000000000000000000000000000000000000000000000000000000000000000" },
+]
+
+fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -313,4 +313,13 @@ if enable_musl
     )
 endif
 
+if sgx
+    # encrypt helloworld binary for helloworld_enc and helloworld_enc_fail tests
+    meson.add_install_script(
+        find_program('encrypt_file.sh'),
+        prefix / install_dir / 'helloworld',
+        prefix / install_dir / 'helloworld_enc',
+    )
+endif
+
 subdir('asm')

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -83,7 +83,22 @@ class TC_01_Bootstrap(RegressionTestCase):
         stdout, _ = self.run_binary(['helloworld'])
         self.assertIn('Hello world!', stdout)
 
-    def test_002_toml_parsing(self):
+    @unittest.skipUnless(HAS_SGX, 'Required tool gramine-sgx-pf-crypt only available with SGX')
+    def test_002_helloworld_enc(self):
+        stdout, _ = self.run_binary(['helloworld_enc'])
+        self.assertIn('Hello world!', stdout)
+
+    @unittest.skipUnless(HAS_SGX, 'Required tool gramine-sgx-pf-crypt only available with SGX')
+    def test_003_helloworld_enc_fail(self):
+        try:
+            self.run_binary(['helloworld_enc_fail'])
+            self.fail('helloworld_enc_fail unexpectedly succeeded')
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode()
+            self.assertRegex(stderr, r'warning: Hash of trusted file .*helloworld_enc.* does not '
+                                      'match with the reference hash in manifest')
+
+    def test_010_toml_parsing(self):
         stdout, _ = self.run_binary(['toml_parsing'])
         self.assertIn('Hello world!', stdout)
 

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -53,6 +53,8 @@ manifests = [
   "gettimeofday",
   "groups",
   "helloworld",
+  "helloworld_enc",
+  "helloworld_enc_fail",
   "hostname",
   "hostname_extra_runtime_conf",
   "host_root_fs",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -55,6 +55,8 @@ manifests = [
   "gettimeofday",
   "groups",
   "helloworld",
+  "helloworld_enc",
+  "helloworld_enc_fail",
   "hostname",
   "hostname_extra_runtime_conf",
   "host_root_fs",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine allowed encrypted files (aka protected files), which do not have a corresponding hash in the manifest file and thus their contents are not reflected in MRENCLAVE. Also, Gramine had trusted files whose contents are reflected in MRENCLAVE but these files are not encrypted.

This PR allows to combine two functionalities and get encrypted-and-trusted files as a result. The manifest syntax doesn't change and looks like this:
```toml
  fs.mounts = [
    { type = "encrypted", path = "/enc_file", uri = "file:enc_file" },
  ]
  sgx.trusted_files = [
    "file:enc_file", # or with {uri = ..., sha256 = ...} syntax
  ]
```

Note that previously Gramine had unintuitive behavior of *ignoring* the entry in `sgx.trusted_files` if it was already marked as encrypted file.

### Discussion

See https://github.com/gramineproject/gramine/issues/513.

Generally, there were three ideas for encrypted + hashed files:
1. Hash the file first, then encrypt it.
   - This seems to have weak security guarantees (e.g., weak resistance against known-plaintext attacks).
   - Implementation would be complicated, because it "reverses" the current Gramine flow of "encrypted at LibOS layer -> hashed at PAL layer".
   - Manifest syntax could probably stay the same as now (reusing `fs.mounts` and `sgx.trusted_files`).
2. Encrypt the file, then hash the first 4KB of the file.
   - This has high security guarantees, and also fast -- no need to hash and verify the whole file.
   - Implementation would be complicated, because we would introduce a new hashing logic, completely bypassing the existing PAL hashing logic.
   - Manifest syntax needs to be changed, and it would be non-trivial (e.g. `fs.mounts = { { type = "encrypted", sha256 = ... }`). I tried it as my first attempt, but it quickly got ugly as this `sha256` field belongs to the FS mount, not to the file.
3. Encrypt the file, then hash the whole file.
   - This has high security guarantees, but slower than 2. On the other hand, the overhead should be negligible as hashed files are typically read completely anyway.
   - Implementation is trivial, see this PR.
   - Manifest syntax stays the same as now, and it is actually logical.

This PR implements idea 3.

### TODOs

- [ ] Fix documentation

## How to test this PR? <!-- (if applicable) -->

Two tests are added.