### PR TITLE
[LibOS] Fix wrong return of `chroot_encrypted_write()` on failure

### DIFF
--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -448,9 +448,10 @@ static ssize_t chroot_encrypted_write(struct libos_handle* hdl, const void* buf,
     if (hdl->inode->size < *pos)
         hdl->inode->size = *pos;
 
+    ret = 0;
 out:
     unlock(&hdl->inode->lock);
-    return actual_count;
+    return ret < 0 ? ret : (ssize_t)actual_count;
 }
 
 static int chroot_encrypted_truncate(struct libos_handle* hdl, file_off_t size) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Instead, a negative error code should be returned in case of failure.


<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1522)
<!-- Reviewable:end -->
