### PR TITLE
[LibOS,PAL/Linux-SGX] Add EDMM lazy allocation support

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -640,12 +640,14 @@ not support :term:`EDMM` feature.
 
 When this feature is enabled, Gramine does not add heap pages (uninitialized
 memory) to the enclave at creation time. Instead, memory is added to the enclave
-on demand. This can greatly reduce startup time for bigger enclaves, reduce
-the :term:`EPC` usage (as only actually allocated memory is used) and allow for
-changing memory permissions (without this Gramine allocates all dynamic memory
-as RWX). Unfortunately it can negatively impact performance, as adding a page
-to the enclave at runtime is a more expensive operation than adding the page
-before enclave creation (because it involves more enclave exits and syscalls).
+on demand (note that for mappings requested with `MAP_NORESERVE`, the enclave
+pages are lazily committed on page fault events). This can greatly reduce
+startup time for bigger enclaves, reduce the :term:`EPC` usage (as only actually
+allocated memory is used) and allow for changing memory permissions (without
+this Gramine allocates all dynamic memory as RWX). Unfortunately it can
+negatively impact performance, as adding a page to the enclave at runtime is a
+more expensive operation than adding the page before enclave creation (because
+it involves more enclave exits and syscalls).
 
 When this feature is enabled, it is not necessary to specify
 ``sgx.enclave_size`` (Gramine will automatically set it to 1TB which should be

--- a/libos/include/libos_flags_conv.h
+++ b/libos/include/libos_flags_conv.h
@@ -25,7 +25,8 @@ static inline pal_prot_flags_t LINUX_PROT_TO_PAL(int prot, int map_flags) {
     return (prot & PROT_READ  ? PAL_PROT_READ  : 0) |
            (prot & PROT_WRITE ? PAL_PROT_WRITE : 0) |
            (prot & PROT_EXEC  ? PAL_PROT_EXEC  : 0) |
-           (map_flags & MAP_PRIVATE ? PAL_PROT_WRITECOPY : 0);
+           (map_flags & MAP_PRIVATE   ? PAL_PROT_WRITECOPY : 0) |
+           (map_flags & MAP_NORESERVE ? PAL_PROT_NORESERVE : 0);
 }
 
 static inline int PAL_PROT_TO_LINUX(pal_prot_flags_t prot) {

--- a/libos/src/sys/libos_mmap.c
+++ b/libos/src/sys/libos_mmap.c
@@ -144,6 +144,11 @@ void* libos_syscall_mmap(void* addr, size_t length, int prot, int flags, int fd,
             default:
                 return (void*)-EINVAL;
         }
+
+        /* ignore MAP_NORESERVE for file-backed mappings as we consider this rare and not worth
+         * optimizing for performance */
+        if (flags & MAP_NORESERVE)
+            flags &= ~MAP_NORESERVE;
     }
 
 #ifdef MAP_32BIT

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -27,6 +27,8 @@ fs.mounts = [
 sgx.max_threads = 16
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+# for munmap test (mapping MAP_NORESERVE)
+sgx.require_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.allowed_files = [
   "file:tmp/",

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -191,7 +191,8 @@ typedef uint32_t pal_prot_flags_t; /* bitfield */
 #define PAL_PROT_WRITE     0x2
 #define PAL_PROT_EXEC      0x4
 #define PAL_PROT_WRITECOPY 0x8
-#define PAL_PROT_MASK      0xF
+#define PAL_PROT_NORESERVE 0x10
+#define PAL_PROT_MASK      0x1F
 
 struct pal_initial_mem_range {
     uintptr_t start;
@@ -244,13 +245,16 @@ int PalVirtualMemoryProtect(void* addr, size_t size, pal_prot_flags_t prot);
 /*!
  * \brief Set upcalls for memory bookkeeping
  *
- * \param alloc  Function to call to get a memory range.
- * \param free   Function to call to release the memory range.
+ * \param alloc          Function to call to get a memory range.
+ * \param free           Function to call to release the memory range.
+ * \param get_vma_info   Function to call to get the VMA info (currently only PAL prot flags).
  *
  * Both \p alloc and \p free must be thread-safe.
  */
 void PalSetMemoryBookkeepingUpcalls(int (*alloc)(size_t size, uintptr_t* out_addr),
-                                    int (*free)(uintptr_t addr, size_t size));
+                                    int (*free)(uintptr_t addr, size_t size),
+                                    int (*get_vma_info)(uintptr_t addr,
+                                                        pal_prot_flags_t* out_prot_flags));
 
 /*
  * PROCESS CREATION

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -308,3 +308,5 @@ const char* pal_event_name(enum pal_event event);
         _PalProcessExit(1);                    \
     } while (0)
 #include "uthash.h"
+
+extern int (*g_mem_bkeep_get_vma_info_upcall)(uintptr_t addr, pal_prot_flags_t* out_flags);

--- a/pal/regression/pal_regression.h
+++ b/pal/regression/pal_regression.h
@@ -34,5 +34,6 @@ void __attribute__((format(printf, 1, 2))) pal_printf(const char* fmt, ...);
 void init_memory_management(void);
 int mem_bkeep_alloc(size_t size, uintptr_t* out_addr);
 int mem_bkeep_free(uintptr_t addr, size_t size);
+int mem_bkeep_get_vma_info(uintptr_t addr, pal_prot_flags_t* out_prot_flags);
 int memory_alloc(size_t size, pal_prot_flags_t prot, void** out_addr);
 int memory_free(void* addr, size_t size);

--- a/pal/src/host/linux-sgx/enclave_api.h
+++ b/pal/src/host/linux-sgx/enclave_api.h
@@ -52,4 +52,7 @@ int64_t sgx_getkey(sgx_key_request_t* keyrequest, sgx_key_128bit_t* key);
 
 int sgx_edmm_add_pages(uint64_t addr, size_t count, uint64_t prot);
 int sgx_edmm_remove_pages(uint64_t addr, size_t count);
+int sgx_edmm_add_pages_callback(uint64_t addr, size_t count, void* prot);
+int sgx_edmm_remove_pages_callback(uint64_t addr, size_t count,
+                                   void* unused __attribute__((unused)));
 int sgx_edmm_set_page_permissions(uint64_t addr, size_t count, uint64_t prot);

--- a/pal/src/host/linux-sgx/enclave_edmm.c
+++ b/pal/src/host/linux-sgx/enclave_edmm.c
@@ -113,6 +113,26 @@ int sgx_edmm_remove_pages(uint64_t addr, size_t count) {
     return 0;
 }
 
+/* wrapper functions for the callbacks */
+int sgx_edmm_add_pages_callback(uintptr_t addr, size_t count, void* prot) {
+    int ret = sgx_edmm_add_pages(addr, count, *(uint64_t*)prot);
+    if (ret < 0)
+        return ret;
+
+    set_enclave_addr_range((uintptr_t)addr, count);
+    return 0;
+}
+
+int sgx_edmm_remove_pages_callback(uintptr_t addr, size_t count,
+                                   void* unused __attribute__((unused))) {
+    int ret = sgx_edmm_remove_pages(addr, count);
+    if (ret < 0)
+        return ret;
+
+    unset_enclave_addr_range((uintptr_t)addr, count);
+    return 0;
+}
+
 int sgx_edmm_set_page_permissions(uint64_t addr, size_t count, uint64_t prot) {
     if (prot & SGX_SECINFO_FLAGS_W) {
         /* HW limitation. */

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -273,12 +273,13 @@ static int file_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64
     }
 
     if (g_pal_linuxsgx_state.edmm_enabled) {
+        assert(g_enclave_page_tracker);
         /* Enclave pages will be written to below, so we must add W permission. */
-        ret = sgx_edmm_add_pages((uint64_t)addr, size / PAGE_SIZE,
-                                 PAL_TO_SGX_PROT(prot | PAL_PROT_WRITE));
-        if (ret < 0) {
+        uint64_t prot_flags = PAL_TO_SGX_PROT(prot | PAL_PROT_WRITE);
+        int ret = walk_unset_pages((uintptr_t)addr, size / PAGE_SIZE, sgx_edmm_add_pages_callback,
+                                   &prot_flags);
+        if (ret < 0)
             return ret;
-        }
     } else {
 #ifdef ASAN
         asan_unpoison_region((uintptr_t)addr, size);
@@ -364,7 +365,9 @@ static int file_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64
 out:
     if (ret < 0) {
         if (g_pal_linuxsgx_state.edmm_enabled) {
-            int tmp_ret = sgx_edmm_remove_pages((uint64_t)addr, size / PAGE_SIZE);
+            assert(g_enclave_page_tracker);
+            int tmp_ret = walk_set_pages((uintptr_t)addr, size / PAGE_SIZE,
+                                         sgx_edmm_remove_pages_callback, NULL);
             if (tmp_ret < 0) {
                 log_error("removing previously allocated pages failed: %s (%d)",
                           pal_strerror(tmp_ret), ret);

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -25,6 +25,7 @@
 #include "pal_linux_error.h"
 #include "pal_rpc_queue.h"
 #include "pal_rtld.h"
+#include "pal_sgx.h"
 #include "pal_topology.h"
 #include "toml.h"
 #include "toml_utils.h"
@@ -626,6 +627,12 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
     }
 
     init_slab_mgr();
+
+    /* initialize the enclave page tracker as soon as we Initialized the slab memory allocator */
+    if (edmm_enabled) {
+        initialize_enclave_page_tracker((uintptr_t)g_enclave_base, GET_ENCLAVE_TCB(enclave_size),
+                                        g_page_size);
+    }
 
     /* initialize enclave properties */
     ret = init_enclave();

--- a/pal/src/host/linux-sgx/pal_memory.c
+++ b/pal/src/host/linux-sgx/pal_memory.c
@@ -18,6 +18,24 @@
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_sgx.h"
+#include "spinlock.h"
+
+enclave_page_tracker_t* g_enclave_page_tracker = NULL;
+
+static spinlock_t g_enclave_page_lock = INIT_SPINLOCK_UNLOCKED;
+
+#define ENCLAVE_PAGE_LOCK()   spinlock_lock(&g_enclave_page_lock)
+#define ENCLAVE_PAGE_UNLOCK() spinlock_unlock(&g_enclave_page_lock)
+#define ENCLAVE_PAGE_LOCKED() spinlock_is_locked(&g_enclave_page_lock)
+
+typedef struct {
+    uintptr_t addr;
+    size_t num_pages;
+} initial_page_alloc_t;
+
+#define MAX_INITIAL_PAGE_ALLOCS 8
+static initial_page_alloc_t g_initial_page_allocs[MAX_INITIAL_PAGE_ALLOCS];
+static size_t g_initial_page_allocs_count = 0;
 
 int _PalVirtualMemoryAlloc(void* addr, uint64_t size, pal_prot_flags_t prot) {
     assert(WITHIN_MASK(prot, PAL_PROT_MASK));
@@ -26,10 +44,31 @@ int _PalVirtualMemoryAlloc(void* addr, uint64_t size, pal_prot_flags_t prot) {
     assert(sgx_is_completely_within_enclave(addr, size));
 
     if (g_pal_linuxsgx_state.edmm_enabled) {
-        int ret = sgx_edmm_add_pages((uint64_t)addr, size / PAGE_SIZE, PAL_TO_SGX_PROT(prot));
-        if (ret < 0) {
-            return ret;
+        /* defer page accepts to page-fault events when `MAP_NORESERVE` is set */
+        if (prot & PAL_PROT_NORESERVE)
+            return 0;
+
+        int ret;
+        uint64_t prot_flags = PAL_TO_SGX_PROT(prot);
+
+        if (g_enclave_page_tracker) {
+            ret = walk_unset_pages((uintptr_t)addr, size / PAGE_SIZE,
+                                   sgx_edmm_add_pages_callback, &prot_flags);
+        } else {
+            /* for enclave pages allocated when the tracker is not ready (on bootstrap) */
+            if (g_initial_page_allocs_count < MAX_INITIAL_PAGE_ALLOCS) {
+                g_initial_page_allocs[g_initial_page_allocs_count].addr = (uintptr_t)addr;
+                g_initial_page_allocs[g_initial_page_allocs_count].num_pages = size / PAGE_SIZE;
+                g_initial_page_allocs_count++;
+            } else {
+                log_error("initial page allocs buffer is full");
+                _PalProcessExit(1);
+            }
+            ret = sgx_edmm_add_pages((uint64_t)addr, size / PAGE_SIZE, prot_flags);
         }
+
+        if (ret < 0)
+            return ret;
     } else {
 #ifdef ASAN
         asan_unpoison_region((uintptr_t)addr, size);
@@ -53,10 +92,11 @@ int _PalVirtualMemoryFree(void* addr, uint64_t size) {
                && addr + size <= g_pal_linuxsgx_state.heap_max);
 
         if (g_pal_linuxsgx_state.edmm_enabled) {
-            int ret = sgx_edmm_remove_pages((uint64_t)addr, size / PAGE_SIZE);
-            if (ret < 0) {
+            assert(g_enclave_page_tracker);
+            int ret = walk_set_pages((uintptr_t)addr, size / PAGE_SIZE,
+                                     sgx_edmm_remove_pages_callback, NULL);
+            if (ret < 0)
                 return ret;
-            }
         } else {
 #ifdef ASAN
             asan_poison_region((uintptr_t)addr, size, ASAN_POISON_USER);
@@ -154,4 +194,134 @@ int init_reserved_ranges(void* urts_ptr, size_t urts_size) {
     g_urts_reserved_ranges_end = g_urts_next_reserved_range
                                  + urts_size / sizeof(*g_urts_next_reserved_range);
     return 0;
+}
+
+/* Create a new page tracker with the specified base address, number of pages, and page size */
+static enclave_page_tracker_t* create_enclave_page_tracker(uintptr_t base_address,
+                                                           size_t num_pages, size_t page_size) {
+    enclave_page_tracker_t* tracker = malloc(sizeof(enclave_page_tracker_t));
+    if (!tracker)
+        INIT_FAIL("cannot initialize enclave page tracker");
+    tracker->data = (unsigned char*)calloc((num_pages + 7) / 8, sizeof(unsigned char));
+    if (!tracker->data)
+        INIT_FAIL("cannot initialize enclave page tracker data");
+
+    tracker->base_address = base_address;
+    tracker->size = num_pages;
+    tracker->page_size = page_size;
+
+    return tracker;
+}
+
+/* initialize the enclave page tracker with the specified base address, enclave memory region size
+ * (in bytes), and page size (in bytes) */
+void initialize_enclave_page_tracker(uintptr_t base_address, size_t memory_size, size_t page_size) {
+    assert(!g_enclave_page_tracker);
+
+    size_t num_pages = (memory_size + page_size - 1) / page_size;
+    g_enclave_page_tracker = create_enclave_page_tracker(base_address, num_pages, page_size);
+
+    /* set initial enclave pages allocations by slab allocator and the enclave page tracker */
+    for (size_t i = 0; i < g_initial_page_allocs_count; i++)
+        set_enclave_addr_range(g_initial_page_allocs[i].addr, g_initial_page_allocs[i].num_pages);
+}
+
+/* convert an address to an index in the page tracker */
+static inline size_t address_to_index(uintptr_t address) {
+    return (address - g_enclave_page_tracker->base_address) / g_enclave_page_tracker->page_size;
+}
+
+/* convert an index in the page tracker to an address */
+static inline uintptr_t index_to_address(size_t index) {
+    return g_enclave_page_tracker->base_address + index * g_enclave_page_tracker->page_size;
+}
+
+/* set an enclave page as allocated in the page tracker */
+static inline void set_enclave_page(size_t index) {
+    assert(ENCLAVE_PAGE_LOCKED());
+    g_enclave_page_tracker->data[index / 8] |= 1 << (index % 8);
+}
+
+/* set an enclave page as free in the page tracker */
+static inline void unset_enclave_page(size_t index) {
+    assert(ENCLAVE_PAGE_LOCKED());
+    g_enclave_page_tracker->data[index / 8] &= ~(1 << (index % 8));
+}
+
+/* check if an enclave page is allocated in the page tracker */
+static inline bool is_enclave_page_set(size_t index) {
+    assert(ENCLAVE_PAGE_LOCKED());
+    return (g_enclave_page_tracker->data[index / 8] & (1 << (index % 8))) != 0;
+}
+
+/* set a range of enclave pages as allocated according to the memory address and number of pages */
+void set_enclave_addr_range(uintptr_t start_addr, size_t num_pages) {
+    ENCLAVE_PAGE_LOCK();
+    for (size_t i = 0; i < num_pages; i++) {
+        uintptr_t address = start_addr + i * g_enclave_page_tracker->page_size;
+        size_t index = address_to_index(address);
+        set_enclave_page(index);
+    }
+    ENCLAVE_PAGE_UNLOCK();
+}
+
+/* set a range of enclave pages as free according to the memory address and number of pages */
+void unset_enclave_addr_range(uintptr_t start_addr, size_t num_pages) {
+    ENCLAVE_PAGE_LOCK();
+    for (size_t i = 0; i < num_pages; i++) {
+        uintptr_t address = start_addr + i * g_enclave_page_tracker->page_size;
+        size_t index = address_to_index(address);
+        unset_enclave_page(index);
+    }
+    ENCLAVE_PAGE_UNLOCK();
+}
+
+/* iterate over the given range of enclave pages in the tracker and perform the specified `callback`
+ * on the consecutive set/unset pages; return error when `callback` failed */
+static int walk_pages(uintptr_t start_addr, size_t count, bool walk_set,
+                      int (*callback)(uintptr_t, size_t, void*), void* arg) {
+    int ret = 0;
+    size_t start = address_to_index(start_addr);
+    size_t end = start + count;
+
+    size_t i = start;
+    while (i < end && i < g_enclave_page_tracker->size) {
+        uintptr_t consecutive_start_addr = 0;
+        size_t consecutive_count = 0;
+
+        /* find consecutive set/unset pages */
+        ENCLAVE_PAGE_LOCK();
+        if (is_enclave_page_set(i) == walk_set) {
+            consecutive_start_addr = index_to_address(i);
+            while (i < end && i < g_enclave_page_tracker->size &&
+                   is_enclave_page_set(i) == walk_set) {
+                consecutive_count++;
+                i++;
+            }
+        } else {
+            i++;
+        }
+        ENCLAVE_PAGE_UNLOCK();
+
+        if (consecutive_count > 0) {
+            /* invoke the `callback` on the consecutive pages */
+            ret = callback(consecutive_start_addr, consecutive_count, arg);
+            if (ret < 0)
+                break;
+        }
+    }
+
+    return ret;
+}
+
+/* wrapper function for walking set pages */
+int walk_set_pages(uintptr_t start_addr, size_t count,
+                   int (*callback)(uintptr_t, size_t, void*), void* arg) {
+    return walk_pages(start_addr, count, true, callback, arg);
+}
+
+/* wrapper function for walking unset pages */
+int walk_unset_pages(uintptr_t start_addr, size_t count,
+                     int (*callback)(uintptr_t, size_t, void*), void* arg) {
+    return walk_pages(start_addr, count, false, callback, arg);
 }

--- a/pal/src/host/linux-sgx/pal_sgx.h
+++ b/pal/src/host/linux-sgx/pal_sgx.h
@@ -5,9 +5,28 @@
 
 #include "pal.h"
 #include "sgx_arch.h"
+#include "spinlock.h"
 
 static inline uint64_t PAL_TO_SGX_PROT(pal_prot_flags_t pal_prot) {
     return (pal_prot & PAL_PROT_READ ? SGX_SECINFO_FLAGS_R : 0)
            | (pal_prot & PAL_PROT_WRITE ? SGX_SECINFO_FLAGS_W : 0)
            | (pal_prot & PAL_PROT_EXEC ? SGX_SECINFO_FLAGS_X : 0);
 }
+
+typedef struct {
+    unsigned char* data;    /* bit array to store page allocation status */
+    uintptr_t base_address; /* base address of the enclave memory region */
+    size_t size;            /* number of pages in the memory region */
+    size_t page_size;       /* size of each page in bytes */
+    spinlock_t lock;        /* lock for the page tracker */
+} enclave_page_tracker_t;
+
+extern enclave_page_tracker_t* g_enclave_page_tracker;
+
+void initialize_enclave_page_tracker(uintptr_t base_address, size_t memory_size, size_t page_size);
+void set_enclave_addr_range(uintptr_t start_address, size_t num_pages);
+void unset_enclave_addr_range(uintptr_t start_address, size_t num_pages);
+int walk_set_pages(uintptr_t start_addr, size_t count,
+                   int (*callback)(uintptr_t, size_t, void*), void* arg);
+int walk_unset_pages(uintptr_t start_addr, size_t count,
+                     int (*callback)(uintptr_t, size_t, void*), void* arg);

--- a/pal/src/pal_memory.c
+++ b/pal/src/pal_memory.c
@@ -60,6 +60,7 @@ int PalVirtualMemoryProtect(void* addr, size_t size, pal_prot_flags_t prot) {
  */
 static int (*g_mem_bkeep_alloc_upcall)(size_t size, uintptr_t* out_addr) = NULL;
 static int (*g_mem_bkeep_free_upcall)(uintptr_t addr, size_t size) = NULL;
+int (*g_mem_bkeep_get_vma_info_upcall)(uintptr_t addr, pal_prot_flags_t* out_prot_flags) = NULL;
 
 static bool g_initial_mem_disabled = false;
 static uintptr_t g_last_alloc_addr = UINTPTR_MAX;
@@ -67,12 +68,15 @@ static uintptr_t g_last_alloc_addr = UINTPTR_MAX;
 struct pal_initial_mem_range g_initial_mem_ranges[0x100] = { 0 };
 
 void PalSetMemoryBookkeepingUpcalls(int (*alloc)(size_t size, uintptr_t* out_addr),
-                                    int (*free)(uintptr_t addr, size_t size)) {
+                                    int (*free)(uintptr_t addr, size_t size),
+                                    int (*get_vma_info)(uintptr_t addr,
+                                                        pal_prot_flags_t* out_prot_flags)) {
     if (!FIRST_TIME()) {
         BUG();
     }
     g_mem_bkeep_alloc_upcall = alloc;
     g_mem_bkeep_free_upcall = free;
+    g_mem_bkeep_get_vma_info_upcall = get_vma_info;
 }
 
 static void insert_range_at(size_t idx, uintptr_t addr, size_t size, pal_prot_flags_t prot,


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The initial implementation of EDMM support pre-accepted every mmapped region of enclave pages. However in some cases, applications (e.g., Java runtime) may rely on lazy allocation of pages, where the VMAs are reserved but not actually committed to physical memory. In particular, `mmap(..., MAP_NORESERVE)` requests are used in such cases -- to mmap a huge chunk of memory (possibly never used in the future) at once and then commit pages on demand on page fault events. Due to the lack of lazy allocation concept in Gramine, this incurred performance and physical memory overhead on allocating and accepting the whole range of enclave pages.

The commit adds the lazy allocation support by deferring page accepts to page-fault events when Gramine notices `MAP_NORESERVE` flag in the mmap request. It also introduces a bit vector indicating the commit status of each enclave page and an upcall from the SGX EDMM backend into the LibOS to ask for additional info on a particular page.

Fixes https://github.com/gramineproject/gramine/issues/1099.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Updated regression tests + CI.
