### PR TITLE
[PAL/Linux-SGX] Add EDMM support for dynamic thread creation

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -21,7 +21,7 @@ fs.mounts = [
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enclave_size = "512M"
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -24,7 +24,7 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sys.stack.size = "8M"
 sgx.enclave_size = "2048M"
-sgx.max_threads = 64
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '64' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -22,7 +22,7 @@ fs.mounts = [
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enclave_size = "256M"
-sgx.max_threads = 3
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '3' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -29,7 +29,7 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.max_threads = 16
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '16' }}
 
 # Memcached does not fail explicitly when enclave memory is exhausted. Instead, Memcached goes into
 # infinite loop without a listening socket. You can trigger this incorrect behavior by increasing

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -28,7 +28,7 @@ fs.mounts = [
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enclave_size = "512M"
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -35,7 +35,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enclave_size = "1G"
-sgx.max_threads = 32
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '32' }}
 
 sgx.remote_attestation = "{{ ra_type }}"
 sgx.ra_client_spid = "{{ ra_client_spid }}"

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -27,7 +27,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enclave_size = "512M"
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -81,11 +81,15 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 # that SGX v1 requires to specify the maximum number of simultaneous threads at
 # enclave creation time.
 #
+# Note that when EDMM is enabled, there is no need to specify a particular
+# number of threads, as Gramine will automatically adjust to the application
+# demands.
+#
 # Note that internally Gramine may spawn two additional threads, one for IPC
 # and one for asynchronous events/alarms. Redis is technically single-threaded
 # but spawns couple additional threads to do background bookkeeping. Therefore,
 # specifying '8' allows to run a maximum of 6 Redis threads which is enough.
-sgx.max_threads = 8
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}
 
 ############################# SGX: TRUSTED FILES ###############################
 

--- a/CI-Examples/rust/rust-hyper-http-server.manifest.template
+++ b/CI-Examples/rust/rust-hyper-http-server.manifest.template
@@ -40,4 +40,4 @@ sys.insecure__allow_eventfd = true
 # - any threads and threadpools you might be starting
 # - helper threads internal to Gramine — see:
 #   https://gramine.readthedocs.io/en/stable/manifest-syntax.html#number-of-threads
-sgx.max_threads = 8
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -29,7 +29,7 @@ fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enclave_size = "256M"
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -723,11 +723,16 @@ Number of threads
     sgx.max_threads = [NUM]
     (Default: 4)
 
-This syntax specifies the maximum number of threads that can be created inside
-the enclave (recall that SGX |~| v1 requires a |~| predetermined maximum number
-of thread slots). The application cannot have more threads than this limit *at
-a time* (however, it is possible to create new threads after old threads are
-destroyed).
+If :term:`EDMM` is not enabled (``sgx.edmm_enable = false``), then this syntax
+specifies the maximum number of threads that can be created inside the enclave
+(recall that SGX |~| v1 requires a |~| predetermined maximum number of thread
+slots). The application cannot have more threads than this limit *at a time*
+(however, it is possible to create new threads after old threads are destroyed).
+
+If :term:`EDMM` is enabled (``sgx.edmm_enable = true``), then this syntax
+specifies the number of pre-allocated thread slots (must be at least ``1``).
+However, the maximum number of threads can exceed this limit during enclave
+execution, by dynamically allocating new thread slots.
 
 Note that Gramine uses several helper threads internally:
 
@@ -746,6 +751,9 @@ Given these internal threads, ``sgx.max_threads`` should be set to at least
 ``4`` even for single-threaded applications (to accommodate for the main thread,
 the IPC thread, the Async thread and one TLS-handshake thread).
 
+.. note::
+   This option will be renamed after non-:term:`EDMM` platform support is
+   dropped.
 
 Number of RPC threads (Exitless feature)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libos/test/abi/x86_64/manifest.template
