### PR TITLE
[PAL/Linux-SGX] Disallow memfault handling if `sgx.require_exinfo = false`

### DIFF
--- a/pal/regression/manifest.template
+++ b/pal/regression/manifest.template
@@ -5,6 +5,9 @@ loader.insecure__use_cmdline_argv = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# for Exception test (memfault handler)
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.allowed_files = [
   "file:test.txt", # for File2 test
   "file:to_send.tmp", # for PalSendHandle test

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -203,25 +203,31 @@ class TC_10_Exception(RegressionTestCase):
 
     @unittest.skipUnless(ON_X86, "x86-specific")
     def test_000_exception(self):
-        _, stderr = self.run_binary(['Exception'])
+        try:
+            _, stderr = self.run_binary(['Exception'])
+            if HAS_SGX and not HAS_EDMM:
+                self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            if HAS_SGX and not HAS_EDMM:
+                self.assertNotEqual(e.returncode, 0)
+                stderr = e.stderr.decode()
+            else:
+                self.fail('expected to return zero')
 
         self.assertTrue(self.is_altstack_different_from_main_stack(stderr))
 
         # Exception Handling (Div-by-Zero)
-        self.assertIn('Arithmetic Exception Handler', stderr)
-
-        # Exception Handling (Memory Fault)
-        self.assertIn('Memory Fault Exception Handler', stderr)
-
-        # Exception Handler Swap
         self.assertIn('Arithmetic Exception Handler 1', stderr)
         self.assertIn('Arithmetic Exception Handler 2', stderr)
 
-        # Exception Handling (Set Context)
-        self.assertIn('Arithmetic Exception Handler 1', stderr)
-
         # Exception Handling (Red zone)
+        self.assertIn('Arithmetic Exception Handler 3', stderr)
         self.assertIn('Red zone test ok.', stderr)
+
+        if not HAS_SGX or HAS_EDMM:
+            # Exception Handling (Memory Fault)
+            self.assertIn('Memory Fault Exception Handler', stderr)
+            self.assertNotIn('Wrong faulting address', stderr)
 
 class TC_20_SingleProcess(RegressionTestCase):
     def test_000_exit_code(self):


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously, Linux-SGX PAL did not check `sgx.require_exinfo` and propogated the address anyway to LibOS/app. However, LibOS can't/shouldn't handle faulting addresses at all if `sgx.require_exinfo = false`, as in this case, no matter what enclave address LibOS/app tried to access, SGX would always report address 0.

This commit adds a check on whether `sgx.require_exinfo` is enabled when a memory fault occurred/to be handled and we loudly fail if it's not.

For more context, see discussions here: https://github.com/gramineproject/gramine/issues/1099#issuecomment-1663842018.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI + manual testing w/ a purpose-built memfault app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1502)
<!-- Reviewable:end -->
