### PR TITLE
[tests] Enable encrypted-files tests in non-SGX setup

### DIFF
--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -288,8 +288,6 @@ class TC_01_Bootstrap(RegressionTestCase):
             if os.path.exists(path):
                 os.unlink(path)
 
-    @unittest.skipUnless(HAS_SGX,
-        'Protected files are only available with SGX')
     def test_221_send_handle_pf(self):
         path = 'tmp/pf/send_handle_test'
         os.makedirs('tmp/pf', exist_ok=True)
@@ -701,9 +699,6 @@ class TC_30_Syscall(RegressionTestCase):
                     os.unlink(path)
         self.assertIn('TEST OK', stdout)
 
-    @unittest.skip('Protected files (as implemented in Linux-SGX PAL) do not support renaming yet')
-    @unittest.skipUnless(HAS_SGX,
-        'Protected files are only available with SGX')
     def test_034_rename_unlink_pf(self):
         os.makedirs('tmp/pf', exist_ok=True)
         file1 = 'tmp/pf/file1'
@@ -792,8 +787,7 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('Child process done', stdout)
         self.assertIn('Parent process done', stdout)
 
-    @unittest.skipUnless(HAS_SGX,
-        'Protected files are only available with SGX')
+    @unittest.skipUnless(HAS_SGX, 'Sealed (protected) files are only available with SGX')
     def test_053_mmap_file_backed_protected(self):
         # create the protected file
         pf_path = 'encrypted_file_mrsigner.dat'


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously encrypted files (aka protected files) were only available for SGX PAL. Since then, encrypted files were moved to LibOS layer and can be used also in non-SGX setup. But we forgot to enable some tests.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1392)
<!-- Reviewable:end -->