+++ b/libos/test/abi/x86_64/manifest.template
@@ -7,7 +7,7 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/libos/test/abi/x86_64/stack_arg.manifest.template
+++ b/libos/test/abi/x86_64/stack_arg.manifest.template
@@ -12,7 +12,7 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/libos/test/abi/x86_64/stack_env.manifest.template
+++ b/libos/test/abi/x86_64/stack_env.manifest.template
@@ -12,7 +12,7 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/libos/test/fs/manifest.template
+++ b/libos/test/fs/manifest.template
@@ -22,7 +22,7 @@ fs.insecure__keys.default = "ffeeddccbbaa99887766554433221100"
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.max_threads = 16
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '16' }}
 
 sgx.allowed_files = [
   "file:tmp/",

--- a/libos/test/regression/bootstrap_cpp.manifest.template
+++ b/libos/test/regression/bootstrap_cpp.manifest.template
@@ -13,7 +13,7 @@ fs.mounts = [
   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
 ]
 
-sgx.max_threads = 8
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -24,7 +24,7 @@ fs.mounts = [
   { type = "encrypted", path = "/encrypted_file_mrsigner.dat", uri = "file:encrypted_file_mrsigner.dat", key_name = "_sgx_mrsigner" },
 ]
 
-sgx.max_threads = 16
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '16' }}
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/multi_pthread.manifest.template
+++ b/libos/test/regression/multi_pthread.manifest.template
@@ -9,7 +9,7 @@ fs.mounts = [
 ]
 
 # app runs with 4 parallel threads + Gramine has couple internal threads
-sgx.max_threads = 8
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}

--- a/libos/test/regression/multi_pthread_exitless.manifest.template
+++ b/libos/test/regression/multi_pthread_exitless.manifest.template
@@ -9,7 +9,7 @@ fs.mounts = [
 ]
 
 # app runs with 4 parallel threads + Gramine has couple internal threads
-sgx.max_threads = 8
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}
 sgx.insecure__rpc_thread_num = 8
 
 sgx.debug = true

--- a/libos/test/regression/openmp.manifest.template
+++ b/libos/test/regression/openmp.manifest.template
@@ -22,7 +22,7 @@ fs.mounts = [
   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
 ]
 
-sgx.max_threads = 32
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '32' }}
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/rwlock.manifest.template
+++ b/libos/test/regression/rwlock.manifest.template
@@ -9,7 +9,7 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.max_threads = 200
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '200' }}
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/shebang_test_script.manifest.template
+++ b/libos/test/regression/shebang_test_script.manifest.template
@@ -10,7 +10,7 @@ fs.mounts = [
   { path = "/bin", uri = "file:/bin" },
 ]
 
-sgx.max_threads = 16
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '16' }}
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/libos/test/regression/socket_ioctl.manifest.template
+++ b/libos/test/regression/socket_ioctl.manifest.template
@@ -8,7 +8,7 @@ fs.mounts = [
   { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
 ]
 
-sgx.max_threads = 4
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/Thread2_edmm.manifest.template
+++ b/pal/regression/Thread2_edmm.manifest.template
@@ -1,7 +1,8 @@
+{% set entrypoint = "Thread2" -%}
+
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 
-sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '2' }}
-sgx.enable_stats = true
+sgx.max_threads = 1
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/Thread2_exitless.manifest.template
+++ b/pal/regression/Thread2_exitless.manifest.template
@@ -2,7 +2,7 @@
 
 loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
 
-sgx.max_threads = 2
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '2' }}
 sgx.insecure__rpc_thread_num = 2
 sgx.enable_stats = true
 sgx.debug = true

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -421,6 +421,22 @@ class TC_20_SingleProcess(RegressionTestCase):
         # Thread Cleanup: Can still start threads.
         self.assertIn('Thread 4 ok.', stderr)
 
+    @unittest.skipUnless(HAS_SGX, 'This test is only meaningful on SGX PAL')
+    def test_512_thread2_edmm(self):
+        if HAS_EDMM:
+            _, stderr = self.run_binary(['Thread2_edmm'])
+            self.assertIn('Thread 2 ok.', stderr)
+            self.assertIn('Thread 3 ok.', stderr)
+            self.assertNotIn('Exiting thread 3 failed.', stderr)
+            self.assertIn('Thread 4 ok.', stderr)
+        else:
+            try:
+                self.run_binary(['Thread2_edmm'])
+                self.fail('expected to return nonzero')
+            except subprocess.CalledProcessError as e:
+                stderr = e.stderr.decode()
+                self.assertIn("PalThreadCreate failed for thread 2.", stderr)
+
     def test_900_misc(self):
         _, stderr = self.run_binary(['Misc'])
         # Query System Time

