### PR TITLE
[LibOS] Move checkpoint special sections to RELRO segment.

### DIFF
--- a/libos/include/libos_checkpoint.h
+++ b/libos/include/libos_checkpoint.h
@@ -112,7 +112,7 @@ struct libos_cp_store {
 typedef int (*cp_func)(CP_FUNC_ARGS);
 typedef int (*rs_func)(RS_FUNC_ARGS);
 
-extern const char* __cp_name;
+extern const char* const __cp_name;
 extern const cp_func __cp_func; // TODO: This should be declared as an array of unspecified size.
 extern const rs_func __rs_func[];
 
@@ -215,7 +215,7 @@ enum {
     })
 
 #define BEGIN_CP_FUNC(name)                                                                \
-    const char* cp_name_##name __attribute__((section(".cp_name." #name))) = #name;        \
+    const char* const cp_name_##name __attribute__((section(".cp_name." #name))) = #name;        \
     extern DEFINE_CP_FUNC(name);                                                           \
     extern DEFINE_RS_FUNC(name);                                                           \
     const cp_func cp_func_##name __attribute__((section(".cp_func." #name))) = &cp_##name; \

--- a/libos/src/arch/x86_64/libos.lds
+++ b/libos/src/arch/x86_64/libos.lds
@@ -50,13 +50,6 @@ SECTIONS
   {
     /* the rest of rodata */
     *(.rodata .rodata.*)
-    . = ALIGN(8);
-    __cp_name = .;
-    *(SORT(.cp_name.*));
-    __cp_func = .;
-    *(SORT(.cp_func.*));
-    __rs_func = .;
-    *(SORT(.rs_func.*));
   }
   .eh_frame_hdr  : { *(.eh_frame_hdr) }
   .eh_frame      : ONLY_IF_RO { *(.eh_frame) }
@@ -74,6 +67,18 @@ SECTIONS
     __init_array_start = .;
     KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) .init_array))
     __init_array_end = .;
+  }
+  .data.rel.ro :
+  {
+    /* the rest of RELRO data segment */
+    *(.data.rel.ro .data.rel.ro.*)
+    . = ALIGN(8);
+    __cp_name = .;
+    *(SORT(.cp_name.*));
+    __cp_func = .;
+    *(SORT(.cp_func.*));
+    __rs_func = .;
+    *(SORT(.rs_func.*));
   }
   . = DATA_SEGMENT_RELRO_END (0, .);
   .data :


### PR DESCRIPTION
## Description of the changes

Currently, `.cp_name.*` and other checkpoint sections are included in the `.rodata` section in the output.  However, these sections require relocation, and are thus marked writable.  This causes the entire text segment of `libsysdb.so` to become RWX.

This change adds `.data.rel.ro` section to the linker script and moves these sections there.  Additionally, other `.data.rel.ro.*` sections in input files are also moved there, improving RELRO coverage.

## How to test this PR?

Run `readelf` on `libsysdb.so`, make sure there are no RWE segments.

