### PR TITLE
[PAL] Recognize `DT_BIND_NOW` dynamic entry

### DIFF
--- a/pal/src/pal_rtld.c
+++ b/pal/src/pal_rtld.c
@@ -8,10 +8,15 @@
  * other. Note that PAL loads only two kinds of ELF binaries: the LibOS shared library and the PAL
  * regression tests. Both these kinds of ELF binaries are assumed to have specific ELF config:
  *
- *   - They must be linked with RELRO (Relocation Read-Only); this simplifies relocation because
- *     only R_X86_64_RELATIVE, R_X86_64_GLOB_DAT and R_X86_64_JUMP_SLOT reloc schemes are used. If
- *     we add support for archs other than x86_64 in future, we need to add more reloc schemes.
- *     Corresponding linker flags are `-Wl,-zrelro -Wl,-znow`.
+ *   - They must be linked with Full RELRO (Relocation Read-Only); this simplifies relocation
+ *     because only R_X86_64_RELATIVE, R_X86_64_GLOB_DAT and R_X86_64_JUMP_SLOT reloc schemes are
+ *     used. If we add support for archs other than x86_64 in future, we need to add more reloc
+ *     schemes. Corresponding linker flags are `-Wl,-zrelro -Wl,-znow`.
+ *
+ *   - They must be linked with immediate binding (in contrast to the linker's default lazy
+ *     binding). Our code performs relocations immediately, i.e., all relocations are processed
+ *     before passing control to the loaded object. Corresponding linker flag is `-Wl,-znow`.
+ *     Note that some linkers generate DT_BIND_NOW entry and some generate the DF_BIND_NOW flag.
  *
  *   - They must have old-style hash (DT_HASH) table; our code doesn't use the hash table itself but
  *     only reads the number of available dynamic symbols from this table and then simply iterates
@@ -261,6 +266,9 @@ static int verify_dynamic_entries(struct link_map* map) {
                 }
                 needed_offset = dynamic_section_entry->d_un.d_val;
                 needed_offset_found = true;
+                break;
+            case DT_BIND_NOW:
+                /* unused, our code always uses immediate binding (doesn't support lazy binding) */
                 break;
             case DT_SONAME:
                 /* unused, semantically a no-op (for PAL binary, extracted in setup_pal_binary()) */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some compilers/linkers generate the `DT_BIND_NOW` entry instead of adding a flag `DF_BIND_NOW` to the `DT_FLAGS` entry. Since our linker anyway always performs all relocations immediately (not lazily), this entry is a no-op.

It looks like some compilers use `DT_BIND_NOW`, though this particular dynentry was superseded by a flag `DF_BIND_NOW`. At the same time, this dynentry simply means "use immediate binding instead of lazy binding" (lazy binding is the default for linkers). And our Gramine-internal linker always uses immediate binding. So we can simply ignore `DT_BIND_NOW` dynentry, as it just hints at what Gramine is doing anyway.

References:
- http://www.qnx.com/developers/docs/qnxcar2/index.jsp?topic=%2Fcom.qnx.doc.neutrino.prog%2Ftopic%2Fdevel_Lazy_binding.html
- https://github.com/gramineproject/gramine/blob/a8edb2e17d7b9e95ff46e8ee4dcee47447808f33/libos/src/meson.build#L159?plain=1
- https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-42444.html
- https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter3-29.html#chapter3-4

See also https://github.com/gramineproject/gramine/discussions/1487#discussioncomment-6808455 for the context and explanations.

See https://github.com/gramineproject/gramine/pull/1473 for the original version of the changes.

Fixes #1509.

## How to test this PR? <!-- (if applicable) -->

Find a compiler that generates `DT_BIND_NOW`. My GCC 10.5 doesn't generate it but instead it generates the flag:
```
$ readelf -a built-debug/lib/x86_64-linux-gnu/gramine/direct/libpal.so
...
Dynamic section at offset 0x3bec0 contains 16 entries:
  Tag        Type                         Name/Value
  ...
 0x000000000000001e (FLAGS)              BIND_NOW
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1508)
<!-- Reviewable:end -->
