### PR TITLE
[LibOS] Add `/sys/devices/system/cpu/kernel_max` file

### DIFF
--- a/libos/src/fs/sys/fs.c
+++ b/libos/src/fs/sys/fs.c
@@ -13,6 +13,23 @@
 #include "libos_fs.h"
 #include "libos_fs_pseudo.h"
 
+#define DEFAULT_KERNEL_MAX_CPUS 8192
+static uint32_t g_kernel_max_cpus = DEFAULT_KERNEL_MAX_CPUS;
+
+static int sys_cpu_kernel_max(struct libos_dentry* dent, char** out_data, size_t* out_size) {
+    __UNUSED(dent);
+    char str[32];
+
+    /* `- 1` because Linux always reports kernel_max like this */
+    int ret = snprintf(str, sizeof(str), "%u\n", g_kernel_max_cpus - 1);
+    if (ret < 0)
+        return ret;
+    if ((size_t)ret >= sizeof(str))
+        return -ERANGE;
+
+    return sys_load(str, out_data, out_size);
+}
+
 int sys_print_as_ranges(char* buf, size_t buf_size, size_t count,
                         bool (*is_present)(size_t ind, const void* arg), const void* callback_arg) {
     size_t buf_pos = 0;
@@ -206,6 +223,17 @@ int sys_load(const char* str, char** out_data, size_t* out_size) {
 }
 
 static void init_cpu_dir(struct pseudo_node* cpu) {
+    uint32_t next_power_of_2 = DEFAULT_KERNEL_MAX_CPUS;
+    assert(IS_POWER_OF_2(next_power_of_2));
+
+    while (next_power_of_2 < g_pal_public_state->topo_info.threads_cnt) {
+        /* this should never happen in real systems, so BUG() railguard is enough */
+        if (__builtin_mul_overflow(next_power_of_2, 2, &next_power_of_2))
+            BUG();
+    }
+    g_kernel_max_cpus = next_power_of_2;
+
+    pseudo_add_str(cpu, "kernel_max", &sys_cpu_kernel_max);
     pseudo_add_str(cpu, "online", &sys_cpu_general_load);
     pseudo_add_str(cpu, "offline", &sys_cpu_general_load);
     pseudo_add_str(cpu, "possible", &sys_cpu_general_load);

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1146,6 +1146,7 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/sys/devices/system/cpu/offline: file', lines)
         self.assertIn('/sys/devices/system/cpu/possible: file', lines)
         self.assertIn('/sys/devices/system/cpu/present: file', lines)
+        self.assertIn('/sys/devices/system/cpu/kernel_max: file', lines)
         for i in range(cpus_cnt):
             cpu = f'/sys/devices/system/cpu/cpu{i}'
             self.assertIn(f'{cpu}: directory', lines)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Extracted from https://github.com/gramineproject/gramine/pull/1454.

## How to test this PR? <!-- (if applicable) -->

Manually:

- Original:
```
~/gramineproject/gramine/CI-Examples/busybox$ cat /sys/devices/system/cpu/kernel_max
8191
```

- Without this PR:
```
~/gramineproject/gramine/CI-Examples/busybox$ gramine-direct busybox cat /sys/devices/system/cpu/kernel_max
cat: can't open '/sys/devices/system/cpu/kernel_max': No such file or directory
```

- With this PR:
```
~/gramineproject/gramine/CI-Examples/busybox$ gramine-direct busybox cat /sys/devices/system/cpu/kernel_max
8191
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1478)
<!-- Reviewable:end -->
