### PR TITLE
[Meson,CI-Examples] Don't create symlinks in Gramine runtime dir

### DIFF
--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -57,6 +57,7 @@ server.manifest: server.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dmbedtls_gramine_dir=$(shell pkg-config --variable=libdir mbedtls_gramine) \
 		-Dra_type=$(RA_TYPE) \
 		-Dra_client_spid=$(RA_CLIENT_SPID) \
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
@@ -79,6 +80,7 @@ client_dcap.manifest: client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dmbedtls_gramine_dir=$(shell pkg-config --variable=libdir mbedtls_gramine) \
 		$< >$@
 
 client_dcap.manifest.sgx client_dcap.sig: sgx_sign_client_dcap
@@ -96,6 +98,7 @@ client_epid.manifest: client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dmbedtls_gramine_dir=$(shell pkg-config --variable=libdir mbedtls_gramine) \
 		$< >$@
 
 client_epid.manifest.sgx client_epid.sig: sgx_sign_client_epid

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -5,7 +5,7 @@ libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:/usr/local/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ mbedtls_gramine_dir }}:/usr/local/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 loader.env.LC_ALL = "C"
 
 loader.env.RA_TLS_CLIENT_INSIDE_SGX = "1"
@@ -15,6 +15,7 @@ loader.insecure__use_host_env = true
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ mbedtls_gramine_dir }}", uri = "file:{{ mbedtls_gramine_dir }}" },
   { path = "/usr/local/lib", uri = "file:/usr/local/lib" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
@@ -33,6 +34,7 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
+  "file:{{ mbedtls_gramine_dir }}/",
   "file:/usr/local/lib/",
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -5,7 +5,7 @@ libos.entrypoint = "/server"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ mbedtls_gramine_dir }}:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
 loader.insecure__use_cmdline_argv = true
 
