### PR TITLE
[LibOS] Import `struct sysinfo` to Gramine

### DIFF
--- a/libos/include/libos_table.h
+++ b/libos/include/libos_table.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "libos_types.h"
+#include "linux_abi/sysinfo.h"
 
 typedef void (*libos_syscall_t)(void);
 

--- a/libos/include/linux_abi/sysinfo.h
+++ b/libos/include/linux_abi/sysinfo.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 Intel Corporation
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+ */
+
+#pragma once
+
+/* Types and structures used by various Linux ABIs (e.g. syscalls). */
+/* These need to be binary-identical with the ones used by Linux. */
+
+/* Copied and slightly adapted from linux/include/uapi/linux/sysinfo.h, ver 5.11. */
+struct sysinfo {
+    long uptime;             /* Seconds since boot */
+    unsigned long loads[3];  /* 1, 5, and 15 minute load averages */
+    unsigned long totalram;  /* Total usable main memory size */
+    unsigned long freeram;   /* Available memory size */
+    unsigned long sharedram; /* Amount of shared memory */
+    unsigned long bufferram; /* Memory used by buffers */
+    unsigned long totalswap; /* Total swap space size */
+    unsigned long freeswap;  /* swap space still available */
+    uint16_t procs;          /* Number of current processes */
+    uint16_t pad;            /* Explicit padding for m68k */
+    unsigned long totalhigh; /* Total high memory size */
+    unsigned long freehigh;  /* Available high memory size */
+    uint32_t mem_unit;       /* Memory unit size in bytes */
+    char _f[20 - 2 * sizeof(unsigned long) - sizeof(uint32_t)];   /* Padding: libc5 uses this... */
+};

--- a/libos/include/linux_abi/types.h
+++ b/libos/include/linux_abi/types.h
@@ -19,7 +19,6 @@
 #include <linux/aio_abi.h>
 #include <linux/eventpoll.h>
 #include <linux/futex.h>
-#include <linux/kernel.h>
 #include <linux/msg.h>
 #include <linux/perf_event.h>
 #include <linux/sem.h>

--- a/libos/src/sys/libos_getrlimit.c
+++ b/libos/src/sys/libos_getrlimit.c
@@ -13,6 +13,7 @@
 #include "libos_thread.h"
 #include "libos_vma.h"
 #include "linux_abi/limits.h"
+#include "linux_abi/sysinfo.h"
 
 /*
  * TODO: implement actual limitation on each resource.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a part of making our LibOS independent of the host headers (we want this b/c the host may not even be Linux).

Previous work from this series: #1275, #1301.
For now only this one struct, because Alpine need it.

## How to test this PR? <!-- (if applicable) -->

Try building on weird hosts (like Alpine).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1426)
<!-- Reviewable:end -->
