### PR TITLE
[LibOS] Add SIGTERM signal to list of pending signals

### DIFF
--- a/CI-Examples/ra-tls-nginx/run.sh
+++ b/CI-Examples/ra-tls-nginx/run.sh
@@ -10,7 +10,8 @@ sleep 10
 test "$(curl --insecure -s https://localhost:8000/)" = "$(cat html/index.html)"
 ret=$?
 
-kill -9 $pid
+kill $pid
+wait $pid
 
 if test $ret -eq 0
 then

--- a/libos/src/bookkeep/libos_signal.c
+++ b/libos/src/bookkeep/libos_signal.c
@@ -151,6 +151,11 @@ void get_all_pending_signals(__sigset_t* set) {
 
     __sigemptyset(set);
 
+    int host_sig = __atomic_load_n(&g_host_injected_signal, __ATOMIC_RELAXED);
+    if (host_sig && host_sig != 0xff) {
+        __sigaddset(set, host_sig);
+    }
+
     if (__atomic_load_n(&current->pending_signals, __ATOMIC_ACQUIRE) == 0
             && __atomic_load_n(&g_process_pending_signals_cnt, __ATOMIC_ACQUIRE) == 0) {
         return;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `get_all_pending_signals()` helper function did not check for the SIGTERM signal (which has a special handling via `g_host_injected_signal`). Syscalls like `rt_sigsuspend()` and `rt_sigtimedwait()` use this helper function. Because of that erroneous behavior, apps like Nginx would wait for signals on one of these syscalls but would *not* react to SIGTERM (i.e., won't react to `kill <app>`).

This PR fixes this bug, which in turns fixes nginx and ra-tls-nginx examples.

## How to test this PR? <!-- (if applicable) -->

Without this PR, ra-tls-nginx example (with `kill $pid`, i.e. without SIGKILL) would not kill Nginx at all. Running this example twice on the same machine would fail with `bind() to 0.0.0.0:8000 failed (98: Address already in use)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1424)
<!-- Reviewable:end -->
