### PR TITLE
[LibOS] Add `flock` syscall

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -592,6 +592,21 @@ all), then the ``struct`` key must be an empty string or not exist at all::
    encrypted or integrity-protected with a key pre-shared between Gramine and
    the device.
 
+Experimental flock (BSD-style locks) support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sys.experimental__enable_flock = [true|false]
+    (Default: false)
+
+This syntax enables the ``flock`` system call in Gramine.
+
+.. warning::
+   This syscall is still under development and may contain security
+   vulnerabilities. This is temporary; the syscall will be enabled by default in
+   the future after thorough validation and this syntax will be removed then.
+
 SGX syntax
 ----------
 

--- a/libos/include/libos_fs_lock.h
+++ b/libos/include/libos_fs_lock.h
@@ -4,7 +4,8 @@
  */
 
 /*
- * File locks. Currently only POSIX locks are implemented.
+ * File locks. Both POSIX locks (fcntl syscall) and BSD locks (flock syscall) are implemented via
+ * a common struct `libos_file_lock`. See `man fcntl` and `man flock` for details.
  */
 
 #pragma once
@@ -22,8 +23,8 @@ struct libos_dentry;
 int init_fs_lock(void);
 
 /*
- * File locks. Currently describes only POSIX locks (also known as advisory record locks). See `man
- * fcntl` for details.
+ * File locks. Describes both POSIX locks aka advisory record locks (fcntl syscall) and BSD locks
+ * (flock syscall). See `man fcntl` and `man flock` for details.
  *
  * The current implementation works over IPC and handles all requests in the main process. It has
  * the following caveats:
@@ -32,28 +33,36 @@ int init_fs_lock(void);
  *   lock is uncontested.
  * - The main process has to be able to look up the same file, so locking will not work for files in
  *   local-process-only filesystems (tmpfs).
- * - There is no deadlock detection (EDEADLK).
  * - The lock requests cannot be interrupted (EINTR).
- * - The locks work only on files that have a dentry (no pipes, sockets etc.)
+ * - The locks work only on files that have a dentry (no pipes, sockets etc.).
+ * - Only for POSIX (fcntl) locks: no deadlock detection (EDEADLK).
  */
+
+enum libos_file_lock_family {
+    FILE_LOCK_UNKNOWN, /* this is only to catch uninitialized-variable errors */
+    FILE_LOCK_POSIX,
+    FILE_LOCK_FLOCK,
+};
 
 DEFINE_LISTP(libos_file_lock);
 DEFINE_LIST(libos_file_lock);
 struct libos_file_lock {
+    /* Lock family: FILE_LOCK_POSIX, FILE_LOCK_FLOCK */
+    enum libos_file_lock_family family;
+
     /* Lock type: F_RDLCK, F_WRLCK, F_UNLCK */
     int type;
 
-    /* First byte of range */
-    uint64_t start;
-
-    /* Last byte of range (use FS_LOCK_EOF for a range until end of file) */
-    uint64_t end;
-
-    /* PID of process taking the lock */
-    IDTYPE pid;
-
     /* List node, used internally */
     LIST_TYPE(libos_file_lock) list;
+
+    /* FILE_LOCK_POSIX fields */
+    uint64_t start; /* First byte of range */
+    uint64_t end;   /* Last byte of range (use FS_LOCK_EOF for a range until end of file) */
+    IDTYPE pid;     /* PID of process taking the lock */
+
+    /* FILE_LOCK_FLOCK fields */
+    uint64_t handle_id; /* Unique handle ID using which the lock is taken */
 };
 
 /*!
@@ -65,13 +74,19 @@ struct libos_file_lock {
  *
  * This is the equivalent of `fnctl(F_SETLK/F_SETLKW)`.
  *
- * If `file_lock->type` is `F_UNLCK`, the function will remove any locks held by the given PID for
- * the given range. Removing a lock never waits.
+ * If `file_lock->type` is `F_UNLCK`, the function will remove locks as follows:
+ * - For POSIX (fcntl) locks, remove all POSIX locks held by the given PID for the given range.
+ * - For BSD (flock) locks, remove all BSD locks held by the given handle ID.
  *
- * If `file_lock->type` is `F_RDLCK` or `F_WRLCK`, the function will create a new lock for the given
- * PID and range, replacing the existing locks held by the given PID for that range. If there are
- * conflicting locks, the function either waits (if `wait` is true), or fails with `-EAGAIN` (if
- * `wait` is false).
+ * Removing a lock never waits.
+ *
+ * If `file_lock->type` is `F_RDLCK` or `F_WRLCK`, the function will create a new lock as follows:
+ * - For POSIX (fcntl) locks, for the given PID and range, replace the existing POSIX locks held by
+ *   the given PID for that range.
+ * - For BSD (flock) locks, replace the existing BSD locks held by the given handle ID.
+ *
+ * If there are conflicting locks, the function either waits (if `wait` is true), or fails with
+ * `-EAGAIN` (if `wait` is false).
  */
 int file_lock_set(struct libos_dentry* dent, struct libos_file_lock* file_lock, bool wait);
 
