### PR TITLE
[Meson] Allow building with `-Dglibc=disabled`

### DIFF
--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -55,11 +55,21 @@ pkgconfig.generate(
     ],
 )
 
+# if glibc is enabled, then make default mbedTLS libs glibc-linked (even if musl is also enabled);
+# musl-only OS distros must disable glibc build so that default mbedTLS libs become musl-linked
+if get_option('glibc') == 'enabled'
+    libc = 'glibc'
+elif get_option('musl') == 'enabled'
+    libc = 'musl'
+else
+    error('Unknown libc specified')
+endif
+
 foreach output : mbedtls_libs_output
     meson.add_install_script('/bin/sh', '-c',
         ('ln -sf ../../../@0@ ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/runtime/glibc/').format(
-            output, get_option('libdir')))
+        '"$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/runtime/@2@/').format(
+            output, get_option('libdir'), libc))
 endforeach
 
 # We rely on the fact that for `mbedtls_gramine` package, we don't need any changes in the default

--- a/subprojects/packagefiles/mbedtls/meson_options.txt
+++ b/subprojects/packagefiles/mbedtls/meson_options.txt
@@ -1,1 +1,3 @@
+# TODO: after deprecating 18.04/bionic, change these to type: 'feature'
+#       see also top-level meson_options.txt
 option('glibc', type: 'combo', choices: ['disabled', 'enabled'], value: 'enabled', yield: true)

--- a/subprojects/packagefiles/mbedtls/meson_options.txt
+++ b/subprojects/packagefiles/mbedtls/meson_options.txt
@@ -1,0 +1,1 @@
+option('glibc', type: 'combo', choices: ['disabled', 'enabled'], value: 'enabled', yield: true)

--- a/tools/sgx/ra-tls/meson.build
+++ b/tools/sgx/ra-tls/meson.build
@@ -8,6 +8,16 @@ install_headers('ra_tls.h', 'ra_tls_common.h', 'secret_prov.h', subdir : 'gramin
 
 libra_tls_inc = include_directories('.')
 
+# if glibc is enabled, then make default RA-TLS libs glibc-linked (even if musl is also enabled);
+# musl-only OS distros must disable glibc build so that default RA-TLS libs become musl-linked
+if get_option('glibc') == 'enabled'
+    libc = 'glibc'
+elif get_option('musl') == 'enabled'
+    libc = 'musl'
+else
+    error('Unknown libc specified')
+endif
+
 ra_tls_map = join_paths(meson.current_source_dir(), 'ra_tls.map')
 ra_tls_link_args = [
     '-Wl,--version-script=@0@'.format(ra_tls_map),
@@ -30,8 +40,8 @@ libra_tls_attest = shared_library('ra_tls_attest',
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libra_tls_attest.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+        get_option('libdir'), libc))
 
 libra_tls_verify = static_library('ra_tls_verify',
     'ra_tls_verify_common.c',
@@ -46,8 +56,8 @@ libra_tls_verify = static_library('ra_tls_verify',
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libra_tls_verify.a ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+        get_option('libdir'), libc))
 
 libra_tls_verify_dep = declare_dependency(
     link_with: libra_tls_verify,
@@ -68,8 +78,8 @@ libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libra_tls_verify_epid.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+        get_option('libdir'), libc))
 
 libsecret_prov_attest = shared_library('secret_prov_attest',
     'secret_prov_attest.c',
@@ -87,8 +97,8 @@ libsecret_prov_attest = shared_library('secret_prov_attest',
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libsecret_prov_attest.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+        get_option('libdir'), libc))
 
 libsecret_prov_verify = static_library('secret_prov_verify',
     'secret_prov_verify.c',
@@ -104,8 +114,8 @@ libsecret_prov_verify = static_library('secret_prov_verify',
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libsecret_prov_verify.a ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+        get_option('libdir'), libc))
 
 libsecret_prov_verify_dep = declare_dependency(
     link_with: libsecret_prov_verify,
@@ -127,8 +137,8 @@ libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
 )
 meson.add_install_script('/bin/sh', '-c',
     'ln -sf ../../../libsecret_prov_verify_epid.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+        get_option('libdir'), libc))
 
 if dcap
     libra_tls_verify_dcap = shared_library('ra_tls_verify_dcap',
@@ -146,8 +156,8 @@ if dcap
     )
     meson.add_install_script('/bin/sh', '-c',
         'ln -sf ../../../libra_tls_verify_dcap.so ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-            get_option('libdir')))
+        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+            get_option('libdir'), libc))
 
     libra_tls_verify_dcap_gramine = shared_library('ra_tls_verify_dcap_gramine',
         'ra_tls_verify_dcap.c',
@@ -165,8 +175,8 @@ if dcap
     )
     meson.add_install_script('/bin/sh', '-c',
         'ln -sf ../../../libra_tls_verify_dcap_gramine.so ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-            get_option('libdir')))
+        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+            get_option('libdir'), libc))
 
     libsecret_prov_verify_dcap = shared_library('secret_prov_verify_dcap',
         'ra_tls_verify_dcap.c',
@@ -185,8 +195,8 @@ if dcap
     )
     meson.add_install_script('/bin/sh', '-c',
         'ln -sf ../../../libsecret_prov_verify_dcap.so ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-            get_option('libdir')))
+        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/@1@/'.format(
+            get_option('libdir'), libc))
 endif
 
 pkgconfig.generate(


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously mbedTLS and RA-TLS libs depended on Glibc being enabled (even if building on musl-only OS distro like Alpine). With this commit, if Glibc is disabled, then mbedTLS and RA-TLS installation scripts install musl-linked versions of these libs.

Fixes #1399. Closes #1417.

## How to test this PR? <!-- (if applicable) -->

Manually on Alpine. Also, CI (glibc-based) must not break.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1400)
<!-- Reviewable:end -->
