### PR TITLE
[LibOS] regression: fix GDB tests

### DIFF
--- a/libos/test/regression/debug.gdb
+++ b/libos/test/regression/debug.gdb
@@ -1,5 +1,6 @@
 set breakpoint pending on
 set pagination off
+set backtrace past-main on
 
 # Check if debug sources are loaded in our program, and we can break inside.
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

~GDB tests expected `_start()` function in the backtrace. However, it depends on the GDB version and on the setting `backtrace past-main off|on`. For simplicity, this commit disables past-main traces. As a side effect, this also fixes Musl traces because Musl tends to have `??` traces when past-main is on.~

UPDATE: GDB tests expect `_start()` function in the backtrace. However, it depends on the GDB version and on the setting `backtrace past-main off|on` (which seems to differ in different GDB versions). So this commit explicitly enables past-main traces.

I found this inconsistent behavior on Alpine 3.18.0. I couldn't find any discussions on the internet about it, so I just fixed as theoretically should be correct.

Check my experiment that proves that `past-main` behavior seems to be ignored on e.g. Ubuntu/GDB9 and honored on e.g. Alpine/GDB13:
- On Alpine 3.18.0:
```
$ gdb --version
GNU gdb (GDB) 13.2

...

(gdb) bt -past-main on
#0  main (argc=1, argv=0x615d388a2f08) at ../libos/test/regression/helloworld.c:4
#1  0x0000615d387a77bb in libc_start_main_stage2 (main=0x40114d <main>, argc=1, argv=0x615d388a2f08)
    at ../src/env/__libc_start_main.c:95
#2  0x0000615d387a776e in __libc_start_main (main=0x40114d <main>, argc=1, argv=0x615d388a2f08, init_dummy=0x401000 <_init>,
    fini_dummy=0x40116d <_fini>, ldso_dummy=0x0) at ../src/env/__libc_start_main.c:86
#3  0x0000000000401046 in _start ()
#4  0x0000000000000001 in ?? ()
#5  0x0000615d388a2ff5 in ?? ()
#6  0x0000000000000000 in ?? ()

(gdb) bt -past-main off
#0  main (argc=1, argv=0x615d388a2f08) at ../libos/test/regression/helloworld.c:4
```
- On Ubuntu 20.04:
```
$ gdb --version
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04.1) 9.2

...

(gdb) bt -past-main on
#0  main (argc=28897, argv=0x0) at ../libos/test/regression/helloworld.c:3
#1  0x000070e18a49d5bd in __libc_start_call_main (main=main@entry=0x401136 <main>, argc=argc@entry=1,
    argv=argv@entry=0x70e18a6c4ee8) at ../sysdeps/nptl/libc_start_call_main.h:58
#2  0x000070e18a49d680 in __libc_start_main_impl (main=0x401136 <main>, argc=1, argv=0x70e18a6c4ee8, init=<optimized out>,
    fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x70e18a6c4ed8) at ../csu/libc-start.c:381
#3  0x000000000040107e in _start ()

(gdb) bt -past-main off
#0  main (argc=28897, argv=0x0) at ../libos/test/regression/helloworld.c:3
#1  0x000070e18a49d5bd in __libc_start_call_main (main=main@entry=0x401136 <main>, argc=argc@entry=1,
    argv=argv@entry=0x70e18a6c4ee8) at ../sysdeps/nptl/libc_start_call_main.h:58
#2  0x000070e18a49d680 in __libc_start_main_impl (main=0x401136 <main>, argc=1, argv=0x70e18a6c4ee8, init=<optimized out>,
    fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x70e18a6c4ed8) at ../csu/libc-start.c:381
#3  0x000000000040107e in _start ()
```

References:
- https://sourceware.org/gdb/onlinedocs/gdb/Backtrace.html
- https://stackoverflow.com/questions/5461731/how-to-backtrace-how-mains-called-with-gdb
- https://bugzilla.redhat.com/show_bug.cgi?id=1461575

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1395)
<!-- Reviewable:end -->
