### PR TITLE
[PAL] Add `post_callback` function arg to `pal_main()`

### DIFF
--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -147,11 +147,14 @@ void notify_failure(unsigned long error);
  * \param first_thread    First thread handle.
  * \param arguments       Application arguments.
  * \param environments    Environment variables.
+ * \param post_callback   Callback into host-specific loader, useful for post-initialization actions
+ *                        like additional logging. Can be NULL.
  *
  * This function must be called by the host-specific loader.
  */
 noreturn void pal_main(uint64_t instance_id, PAL_HANDLE parent_process, PAL_HANDLE first_thread,
-                       const char** arguments, const char** environments);
+                       const char** arguments, const char** environments,
+                       void (*post_callback)(void));
 
 /* For initialization */
 

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -390,5 +390,6 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     }
 
     /* call to main function */
-    pal_main(instance_id, parent, first_thread, first_process ? argv + 3 : argv + 5, envp);
+    pal_main(instance_id, parent, first_thread, first_process ? argv + 3 : argv + 5, envp,
+             /*post_callback=*/NULL);
 }

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -368,7 +368,8 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
                        PAL_HANDLE parent_process,  /* parent process if it's a child */
                        PAL_HANDLE first_thread,    /* first thread handle */
                        const char** arguments,     /* application arguments */
-                       const char** environments   /* environment variables */) {
+                       const char** environments   /* environment variables */,
+                       void (*post_callback)(void) /* callback into host-specific loader */) {
     if (!instance_id) {
         assert(!parent_process);
         if (_PalRandomBitsRead(&instance_id, sizeof(instance_id)) < 0) {
@@ -580,6 +581,9 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     if (ret < 0)
         INIT_FAIL("Unable to load loader.entrypoint: %ld", ret);
     free(entrypoint_name);
+
+    if (post_callback)
+        post_callback();
 
     pal_disable_early_memory_bookkeeping();
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is useful so that the host-specific PAL can perform some post-initialization actions. In particular, the
`print_warnings_on_insecure_configs()` func in SGX PAL is moved to the post-initialization phase because this info should be logged into the `loader.log_file` (if it was specified in the manifest) instead of on the terminal.

## How to test this PR? <!-- (if applicable) -->

Manually. E.g., add `loader.log_file = "gramine.log"` to the Helloworld example and observe the behavior under `gramine-sgx`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1467)
<!-- Reviewable:end -->
