### PR TITLE
[common] Fix corner case of `strtol("0", .., 0)`

### DIFF
--- a/common/src/string/atoi.c
+++ b/common/src/string/atoi.c
@@ -48,6 +48,7 @@ long strtol(const char* str, char** out_end, int base) {
     const char* s;
     int sign;
 
+    int original_base = base;
     begin_number(str, base, &s, &base, &sign);
 
     long value = 0;
@@ -67,6 +68,13 @@ long strtol(const char* str, char** out_end, int base) {
 
         s++;
         nothing_parsed = false;
+    }
+
+    if (nothing_parsed && original_base == 0 && base == 8) {
+        /* corner case of parsing strtol("+0", .., 0) -- the only digit '0' was eaten by
+         * begin_number() which considered it an octal-base prefix, revert it */
+        nothing_parsed = false;
+        value = 0;
     }
 
     if (out_end)

--- a/pal/regression/strtoll_test.c
+++ b/pal/regression/strtoll_test.c
@@ -27,6 +27,15 @@ int main(int argc, const char** argv) {
              __LINE__, a, next, 0, ptr);
     }
 
+    /* corner case of parsing "0" with base 0 -- Gramine had a bug of not updating `next` */
+    ptr = "0";
+    next = ptr;
+    a = strtoll(ptr, (char**)&next, 0);
+    if (a != 0 || next != ptr + 1) {
+        FAIL("Wrong return values in %d, got (a, next) = (%lld, %p), expected (%d, %p)",
+             __LINE__, a, next, 0, ptr + 1);
+    }
+
     pal_printf("TEST OK\n");
     return 0;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, parsing "0" using `strtol(.., /*base=*/0)` returned incorrect endptr (i.e. the function failed to parse the number).

Looks like this corner case was introduced as part of this fix: https://github.com/gramineproject/gramine/commit/4003cb63a60d13061b17720514d244c6cfb7db0a

## How to test this PR? <!-- (if applicable) -->

Added a test case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1481)
<!-- Reviewable:end -->
