### PR TITLE
[PAL/Linux-SGX] Remove no-XSAVE code paths (dead code)

### DIFF
--- a/pal/src/host/linux-sgx/enclave_entry.S
+++ b/pal/src/host/linux-sgx/enclave_entry.S
@@ -143,12 +143,12 @@ enclave_entry:
     popfq
 
     # Clear "extended" state (FPU aka x87, SSE, AVX, ...).
-    # TODO: We currently clear only state covered by FXRSTOR but not by XRSTOR (e.g., no clearing of
-    #       YMM/ZMM regs). This is because we didn't read the value of XFRM yet, so we don't know
-    #       whether XRSTOR is safe at this point.
-    leaq g_xsave_reset_state(%rip), %rax
-    fxrstor (%rax)
+    movq %rdx, %rbx
+    mov $0xffffffff, %eax
+    mov %eax, %edx
+    xrstor64 g_xsave_reset_state(%rip)
     xorq %rax, %rax
+    movq %rbx, %rdx
 
     # register states need to be carefully checked, so we move handling to handle_ecall() in C code
     callq handle_ecall
@@ -694,16 +694,10 @@ sgx_ocall:
     #
     # g_pal_linuxsgx_state.enclave_info.attributes.xfrm will always be zero before init_enclave has
     # been called by pal_linux_main. So during early init nothing should use features not covered by
-    # fxrstor, like AVX.
-    cmpl $0, g_xsave_enabled(%rip)
-    jne 1f
-    fxrstor64 g_xsave_reset_state(%rip)
-    jmp 2f
-1:
+    # xrstor, like AVX.
     mov $0xffffffff, %eax
     mov %eax, %edx
     xrstor64 g_xsave_reset_state(%rip)
-2:
 
 #ifdef DEBUG
     # Store pointer to context in RDX, for the SGX profiler.
@@ -873,10 +867,6 @@ _restore_sgx_context:
     .type __save_xregs, @function
 __save_xregs:
     .cfi_startproc
-    movl g_xsave_enabled(%rip), %eax
-    cmpl $0, %eax
-    jz 1f
-
     # clear XSAVE area header
     movq $0, XSAVE_HEADER_OFFSET + 0 * 8(%rdi)
     movq $0, XSAVE_HEADER_OFFSET + 1 * 8(%rdi)
@@ -890,9 +880,6 @@ __save_xregs:
     movl $0xffffffff, %eax
     movl $0xffffffff, %edx
     xsave64 (%rdi)
-    jmp *%r11
-1:
-    fxsave64 (%rdi)
     jmp *%r11
     .cfi_endproc
 
@@ -918,16 +905,9 @@ save_xregs:
     .type __restore_xregs, @function
 __restore_xregs:
     .cfi_startproc
-    movl g_xsave_enabled(%rip), %eax
-    cmpl $0, %eax
-    jz 1f
-
     movl $0xffffffff, %eax
     movl $0xffffffff, %edx
     xrstor64 (%rdi)
-    jmp *%r11
-1:
-    fxrstor64 (%rdi)
     jmp *%r11
     .cfi_endproc
 

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -1153,6 +1153,13 @@ static int verify_hw_requirements(char* envp[]) {
                   "Please upgrade your hardware.", missing);
         return -EINVAL;
     }
+
+    if (!(values[CPUID_WORD_ECX] & (1 << 27))) {
+        log_error("Gramine with Linux-SGX backend requires XSAVE support in OS (OSXSAVE). "
+                  "Please use an OS with XSAVE support.");
+        return -EINVAL;
+    }
+
     return 0;
 }
 

--- a/pal/src/host/linux-sgx/pal_exception.c
+++ b/pal/src/host/linux-sgx/pal_exception.c
@@ -101,13 +101,8 @@ static void save_pal_context(PAL_CONTEXT* ctx, sgx_cpu_context_t* uc,
     fpx_sw->extended_size = g_xsave_size;
     fpx_sw->xfeatures     = g_xsave_features;
     memset(fpx_sw->padding, 0, sizeof(fpx_sw->padding));
-    if (g_xsave_enabled) {
-        fpx_sw->xstate_size = g_xsave_size + PAL_FP_XSTATE_MAGIC2_SIZE;
-        *(__typeof__(PAL_FP_XSTATE_MAGIC2)*)((void*)xregs_state + g_xsave_size) =
-            PAL_FP_XSTATE_MAGIC2;
-    } else {
-        fpx_sw->xstate_size = g_xsave_size;
-    }
+    fpx_sw->xstate_size = g_xsave_size + PAL_FP_XSTATE_MAGIC2_SIZE;
+    *(__typeof__(PAL_FP_XSTATE_MAGIC2)*)((void*)xregs_state + g_xsave_size) = PAL_FP_XSTATE_MAGIC2;
 }
 
 static void emulate_rdtsc_and_print_warning(sgx_cpu_context_t* uc) {

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -84,7 +84,6 @@ extern char __text_start, __text_end, __data_start, __data_end;
 extern const uint32_t g_cpu_extension_sizes[];
 extern const uint32_t g_cpu_extension_offsets[];
 
-extern int g_xsave_enabled;
 extern uint64_t g_xsave_features;
 extern uint32_t g_xsave_size;
 #define XSAVE_RESET_STATE_SIZE (512 + 64)  // 512 for legacy regs, 64 for xsave header


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Commit ["[PAL/Linux-SGX] Enforce AES-NI, XSAVE and RDRAND"](https://github.com/gramineproject/gramine/commit/7f72f133d134cd1e11294209a3702d555837ccb9) enforced the XSAVE CPU feature. The Linux-SGX PAL still had some code that use no-XSAVE code paths, falling back to older FXSAVE. With that commit, such code became dead code.

Also, this commit adds an additional enforcement: the OS must also enable the XSAVE feature, which is reflected in CPUID.1:ECX.OSXSAVE.

## How to test this PR? <!-- (if applicable) -->

CI should be enough. Also, testing on some big new Intel CPUs would be beneficial (to test e.g. AMX enablement).

This was detected while working on https://github.com/gramineproject/gramine/issues/955 (which we hit again).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1402)
<!-- Reviewable:end -->
