### PR TITLE
[common] Do not expand `__FILE_NAME__` to our func call

### DIFF
--- a/common/include/log.h
+++ b/common/include/log.h
@@ -14,26 +14,45 @@ enum {
     LOG_LEVEL_ALL     = 5,
 };
 
-/*
- * __FILE_NAME__ was introduced in GCC12 and clang9.
- * If it's not defined we have to do our own magic.
- */
 #ifndef __FILE_NAME__
+#ifndef __OPTIMIZE__
+/* __FILE_NAME__ was introduced in GCC12 and clang9. If it's not defined we do our own magic. */
 static inline const char* truncate_file_name(const char* filename) {
     const char* ret = filename;
-
     while (*filename != '\0') {
         if (*filename == '/') {
             ret = filename + 1;
         }
         filename++;
     }
-
     return ret;
 }
-
 #define __FILE_NAME__ (truncate_file_name(__FILE__))
-#endif
+#else // ifndef __OPTIMIZE__
+/* Below macros will be optimized at compile-time, incurring no perf overhead at runtime. */
+#define TRY_TRUNCATE_FILE_NAME_AT_LOC(s, loc) \
+    (sizeof(s) >= (loc) && (s)[sizeof(s)-(loc)] == '/') ? ((s) + sizeof(s) - (loc) + 1)
+#define TRUNCATE_FILE_NAME(s) \
+    (TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 1)  : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 2)  : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 3)  : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 4)  : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 5)  : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 6)  : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 7)  : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 8)  : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 9)  : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 10) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 11) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 12) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 13) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 14) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 15) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 16) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 17) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 18) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 19) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 20) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 21) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 22) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 23) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 24) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 25) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 26) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 27) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 28) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 29) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 30) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 31) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 32) : \
+     TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 33) : TRY_TRUNCATE_FILE_NAME_AT_LOC(s, 34) : (s))
+#define __FILE_NAME__ (TRUNCATE_FILE_NAME(__FILE__))
+#endif // ifndef __OPTIMIZE__
+#endif // #ifndef __FILE_NAME__
 
 /* All of them implicitly append a newline at the end of the message. */
 #define log_always(fmt...)   _log(LOG_LEVEL_NONE, __FILE_NAME__, __func__, __LINE__, fmt)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously we had a function that emulated `__FILE_NAME__` macro (which was introduced only recently in GCC12 and Clang9) by truncating the file name in a loop. It led to unnecessary calls to this func even when logs were disabled, ultimately resulting in perf overhead. We observed around 5% overhead because of this on file-I/O intensive benchmarks (because there we print a lot of log_debug info).

This PR simply falls back to a more clunky `__FILE__` macro when `__FILE_NAME__` is not defined.

Fixes #1456.

## How to test this PR? <!-- (if applicable) -->

See how I test in https://github.com/gramineproject/gramine/issues/1456. With this PR, manual inspection. You may also want to run some simple FS benchmark (like calling `read()` syscall in a loop) and observe perf overhead, e.g. via `perf record`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1457)
<!-- Reviewable:end -->
