### PR TITLE
[curl] Make curl dependency compatible with Meson 1.2.0

### DIFF
--- a/subprojects/packagefiles/curl-7.84.0/meson.build
+++ b/subprojects/packagefiles/curl-7.84.0/meson.build
@@ -18,6 +18,6 @@ curl = custom_target('curl',
 )
 
 curl_minimal_dep = declare_dependency(
-    link_with: curl,
+    link_with: [curl[0]],
     include_directories: 'include',
 )


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It is unclear why, but starting from v1.2.0 Meson refuses to see the static `libcurl.a` library unless it is more explicitly specified.

WIP.

## How to test this PR? <!-- (if applicable) -->

Test with e.g. GSC on Ubuntu 20.04.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1461)
<!-- Reviewable:end -->
