### PR TITLE
[LibOS] Add `/sys/devices/system/cpu/{offline,present}` files

### DIFF
--- a/libos/src/fs/sys/cpu_info.c
+++ b/libos/src/fs/sys/cpu_info.c
@@ -17,6 +17,10 @@ static bool is_online(size_t ind, const void* arg) {
     return g_pal_public_state->topo_info.threads[ind].is_online;
 }
 
+static bool is_offline(size_t ind, const void* arg) {
+    return !is_online(ind, arg);
+}
+
 static bool return_true(size_t ind, const void* arg) {
     __UNUSED(ind);
     __UNUSED(arg);
@@ -31,7 +35,11 @@ int sys_cpu_general_load(struct libos_dentry* dent, char** out_data, size_t* out
 
     if (strcmp(name, "online") == 0) {
         ret = sys_print_as_ranges(str, sizeof(str), topo->threads_cnt, is_online, NULL);
-    } else if (strcmp(name, "possible") == 0) {
+    } else if (strcmp(name, "offline") == 0) {
+        ret = sys_print_as_ranges(str, sizeof(str), topo->threads_cnt, is_offline, NULL);
+    } else if (strcmp(name, "possible") == 0 || strcmp(name, "present") == 0) {
+        /* we simplify and always output "present" CPUs same as "possible" CPUs; this will need to
+         * be changed if we add support for hot-plugging CPUs / shutting down / powering up CPUs */
         ret = sys_print_as_ranges(str, sizeof(str), topo->threads_cnt, return_true, NULL);
     } else {
         log_debug("unrecognized file: %s", name);

--- a/libos/src/fs/sys/fs.c
+++ b/libos/src/fs/sys/fs.c
@@ -207,7 +207,9 @@ int sys_load(const char* str, char** out_data, size_t* out_size) {
 
 static void init_cpu_dir(struct pseudo_node* cpu) {
     pseudo_add_str(cpu, "online", &sys_cpu_general_load);
+    pseudo_add_str(cpu, "offline", &sys_cpu_general_load);
     pseudo_add_str(cpu, "possible", &sys_cpu_general_load);
+    pseudo_add_str(cpu, "present", &sys_cpu_general_load);
 
     struct pseudo_node* cpuX = pseudo_add_dir(cpu, NULL);
     cpuX->name_exists = &sys_resource_name_exists;

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1142,6 +1142,10 @@ class TC_40_FileSystem(RegressionTestCase):
         lines = stdout.splitlines()
 
         self.assertIn('/sys/devices/system/cpu: directory', lines)
+        self.assertIn('/sys/devices/system/cpu/online: file', lines)
+        self.assertIn('/sys/devices/system/cpu/offline: file', lines)
+        self.assertIn('/sys/devices/system/cpu/possible: file', lines)
+        self.assertIn('/sys/devices/system/cpu/present: file', lines)
         for i in range(cpus_cnt):
             cpu = f'/sys/devices/system/cpu/cpu{i}'
             self.assertIn(f'{cpu}: directory', lines)
@@ -1167,6 +1171,8 @@ class TC_40_FileSystem(RegressionTestCase):
                 self.assertIn(f'{cache}/physical_line_partition: file', lines)
 
         self.assertIn('/sys/devices/system/node: directory', lines)
+        self.assertIn('/sys/devices/system/node/online: file', lines)
+        self.assertIn('/sys/devices/system/node/possible: file', lines)
         nodes_cnt = len([line for line in lines
                          if re.match(r'/sys/devices/system/node/node[0-9]+:', line)])
         self.assertGreater(nodes_cnt, 0)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Adds `/sys/devices/system/cpu/{offline,present}` files.

Also improve the `sysfs` LibOS regression test to verify that these new CPU-related files exist, plus that the old CPU- and NUMA-node-related files exist.

Without this, `lscpu` tool works incorrectly under Gramine.

Extracted from #1454.

## How to test this PR? <!-- (if applicable) -->

- Use this diff on Ubuntu (need to have `lscpu` installed):
```diff
~/gramineproject/gramine/CI-Examples/helloworld$ git diff

diff --git a/CI-Examples/helloworld/helloworld.manifest.template b/CI-Examples/helloworld/helloworld.manifest.template
@@ -1,14 +1,16 @@
 # Hello World manifest file example

 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "/helloworld"
+libos.entrypoint = "/lscpu"
 loader.log_level = "{{ log_level }}"

-loader.env.LD_LIBRARY_PATH = "/lib"
+loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu/"

 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "/helloworld", uri = "file:helloworld" },
+  { path = "/lscpu", uri = "file:/usr/bin/lscpu" },
+  { path = "/lib/x86_64-linux-gnu/", uri = "file:/lib/x86_64-linux-gnu/" },
 ]

 sgx.debug = true
```

- Run `gramine-direct`, it will show **wrong CPU results** without this PR:
```
~/gramineproject/gramine/CI-Examples/helloworld$ gramine-direct helloworld
Architecture:         x86_64
CPU op-mode(s):       32-bit, 64-bit
Byte Order:           Little Endian
CPU(s):               0          // OOPS!
On-line CPU(s) list:  0-11
Off-line CPU(s) list:
Thread(s) per core:   2
Core(s) per socket:   6
...
```

- Run with , it will show correct CPU results with this PR:
```
~/gramineproject/gramine/CI-Examples/helloworld$ gramine-direct helloworld
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              12
On-line CPU(s) list: 0-11
Thread(s) per core:  2
Core(s) per socket:  6
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1476)
<!-- Reviewable:end -->
