### PR TITLE
[LibOS] Add "siblings" line to `/proc/cpuinfo`

### DIFF
--- a/libos/src/arch/x86_64/fs_proc/info.c
+++ b/libos/src/arch/x86_64/fs_proc/info.c
@@ -37,11 +37,20 @@ int proc_cpuinfo_display_cpu(char** str, size_t* size, size_t* max,
     ADD_INFO("core id\t\t: %lu\n",   thread->core_id);
 
     size_t cores_in_socket = 0;
-    for (size_t j = 0; j < topo->cores_cnt; j++) { // slow, but shouldn't matter
-        if (topo->cores[j].socket_id == core->socket_id)
+    for (size_t i = 0; i < topo->cores_cnt; i++) { // slow, but shouldn't matter
+        if (topo->cores[i].socket_id == core->socket_id)
             cores_in_socket++;
     }
     ADD_INFO("cpu cores\t: %zu\n", cores_in_socket);
+
+    size_t siblings_on_socket = 0;
+    for (size_t i = 0; i < topo->threads_cnt; i++) { // slow, but shouldn't matter
+        if (!topo->threads[i].is_online)
+            continue;
+        if (topo->cores[topo->threads[i].core_id].socket_id == core->socket_id)
+            siblings_on_socket++;
+    }
+    ADD_INFO("siblings\t: %zu\n", siblings_on_socket);
 
     char* cpu_flags = NULL;
     int ret = libos_get_cpu_flags(&cpu_flags);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some libraries fail if they cannot find the "siblings" line (in particular, `libmkl-gnu-thread` aka "Intel MKL OpenMP threading library for GNU Fortran/C compilers"). This may ultimately lead to the application being run on only a subset of available CPUs, hampering performance.

Extracted from https://github.com/gramineproject/gramine/pull/1454.

## How to test this PR? <!-- (if applicable) -->

Manually using Busybox:

- On original platform:
```
$ cat /proc/cpuinfo
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
physical id     : 0
siblings        : 12
...
```

- `gramine-direct busybox cat /proc/cpuinfo`, Without this PR:
```
~/gramineproject/gramine/CI-Examples/busybox$ gramine-direct busybox cat /proc/cpuinfo
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
physical id     : 0
...   // NO SIBLINGS LINE
```

- `gramine-direct busybox cat /proc/cpuinfo`, With this PR:
```
~/gramineproject/gramine/CI-Examples/busybox$ gramine-direct busybox cat /proc/cpuinfo
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
physical id     : 0
siblings        : 12
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1477)
<!-- Reviewable:end -->
