### PR TITLE
[LibOS] Rename POSIX lock related structs and functions

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -191,8 +191,6 @@ struct libos_fs_ops {
  * pretends to have many files in a directory. */
 #define DENTRY_MAX_CHILDREN 1000000
 
-struct fs_lock_info;
-
 /*
  * Describes a single path within a mounted filesystem. If `inode` is set, it is the file at given
  * path.
@@ -227,13 +225,13 @@ struct libos_dentry {
      * `g_dcache_lock`. */
     struct libos_mount* attached_mount;
 
-    /* File lock information, stored only in the main process. Managed by `libos_fs_lock.c`. */
-    struct fs_lock* fs_lock;
+    /* File locks information, stored only in the main process. Managed by `libos_fs_lock.c`. */
+    struct dent_file_locks* file_locks;
 
     /* True if the file might have locks placed by current process. Used in processes other than
      * main process, to prevent unnecessary IPC calls on handle close. Managed by
      * `libos_fs_lock.c`. */
-    bool maybe_has_fs_locks;
+    bool maybe_has_file_locks;
 
     refcount_t ref_count;
 };

--- a/libos/include/libos_fs_lock.h
+++ b/libos/include/libos_fs_lock.h
@@ -22,7 +22,8 @@ struct libos_dentry;
 int init_fs_lock(void);
 
 /*
- * POSIX locks (also known as advisory record locks). See `man fcntl` for details.
+ * File locks. Currently describes only POSIX locks (also known as advisory record locks). See `man
+ * fcntl` for details.
  *
  * The current implementation works over IPC and handles all requests in the main process. It has
  * the following caveats:
@@ -36,9 +37,9 @@ int init_fs_lock(void);
  * - The locks work only on files that have a dentry (no pipes, sockets etc.)
  */
 
