### PR TITLE
[Meson] Replace `combo` with `feature` where possible

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,17 +28,17 @@ if syslibdir == ''
     syslibdir = '/' / get_option('libdir')
 endif
 
-direct = get_option('direct') == 'enabled'
-sgx = get_option('sgx') == 'enabled'
-skeleton = get_option('skeleton') == 'enabled'
+direct = get_option('direct').enabled()
+sgx = get_option('sgx').enabled()
+skeleton = get_option('skeleton').enabled()
 
-dcap = get_option('dcap') == 'enabled'
-ubsan = get_option('ubsan') == 'enabled'
-asan = get_option('asan') == 'enabled'
-vtune = get_option('vtune') == 'enabled'
+dcap = get_option('dcap').enabled()
+ubsan = get_option('ubsan').enabled()
+asan = get_option('asan').enabled()
+vtune = get_option('vtune').enabled()
 
-enable_libgomp = get_option('libgomp') == 'enabled'
-enable_tests = get_option('tests') == 'enabled'
+enable_libgomp = get_option('libgomp').enabled()
+enable_tests = get_option('tests').enabled()
 
 cc = meson.get_compiler('c')
 host_has_glibc = cc.get_define('__GLIBC__', prefix: '#include <features.h>') != ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,24 +1,23 @@
-# TODO: after deprecating 18.04/bionic, change these to type: 'feature'
-option('direct', type: 'combo', choices: ['disabled', 'enabled'],
+option('direct', type: 'feature', value: 'disabled',
     description: 'Build and install gramine-direct (aka Linux aka nonsgx)')
-option('sgx', type: 'combo', choices: ['disabled', 'enabled'],
+option('sgx', type: 'feature', value: 'disabled',
     description: 'Build and install gramine-sgx (aka Linux-SGX)')
-option('skeleton', type: 'combo', choices: ['disabled', 'enabled'],
+option('skeleton', type: 'feature', value: 'disabled',
     description: 'Build skeleton PAL')
 
 option('libc', type: 'combo', choices: ['none', 'glibc', 'musl'],
     value: 'glibc', description: 'Choose (patched) libc that is to be built into runtime directory')
 
-option('tests', type: 'combo', choices: ['disabled', 'enabled'],
+option('tests', type: 'feature', value: 'disabled',
     description: 'Build test binaries')
 
-option('dcap', type: 'combo', choices: ['disabled', 'enabled'],
+option('dcap', type: 'feature', value: 'disabled',
     description: 'Build additional utilities linked against DCAP library')
-option('ubsan', type: 'combo', choices: ['disabled', 'enabled'],
+option('ubsan', type: 'feature', value: 'disabled',
     description: 'Enable undefined behavior sanitizer')
-option('asan', type: 'combo', choices: ['disabled', 'enabled'],
+option('asan', type: 'feature', value: 'disabled',
     description: 'Enable address sanitizer (Clang only)')
-option('libgomp', type: 'combo', choices: ['disabled', 'enabled'],
+option('libgomp', type: 'feature', value: 'disabled',
     description: 'Build patched libgomp (takes long time)')
 
 option('sgx_driver', type: 'combo',
@@ -32,7 +31,7 @@ option('sgx_driver_device', type: 'string',
 option('syslibdir', type: 'string',
     description: 'Path to the system library directory')
 
-option('vtune', type: 'combo', choices: ['disabled', 'enabled'],
+option('vtune', type: 'feature', value: 'disabled',
     description: 'Enable profiling with VTune for Gramine with SGX')
 option('vtune_sdk_path', type: 'string',
     value: '/opt/intel/oneapi/vtune/latest/sdk',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `combo` options were left from the times when Meson was v0.47 (default on Ubuntu 18.04). Since those times, we moved to Meson at least v0.56 which has better-suited `feature` options.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1414)
<!-- Reviewable:end -->
