### PR TITLE
[packaging] Alpine

### DIFF
--- a/.ci/alpine3.17.dockerfile
+++ b/.ci/alpine3.17.dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.17
+
+RUN apk add \
+    alpine-sdk \
+    doas \
+    jq \
+    meson \
+    nasm
+
+COPY packaging/alpine/APKBUILD /APKBUILD
+RUN abuild -F -r builddeps
+RUN rm -f /APKBUILD

--- a/.ci/pkg-apk-alpine3.17.jenkinsfile
+++ b/.ci/pkg-apk-alpine3.17.jenkinsfile
@@ -1,0 +1,41 @@
+pipeline {
+    agent any
+    stages {
+        stage('makedist') {
+            agent {
+                dockerfile {
+                    filename '.ci/alpine3.17.dockerfile'
+                    reuseNode true
+                }
+            }
+            steps {
+                sh '''
+                    ABUILD_USERDIR=$PWD/abuild
+                    export ABUILD_USERDIR
+                    cd packaging/alpine
+                    abuild snapshot
+                '''
+            }
+        }
+        stage('build') {
+            agent {
+                dockerfile {
+                    filename '.ci/alpine3.17.dockerfile'
+                    args '--network=none'
+                    reuseNode true
+                }
+            }
+            steps {
+                sh '''
+                    ABUILD_USERDIR=$PWD/abuild
+                    REPODEST=$PWD/packages
+                    export ABUILD_USERDIR REPODEST
+                    cd packaging/alpine
+                    abuild-keygen -an
+                    abuild checksum all
+                '''
+                archiveArtifacts 'packages/'
+            }
+        }
+    }
+}

--- a/packaging/alpine/.gitignore
+++ b/packaging/alpine/.gitignore
@@ -1,0 +1,3 @@
+/build-dist/
+/pkg/
+/src/

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -1,0 +1,85 @@
+# Contributor: Amie Raine <amie@invisiblethingslab.com>
+# Maintainer: Amie Raine <amie@invisiblethingslab.com>
+pkgname=gramine
+_real_pkgver=1.4post~UNRELEASED
+pkgver=$(printf %s "$_real_pkgver" | sed \
+    -e "s:post~UNRELEASED:_git$(printf %d 0x"$(git rev-parse HEAD 2>/dev/null | cut -c1-8)"):" \
+    -e 's:~:_:' \
+)
+pkgrel=0
+pkgdesc="A lightweight usermode guest OS designed to run a single Linux application"
+url="https://github.com/gramineproject/gramine"
+arch="x86_64"
+license="LGPL-3.0-or-later"
+makedepends="
+    autoconf
+    binutils-dev
+    bison
+    coreutils
+    findutils
+    gawk
+    gettext
+    grep
+    jq
+    libunwind
+    linux-headers
+    meson
+    musl-dev
+    nasm
+    openssl1.1-compat-dev
+    protobuf-c-compiler
+    protobuf-c-dev
+    py3-click
+    py3-elftools
+    py3-jinja2
+    py3-pytest
+    "
+depends="
+    py3-click
+    py3-cryptography
+    py3-elftools
+    py3-jinja2
+    py3-tomli
+    py3-tomli-w
+    "
+source="$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$_real_pkgver/"
+options="!check" # tests assume a glibc environment
+
+prepare() {
+    meson setup \
+        --wrap-mode=nodownload \
+        --prefix=/usr \
+        --buildtype=release \
+        -Ddirect=enabled \
+        -Dsgx=enabled \
+        -Dlibc=musl \
+        . build/
+
+    # sanity check for version number
+    test "$(meson introspect build/ --projectinfo | jq -r '.version')" = "$_real_pkgver" \
+        || die '$_real_pkgver does not match what is in meson.build'
+
+    default_prepare
+}
+
+build() {
+    meson compile -C build
+}
+
+package() {
+    DESTDIR="$pkgdir" meson install --no-rebuild -C build
+
+    for pc in \
+        "$pkgdir"/usr/lib/pkgconfig/ra_tls_gramine.pc \
+        "$pkgdir"/usr/lib/pkgconfig/secret_prov_gramine.pc \
+    ; do
+        sed -i -e "s:$_real_pkgver:$pkgver:" "$pc"
+    done
+}
+
+snapshot() {
+    meson setup -Dskeleton=enabled -Dlibc=musl build-dist/ ../..
+    meson dist -C build-dist/ --no-test --include-subprojects --format=gztar
+    install -D build-dist/meson-dist/"$pkgname-$_real_pkgver".tar.gz "$pkgname-$pkgver.tar.gz"
+}


### PR DESCRIPTION
Taken over #1421, with fixes and CI.

## How to test

CI (esp. `pkg-apk-alpine3.17`)

## How to test yourself

Quick and dirty, but always works. Leaves root-owned files in you repo (you can clean with `sudo git clean -dxf` afterwards). Proper testing would require proper alpine packaging setup (read more here: https://wiki.alpinelinux.org/wiki/Creating_an_Alpine_package), which is not in scope here.

```
docker run -it --rm alpine:latest --volume $PWD:/gramine
cd /gramine/packaging/alpine
apk add alpine-sdk jq meson nasm
abuild-keygen -an
abuild -F -r snapshot checksum all
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1439)
<!-- Reviewable:end -->
