### PR TITLE
[Meson] Remove ambigious `prefix` variable

### DIFF
--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -310,7 +310,7 @@ endforeach
 if get_option('libc') == 'musl'
     meson.add_install_script(
         find_program('install_musl_tests.sh'),
-        prefix / install_dir / 'musl',
+        get_option('prefix') / install_dir / 'musl',
         musl_execs,
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,6 @@ project(
 # we need this subdir() early, because we need scripts defined there for setting up global vars
 subdir('scripts')
 
-prefix = get_option('prefix')
 pkglibdir = get_option('libdir') / meson.project_name()
 pkgdatadir = get_option('datadir') / meson.project_name()
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,10 +1,10 @@
 conf = configuration_data()
 conf.set_quoted('IN_GIT', '')
-conf.set_quoted('PREFIX', prefix)
+conf.set_quoted('PREFIX', get_option('prefix'))
 conf.set_quoted('BINDIR', get_option('bindir'))
 
 if direct
-    hostpalpath_direct = prefix / pkglibdir / 'direct'
+    hostpalpath_direct = get_option('prefix') / pkglibdir / 'direct'
     conf_gramine_direct = configuration_data()
     conf_gramine_direct.merge_from(conf)
     conf_gramine_direct.set('SGX', 0)
@@ -24,13 +24,13 @@ endif
 if sgx
     subdir('sgx')
 
-    hostpalpath_linux_sgx = prefix / pkglibdir / 'sgx'
+    hostpalpath_linux_sgx = get_option('prefix') / pkglibdir / 'sgx'
     conf_gramine_sgx = configuration_data()
     conf_gramine_sgx.merge_from(conf)
     conf_gramine_sgx.set('SGX', 1)
     conf_gramine_sgx.set_quoted('HOST_PAL_PATH', hostpalpath_linux_sgx)
     conf_gramine_sgx.set_quoted('LIBPAL_PATH', hostpalpath_linux_sgx / 'libpal.so')
-    conf_gramine_sgx.set_quoted('PAL_CMD', prefix / pkglibdir / 'sgx' / 'loader')
+    conf_gramine_sgx.set_quoted('PAL_CMD', get_option('prefix') / pkglibdir / 'sgx' / 'loader')
     conf_gramine_sgx.set_quoted('CONFIG_SGX_DRIVER', sgx_driver)
 
     configure_file(


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Instead, always use non-ambigious `get_option('prefix')`.

Extracted from #619. That PR had no movement for ~1 year already, so I decided to create a small PR with just this change.

It was also a request from a review of #619 (see top-level comments from Woju and Borys).

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1415)
<!-- Reviewable:end -->
