### PR TITLE
[LibOS,PAL] Fix wrong handling of sysfs NUMA nodes when nodes are offline

### DIFF
--- a/pal/include/arch/x86_64/pal_topology.h
+++ b/pal/include/arch/x86_64/pal_topology.h
@@ -112,10 +112,13 @@ struct pal_topo_info {
 
     /*
      * Has `online_numa_nodes_cnt * online_numa_nodes_cnt` valid elements, where
-     * `online_numa_nodes_cnt` is the number of NUMA nodes that have `is_online == true`.
+     * `online_numa_nodes_cnt` is the number of NUMA nodes that have `is_online == true`. For
+     * simplicity, this array is allocated as `possible_numa_nodes_cnt * possible_numa_nodes_cnt`
+     * but only the first `online_numa_nodes_cnt` elements in each row/column are usable, and the
+     * rest are invalid.
      *
      * Value in `numa_distance_matrix[i*online_numa_nodes_cnt + j]` is a NUMA distance from online
-     * node i to online node j.
+     * node i to online node j (i.e. indexing only through the online nodes).
      *
      * It may be surprising that this array contains only online nodes, but this is what Linux does:
      *   https://elixir.bootlin.com/linux/v6.4/source/drivers/base/node.c#L543

--- a/pal/include/arch/x86_64/pal_topology.h
+++ b/pal/include/arch/x86_64/pal_topology.h
@@ -110,7 +110,15 @@ struct pal_topo_info {
     size_t numa_nodes_cnt;
     struct pal_numa_node_info* numa_nodes;
 
-    /* Has `numa_nodes_cnt * numa_nodes_cnt` elements.
-     * numa_distance_matrix[i*numa_nodes_cnt + j] is NUMA distance from node i to node j. */
+    /*
+     * Has `online_numa_nodes_cnt * online_numa_nodes_cnt` valid elements, where
+     * `online_numa_nodes_cnt` is the number of NUMA nodes that have `is_online == true`.
+     *
+     * Value in `numa_distance_matrix[i*online_numa_nodes_cnt + j]` is a NUMA distance from online
+     * node i to online node j.
+     *
+     * It may be surprising that this array contains only online nodes, but this is what Linux does:
+     *   https://elixir.bootlin.com/linux/v6.4/source/drivers/base/node.c#L543
+     */
     size_t* numa_distance_matrix;
 };


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine iterated through all NUMA nodes within the range obtained from the host's `/sys/devices/system/node/possible` file to get `cpulist` and `distance`. It also used the count of possible nodes to parse the `distance` between nodes.

However, there is no `/sys/devices/system/node/nodeX` directory when a node is not online. Also, `/sys/devices/system/node/nodeX/distance` lists distances between online nodes only (jumping over offline nodes).

This can lead to failures when Gramine tries to read values of `cpulist` and `distance` pseudo-files from the directory. Plus a correct parsing of `distance` should consider only online nodes.

For context, see https://github.com/gramineproject/gramine/issues/1452.

Fixes #1452.

The main Linux source ref: https://github.com/torvalds/linux/blob/v6.4/drivers/base/node.c#L543-L564

## How to test this PR? <!-- (if applicable) -->

Manually on weird NUMA platforms...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1454)
<!-- Reviewable:end -->
