### PR TITLE
[LibOS] Ignore O_TRUNC flag for FIFO files

### DIFF
--- a/libos/src/fs/libos_namei.c
+++ b/libos/src/fs/libos_namei.c
@@ -408,6 +408,7 @@ int dentry_open(struct libos_handle* hdl, struct libos_dentry* dent, int flags) 
     /* truncate regular writable file if O_TRUNC is given */
     if ((flags & O_TRUNC) && ((flags & O_RDWR) | (flags & O_WRONLY))
             && (dent->inode->type != S_IFDIR)
+            && (dent->inode->type != S_IFIFO)
             && (dent->inode->type != S_IFLNK)) {
 
         if (!(fs->fs_ops && fs->fs_ops->truncate))

--- a/libos/src/fs/pipe/fs.c
+++ b/libos/src/fs/pipe/fs.c
@@ -212,7 +212,7 @@ static int fifo_open(struct libos_handle* hdl, struct libos_dentry* dent, int fl
          * one end (read or write) in our emulation, so we treat such FIFOs as read-only. This
          * covers most apps seen in the wild (in particular, LTP apps). */
         log_warning("FIFO (named pipe) '%s' cannot be opened in read-write mode in Gramine. "
-                    "Treating it as read-only.", dent->mount->path);
+                    "Treating it as read-only.", dent->name);
         flags = (flags & ~O_ACCMODE) | O_RDONLY;
     }
 

--- a/libos/test/regression/mkfifo.c
+++ b/libos/test/regression/mkfifo.c
@@ -60,9 +60,9 @@ int main(int argc, char** argv) {
         /* server */
         fd = -1;
         while (fd < 0) {
-            /* wait until client is ready for read */
+            /* wait until client is ready for read (O_TRUNC flag here is only for testing) */
             errno = 0;
-            fd = open(FIFO_PATH, O_NONBLOCK | O_WRONLY);
+            fd = open(FIFO_PATH, O_NONBLOCK | O_WRONLY | O_TRUNC);
             if (fd < 0 && errno != ENXIO) {
                 perror("[parent] open error");
                 return 1;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

During enablement of mxnet-model-server in gramine one issue is observed that for FIFO files opening it with `O_TRUNC` returns `EINVAL`. In the native `O_TRUNC` flag for FIFO files is ignored. See `man 2 open`. This PR also emulates the same behaviour for gramine.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Modify this line https://github.com/gramineproject/gramine/blob/702ac42f81452b288b66b00308763584c3d115d3/libos/test/regression/mkfifo.c#L30  by adding `O_TRUNC` flag and replacing `O_RDONLY` by `O_RDWR` and test this PR by running regression test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1401)
<!-- Reviewable:end -->
