### PR TITLE
[LibOS] Add aux vectors `AT_UID`, `AT_EUID`, `AT_GID`, `AT_EGID`, `AT_SECURE`

### DIFF
--- a/libos/include/libos_defs.h
+++ b/libos/include/libos_defs.h
@@ -16,6 +16,7 @@
 #define DEFAULT_VMA_COUNT 64
 
 /* ELF aux vectors  */
-#define REQUIRED_ELF_AUXV       9  /* number of LibOS-supported vectors */
+#define REQUIRED_ELF_AUXV       14 /* number of LibOS-supported vectors */
 #define REQUIRED_ELF_AUXV_SPACE 16 /* extra memory space (in bytes) */
+
 #define LIBOS_SYSCALL_BOUND __NR_syscalls


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

These aux vectors are required by Glibc and musl to determine whether the loaded executable should be treated securely (e.g., secure treatment ignores `LD_LIBRARY_PATH` and `LD_PRELOAD` envvars). Glibc expects this info in `AT_SECURE` whereas musl decides based on UID/EUID/GID/EGID.

Fixes #1394. See it for more context.

References:
- https://man7.org/linux/man-pages/man3/getauxval.3.html
- https://lwn.net/Articles/519085/
- https://github.com/bminor/musl/commit/75ce4503950621b11fcc7f1fd1187dbcf3cde312
- https://elixir.bootlin.com/musl/v1.2.4/source/ldso/dynlink.c#L1817
- https://github.com/bminor/glibc/blob/1d44530a5be2442e064baa48139adc9fdfb1fc6b/sysdeps/unix/sysv/linux/dl-parse_auxv.h#L46

## How to test this PR? <!-- (if applicable) -->

Manual check:
- First
```diff
diff --git a/libos/test/regression/uid_gid.manifest.template b/libos/test/regression/uid_gid.manifest.template
@@ -2,6 +2,7 @@ loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"

 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+loader.env.LD_SHOW_AUXV = "1"

 loader.uid = 1338
 loader.gid = 1337
```

- Then build and run:
```sh
libos/test/regression$ gramine-direct uid_gid
AT_PHDR:              0x400040
AT_PHNUM:             13
AT_PAGESZ:            4096
AT_ENTRY:             0x4010f0
AT_BASE:              0x3be570ffe000
AT_RANDOM:            0x3be571074f90
AT_PHENT:             56
AT_SYSINFO_EHDR:      0x3be570ffd000
AT_SECURE:            0
AT_UID:               1338
AT_EUID:              1338
AT_GID:               1337
AT_EGID:              1337
TEST OK
```

I also tested on Alpine 3.18.0 with Musl 1.2.4, using GDB and stepping through https://elixir.bootlin.com/musl/v1.2.4/source/ldso/dynlink.c#L1817