### PR TITLE
[LibOS] Allow creation of encryption-key pseudo-files

### DIFF
--- a/libos/include/libos_fs_pseudo.h
+++ b/libos/include/libos_fs_pseudo.h
@@ -61,7 +61,8 @@ struct libos_dev_ops {
     int (*truncate)(struct libos_handle* hdl, uint64_t len);
 };
 
-#define PSEUDO_PERM_DIR     PERM_r_xr_xr_x  /* default for directories */
+#define PSEUDO_PERM_DIR_R   PERM_r_xr_xr_x  /* default for directories */
+#define PSEUDO_PERM_DIR_RW  PERM_rwxrwxrwx
 #define PSEUDO_PERM_LINK    PERM_rwxrwxrwx  /* default for links */
 #define PSEUDO_PERM_FILE_R  PERM_r__r__r__  /* default for all other files */
 #define PSEUDO_PERM_FILE_RW PERM_rw_rw_rw_
@@ -110,6 +111,9 @@ struct pseudo_node {
 
     /* Retrieves all file names for this node. Works the same as `readdir`. */
     int (*list_names)(struct libos_dentry* parent, readdir_callback_t callback, void* arg);
+
+    /* Creates a file with a given name. */
+    int (*creat)(struct libos_dentry* parent, const char* name, struct pseudo_node** out_node);
 
     /* File permissions. See `PSEUDO_PERM_*` above for defaults. */
     mode_t perm;

--- a/tools/sgx/ra-tls/secret_prov_attest.c
+++ b/tools/sgx/ra-tls/secret_prov_attest.c
@@ -420,9 +420,9 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
                 exit(1);
             }
 
-            int fd = open(path_buf, O_WRONLY);
+            int fd = open(path_buf, O_WRONLY | O_CREAT | O_TRUNC, 0666);
             if (fd < 0) {
-                ERROR("Secret provisioning cannot open '%s'\n", path_buf);
+                ERROR("Secret provisioning cannot open '%s' for writing\n", path_buf);
                 exit(1);
             }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine disallowed creation of pseudo-files under `/dev/attestation/keys/[KEY_NAME]`, if the corresponding key name was not specified as `fs.insecure__keys.[KEY_NAME]` in the manifest. This happened because Gramine's pseudo FS didn't have the concept of file creation (all files were assumed to be created at init time).

This commit fixes it by adding the `creat()` callback in pseudo FS. Currently, only the `/dev/attestation/keys/` dir implements this callback. A LibOS test `keys` is updated.

Reported by @mythi. Thanks to him!

Notice that our documentation implies that such key files **can be created**. So this was a bug in Gramine, and no changes to the documentation are required: https://gramine.readthedocs.io/en/stable/manifest-syntax.html#encrypted-files.

## How to test this PR? <!-- (if applicable) -->

Added a LibOS regression test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1412)
<!-- Reviewable:end -->