@@ -13,6 +13,7 @@ sys.enable_sigterm_injection = true
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ mbedtls_gramine_dir }}", uri = "file:{{ mbedtls_gramine_dir }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/etc", uri = "file:/etc" },
@@ -30,6 +31,7 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:server",
   "file:{{ gramine.runtimedir() }}/",
+  "file:{{ mbedtls_gramine_dir }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:ssl/ca.crt",

--- a/CI-Examples/ra-tls-nginx/Makefile
+++ b/CI-Examples/ra-tls-nginx/Makefile
@@ -14,6 +14,7 @@ all: nginx.manifest.sgx nginx.sig
 	gramine-manifest \
 		-Dentrypoint=$$(command -v gramine-ratls) \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
+		-Dra_tls_gramine_dir=$(shell pkg-config --variable=libdir ra_tls_gramine) \
 		-Dra_type=$(RA_TYPE) \
 		-Dra_client_spid=$(RA_CLIENT_SPID) \
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \

--- a/CI-Examples/ra-tls-nginx/nginx.manifest.template
+++ b/CI-Examples/ra-tls-nginx/nginx.manifest.template
@@ -6,7 +6,7 @@ loader.argv = [
 libos.entrypoint = "/gramine-ratls"
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/usr/local/lib:/usr{{ arch_libdir }}:{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/usr/local/lib:/usr/local/lib/ra_tls:/usr{{ arch_libdir }}:{{ arch_libdir }}"
 
 loader.uid = 65534
 loader.gid = 65534
@@ -21,6 +21,7 @@ fs.mounts = [
     { path = "/lib", uri = "file:/lib" },
     { path = "/usr/lib", uri = "file:/usr/lib" },
     { path = "/usr/local/lib", uri = "file:{{ gramine.runtimedir() }}" },
+    { path = "/usr/local/lib/ra_tls", uri = "file:{{ ra_tls_gramine_dir }}" },
 
     { path = "/tmp", type = "tmpfs" },
 
@@ -50,6 +51,7 @@ sgx.debug = true
 sgx.trusted_files = [
     "file:{{ gramine.libos }}",
     "file:{{ gramine.runtimedir() }}/",
+    "file:{{ ra_tls_gramine_dir }}/",
 
     "file:{{ entrypoint }}",
     "file:/usr/sbin/nginx",

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -78,6 +78,7 @@ secret_prov_minimal/client.manifest: secret_prov_minimal/client.manifest.templat
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dsecret_prov_gramine_dir=$(shell pkg-config --variable=libdir secret_prov_gramine) \
 		-Dra_type=$(RA_TYPE) \
 		-Dra_client_spid=$(RA_CLIENT_SPID) \
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
@@ -102,6 +103,7 @@ secret_prov/client.manifest: secret_prov/client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dsecret_prov_gramine_dir=$(shell pkg-config --variable=libdir secret_prov_gramine) \
 		-Dra_type=$(RA_TYPE) \
 		-Dra_client_spid=$(RA_CLIENT_SPID) \
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
@@ -124,6 +126,7 @@ secret_prov_pf/client.manifest: secret_prov_pf/client.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dsecret_prov_gramine_dir=$(shell pkg-config --variable=libdir secret_prov_gramine) \
 		-Dra_type=$(RA_TYPE) \
 		-Dra_client_spid=$(RA_CLIENT_SPID) \
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \

--- a/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
@@ -5,12 +5,13 @@ libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib::{{ secret_prov_gramine_dir }}:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
-  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "{{ secret_prov_gramine_dir }}", uri = "file:{{ secret_prov_gramine_dir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/client", uri = "file:client" },
   { path = "/ca.crt", uri = "file:../ssl/ca.crt" },
   { path = "/etc/hosts", uri = "file:../helper-files/hosts" },
@@ -30,6 +31,7 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
+  "file:{{ secret_prov_gramine_dir }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:../ssl/ca.crt",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
@@ -5,7 +5,7 @@ libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib::{{ secret_prov_gramine_dir }}:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 loader.env.LD_PRELOAD = "libsecret_prov_attest.so"
 loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
 loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "/ca.crt"
@@ -13,6 +13,7 @@ loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdumm
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ secret_prov_gramine_dir }}", uri = "file:{{ secret_prov_gramine_dir }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/client", uri = "file:client" },
@@ -34,6 +35,7 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
+  "file:{{ secret_prov_gramine_dir }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:../ssl/ca.crt",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
@@ -5,7 +5,7 @@ libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib::{{ secret_prov_gramine_dir }}:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 loader.env.LD_PRELOAD = "libsecret_prov_attest.so"
 loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
 loader.env.SECRET_PROVISION_SET_KEY = "default"
@@ -14,6 +14,7 @@ loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdumm
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ secret_prov_gramine_dir }}", uri = "file:{{ secret_prov_gramine_dir }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
   { path = "/client", uri = "file:client" },
@@ -36,6 +37,7 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
+  "file:{{ secret_prov_gramine_dir }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr{{ arch_libdir }}/",
   "file:../ssl/ca.crt",

--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -55,13 +55,6 @@ pkgconfig.generate(
     ],
 )
 
-foreach output : mbedtls_libs_output
-    meson.add_install_script('/bin/sh', '-c',
-        ('ln -sf ../../../@0@ ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/runtime/glibc/').format(
-            output, get_option('libdir')))
-endforeach
-
 # We rely on the fact that for `mbedtls_gramine` package, we don't need any changes in the default
 # mbedTLS headers
 install_subdir('mbedtls-mbedtls-3.4.0/include/mbedtls', install_dir: get_option('includedir') / 'gramine')

--- a/tools/sgx/ra-tls/meson.build
+++ b/tools/sgx/ra-tls/meson.build
@@ -28,10 +28,6 @@ libra_tls_attest = shared_library('ra_tls_attest',
     install: true,
     install_rpath: get_option('prefix') / get_option('libdir'),
 )
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libra_tls_attest.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
 
 libra_tls_verify = static_library('ra_tls_verify',
     'ra_tls_verify_common.c',
@@ -44,10 +40,6 @@ libra_tls_verify = static_library('ra_tls_verify',
     install: true,
     install_rpath: get_option('prefix') / get_option('libdir'),
 )
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libra_tls_verify.a ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
 
 libra_tls_verify_dep = declare_dependency(
     link_with: libra_tls_verify,
@@ -66,10 +58,6 @@ libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
     install: true,
     install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
 )
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libra_tls_verify_epid.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
 
 libsecret_prov_attest = shared_library('secret_prov_attest',
     'secret_prov_attest.c',
@@ -85,10 +73,6 @@ libsecret_prov_attest = shared_library('secret_prov_attest',
     install: true,
     install_rpath: get_option('prefix') / get_option('libdir'),
 )
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libsecret_prov_attest.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
 
 libsecret_prov_verify = static_library('secret_prov_verify',
     'secret_prov_verify.c',
@@ -102,10 +86,6 @@ libsecret_prov_verify = static_library('secret_prov_verify',
     install: true,
     install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
 )
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libsecret_prov_verify.a ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
 
 libsecret_prov_verify_dep = declare_dependency(
     link_with: libsecret_prov_verify,
@@ -125,10 +105,6 @@ libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
     install: true,
     install_rpath: get_option('prefix') / get_option('libdir'),
 )
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libsecret_prov_verify_epid.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
 
 if dcap
     libra_tls_verify_dcap = shared_library('ra_tls_verify_dcap',
@@ -144,10 +120,6 @@ if dcap
         install: true,
         install_rpath: get_option('prefix') / get_option('libdir'),
     )
-    meson.add_install_script('/bin/sh', '-c',
-        'ln -sf ../../../libra_tls_verify_dcap.so ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-            get_option('libdir')))
 
     libra_tls_verify_dcap_gramine = shared_library('ra_tls_verify_dcap_gramine',
         'ra_tls_verify_dcap.c',
@@ -163,10 +135,6 @@ if dcap
         install: true,
         install_rpath: get_option('prefix') / get_option('libdir'),
     )
-    meson.add_install_script('/bin/sh', '-c',
-        'ln -sf ../../../libra_tls_verify_dcap_gramine.so ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-            get_option('libdir')))
 
     libsecret_prov_verify_dcap = shared_library('secret_prov_verify_dcap',
         'ra_tls_verify_dcap.c',
@@ -183,10 +151,6 @@ if dcap
         install: true,
         install_rpath: get_option('prefix') / get_option('libdir'),
     )
-    meson.add_install_script('/bin/sh', '-c',
-        'ln -sf ../../../libsecret_prov_verify_dcap.so ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-            get_option('libdir')))
 endif
 
 pkgconfig.generate(


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine runtime dir is used for libc libraries (glibc or musl). Previously, we also added symlinks to Gramine-specific mbedTLS, RA-TLS and SecretProv libraries into this runtime dir. However, these latter libraries are built using the toolchain of the OS distro and thus may have a different libc than specified in the Gramine runtime dir. Therefore, the two kinds of libraries should be separated, and no symlinks should be created.

This is a *breaking* change for applications, because if the app uses Gramine-specific mbedTLS, RA-TLS or SecretProv libs it is required to add corresponding entries in the manifest. This commit updates our CI examples accordingly.

Fixes #1399. Closes #1400.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1417)
<!-- Reviewable:end -->