-DEFINE_LISTP(posix_lock);
-DEFINE_LIST(posix_lock);
-struct posix_lock {
+DEFINE_LISTP(libos_file_lock);
+DEFINE_LIST(libos_file_lock);
+struct libos_file_lock {
     /* Lock type: F_RDLCK, F_WRLCK, F_UNLCK */
     int type;
 
@@ -52,73 +53,75 @@ struct posix_lock {
     IDTYPE pid;
 
     /* List node, used internally */
-    LIST_TYPE(posix_lock) list;
+    LIST_TYPE(libos_file_lock) list;
 };
 
 /*!
  * \brief Set or remove a lock on a file.
  *
- * \param dent  The dentry for a file.
- * \param pl    Parameters of new lock.
- * \param wait  If true, will wait until a lock can be taken.
+ * \param dent       The dentry for a file.
+ * \param file_lock  Parameters of new lock.
+ * \param wait       If true, will wait until a lock can be taken.
  *
  * This is the equivalent of `fnctl(F_SETLK/F_SETLKW)`.
  *
- * If `pl->type` is `F_UNLCK`, the function will remove any locks held by the given PID for the
- * given range. Removing a lock never waits.
+ * If `file_lock->type` is `F_UNLCK`, the function will remove any locks held by the given PID for
+ * the given range. Removing a lock never waits.
  *
- * If `pl->type` is `F_RDLCK` or `F_WRLCK`, the function will create a new lock for the given PID
- * and range, replacing the existing locks held by the given PID for that range. If there are
+ * If `file_lock->type` is `F_RDLCK` or `F_WRLCK`, the function will create a new lock for the given
+ * PID and range, replacing the existing locks held by the given PID for that range. If there are
  * conflicting locks, the function either waits (if `wait` is true), or fails with `-EAGAIN` (if
  * `wait` is false).
  */
-int posix_lock_set(struct libos_dentry* dent, struct posix_lock* pl, bool wait);
+int file_lock_set(struct libos_dentry* dent, struct libos_file_lock* file_lock, bool wait);
 
 /*!
  * \brief Check for conflicting locks on a file.
  *
- * \param      dent    The dentry for a file.
- * \param      pl      Parameters of new lock (type cannot be `F_UNLCK`).
- * \param[out] out_pl  On success, set to `F_UNLCK` or details of a conflicting lock.
+ * \param      dent           The dentry for a file.
+ * \param      file_lock      Parameters of new lock (type cannot be `F_UNLCK`).
+ * \param[out] out_file_lock  On success, set to `F_UNLCK` or details of a conflicting lock.
  *
  * This is the equivalent of `fcntl(F_GETLK)`.
  *
  * The function checks if there are locks by other PIDs preventing the proposed lock from being
- * placed. If the lock could be placed, `out_pl->type` is set to `F_UNLCK`. Otherwise, `out_pl`
- * fields (`type`, `start, `end`, `pid`) are set to details of a conflicting lock.
+ * placed. If the lock could be placed, `out_file_lock->type` is set to `F_UNLCK`. Otherwise,
+ * `out_file_lock` fields (`type`, `start, `end`, `pid`) are set to details of a conflicting lock.
  */
-int posix_lock_get(struct libos_dentry* dent, struct posix_lock* pl, struct posix_lock* out_pl);
+int file_lock_get(struct libos_dentry* dent, struct libos_file_lock* file_lock,
+                  struct libos_file_lock* out_file_lock);
 
 /* Removes all locks for a given PID. Should be called before process exit. */
-int posix_lock_clear_pid(IDTYPE pid);
+int file_lock_clear_pid(IDTYPE pid);
 
 /*!
  * \brief Set or remove a lock on a file (IPC handler).
  *
- * \param path  Absolute path for a file.
- * \param pl    Parameters of new lock.
- * \param wait  If true, will postpone the response until a lock can be taken.
- * \param vmid  Target process for IPC response.
- * \param seq   Sequence number for IPC response.
+ * \param path       Absolute path for a file.
+ * \param file_lock  Parameters of new lock.
+ * \param wait       If true, will postpone the response until a lock can be taken.
+ * \param vmid       Target process for IPC response.
+ * \param seq        Sequence number for IPC response.
  *
- * This is a version of `posix_lock_set` called from an IPC callback. This function is responsible
+ * This is a version of `file_lock_set` called from an IPC callback. This function is responsible
  * for either sending an IPC response immediately, or scheduling one for later (if `wait` is true
  * and the lock cannot be taken immediately).
  *
  * This function will only return a negative error code when failing to send a response. A failure
  * to add a lock (-EAGAIN, -ENOMEM etc.) will be sent in the response instead.
  */
-int posix_lock_set_from_ipc(const char* path, struct posix_lock* pl, bool wait, IDTYPE vmid,
-                            unsigned long seq);
+int file_lock_set_from_ipc(const char* path, struct libos_file_lock* file_lock, bool wait,
+                           IDTYPE vmid, unsigned long seq);
 
 /*!
  * \brief Check for conflicting locks on a file (IPC handler).
  *
- * \param      path    Absolute path for a file.
- * \param      pl      Parameters of new lock (type cannot be `F_UNLCK`).
- * \param[out] out_pl  On success, set to `F_UNLCK` or details of a conflicting lock.
+ * \param      path           Absolute path for a file.
+ * \param      file_lock      Parameters of new lock (type cannot be `F_UNLCK`).
+ * \param[out] out_file_lock  On success, set to `F_UNLCK` or details of a conflicting lock.
  *
- * This is a version of `posix_lock_get` called from an IPC callback. The caller is responsible to
- * send the returned value and `out_pl` in an IPC response.
+ * This is a version of `file_lock_get` called from an IPC callback. The caller is responsible to
+ * send the returned value and `out_file_lock` in an IPC response.
  */
-int posix_lock_get_from_ipc(const char* path, struct posix_lock* pl, struct posix_lock* out_pl);
+int file_lock_get_from_ipc(const char* path, struct libos_file_lock* file_lock,
+                           struct libos_file_lock* out_file_lock);

--- a/libos/include/libos_ipc.h
+++ b/libos/include/libos_ipc.h
@@ -32,9 +32,9 @@ enum {
     IPC_MSG_SYNC_CONFIRM_UPGRADE,
     IPC_MSG_SYNC_CONFIRM_DOWNGRADE,
     IPC_MSG_SYNC_CONFIRM_CLOSE,
-    IPC_MSG_POSIX_LOCK_SET,
-    IPC_MSG_POSIX_LOCK_GET,
-    IPC_MSG_POSIX_LOCK_CLEAR_PID,
+    IPC_MSG_FILE_LOCK_SET,
+    IPC_MSG_FILE_LOCK_GET,
+    IPC_MSG_FILE_LOCK_CLEAR_PID,
     IPC_MSG_CODE_BOUND,
 };
 
@@ -271,13 +271,13 @@ int ipc_sync_confirm_downgrade_callback(IDTYPE src, void* data, unsigned long se
 int ipc_sync_confirm_close_callback(IDTYPE src, void* data, unsigned long seq);
 
 /*
- * POSIX_LOCK_SET: `struct libos_ipc_posix_lock` -> `int`
- * POSIX_LOCK_GET: `struct libos_ipc_posix_lock` -> `struct libos_ipc_posix_lock_resp`
- * POSIX_LOCK_CLEAR_PID: `IDTYPE` -> `int`
+ * FILE_LOCK_SET: `struct libos_ipc_file_lock` -> `int`
+ * FILE_LOCK_GET: `struct libos_ipc_file_lock` -> `struct libos_ipc_file_lock_resp`
+ * FILE_LOCK_CLEAR_PID: `IDTYPE` -> `int`
  */
 
-struct libos_ipc_posix_lock {
-    /* see `struct posix_lock` in `libos_fs_lock.h` */
+struct libos_ipc_file_lock {
+    /* see `struct libos_file_lock` in `libos_fs_lock.h` */
     int type;
     uint64_t start;
     uint64_t end;
@@ -287,22 +287,23 @@ struct libos_ipc_posix_lock {
     char path[]; /* null-terminated */
 };
 
-struct libos_ipc_posix_lock_resp {
+struct libos_ipc_file_lock_resp {
     int result;
 
-    /* see `struct posix_lock` in `libos_fs_lock.h` */
+    /* see `struct libos_file_lock` in `libos_fs_lock.h` */
     int type;
     uint64_t start;
     uint64_t end;
     IDTYPE pid;
 };
 
-struct posix_lock;
+struct libos_file_lock;
 
-int ipc_posix_lock_set(const char* path, struct posix_lock* pl, bool wait);
-int ipc_posix_lock_set_send_response(IDTYPE vmid, unsigned long seq, int result);
-int ipc_posix_lock_get(const char* path, struct posix_lock* pl, struct posix_lock* out_pl);
-int ipc_posix_lock_clear_pid(IDTYPE pid);
-int ipc_posix_lock_set_callback(IDTYPE src, void* data, unsigned long seq);
-int ipc_posix_lock_get_callback(IDTYPE src, void* data, unsigned long seq);
-int ipc_posix_lock_clear_pid_callback(IDTYPE src, void* data, unsigned long seq);
+int ipc_file_lock_set(const char* path, struct libos_file_lock* file_lock, bool wait);
+int ipc_file_lock_set_send_response(IDTYPE vmid, unsigned long seq, int result);
+int ipc_file_lock_get(const char* path, struct libos_file_lock* file_lock,
+                      struct libos_file_lock* out_file_lock);
+int ipc_file_lock_clear_pid(IDTYPE pid);
+int ipc_file_lock_set_callback(IDTYPE src, void* data, unsigned long seq);
+int ipc_file_lock_get_callback(IDTYPE src, void* data, unsigned long seq);
+int ipc_file_lock_clear_pid_callback(IDTYPE src, void* data, unsigned long seq);

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -293,16 +293,16 @@ static struct libos_handle* __detach_fd_handle(struct libos_fd_handle* fd, int* 
 
 static int clear_posix_locks(struct libos_handle* handle) {
     if (handle && handle->dentry) {
-        /* Clear POSIX locks for a file. We are required to do that every time a FD is closed, even
-         * if the process holds other handles for that file, or duplicated FDs for the same
-         * handle. */
-        struct posix_lock pl = {
+        /* Clear file (POSIX) locks for a file. We are required to do that every time a FD is
+         * closed, even if the process holds other handles for that file, or duplicated FDs for the
+         * same handle. */
+        struct libos_file_lock file_lock = {
             .type = F_UNLCK,
             .start = 0,
             .end = FS_LOCK_EOF,
             .pid = g_process.pid,
         };
-        int ret = posix_lock_set(handle->dentry, &pl, /*block=*/false);
+        int ret = file_lock_set(handle->dentry, &file_lock, /*block=*/false);
         if (ret < 0) {
             log_warning("error releasing locks: %s", unix_strerror(ret));
             return ret;

--- a/libos/src/fs/libos_dcache.c
+++ b/libos/src/fs/libos_dcache.c
@@ -532,8 +532,8 @@ BEGIN_CP_FUNC(dentry) {
         INIT_LIST_HEAD(new_dent, siblings);
         refcount_set(&new_dent->ref_count, 0);
 
-        /* `fs_lock` is used only by process leader. */
-        new_dent->fs_lock = NULL;
+        /* `file_locks` is used only by process leader. */
+        new_dent->file_locks = NULL;
 
         DO_CP_MEMBER(str, dent, new_dent, name);
 

--- a/libos/src/ipc/libos_ipc_fs_lock.c
+++ b/libos/src/ipc/libos_ipc_fs_lock.c
@@ -10,14 +10,14 @@
 #include "libos_fs_lock.h"
 #include "libos_ipc.h"
 
-int ipc_posix_lock_set(const char* path, struct posix_lock* pl, bool wait) {
+int ipc_file_lock_set(const char* path, struct libos_file_lock* file_lock, bool wait) {
     assert(g_process_ipc_ids.leader_vmid);
 
-    struct libos_ipc_posix_lock msgin = {
-        .type = pl->type,
-        .start = pl->start,
-        .end = pl->end,
-        .pid = pl->pid,
+    struct libos_ipc_file_lock msgin = {
+        .type = file_lock->type,
+        .start = file_lock->start,
+        .end = file_lock->end,
+        .pid = file_lock->pid,
 
         .wait = wait,
     };
@@ -25,12 +25,12 @@ int ipc_posix_lock_set(const char* path, struct posix_lock* pl, bool wait) {
     size_t path_len = strlen(path);
     size_t total_msg_size = get_ipc_msg_size(sizeof(msgin) + path_len + 1);
     struct libos_ipc_msg* msg = __alloca(total_msg_size);
-    init_ipc_msg(msg, IPC_MSG_POSIX_LOCK_SET, total_msg_size);
+    init_ipc_msg(msg, IPC_MSG_FILE_LOCK_SET, total_msg_size);
     memcpy(msg->data, &msgin, sizeof(msgin));
 
     /* Copy path after message (`msg->data` is unaligned, so we have to compute the offset
      * manually) */
-    char* path_ptr = (char*)&msg->data + offsetof(struct libos_ipc_posix_lock, path);
+    char* path_ptr = (char*)&msg->data + offsetof(struct libos_ipc_file_lock, path);
     memcpy(path_ptr, path, path_len + 1);
 
     void* data;
@@ -42,7 +42,7 @@ int ipc_posix_lock_set(const char* path, struct posix_lock* pl, bool wait) {
     return result;
 }
 
-int ipc_posix_lock_set_send_response(IDTYPE vmid, unsigned long seq, int result) {
+int ipc_file_lock_set_send_response(IDTYPE vmid, unsigned long seq, int result) {
     assert(!g_process_ipc_ids.leader_vmid);
 
     size_t total_msg_size = get_ipc_msg_size(sizeof(result));
@@ -52,25 +52,26 @@ int ipc_posix_lock_set_send_response(IDTYPE vmid, unsigned long seq, int result)
     return ipc_send_message(vmid, msg);
 }
 
-int ipc_posix_lock_get(const char* path, struct posix_lock* pl, struct posix_lock* out_pl) {
+int ipc_file_lock_get(const char* path, struct libos_file_lock* file_lock,
+                      struct libos_file_lock* out_file_lock) {
     assert(g_process_ipc_ids.leader_vmid);
 
-    struct libos_ipc_posix_lock msgin = {
-        .type = pl->type,
-        .start = pl->start,
-        .end = pl->end,
-        .pid = pl->pid,
+    struct libos_ipc_file_lock msgin = {
+        .type = file_lock->type,
+        .start = file_lock->start,
+        .end = file_lock->end,
+        .pid = file_lock->pid,
     };
 
     size_t path_len = strlen(path);
     size_t total_msg_size = get_ipc_msg_size(sizeof(msgin) + path_len + 1);
     struct libos_ipc_msg* msg = __alloca(total_msg_size);
-    init_ipc_msg(msg, IPC_MSG_POSIX_LOCK_GET, total_msg_size);
+    init_ipc_msg(msg, IPC_MSG_FILE_LOCK_GET, total_msg_size);
     memcpy(msg->data, &msgin, sizeof(msgin));
 
     /* Copy path after message (`msg->data` is unaligned, so we have to compute the offset
      * manually) */
-    char* path_ptr = (char*)&msg->data + offsetof(struct libos_ipc_posix_lock, path);
+    char* path_ptr = (char*)&msg->data + offsetof(struct libos_ipc_file_lock, path);
     memcpy(path_ptr, path, path_len + 1);
 
     void* data;
@@ -78,24 +79,24 @@ int ipc_posix_lock_get(const char* path, struct posix_lock* pl, struct posix_loc
     if (ret < 0)
         return ret;
 
-    struct libos_ipc_posix_lock_resp* resp = data;
+    struct libos_ipc_file_lock_resp* resp = data;
     int result = resp->result;
     if (resp->result == 0) {
-        out_pl->type = resp->type;
-        out_pl->start = resp->start;
-        out_pl->end = resp->end;
-        out_pl->pid = resp->pid;
+        out_file_lock->type = resp->type;
+        out_file_lock->start = resp->start;
+        out_file_lock->end = resp->end;
+        out_file_lock->pid = resp->pid;
     }
     free(data);
     return result;
 }
 
-int ipc_posix_lock_clear_pid(IDTYPE pid) {
+int ipc_file_lock_clear_pid(IDTYPE pid) {
     assert(g_process_ipc_ids.leader_vmid);
 
     size_t total_msg_size = get_ipc_msg_size(sizeof(pid));
     struct libos_ipc_msg* msg = __alloca(total_msg_size);
-    init_ipc_msg(msg, IPC_MSG_POSIX_LOCK_CLEAR_PID, total_msg_size);
+    init_ipc_msg(msg, IPC_MSG_FILE_LOCK_CLEAR_PID, total_msg_size);
     memcpy(msg->data, &pid, sizeof(pid));
 
     void* data;
@@ -107,35 +108,35 @@ int ipc_posix_lock_clear_pid(IDTYPE pid) {
     return result;
 }
 
-int ipc_posix_lock_set_callback(IDTYPE src, void* data, unsigned long seq) {
-    struct libos_ipc_posix_lock* msgin = data;
-    struct posix_lock pl = {
+int ipc_file_lock_set_callback(IDTYPE src, void* data, unsigned long seq) {
+    struct libos_ipc_file_lock* msgin = data;
+    struct libos_file_lock file_lock = {
         .type = msgin->type,
         .start = msgin->start,
         .end = msgin->end,
         .pid = msgin->pid,
     };
 
-    return posix_lock_set_from_ipc(msgin->path, &pl, msgin->wait, src, seq);
+    return file_lock_set_from_ipc(msgin->path, &file_lock, msgin->wait, src, seq);
 }
 
-int ipc_posix_lock_get_callback(IDTYPE src, void* data, unsigned long seq) {
-    struct libos_ipc_posix_lock* msgin = data;
-    struct posix_lock pl = {
+int ipc_file_lock_get_callback(IDTYPE src, void* data, unsigned long seq) {
+    struct libos_ipc_file_lock* msgin = data;
+    struct libos_file_lock file_lock = {
         .type = msgin->type,
         .start = msgin->start,
         .end = msgin->end,
         .pid = msgin->pid,
     };
 
-    struct posix_lock pl2 = {0};
-    int result = posix_lock_get_from_ipc(msgin->path, &pl, &pl2);
-    struct libos_ipc_posix_lock_resp msgout = {
+    struct libos_file_lock file_lock2 = {0};
+    int result = file_lock_get_from_ipc(msgin->path, &file_lock, &file_lock2);
+    struct libos_ipc_file_lock_resp msgout = {
         .result = result,
-        .type = pl2.type,
-        .start = pl2.start,
-        .end = pl2.end,
-        .pid = pl2.pid,
+        .type = file_lock2.type,
+        .start = file_lock2.start,
+        .end = file_lock2.end,
+        .pid = file_lock2.pid,
     };
 
     size_t total_msg_size = get_ipc_msg_size(sizeof(msgout));
@@ -145,9 +146,9 @@ int ipc_posix_lock_get_callback(IDTYPE src, void* data, unsigned long seq) {
     return ipc_send_message(src, msg);
 }
 
-int ipc_posix_lock_clear_pid_callback(IDTYPE src, void* data, unsigned long seq) {
+int ipc_file_lock_clear_pid_callback(IDTYPE src, void* data, unsigned long seq) {
     IDTYPE* pid = data;
-    int result = posix_lock_clear_pid(*pid);
+    int result = file_lock_clear_pid(*pid);
 
     size_t total_msg_size = get_ipc_msg_size(sizeof(result));
     struct libos_ipc_msg* msg = __alloca(total_msg_size);

--- a/libos/src/ipc/libos_ipc_worker.c
+++ b/libos/src/ipc/libos_ipc_worker.c
@@ -60,9 +60,9 @@ static ipc_callback ipc_callbacks[] = {
     [IPC_MSG_SYNC_CONFIRM_DOWNGRADE] = ipc_sync_confirm_downgrade_callback,
     [IPC_MSG_SYNC_CONFIRM_CLOSE]     = ipc_sync_confirm_close_callback,
 
-    [IPC_MSG_POSIX_LOCK_SET]       = ipc_posix_lock_set_callback,
-    [IPC_MSG_POSIX_LOCK_GET]       = ipc_posix_lock_get_callback,
-    [IPC_MSG_POSIX_LOCK_CLEAR_PID] = ipc_posix_lock_clear_pid_callback,
+    [IPC_MSG_FILE_LOCK_SET]       = ipc_file_lock_set_callback,
+    [IPC_MSG_FILE_LOCK_GET]       = ipc_file_lock_get_callback,
+    [IPC_MSG_FILE_LOCK_CLEAR_PID] = ipc_file_lock_clear_pid_callback,
 };
 
 static void ipc_leader_died_callback(void) {

--- a/libos/src/sys/libos_exit.c
+++ b/libos/src/sys/libos_exit.c
@@ -131,11 +131,11 @@ noreturn void thread_exit(int error_code, int term_signal) {
         /* UNREACHABLE */
     }
 
-    /* Clear POSIX locks before we notify parent: after a successful `wait()` by parent, our locks
-     * should already be gone. */
-    int ret = posix_lock_clear_pid(g_process.pid);
+    /* Clear file (POSIX) locks before we notify parent: after a successful `wait()` by parent, our
+     * locks should already be gone. */
+    int ret = file_lock_clear_pid(g_process.pid);
     if (ret < 0)
-        log_warning("error clearing POSIX locks: %s", unix_strerror(ret));
+        log_warning("error clearing file (POSIX) locks: %s", unix_strerror(ret));
 
     detach_all_fds();
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a preparatory commit to introduce flock (BSD locks) support. Previously, Gramine supported only POSIX locks, which was reflected in struct and function names (the `posix_` prefix and the `pl` abbreviation). With BSD locks, the same structs and functions will be used for both lock types, so this commit renames `posix` to `file` and `pl` to `file_lock`. Additionally, misleadingly named `struct fs_lock` is renamed to `struct dent_file_locks` (means: association of a dentry with its file locks).

Created in response to the comments in #1212.

## How to test this PR? <!-- (if applicable) -->

CI is enough. Pure renaming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1406)
<!-- Reviewable:end -->
