### PR TITLE
[Glibc] Apply a fix of CVE-2023-25139 (glibc bug 30068)

### DIFF
--- a/subprojects/packagefiles/glibc-2.37/fix-bug-30068.patch
+++ b/subprojects/packagefiles/glibc-2.37/fix-bug-30068.patch
@@ -1,0 +1,58 @@
+diff --git a/stdio-common/vfprintf-process-arg.c b/stdio-common/vfprintf-process-arg.c
+index 24c9125f9fa930602953ad9569244d6e282e4d9d..8c0fcbcf785a947527b376d41b8cf1dc4e9ee029 100644 (file)
+--- a/stdio-common/vfprintf-process-arg.c
++++ b/stdio-common/vfprintf-process-arg.c
+@@ -186,11 +186,17 @@ LABEL (unsigned_number):      /* Unsigned number of base BASE.  */
+   bool octal_marker = (prec <= number_length && number.word != 0
+                        && alt && base == 8);
+ 
+-  prec = MAX (0, prec - (workend - string));
++  /* At this point prec_inc is the additional bytes required for the
++     specificed precision.  It is 0 if the precision would not have
++     required additional bytes i.e. the number of input digits is more
++     than the precision.  It is greater than zero if the precision is
++     more than the number of digits without grouping (precision only
++     considers digits).  */
++  unsigned int prec_inc = MAX (0, prec - (workend - string));
+ 
+   if (!left)
+     {
+-      width -= number_length + prec;
++      width -= number_length + prec_inc;
+ 
+       if (number.word != 0 && alt && (base == 16 || base == 2))
+         /* Account for 0X, 0x, 0B or 0b hex or binary marker.  */
+@@ -221,7 +227,7 @@ LABEL (unsigned_number):      /* Unsigned number of base BASE.  */
+           Xprintf_buffer_putc (buf, spec);
+         }
+ 
+-      width += prec;
++      width += prec_inc;
+       Xprintf_buffer_pad (buf, L_('0'), width);
+ 
+       if (octal_marker)
+@@ -237,6 +243,8 @@ LABEL (unsigned_number):      /* Unsigned number of base BASE.  */
+     }
+   else
+     {
++      /* Perform left justification adjustments.  */
++
+       if (is_negative)
+         {
+           Xprintf_buffer_putc (buf, L_('-'));
+@@ -263,9 +271,13 @@ LABEL (unsigned_number):      /* Unsigned number of base BASE.  */
+       if (octal_marker)
+        --width;
+ 
+-      width -= workend - string + prec;
++      /* Adjust the width by subtracting the number of bytes
++         required to represent the number with grouping characters
++        (NUMBER_LENGTH) and any additional bytes required for
++        precision.  */
++      width -= number_length + prec_inc;
+ 
+-      Xprintf_buffer_pad (buf, L_('0'), prec);
++      Xprintf_buffer_pad (buf, L_('0'), prec_inc);
+ 
+       if (octal_marker)
+         Xprintf_buffer_putc (buf, L_('0'));

--- a/subprojects/packagefiles/glibc-2.37/meson.build
+++ b/subprojects/packagefiles/glibc-2.37/meson.build
@@ -73,6 +73,12 @@ glibc = custom_target('glibc',
         'glibc-2.37/configure',
         'gramine-syscall.patch',
         'hp-timing.patch',
+        # backporting the fix for CVE-2023-25139; drop when we update to glibc 2.38;
+        # see the following:
+        #  - https://nvd.nist.gov/vuln/detail/CVE-2023-25139
+        #  - https://sourceware.org/bugzilla/show_bug.cgi?id=30068
+        #  - https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c980549cc6a1c03c23cc2fe3e7b0fe626a0364b0
+        'fix-bug-30068.patch',
     ],
 
     output: glibc_output,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Glibc v2.37 introduced a bug in `vfprintf()` family of functions, where mishandling of grouping when formatting integers leads to a buffer overflow. This is considered a critical vulnerability, so Gramine must apply a fix. The fix is taken from glibc commit c980549cc6a.

See:
- https://nvd.nist.gov/vuln/detail/CVE-2023-25139
- https://sourceware.org/bugzilla/show_bug.cgi?id=30068
- https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c980549cc6a1c03c23cc2fe3e7b0fe626a0364b0
- https://github.com/bminor/glibc/commit/c980549cc6a

## How to test this PR? <!-- (if applicable) -->

I tested manually on the reproducer from https://sourceware.org/bugzilla/show_bug.cgi?id=30068. Here's a diff:
```diff
diff --git a/CI-Examples/helloworld/helloworld.c b/CI-Examples/helloworld/helloworld.c
index 2efc7765..e7940174 100644
--- a/CI-Examples/helloworld/helloworld.c
+++ b/CI-Examples/helloworld/helloworld.c
@@ -1,6 +1,21 @@
#include <stdio.h>
+#include <locale.h>
+#include <string.h>

-int main(void) {
-    printf("Hello, world\n");
-    return 0;
+int main (void)
+{
+  char buf[strlen ("1234567890123:") + 1];
+  __builtin_memset (buf, 'x', sizeof (buf));
+  if (setlocale (LC_ALL, ""))
+    {
+      printf ("1234567890123:\n");
+      printf ("%0+ -'13ld:\n", 1234567L);
+      sprintf (buf, "%0+ -'13ld:", 1234567L);
+      for (size_t i = 0; i < strlen ("1234567890123:") + 1; i++)
+       {
+         printf ("%c", buf[i]);
+       }
+      printf ("\n");
+    }
+  return 0;
}
diff --git a/CI-Examples/helloworld/helloworld.manifest.template b/CI-Examples/helloworld/helloworld.manifest.template
index e15f0d2b..375bdab2 100644
--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -5,9 +5,11 @@ libos.entrypoint = "/helloworld"
loader.log_level = "{{ log_level }}"

loader.env.LD_LIBRARY_PATH = "/lib"
+loader.env.LC_ALL = "en_US.UTF-8"

fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ gramine.runtimedir() }}/locale", uri = "file:/usr/lib/locale" },
   { path = "/helloworld", uri = "file:helloworld" },
]

@@ -18,4 +20,5 @@ sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:helloworld",
   "file:{{ gramine.runtimedir() }}/",
+  "file:/usr/lib/locale/",
]
```

This requires a `en_US.UTF-8` locale to be installed on your machine, and available under `/usr/lib/locale`.

- Without this PR and built with `make SGX=1` (i.e. release build with `-O3`):
```
~/gramineproject/gramine/CI-Examples/helloworld$ gramine-direct helloworld
*** buffer overflow detected ***: terminated

~/gramineproject/gramine/CI-Examples/helloworld$ gramine-sgx helloworld
… blabla …
*** buffer overflow detected ***: terminated
```

- With this PR:
```
~/gramineproject/gramine/CI-Examples/helloworld$ gramine-direct helloworld
1234567890123:
+1,234,567   :
+1,234,567   :

~/gramineproject/gramine/CI-Examples/helloworld$ gramine-sgx helloworld
… blabla …
1234567890123:
+1,234,567   :
+1,234,567   :
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1440)
<!-- Reviewable:end -->
