### PR TITLE
[CI] Fix linux-sgx-vm-gcc-release pipeline after update to Debian 12

### DIFF
--- a/.ci/linux-sgx-vm-gcc-release.jenkinsfile
+++ b/.ci/linux-sgx-vm-gcc-release.jenkinsfile
@@ -19,6 +19,12 @@ node('whatnots') {
     // kernel for simplicity)
     env.DOCKER_ARGS_COMMON += ' --volume=/boot:/boot:ro'
 
+    // Required because host Debian's path /usr/src/linux-headers-<version>/scripts is a symlink
+    // to /usr/lib/linux-kbuild-<version>, thus the latter path must be explicitly forwarded
+    kernel_ver = sh(returnStdout: true, script: 'uname -r | cut -d. -f1,2').trim()
+    env.DOCKER_ARGS_COMMON +=
+        " --volume=/usr/lib/linux-kbuild-${kernel_ver}:/usr/lib/linux-kbuild-${kernel_ver}:ro"
+
     // only root and `kvm` group can access /dev/kvm, so add `kvm` GID to the in-Docker user
     kvm_gid = sh(returnStdout: true, script: 'getent group kvm | cut -d: -f3').trim()
     env.DOCKER_ARGS_COMMON += ' --group-add ' + kvm_gid

--- a/.ci/ubuntu22.04.dockerfile
+++ b/.ci/ubuntu22.04.dockerfile
@@ -87,15 +87,15 @@ RUN python3 -m pip install -U \
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     cpio \
     dwarves \
-    g++-10 \
-    gcc-10 \
+    g++-12 \
+    gcc-12 \
     kmod \
     qemu-kvm
 
-# Kernel on the host machine is built with GCC-10, so we need to set it as default in Docker
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
-    update-alternatives --set gcc /usr/bin/gcc-10 && \
-    update-alternatives --set g++ /usr/bin/g++-10
+# Kernel on the host machine is built with GCC-12, so we need to set it as default in Docker
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 10 && \
+    update-alternatives --set gcc /usr/bin/gcc-12 && \
+    update-alternatives --set g++ /usr/bin/g++-12
 
 CMD ["bash"]

--- a/libos/test/regression/device_ioctl_parse_fail.c
+++ b/libos/test/regression/device_ioctl_parse_fail.c
@@ -2,6 +2,7 @@
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The Jenkins worker node for this pipeline was updated from Debian 11 to Debian12, which broke the pipeline. This commit contains assorted fixes required to make it work again.

The corresponding PR is https://github.com/gramineproject/device-testing-tools/pull/10 (must be merged first).

## How to test this PR? <!-- (if applicable) -->

Check the status of `linux-sgx-vm-gcc-release` job.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1512)
<!-- Reviewable:end -->
