### PR TITLE
[meson,tools] Introduce `epid` Meson option

### DIFF
--- a/Documentation/devel/building.rst
+++ b/Documentation/devel/building.rst
@@ -192,7 +192,7 @@ Additional build options
 
   .. note::
      EPID version of RA-TLS library (``ra_tls_verify_epid.so``) is built by
-     default.
+     default. You can disable the build via  :command:`meson -Depid=disabled`.
 
 - To create a debug build, run :command:`meson --buildtype=debug`. This adds
   debug symbols in all Gramine components, builds them without optimizations,

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ direct = get_option('direct') == 'enabled'
 sgx = get_option('sgx') == 'enabled'
 skeleton = get_option('skeleton') == 'enabled'
 
+epid = get_option('epid') == 'enabled'
 dcap = get_option('dcap') == 'enabled'
 ubsan = get_option('ubsan') == 'enabled'
 asan = get_option('asan') == 'enabled'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,8 +14,11 @@ option('musl', type: 'combo', choices: ['disabled', 'enabled'],
 option('tests', type: 'combo', choices: ['disabled', 'enabled'],
     description: 'Build test binaries')
 
+option('epid', type: 'combo', choices: ['disabled', 'enabled'],
+    value: 'enabled', description: 'Build EPID-based attestation utilities')
 option('dcap', type: 'combo', choices: ['disabled', 'enabled'],
-    description: 'Build additional utilities linked against DCAP library')
+    description: 'Build DCAP-based attestation utilities (linked against DCAP library)')
+
 option('ubsan', type: 'combo', choices: ['disabled', 'enabled'],
     description: 'Enable undefined behavior sanitizer')
 option('asan', type: 'combo', choices: ['disabled', 'enabled'],

--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -55,12 +55,15 @@ pkgconfig.generate(
     ],
 )
 
-foreach output : mbedtls_libs_output
-    meson.add_install_script('/bin/sh', '-c',
-        ('ln -sf ../../../@0@ ' +
-        '"$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/runtime/glibc/').format(
-            output, get_option('libdir')))
-endforeach
+# install mbedTLS symlinks into Gramine runtime dir only if attestation was requested
+if get_option('epid') == 'enabled' or get_option('dcap') == 'enabled'
+    foreach output : mbedtls_libs_output
+        meson.add_install_script('/bin/sh', '-c',
+            ('ln -sf ../../../@0@ ' +
+            '"$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/runtime/glibc/').format(
+                output, get_option('libdir')))
+    endforeach
+endif
 
 # We rely on the fact that for `mbedtls_gramine` package, we don't need any changes in the default
 # mbedTLS headers

--- a/subprojects/packagefiles/mbedtls/meson_options.txt
+++ b/subprojects/packagefiles/mbedtls/meson_options.txt
@@ -1,0 +1,4 @@
+# TODO: after deprecating 18.04/bionic, change these to type: 'feature'
+#       see also top-level meson_options.txt
+option('epid', type: 'combo', choices: ['disabled', 'enabled'], value: 'enabled', yield: true)
+option('dcap', type: 'combo', choices: ['disabled', 'enabled'], yield: true)

--- a/tools/sgx/meson.build
+++ b/tools/sgx/meson.build
@@ -1,9 +1,15 @@
 subdir('common')
 
-subdir('ias-request')
 subdir('is-sgx-available')
 subdir('pf_crypt')
 subdir('pf_tamper')
-subdir('quote-view')
-subdir('ra-tls')
-subdir('verify-ias-report')
+
+if epid or dcap
+    subdir('quote-view')
+    subdir('ra-tls')
+endif
+
+if epid
+    subdir('ias-request')
+    subdir('verify-ias-report')
+endif

--- a/tools/sgx/ra-tls/meson.build
+++ b/tools/sgx/ra-tls/meson.build
@@ -54,23 +54,6 @@ libra_tls_verify_dep = declare_dependency(
     include_directories: pal_sgx_inc,
 )
 
-libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
-    'ra_tls_verify_epid.c',
-
-    link_args: ra_tls_link_args,
-    dependencies: [
-        libra_tls_verify_dep.as_link_whole(),
-        mbedtls_static_dep,
-        sgx_util_dep,
-    ],
-    install: true,
-    install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
-)
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libra_tls_verify_epid.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
-
 libsecret_prov_attest = shared_library('secret_prov_attest',
     'secret_prov_attest.c',
     'secret_prov_common.c',
@@ -112,23 +95,42 @@ libsecret_prov_verify_dep = declare_dependency(
     include_directories: pal_sgx_inc,
 )
 
-libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
-    'ra_tls_verify_epid.c',
+if epid
+    libra_tls_verify_epid = shared_library('ra_tls_verify_epid',
+        'ra_tls_verify_epid.c',
 
-    link_args: secret_prov_link_args,
-    dependencies: [
-        libsecret_prov_verify_dep.as_link_whole(),
-        mbedtls_static_dep,
-        sgx_util_dep,
-        threads_dep,
-    ],
-    install: true,
-    install_rpath: get_option('prefix') / get_option('libdir'),
-)
-meson.add_install_script('/bin/sh', '-c',
-    'ln -sf ../../../libsecret_prov_verify_epid.so ' +
-    '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
-        get_option('libdir')))
+        link_args: ra_tls_link_args,
+        dependencies: [
+            libra_tls_verify_dep.as_link_whole(),
+            mbedtls_static_dep,
+            sgx_util_dep,
+        ],
+        install: true,
+        install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
+    )
+    meson.add_install_script('/bin/sh', '-c',
+        'ln -sf ../../../libra_tls_verify_epid.so ' +
+        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
+            get_option('libdir')))
+
+    libsecret_prov_verify_epid = shared_library('secret_prov_verify_epid',
+        'ra_tls_verify_epid.c',
+
+        link_args: secret_prov_link_args,
+        dependencies: [
+            libsecret_prov_verify_dep.as_link_whole(),
+            mbedtls_static_dep,
+            sgx_util_dep,
+            threads_dep,
+        ],
+        install: true,
+        install_rpath: get_option('prefix') / get_option('libdir'),
+    )
+    meson.add_install_script('/bin/sh', '-c',
+        'ln -sf ../../../libsecret_prov_verify_epid.so ' +
+        '"$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/runtime/glibc/'.format(
+            get_option('libdir')))
+endif
 
 if dcap
     libra_tls_verify_dcap = shared_library('ra_tls_verify_dcap',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine always built EPID-based tools (e.g. IAS ones) and libraries (RA-TLS, SecreProv). However, in many deployments EPID is not required at all. This commit introduces the `epid` Meson option; `-Depid=disabled` can be used to disable EPID tools and libs. To preserve backward-compatibility, this option is enabled by default.

Also, if both EPID and DCAP options are disabled, then more tools and libs are not built (e.g. generic RA-TLS libs).

This is yet another attempt/proposal at circumventing the problem of `Dglibc=disabled`. It circumvents this problem in a hopefully nicer way, by removing the need for RA-TLS and SecretProv libraries inside Gramine runtime dir when the user builds Gramine without SGX attestation at all: `-Depid=disabled -Ddcap=disabled`.

See my other attempts:
- #1400 
- #1417 

Also read #1399 for context.

## How to test this PR? <!-- (if applicable) -->

CI tests the backwards-compatibility.

Manual test is smth like this, to generate the SGX-attestation-less version of Gramine:
```
meson setup build/ -Dskeleton=enabled -Ddirect=enabled -Dsgx=enabled \
    -Depid=disabled -Ddcap=disabled -Dtests=disabled
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1420)
<!-- Reviewable:end -->
