### PR TITLE
[PAL/Linux-SGX] Enable optional CPU features only if allowed by XCR0

### DIFF
--- a/common/include/arch/x86_64/cpu.h
+++ b/common/include/arch/x86_64/cpu.h
@@ -67,6 +67,12 @@ static inline uint64_t get_tsc(void) {
     return lo | ((uint64_t)hi << 32);
 }
 
+static inline uint64_t xgetbv(uint32_t xcr_number) {
+    unsigned long lo, hi;
+    __asm__ volatile("xgetbv" : "=a" (lo), "=d" (hi) : "c" (xcr_number));
+    return lo | ((uint64_t)hi << 32);
+}
+
 /*!
  * \brief Low-level wrapper around RDRAND instruction (get hardware-generated random value).
  */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Host OS can disable certain CPU features by unsetting their bits in XCR0 register (even when the CPU feature is available on the CPU). Linux-SGX PAL previously enabled optional CPU features (by setting bits in SGX-specific XFRM field) by consulting only CPUID leaves. This could lead to a mismatch between XFRM and XCR0, which in turn leads to a `-EIO` error during ECREATE ioctl (because ECREATE checks whether XFRM value is a subset of XCR0 and raises #GP if not).

See https://github.com/gramineproject/gramine/issues/955 for some context.

See about XCR0: https://en.wikipedia.org/wiki/Control_register#XCR0_and_XSS

See about EENTER and XFRM vs XCR0 check: https://www.felixcloutier.com/x86/ecreate. In particular, there is this line in the pseudo-code:
```
IF ( (TMP_SECS.ATTRIBUTES.XFRM & XCR0) ≠ TMP_SECS.ATTRIBUES.XFRM) THEN #GP(0); FI;
```

This PR is based on top of https://github.com/gramineproject/gramine/pull/1402. See there also for details.

## How to test this PR? <!-- (if applicable) -->

Manually on "weird" VMs where XCR0 bits are disabled.