### PR TITLE
[PAL] Fail if Gramine binaries are built with RELR relocs

### DIFF
--- a/pal/include/elf/elf.h
+++ b/pal/include/elf/elf.h
@@ -321,7 +321,8 @@ typedef struct {
 #define SHT_PREINIT_ARRAY  16         /* Array of pre-constructors */
 #define SHT_GROUP          17         /* Section group */
 #define SHT_SYMTAB_SHNDX   18         /* Extended section indeces */
-#define SHT_NUM            19         /* Number of defined types.  */
+#define SHT_RELR           19         /* RELR relative relocations */
+#define SHT_NUM            20         /* Number of defined types.  */
 #define SHT_LOOS           0x60000000 /* Start OS-specific.  */
 #define SHT_GNU_ATTRIBUTES 0x6ffffff5 /* Object attributes.  */
 #define SHT_GNU_HASH       0x6ffffff6 /* GNU-style hash table.  */
@@ -498,6 +499,11 @@ typedef struct {
     Elf64_Sxword r_addend; /* Addend */
 } Elf64_Rela;
 
+/* RELR relocation table entry */
+
+typedef Elf32_Word  Elf32_Relr;
+typedef Elf64_Xword Elf64_Relr;
+
 /* How to extract and insert information held in the r_info field.  */
 
 #define ELF32_R_SYM(val)        ((val) >> 8)
@@ -653,7 +659,11 @@ typedef struct {
 #define DT_ENCODING        32          /* Start of encoded range */
 #define DT_PREINIT_ARRAY   32          /* Array with addresses of preinit fct*/
 #define DT_PREINIT_ARRAYSZ 33          /* size in bytes of DT_PREINIT_ARRAY */
-#define DT_NUM             34          /* Number used */
+#define DT_SYMTAB_SHNDX    34          /* Address of SYMTAB_SHNDX section */
+#define DT_RELRSZ          35          /* Total size of RELR relative relocations */
+#define DT_RELR            36          /* Address of RELR relative relocations */
+#define DT_RELRENT         37          /* Size of one RELR relative relocaction */
+#define DT_NUM             38          /* Number used */
 #define DT_LOOS            0x6000000d  /* Start of OS-specific */
 #define DT_HIOS            0x6ffff000  /* End of OS-specific */
 #define DT_LOPROC          0x70000000  /* Start of processor-specific */
@@ -2655,7 +2665,9 @@ typedef ElfW(Ehdr)   elf_ehdr_t;
 typedef ElfW(Half)   elf_half_t;
 typedef ElfW(Off)    elf_off_t;
 typedef ElfW(Phdr)   elf_phdr_t;
+typedef ElfW(Rel)    elf_rel_t;
 typedef ElfW(Rela)   elf_rela_t;
+typedef ElfW(Relr)   elf_relr_t;
 typedef ElfW(Sym)    elf_sym_t;
 typedef ElfW(Word)   elf_word_t;
 typedef ElfW(Xword)  elf_xword_t;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

RELR (relative relocs) is a new type of relocations recently added to compilers/linkers, e.g. glibc 2.36 and musl 1.2.4. These relocs are not enabled by default; however, if the system enables them during Gramine build, Gramine would segfault. This is because Gramine has its own self-relocation code that relocates the SGX PAL and the LibOS binaries. Before this commit, the code ignored RELR relocs, which led to some symbols being not relocated and ultimately to segfaults.

This commit makes Gramine aware of RELR relocs, though we simply loudly fail when we detect such type. Currently, Gramine build environment must disable such relocs.

Fixes #1446.

For the context, see #1446.

Good references:
- https://maskray.me/blog/2021-10-31-relative-relocations-and-relr
- https://git.musl-libc.org/cgit/musl/commit/?id=d32dadd60efb9d3b255351a3b532f8e4c3dd0db1
- https://reviews.llvm.org/D120701

The updates to `elf.h` were taken from this Glibc commit: https://github.com/bminor/glibc/commit/4610b24f5e4e6d2c4b769594efa6d460943163bb

## How to test this PR? <!-- (if applicable) -->

Manually try building with `LDFLAGS="$LDFLAGS -Wl,-z,pack-relative-relocs"` on an OS with Glibc 2.36 (e.g. Ubuntu 23.04). I'll post my experiments soon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1473)
<!-- Reviewable:end -->