--- a/pal/regression/tests.toml
+++ b/pal/regression/tests.toml
@@ -23,6 +23,7 @@ manifests = [
   "Process4",
   "Symbols",
   "Thread2",
+  "Thread2_edmm",
   "Thread2_exitless",
   "normalize_path",
   "printf_test",

--- a/pal/src/host/linux-sgx/enclave_api.h
+++ b/pal/src/host/linux-sgx/enclave_api.h
@@ -53,3 +53,4 @@ int64_t sgx_getkey(sgx_key_request_t* keyrequest, sgx_key_128bit_t* key);
 int sgx_edmm_add_pages(uint64_t addr, size_t count, uint64_t prot);
 int sgx_edmm_remove_pages(uint64_t addr, size_t count);
 int sgx_edmm_set_page_permissions(uint64_t addr, size_t count, uint64_t prot);
+int sgx_edmm_convert_pages_to_tcs(uint64_t addr, size_t count);

--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -988,15 +988,14 @@ int ocall_resume_thread(void* tcs) {
     return retval;
 }
 
-int ocall_clone_thread(void) {
+int ocall_clone_thread(void* dynamic_tcs) {
     int retval = 0;
-    void* dummy = NULL;
     /* FIXME: if there was an EINTR, there may be an untrusted thread left over */
     do {
         /* clone must happen in the context of current (enclave) thread, cannot use exitless;
          * in particular, the new (enclave) thread must have the same signal mask as the current
          * enclave thread (and NOT signal mask of the RPC thread) */
-        retval = sgx_ocall(OCALL_CLONE_THREAD, dummy);
+        retval = sgx_ocall(OCALL_CLONE_THREAD, dynamic_tcs);
     } while (retval == -EINTR);
 
     if (retval < 0 && retval != -ENOMEM && retval != -EAGAIN && retval != -EINVAL &&

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -82,7 +82,7 @@ int ocall_sched_setaffinity(void* tcs, unsigned long* cpu_mask, size_t cpu_mask_
 
 int ocall_sched_getaffinity(void* tcs, unsigned long* cpu_mask, size_t cpu_mask_len);
 
-int ocall_clone_thread(void);
+int ocall_clone_thread(void* dynamic_tcs);
 
 int ocall_create_process(size_t nargs, const char** args, uintptr_t (*reserved_mem_ranges)[2],
                          size_t reserved_mem_ranges_len, int* out_stream_fd);

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -15,6 +15,7 @@
 
 extern const size_t g_page_size;
 extern pid_t g_host_pid;
+extern bool g_vtune_profile_enabled;
 
 #undef IS_ALLOC_ALIGNED
 #undef IS_ALLOC_ALIGNED_PTR
@@ -56,6 +57,8 @@ struct pal_enclave {
 };
 
 extern struct pal_enclave g_pal_enclave;
+
+void* realloc(void* ptr, size_t new_size);
 
 int open_sgx_driver(void);
 bool is_wrfsbase_supported(void);
@@ -111,17 +114,19 @@ void eresume_pointer(void);
 void async_exit_pointer_end(void);
 
 int get_tid_from_tcs(void* tcs);
-int clone_thread(void);
+int clone_thread(void* dynamic_tcs);
 
-void create_tcs_mapper(void* tcs_base, unsigned int thread_num);
+int create_tcs_mapper(void* tcs_base, unsigned int thread_num);
 int pal_thread_init(void* tcbptr);
 void map_tcs(unsigned int tid);
-void unmap_tcs(void);
+void unmap_my_tcs(void);
 int current_enclave_thread_cnt(void);
 void thread_exit(int status);
 
 int sgx_signal_setup(void);
 int block_async_signals(bool block);
+
+int set_tcs_debug_flag_if_debugging(void* tcs_addrs[], size_t count);
 
 #ifdef DEBUG
 /* SGX profiling (sgx_profile.c) */

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -252,12 +252,13 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     unsigned long enclave_heap_min;
     char* sig_path = NULL;
     int sigfile_fd = -1;
-    int enclave_mem = -1;
     size_t areas_size = 0;
     struct mem_area* areas = NULL;
 
-    /* this array may overflow the stack, so we allocate it in BSS */
-    static void* tcs_addrs[MAX_DBG_THREADS];
+    void** tcs_addrs = (void**)malloc(sizeof(void*) * enclave->thread_num);
+    if (!tcs_addrs) {
+        return -ENOMEM;
+    }
 
     enclave_image = DO_SYSCALL(open, enclave->libpal_uri + URI_PREFIX_FILE_LEN,
                                O_RDONLY | O_CLOEXEC, 0);
@@ -417,7 +418,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     struct mem_area* tls_area = &areas[area_num++];
 
     struct mem_area* stack_areas = &areas[area_num]; /* memorize for later use */
-    for (uint32_t t = 0; t < enclave->thread_num; t++) {
+    for (size_t t = 0; t < enclave->thread_num; t++) {
         areas[area_num] = (struct mem_area){.desc         = "stack",
                                             .skip_eextend = false,
                                             .data_src     = ZERO,
@@ -429,7 +430,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     }
 
     struct mem_area* sig_stack_areas = &areas[area_num]; /* memorize for later use */
-    for (uint32_t t = 0; t < enclave->thread_num; t++) {
+    for (size_t t = 0; t < enclave->thread_num; t++) {
         areas[area_num] = (struct mem_area){.desc         = "sig_stack",
                                             .skip_eextend = false,
                                             .data_src     = ZERO,
@@ -507,7 +508,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
         }
 
         if (areas[i].data_src == TLS) {
-            for (uint32_t t = 0; t < enclave->thread_num; t++) {
+            for (size_t t = 0; t < enclave->thread_num; t++) {
                 struct pal_enclave_tcb* gs = data + g_page_size * t;
                 memset(gs, 0, g_page_size);
                 assert(sizeof(*gs) <= g_page_size);
@@ -526,7 +527,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
                 gs->thread = NULL;
             }
         } else if (areas[i].data_src == TCS) {
-            for (uint32_t t = 0; t < enclave->thread_num; t++) {
+            for (size_t t = 0; t < enclave->thread_num; t++) {
                 sgx_arch_tcs_t* tcs = data + g_page_size * t;
                 memset(tcs, 0, g_page_size);
                 // .ossa, .oentry, .ofs_base and .ogs_base are offsets from enclave base, not VAs.
@@ -567,7 +568,11 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
         goto out;
     }
 
-    create_tcs_mapper((void*)tcs_area->addr, enclave->thread_num);
+    ret = create_tcs_mapper((void*)tcs_area->addr, enclave->thread_num);
+    if (ret < 0) {
+        log_error("Create tcs mapper failed: %s", unix_strerror(ret));
+        goto out;
+    }
 
     struct enclave_dbginfo* dbg = (void*)DO_SYSCALL(mmap, DBGINFO_ADDR,
                                                     sizeof(struct enclave_dbginfo),
@@ -587,39 +592,13 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
         dbg->aep            = async_exit_pointer;
         dbg->eresume        = eresume_pointer;
         dbg->thread_tids[0] = dbg->pid;
-        for (int i = 0; i < MAX_DBG_THREADS; i++)
-            dbg->tcs_addrs[i] = tcs_addrs[i];
+        for (size_t t = 0; t < enclave->thread_num; t++)
+            dbg->tcs_addrs[t] = tcs_addrs[t];
     }
 
-    if (g_sgx_enable_stats || g_vtune_profile_enabled) {
-        /* set TCS.FLAGS.DBGOPTIN in all enclave threads to enable perf counters, Intel PT, etc */
-        ret = DO_SYSCALL(open, "/proc/self/mem", O_RDWR | O_LARGEFILE | O_CLOEXEC, 0);
-        if (ret < 0) {
-            log_error("Setting TCS.FLAGS.DBGOPTIN failed: %s", unix_strerror(ret));
-            goto out;
-        }
-        enclave_mem = ret;
-
-        for (size_t i = 0; i < enclave->thread_num; i++) {
-            uint64_t tcs_flags;
-            uint64_t* tcs_flags_ptr = tcs_addrs[i] + offsetof(sgx_arch_tcs_t, flags);
-
-            ret = DO_SYSCALL(pread64, enclave_mem, &tcs_flags, sizeof(tcs_flags),
-                             (off_t)tcs_flags_ptr);
-            if (ret < 0) {
-                log_error("Reading TCS.FLAGS.DBGOPTIN failed: %s", unix_strerror(ret));
-                goto out;
-            }
-
-            tcs_flags |= TCS_FLAGS_DBGOPTIN;
-
-            ret = DO_SYSCALL(pwrite64, enclave_mem, &tcs_flags, sizeof(tcs_flags),
-                             (off_t)tcs_flags_ptr);
-            if (ret < 0) {
-                log_error("Writing TCS.FLAGS.DBGOPTIN failed: %s", unix_strerror(ret));
-                goto out;
-            }
-        }
+    ret = set_tcs_debug_flag_if_debugging(tcs_addrs, enclave->thread_num);
+    if (ret < 0) {
+        goto out;
     }
 
 #ifdef DEBUG
@@ -630,7 +609,6 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
      * We report it here, before enclave start (as opposed to setup_pal_binary()), because we want
      * both GDB integration and profiling to be active from the very beginning of enclave execution.
      */
-
     debug_map_add(enclave->libpal_uri + URI_PREFIX_FILE_LEN, (void*)pal_area->addr);
     sgx_profile_report_elf(enclave->libpal_uri + URI_PREFIX_FILE_LEN, (void*)pal_area->addr);
 #endif
@@ -645,10 +623,9 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     ret = 0;
 
 out:
+    free(tcs_addrs);
     if (enclave_image >= 0)
         DO_SYSCALL(close, enclave_image);
-    if (enclave_mem >= 0)
-        DO_SYSCALL(close, enclave_mem);
     if (sigfile_fd >= 0)
         DO_SYSCALL(close, sigfile_fd);
     if (areas)
@@ -1055,8 +1032,8 @@ static int load_enclave(struct pal_enclave* enclave, char* args, size_t args_siz
 
     /* initialize TCB at the top of the alternative stack */
     PAL_HOST_TCB* tcb = alt_stack + ALT_STACK_SIZE - sizeof(PAL_HOST_TCB);
-    pal_host_tcb_init(tcb, /*stack=*/NULL,
-                      alt_stack); /* main thread uses the stack provided by Linux */
+    /* main thread uses the stack provided by Linux */
+    pal_host_tcb_init(tcb, /*stack=*/NULL, alt_stack);
     ret = pal_thread_init(tcb);
     if (ret < 0)
         return ret;
@@ -1078,7 +1055,7 @@ static int load_enclave(struct pal_enclave* enclave, char* args, size_t args_siz
                         &qe_targetinfo, &topo_info, &dns_conf, enclave->edmm_enabled,
                         reserved_mem_ranges, reserved_mem_ranges_size);
 
-    unmap_tcs();
+    unmap_my_tcs();
     DO_SYSCALL(munmap, alt_stack, ALT_STACK_SIZE);
     DO_SYSCALL(exit, 0);
     die_or_inf_loop();

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -28,8 +28,6 @@
 
 #define DEFAULT_BACKLOG 2048
 
-extern bool g_vtune_profile_enabled;
-
 rpc_queue_t* g_rpc_queue = NULL; /* pointer to untrusted queue */
 
 static long sgx_ocall_exit(void* args) {
@@ -62,7 +60,7 @@ static long sgx_ocall_exit(void* args) {
     block_async_signals(true);
     ecall_thread_reset();
 
-    unmap_tcs();
+    unmap_my_tcs();
 
     if (!current_enclave_thread_cnt()) {
         /* no enclave threads left, kill the whole process */
@@ -242,8 +240,7 @@ static long sgx_ocall_sched_getaffinity(void* args) {
 }
 
 static long sgx_ocall_clone_thread(void* args) {
-    __UNUSED(args);
-    return clone_thread();
+    return clone_thread(args);
 }
 
 static long sgx_ocall_create_process(void* args) {

--- a/pal/src/host/linux-sgx/host_profile.c
+++ b/pal/src/host/linux-sgx/host_profile.c
@@ -30,8 +30,6 @@
 #include "ittnotify.h" // for __itt_module_load(...) which is defined as a macro
 #endif
 
-extern bool g_vtune_profile_enabled;
-
 // FIXME: this is glibc realpath, declared here because the headers will conflict with PAL
 char* realpath(const char* path, char* resolved_path);
 

--- a/pal/src/host/linux-sgx/host_thread.c
+++ b/pal/src/host/linux-sgx/host_thread.c
@@ -13,14 +13,16 @@
 #include "host_internal.h"
 #include "spinlock.h"
 
-struct thread_map {
+struct enclave_thread_map {
     unsigned int    tid;
     sgx_arch_tcs_t* tcs;
 };
 
-static sgx_arch_tcs_t* g_enclave_tcs;
-static int g_enclave_thread_num;
-static struct thread_map* g_enclave_thread_map;
+static struct enclave_thread_map* g_enclave_thread_map = NULL;
+static spinlock_t g_enclave_thread_map_lock = INIT_SPINLOCK_UNLOCKED;
+
+/* total number of items in g_enclave_thread_map; protected by g_enclave_thread_map_lock */
+static size_t g_enclave_thread_num = 0;
 
 bool g_sgx_enable_stats = false;
 
@@ -85,56 +87,132 @@ void pal_host_tcb_init(PAL_HOST_TCB* tcb, void* stack, void* alt_stack) {
     tcb->last_async_event = PAL_EVENT_NO_EVENT;
 }
 
-static spinlock_t tcs_lock = INIT_SPINLOCK_UNLOCKED;
+int create_tcs_mapper(void* tcs_base, unsigned int thread_num) {
+    sgx_arch_tcs_t* enclave_tcs = tcs_base;
 
-void create_tcs_mapper(void* tcs_base, unsigned int thread_num) {
-    size_t thread_map_size = ALIGN_UP_POW2(sizeof(struct thread_map) * thread_num, PRESET_PAGESIZE);
-
-    g_enclave_tcs = tcs_base;
-    g_enclave_thread_num = thread_num;
-    g_enclave_thread_map = (struct thread_map*)DO_SYSCALL(mmap, NULL, thread_map_size,
-                                                          PROT_READ | PROT_WRITE,
-                                                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    g_enclave_thread_map = malloc(sizeof(struct enclave_thread_map) * thread_num);
+    if (!g_enclave_thread_map) {
+        return -ENOMEM;
+    }
 
     for (uint32_t i = 0; i < thread_num; i++) {
         g_enclave_thread_map[i].tid = 0;
-        g_enclave_thread_map[i].tcs = &g_enclave_tcs[i];
+        g_enclave_thread_map[i].tcs = &enclave_tcs[i];
     }
+    g_enclave_thread_num = thread_num;
+    return 0;
+}
+
+static int add_dynamic_tcs(sgx_arch_tcs_t* tcs) {
+    int ret;
+    struct enclave_dbginfo* dbginfo = (struct enclave_dbginfo*)DBGINFO_ADDR;
+
+    ret = set_tcs_debug_flag_if_debugging((void**)&tcs, /*count=*/1);
+    if (ret < 0) {
+        return ret;
+    }
+
+    size_t i = 0;
+    spinlock_lock(&g_enclave_thread_map_lock);
+    for (i = 0; i < g_enclave_thread_num; i++) {
+        if (g_enclave_thread_map[i].tcs == tcs) {
+            log_error("Dynamic TCS page %p was already added to the list of enclave threads", tcs);
+            BUG();
+        }
+        if (!g_enclave_thread_map[i].tcs) {
+            g_enclave_thread_map[i].tcs = tcs;
+            dbginfo->tcs_addrs[i] = tcs;
+            break;
+        }
+    }
+
+    if (i == g_enclave_thread_num) {
+        /* Current map is full. */
+        if (g_enclave_thread_num >= MAX_DBG_THREADS) {
+            log_error("Number of simultaneous enclave threads equals to or exceeds %u, "
+                      "not supported", MAX_DBG_THREADS);
+            ret = -EOVERFLOW;
+            goto out;
+        }
+
+        size_t new_enclave_thread_num = MIN(g_enclave_thread_num * 2, (size_t)MAX_DBG_THREADS);
+        struct enclave_thread_map* new_enclave_thread_map = realloc(
+            g_enclave_thread_map, sizeof(struct enclave_thread_map) * new_enclave_thread_num);
+        if (!new_enclave_thread_map) {
+            ret = -ENOMEM;
+            goto out;
+        }
+
+        memset(new_enclave_thread_map + g_enclave_thread_num, 0,
+               sizeof(struct enclave_thread_map) * (new_enclave_thread_num - g_enclave_thread_num));
+
+        g_enclave_thread_num = new_enclave_thread_num;
+        g_enclave_thread_map = new_enclave_thread_map;
+
+        g_enclave_thread_map[i].tcs = tcs;
+        dbginfo->tcs_addrs[i] = tcs;
+    }
+
+    ret = 0;
+out:
+    spinlock_unlock(&g_enclave_thread_map_lock);
+    return ret;
 }
 
 void map_tcs(unsigned int tid) {
-    spinlock_lock(&tcs_lock);
-    for (int i = 0; i < g_enclave_thread_num; i++)
-        if (!g_enclave_thread_map[i].tid) {
-            g_enclave_thread_map[i].tid = tid;
-            pal_get_host_tcb()->tcs = g_enclave_thread_map[i].tcs;
-            ((struct enclave_dbginfo*)DBGINFO_ADDR)->thread_tids[i] = tid;
-            break;
+    while (true) {
+        spinlock_lock(&g_enclave_thread_map_lock);
+        for (size_t i = 0; i < g_enclave_thread_num; i++) {
+            if (!g_enclave_thread_map[i].tcs)
+                continue;
+            if (!g_enclave_thread_map[i].tid) {
+                g_enclave_thread_map[i].tid = tid;
+                pal_get_host_tcb()->tcs = g_enclave_thread_map[i].tcs;
+                ((struct enclave_dbginfo*)DBGINFO_ADDR)->thread_tids[i] = tid;
+                spinlock_unlock(&g_enclave_thread_map_lock);
+                return;
+            }
         }
-    spinlock_unlock(&tcs_lock);
+
+        if (!g_pal_enclave.edmm_enabled) {
+            /* no static or dynamic TCS pages available, bail out */
+            spinlock_unlock(&g_enclave_thread_map_lock);
+            return;
+        }
+        spinlock_unlock(&g_enclave_thread_map_lock);
+        /*
+         * At least one dynamic TCS is available in the in-enclave map of TCSs. However,
+         * the host-enclave map of TCSs may be briefly out of sync with the in-enclave map
+         * because the enclave decided to reuse some TCS that is being currently unmapped
+         * by another thread -- in this case, the host-enclave map may still have all TCS slots
+         * occupied, but only for a small window of time until the exiting thread calls
+         * `unmap_my_tcs()`.
+         */
+        CPU_RELAX();
+    }
 }
 
-void unmap_tcs(void) {
-    spinlock_lock(&tcs_lock);
-
-    int index = pal_get_host_tcb()->tcs - g_enclave_tcs;
-    struct thread_map* map = &g_enclave_thread_map[index];
-
-    assert(index < g_enclave_thread_num);
-
+void unmap_my_tcs(void) {
+    size_t i = 0;
+    spinlock_lock(&g_enclave_thread_map_lock);
+    for (i = 0; i < g_enclave_thread_num; i++)
+        if (g_enclave_thread_map[i].tcs == pal_get_host_tcb()->tcs) {
+            g_enclave_thread_map[i].tid = 0;
+            ((struct enclave_dbginfo*)DBGINFO_ADDR)->thread_tids[i] = 0;
+            break;
+        }
+    assert(i < g_enclave_thread_num);
     pal_get_host_tcb()->tcs = NULL;
-    ((struct enclave_dbginfo*)DBGINFO_ADDR)->thread_tids[index] = 0;
-    map->tid = 0;
-    spinlock_unlock(&tcs_lock);
+    spinlock_unlock(&g_enclave_thread_map_lock);
 }
 
 int current_enclave_thread_cnt(void) {
     int ret = 0;
-    spinlock_lock(&tcs_lock);
-    for (int i = 0; i < g_enclave_thread_num; i++)
+    spinlock_lock(&g_enclave_thread_map_lock);
+    for (size_t i = 0; i < g_enclave_thread_num; i++)
         if (g_enclave_thread_map[i].tid)
             ret++;
-    spinlock_unlock(&tcs_lock);
+    spinlock_unlock(&g_enclave_thread_map_lock);
     return ret;
 }
 
@@ -174,11 +252,9 @@ int pal_thread_init(void* tcbptr) {
     map_tcs(tid); /* updates tcb->tcs */
 
     if (!tcb->tcs) {
-        log_error(
-            "There are no available TCS pages left for a new thread!\n"
-            "Please try to increase sgx.max_threads in the manifest.\n"
-            "The current value is %d",
-            g_enclave_thread_num);
+        log_error("There are no available TCS pages left for a new thread. Please try to increase"
+                  " sgx.max_threads in the manifest. The current value is %lu",
+                  g_pal_enclave.thread_num);
         ret = -ENOMEM;
         goto out;
     }
@@ -194,7 +270,7 @@ int pal_thread_init(void* tcbptr) {
     /* not-first (child) thread, start it */
     ecall_thread_start();
 
-    unmap_tcs();
+    unmap_my_tcs();
     ret = 0;
 out:
     if (ret != 0)
@@ -245,8 +321,16 @@ noreturn void thread_exit(int status) {
     __builtin_unreachable();
 }
 
-int clone_thread(void) {
+int clone_thread(void* dynamic_tcs) {
     int ret = 0;
+
+    if (dynamic_tcs) {
+        /* enclave decided to add a new TCS page (to accommodate more enclave threads) */
+        ret = add_dynamic_tcs(dynamic_tcs);
+        if (ret < 0) {
+            return ret;
+        }
+    }
 
     void* stack = (void*)DO_SYSCALL(mmap, NULL, THREAD_STACK_SIZE + ALT_STACK_SIZE,
                                     PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -294,12 +378,51 @@ int clone_thread(void) {
 }
 
 int get_tid_from_tcs(void* tcs) {
-    int index = (sgx_arch_tcs_t*)tcs - g_enclave_tcs;
-    struct thread_map* map = &g_enclave_thread_map[index];
-    if (index >= g_enclave_thread_num)
-        return -EINVAL;
-    if (!map->tid)
-        return -EINVAL;
+    int tid = 0;
+    spinlock_lock(&g_enclave_thread_map_lock);
+    for (size_t i = 0; i < g_enclave_thread_num; i++) {
+        if (g_enclave_thread_map[i].tcs == tcs) {
+            tid = g_enclave_thread_map[i].tid;
+            break;
+        }
+    }
+    spinlock_unlock(&g_enclave_thread_map_lock);
+    return tid ? tid : -EINVAL;
+}
 
-    return map->tid;
+int set_tcs_debug_flag_if_debugging(void* tcs_addrs[], size_t count) {
+    if (!g_sgx_enable_stats && !g_vtune_profile_enabled)
+        return 0;
+
+    /* set TCS.FLAGS.DBGOPTIN in enclave threads to enable perf counters, Intel PT, etc */
+    int ret = DO_SYSCALL(open, "/proc/self/mem", O_RDWR | O_LARGEFILE | O_CLOEXEC, 0);
+    if (ret < 0) {
+        log_error("Setting TCS.FLAGS.DBGOPTIN failed: %s", unix_strerror(ret));
+        return ret;
+    }
+    int enclave_mem = ret;
+
+    for (size_t i = 0; i < count; i++) {
+        uint64_t tcs_flags;
+        uint64_t* tcs_flags_ptr = tcs_addrs[i] + offsetof(sgx_arch_tcs_t, flags);
+
+        ret = DO_SYSCALL(pread64, enclave_mem, &tcs_flags, sizeof(tcs_flags), (off_t)tcs_flags_ptr);
+        if (ret < 0) {
+            log_error("Reading TCS.FLAGS.DBGOPTIN failed: %s", unix_strerror(ret));
+            goto out;
+        }
+
+        tcs_flags |= TCS_FLAGS_DBGOPTIN;
+
+        ret = DO_SYSCALL(pwrite64, enclave_mem, &tcs_flags, sizeof(tcs_flags),
+                         (off_t)tcs_flags_ptr);
+        if (ret < 0) {
+            log_error("Writing TCS.FLAGS.DBGOPTIN failed: %s", unix_strerror(ret));
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    DO_SYSCALL(close, enclave_mem);
+    return ret;
 }

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -401,6 +401,7 @@ extern void* g_enclave_base;
 extern void* g_enclave_top;
 extern bool g_allowed_files_warn;
 extern uint64_t g_tsc_hz;
+extern size_t g_unused_tcs_pages_num;
 
 static int print_warnings_on_insecure_configs(PAL_HANDLE parent_process) {
     int ret;
@@ -748,6 +749,20 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
                   edmm_enabled);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
+
+    int64_t thread_num_int64;
+    ret = toml_int_in(g_pal_public_state.manifest_root, "sgx.max_threads",
+            /*defaultval=*/-1, &thread_num_int64);
+    if (ret < 0) {
+        log_error("Cannot parse 'sgx.max_threads'");
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+    if (thread_num_int64 <= 0) {
+        log_error("Invalid 'sgx.max_threads' value");
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+    /* `- 1` is because we have the main thread that already uses one TCS */
+    g_unused_tcs_pages_num = thread_num_int64 - 1;
 
     int64_t rpc_thread_num;
     ret = toml_int_in(g_pal_public_state.manifest_root, "sgx.insecure__rpc_thread_num",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Enclave Dynamic Memory Management (EDMM) allows dynamic change from enclave regular pages to enclave TCS pages, which are used to save and restore thread specific information.
This commit adds support for dynamically adding threads during enclave runtime and removes the hard limit of max threads that can be used in an enclave.
`sgx.max_threads` manifest option is maximum number of threads when enclave creation. With `sgx.edmm_enable = true`, maximum number of threads can exceed it during enclave execution.

Fixes #1223 and the design is also in it.

## How to test this PR? <!-- (if applicable) -->

new PAL regression test `Thread2_edmm`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1451)
<!-- Reviewable:end -->
