### PR TITLE
[Meson] Use same version in `mbedtls_gramine` project as Gramine

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@
 project(
     'gramine',
     'c', 'cpp',
-    version: '1.4post~UNRELEASED',
+    version: '1.4post~UNRELEASED', # keep synced with subprojects/packagefiles/mbedtls/meson.build
     license: 'LGPLv3+',
 
     meson_version: '>=0.56',

--- a/subprojects/packagefiles/mbedtls/meson.build
+++ b/subprojects/packagefiles/mbedtls/meson.build
@@ -1,4 +1,8 @@
-project('mbedtls', 'c')
+project(
+    'mbedtls',
+    'c',
+    version: '1.4post~UNRELEASED', # keep synced with top-level meson.build
+)
 
 pkgconfig = import('pkgconfig')
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Unfortunately, Meson 0.56 doesn't have a way to deduplicate `project.version` field, so we simply copy the value.

I looked through Meson documentation, and also read https://stackoverflow.com/questions/59201214/can-the-meson-project-version-be-assigned-dynamically. But looks like no way to do what I want nicely :(

Created in response to comments in #1421.

## How to test this PR? <!-- (if applicable) -->

Just manually:

- Without this PR:
```
$ cat built/lib/x86_64-linux-gnu/pkgconfig/mbedtls_gramine.pc
...
Name: mbedtls_gramine
Description: A version of mbedtls patched for Gramine
Version: undefined
```

- With this PR:
```
$ cat built/lib/x86_64-linux-gnu/pkgconfig/mbedtls_gramine.pc
...
Name: mbedtls_gramine
Description: A version of mbedtls patched for Gramine
Version: 1.4post~UNRELEASED
```