### PR TITLE
[glibc] Fix wrong warning option in compile script

### DIFF
--- a/subprojects/packagefiles/glibc-2.37/compile.sh
+++ b/subprojects/packagefiles/glibc-2.37/compile.sh
@@ -19,7 +19,7 @@ shift 8
 CC=gcc
 CXX=g++
 AS=gcc
-CFLAGS="-O2 -Wno-unused-values $EXTRA_CFLAGS"
+CFLAGS="-O2 -Wno-unused-value $EXTRA_CFLAGS"
 CPPFLAGS="\
     -I$(realpath "$CURRENT_SOURCE_DIR")/../../libos/include \
     -I$(realpath "$CURRENT_SOURCE_DIR")/../../libos/include/arch/$CPU_FAMILY \


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This was reported by @jyizheng. Thanks to him!

See discussions in https://github.com/gramineproject/gramine/discussions/1487 for details.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1490)
<!-- Reviewable:end -->