@@ -84,14 +99,20 @@ int file_lock_set(struct libos_dentry* dent, struct libos_file_lock* file_lock, 
  *
  * This is the equivalent of `fcntl(F_GETLK)`.
  *
- * The function checks if there are locks by other PIDs preventing the proposed lock from being
- * placed. If the lock could be placed, `out_file_lock->type` is set to `F_UNLCK`. Otherwise,
- * `out_file_lock` fields (`type`, `start, `end`, `pid`) are set to details of a conflicting lock.
+ * The function checks if there are conflicting locks:
+ * - For POSIX (fcntl) locks, check for other PIDs preventing the proposed lock from being placed.
+ * - For BSD (flock) locks, check for other handle IDs preventing the proposed lock from being
+ *   placed.
+ *
+ * If the lock could be placed, `out_file_lock->type` is set to `F_UNLCK`. Otherwise,
+ * `out_file_lock` fields (`type`, `start, `end`, `pid`, `handle_id`) are set to details of a
+ * conflicting lock.
  */
 int file_lock_get(struct libos_dentry* dent, struct libos_file_lock* file_lock,
                   struct libos_file_lock* out_file_lock);
 
-/* Removes all locks for a given PID. Should be called before process exit. */
+/* Removes all locks for a given PID. Applicable only for POSIX locks. Should be called before
+ * process exit. */
 int file_lock_clear_pid(IDTYPE pid);
 
 /*!

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -134,6 +134,22 @@ struct libos_handle {
     enum libos_handle_type type;
     bool is_dir;
 
+    /* Unique ID. This field does not change, so reading it does not require holding any locks.
+     * Currently used only for `flock` system call. */
+    uint64_t id;
+    /*
+     * Specifies whether this handle was created by this process or inherited from the parent
+     * process. Used to perform an operation on the handle only once per Gramine instance (with
+     * multiple processes). Currently used to perform LOCK_UN operation in `flock` system call when
+     * the "last" file descriptor to this handle is closed (by "last" FD we assume here the last FD
+     * referring to this handle in the creator process).
+     *
+     * FIXME: Problematic case: P1 opens a handle, spawns P2 and terminates; in this case the
+     *        operation (e.g. LOCK_UN) would be performed even though the handle is still opened in
+     *        P2. Unfortunately, Gramine lacks system-wide tracking of handle FDs.
+     */
+    bool created_by_process;
+
     refcount_t ref_count;
 
     struct libos_fs* fs;

--- a/libos/include/libos_ipc.h
+++ b/libos/include/libos_ipc.h
@@ -10,6 +10,7 @@
 
 #include "avl_tree.h"
 #include "libos_defs.h"
+#include "libos_fs_lock.h"
 #include "libos_handle.h"
 #include "libos_internal.h"
 #include "libos_thread.h"
@@ -278,10 +279,12 @@ int ipc_sync_confirm_close_callback(IDTYPE src, void* data, unsigned long seq);
 
 struct libos_ipc_file_lock {
     /* see `struct libos_file_lock` in `libos_fs_lock.h` */
+    enum libos_file_lock_family family;
     int type;
     uint64_t start;
     uint64_t end;
     IDTYPE pid;
+    uint64_t handle_id;
 
     bool wait;
     char path[]; /* null-terminated */
@@ -291,10 +294,12 @@ struct libos_ipc_file_lock_resp {
     int result;
 
     /* see `struct libos_file_lock` in `libos_fs_lock.h` */
+    enum libos_file_lock_family family;
     int type;
     uint64_t start;
     uint64_t end;
     IDTYPE pid;
+    uint64_t handle_id;
 };
 
 struct libos_file_lock;

--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -547,8 +547,8 @@ skip = yes
 [flistxattr*]
 skip = yes
 
-# no flock()
-[flock*]
+# uses futexes on memory shared between processes
+[flock03]
 skip = yes
 
 # %fs test, i386 only

--- a/libos/test/ltp/manifest.template
+++ b/libos/test/ltp/manifest.template
@@ -17,6 +17,9 @@ fs.mounts = [
   { path = "/tmp", uri = "file:/tmp" },
 ]
 
+# for flock tests
+sys.experimental__enable_flock = true
+
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 sgx.debug = true

--- a/libos/test/regression/fcntl_lock.c
+++ b/libos/test/regression/fcntl_lock.c
@@ -21,6 +21,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #define TEST_FILE "tmp/lock_file"
 
 static int g_fd;
@@ -220,24 +222,18 @@ static void close_pipes(int pipes[2][2]) {
 
 static void write_pipe(int pipe[2]) {
     char c = 0;
-    int ret;
-    do {
-        ret = write(pipe[1], &c, sizeof(c));
-    } while (ret == -1 && errno == EINTR);
-    if (ret == -1)
-        err(1, "write");
+    ssize_t x = CHECK(write(pipe[1], &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        errx(1, "pipe write: %zd", x);
+    }
 }
 
 static void read_pipe(int pipe[2]) {
-    char c;
-    int ret;
-    do {
-        ret = read(pipe[0], &c, sizeof(c));
-    } while (ret == -1 && errno == EINTR);
-    if (ret == -1)
-        err(1, "read");
-    if (ret == 0)
-        errx(1, "pipe closed");
+    char c = 0;
+    ssize_t x = CHECK(read(pipe[0], &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        errx(1, "pipe read: %zd", x);
+    }
 }
 
 /* Test: child takes a lock and then exits. The lock should be released. */

--- a/libos/test/regression/flock_lock.c
+++ b/libos/test/regression/flock_lock.c
@@ -1,0 +1,243 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Liang Ma <liang3.ma@intel.com>
+ */
+
+/*
+ * Test for `flock` syscall (`flock(LOCK_EX/LOCK_SH/LOCK_UN`). We assert that the calls succeed (or
+ * taking a lock fails), and log all details for debugging purposes.
+ *
+ * The tests involve multithreaded, dup and file-backed mmap cases, as well as testing for a mix
+ * with POSIX (fcntl) locks. We don't add complex multi-process cases here because they are already
+ * covered by LTP tests `flock03` and `flock04`.
+ */
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#define TEST_FILE  "tmp/flock_file"
+#define TEST_FILE2 "tmp/flock_file2"
+#define FILE_SIZE 1024
+
+struct thread_args {
+    int pipes[2][2];
+};
+
+static const char* str_type(int type) {
+    switch (type) {
+        case LOCK_SH: return "LOCK_SH";
+        case LOCK_EX: return "LOCK_EX";
+        case LOCK_UN: return "LOCK_UN";
+        case LOCK_SH | LOCK_NB: return "LOCK_SH | LOCK_NB";
+        case LOCK_EX | LOCK_NB: return "LOCK_EX | LOCK_NB";
+        default: return "???";
+    }
+}
+
+static void try_flock(int fd, int operation, int expected_ret) {
+    int ret = flock(fd, operation);
+    if (ret != expected_ret) {
+        errx(1, "flock(%d, %s) error with return value = %d, expected value = %d",
+             fd, str_type(operation), ret, expected_ret);
+    }
+}
+
+static void try_fcntl(int fd, int operation, int type, int expected_ret, int expected_errno) {
+    struct flock fl = {
+        .l_type = type,
+        .l_whence = SEEK_SET,
+        .l_start = 0,
+        .l_len = 0,
+    };
+    int ret = fcntl(fd, operation, &fl);
+    if (ret != expected_ret) {
+        errx(1, "fcntl(%d) error with return value = %d, expected value = %d",
+             fd, ret, expected_ret);
+    }
+    if (ret < 0 && errno != expected_errno) {
+        errx(1, "fcntl(%d) error with errno = %d, expected errno = %d", fd, errno, expected_errno);
+    }
+}
+
+static void open_pipes(int pipes[2][2]) {
+    for (unsigned int i = 0; i < 2; i++) {
+        CHECK(pipe(pipes[i]));
+    }
+}
+
+static void close_pipes(int pipes[2][2]) {
+    for (unsigned int i = 0; i < 2; i++) {
+        for (unsigned int j = 0; j < 2; j++) {
+            CHECK(close(pipes[i][j]));
+        }
+    }
+}
+
+static void write_pipe(int pipe[2]) {
+    char c = 0;
+    ssize_t x = CHECK(write(pipe[1], &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        errx(1, "pipe write: %zd", x);
+    }
+}
+
+static void read_pipe(int pipe[2]) {
+    char c = 0;
+    ssize_t x = CHECK(read(pipe[0], &c, sizeof(c)));
+    if (x != sizeof(c)) {
+        errx(1, "pipe read: %zd", x);
+    }
+}
+
+static void test_flock_dup_open(void) {
+    printf("testing locks with the dup and open...\n");
+    int fd = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    try_flock(fd, LOCK_EX, 0);
+
+    int fd2 = CHECK(dup(fd));
+    try_flock(fd2, LOCK_EX, 0);
+    try_flock(fd, LOCK_UN, 0);
+    try_flock(fd2, LOCK_EX, 0);
+
+    int fd3 = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    CHECK(close(fd));
+    try_flock(fd3, LOCK_EX | LOCK_NB, -1);
+    CHECK(close(fd2));
+    try_flock(fd3, LOCK_EX | LOCK_NB, 0);
+    CHECK(close(fd3));
+}
+
+static void test_flock_mix_with_fcntl(void) {
+    printf("testing locks with BSD (flock) and POSIX (fcntl) mix...\n");
+
+    int fd = open("/dev/attestation", O_RDONLY);
+    if (fd < 0) {
+        printf("   - Gramine not detected, skipping this Gramine-specific test\n");
+        return;
+    }
+    CHECK(close(fd));
+
+    /* test in the same process (lock same file) */
+    fd = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    try_flock(fd, LOCK_SH, 0);
+    try_fcntl(fd, F_SETLK, F_RDLCK, -1, EPERM);
+
+    /* test in the same process (lock another file) */
+    int fd2 = CHECK(open(TEST_FILE2, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    try_fcntl(fd2, F_SETLK, F_RDLCK, 0, 0);
+    CHECK(close(fd2));
+
+    /* test in another process (lock same file) */
+    pid_t pid = CHECK(fork());
+    if (pid == 0) {
+        try_fcntl(fd, F_SETLK, F_RDLCK, -1, EPERM);
+        exit(0);
+    }
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        errx(1, "child died with status: %#x", status);
+    }
+
+    CHECK(close(fd));
+    CHECK(unlink(TEST_FILE2));
+}
+
+static void test_mmap_flock_close_unmap(void) {
+    printf("testing locks with the mmap and flock...\n");
+    int fd1, fd2;
+    void* file_data;
+
+    fd1 = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    file_data = mmap(NULL, FILE_SIZE, PROT_READ, MAP_SHARED, fd1, 0);
+    if (file_data == MAP_FAILED) {
+        err(1, "mmap");
+    }
+    try_flock(fd1, LOCK_EX, 0);
+    CHECK(close(fd1));
+    fd2 = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    try_flock(fd2, LOCK_EX | LOCK_NB, -1);
+    CHECK(munmap(file_data, FILE_SIZE));
+    try_flock(fd2, LOCK_EX, 0);
+    CHECK(close(fd2));
+}
+
+static void* thread_flock_first(void* arg) {
+    struct thread_args* args = (struct thread_args*)arg;
+
+    int fd = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    try_flock(fd, LOCK_EX | LOCK_NB, 0);
+    write_pipe(args->pipes[0]);
+    read_pipe(args->pipes[1]);
+    try_flock(fd, LOCK_UN, 0);
+    write_pipe(args->pipes[0]);
+    read_pipe(args->pipes[1]);
+    try_flock(fd, LOCK_SH | LOCK_NB, 0);
+    CHECK(close(fd));
+
+    return arg;
+}
+
+static void* thread_flock_second(void* arg) {
+    struct thread_args* args = (struct thread_args*)arg;
+
+    int fd = CHECK(open(TEST_FILE, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0600));
+    read_pipe(args->pipes[0]);
+    try_flock(fd, LOCK_EX | LOCK_NB, -1);
+    write_pipe(args->pipes[1]);
+    read_pipe(args->pipes[0]);
+    try_flock(fd, LOCK_SH | LOCK_NB, 0);
+    write_pipe(args->pipes[1]);
+    CHECK(close(fd));
+
+    return arg;
+}
+
+static void test_flock_multithread(void) {
+    printf("testing flock with multithread...\n");
+    int ret;
+    pthread_t threads[2];
+    struct thread_args args = {0};
+    open_pipes(args.pipes);
+
+    ret = pthread_create(&threads[0], NULL, thread_flock_first, (void*)&args);
+    if (ret != 0)
+        errx(1, "pthread_create");
+
+    ret = pthread_create(&threads[1], NULL, thread_flock_second, (void*)&args);
+    if (ret != 0)
+        errx(1, "pthread_create");
+
+    for (int i = 0; i < 2; i++) {
+        if ((ret = pthread_join(threads[i], NULL)) != 0) {
+            errx(1, "pthread_join");
+        }
+    }
+    close_pipes(args.pipes);
+}
+
+int main(void) {
+    setbuf(stdout, NULL);
+
+    test_flock_dup_open();
+    test_flock_mix_with_fcntl();
+    test_mmap_flock_close_unmap();
+    test_flock_multithread();
+
+    CHECK(unlink(TEST_FILE));
+    printf("TEST OK\n");
+    return 0;
+}

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -7,6 +7,9 @@ loader.insecure__use_cmdline_argv = true
 # for eventfd test
 sys.insecure__allow_eventfd = true
 
+# for flock_lock test
+sys.experimental__enable_flock = true
+
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -33,6 +33,7 @@ tests = {
     'fdleak': {},
     'file_check_policy': {},
     'file_size': {},
+    'flock_lock': {},
     'fopen_cornercases': {},
     'fork_and_exec': {},
     'fp_multithread': {

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -969,6 +969,16 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['sid'])
         self.assertIn("TEST OK", stdout)
 
+    def test_140_flock_lock(self):
+        try:
+            stdout, _ = self.run_binary(['flock_lock'])
+        finally:
+            if os.path.exists('tmp/flock_file'):
+                os.remove('tmp/flock_file')
+            if os.path.exists('tmp/flock_file2'):
+                os.remove('tmp/flock_file2')
+        self.assertIn('TEST OK', stdout)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -36,6 +36,7 @@ manifests = [
   "file_check_policy_allow_all_but_log",
   "file_check_policy_strict",
   "file_size",
+  "flock_lock",
   "fopen_cornercases",
   "fork_and_exec",
   "fork_disallowed",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -38,6 +38,7 @@ manifests = [
   "file_check_policy_allow_all_but_log",
   "file_check_policy_strict",
   "file_size",
+  "flock_lock",
   "fopen_cornercases",
   "fork_and_exec",
   "fork_disallowed",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `flock` implementation introduces flock (aka BSD) locks, in addition to already-existing fcntl (aka POSIX) locks. The flock heavily reuses the current logic of `libos_file_lock` and `dent_file_locks`.

Since flock locks are tied to the handle, we introduce a new field `struct libos_file_lock::handle_id` that serves to distinguish flock  locks from fcntl locks. Similarly to fcntl locks, interruptable flock locks are not supported.

This is a reincarnation of #1212. It was easier to make it a new PR, then to continue working on the old PR.

Closes #1212.

## How to test this PR? <!-- (if applicable) -->

New tests are added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1416)
<!-- Reviewable:end -->
