### PR TITLE
[LibOS] Check existence of file during `chroot_stat()`

### DIFF
--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -354,6 +354,27 @@ static int chroot_truncate(struct libos_handle* hdl, file_off_t size) {
     return ret;
 }
 
+static int chroot_stat(struct libos_dentry* dent, struct stat* buf) {
+    assert(locked(&g_dcache_lock));
+    assert(dent->inode);
+
+    int ret;
+
+    /* Temporary open of the file is required only to check if the file still exists. Without the
+     * open and if the same file was opened before, Gramine would serve this `stat()` callback from
+     * the cached `dent->inode` and wouldn't notice that the file was removed on the host. Note that
+     * such check is relevant only to chroot files, because all other file types are either pseudo
+     * in-memory files (dev, etc, sys, tmpfs) or fully controlled by Gramine files (encrypted). */
+    PAL_HANDLE palhdl;
+    ret = chroot_temp_open(dent, dent->inode->type, &palhdl);
+    if (ret < 0)
+        return ret;
+
+    ret = generic_inode_stat(dent, buf);
+    PalObjectClose(palhdl);
+    return ret < 0 ? pal_to_unix_errno(ret) : 0;
+}
+
 int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void* arg) {
     int ret;
     PAL_HANDLE palhdl;
@@ -512,7 +533,7 @@ struct libos_d_ops chroot_d_ops = {
     .lookup  = &chroot_lookup,
     .creat   = &chroot_creat,
     .mkdir   = &chroot_mkdir,
-    .stat    = &generic_inode_stat,
+    .stat    = &chroot_stat,
     .readdir = &chroot_readdir,
     .unlink  = &chroot_unlink,
     .rename  = &chroot_rename,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR temporarily opens the file during `stat()` callback to check if the file still exists on the host. Without this open and if the same file was opened before, Gramine would serve the `chroot_stat()` callback from the cached `dent->inode` and wouldn't notice that the file was removed on the host. Note that such check is relevant only to chroot files, because all other file types are either pseudo in-memory files (dev, etc, sys, tmpfs) or fully controlled by Gramine files (encrypted).

Fixes #1422.

## How to test this PR? <!-- (if applicable) -->

I don't know how to add such a test to our CI, that will start the Gramine process and then remove the host file under it.

Here is the manual test:
1. Change `large_file.c` LibOS regression test:
```diff
diff --git a/libos/test/regression/large_file.c b/libos/test/regression/large_file.c
@@ -91,6 +91,13 @@ int main(void) {
     if (close(fd) < 0)
         err(1, "close");

+    struct stat st;
+    if (stat(TEST_FILE, &st) < 0)
+        err(1, "stat");
+    sleep(5);
+    if (stat(TEST_FILE, &st) < 0)
+        err(1, "stat");
+
     printf("TEST OK\n");
     return 0;
 }
```

2. Check native:
   a. `<gramine install dir>/lib/x86_64-linux-gnu/gramine/tests/libos/regression/large_file` in one terminal
   b. `rm -rf libos/test/regression/tmp/large_file` in another terminal
   c. native app must complain in first terminal: `large_file: stat: No such file or directory`

3. Check Gramine:
   a. `gramine-direct large_file` in one terminal
   b. `rm -rf libos/test/regression/tmp/large_file` in another terminal
   c. Gramine app must complain in first terminal: `large_file: stat: No such file or directory`
   d. (without this PR, Gramine app incorrectly succeeds: `TEST OK`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1423)
<!-- Reviewable:end -->
