### PR TITLE
[LibOS] Update mmapped regions when writing to encrypted files

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -282,6 +282,9 @@ struct libos_inode {
     /* Filesystem-specific data */
     void* data;
 
+    /* Number of VMAs the file is mmapped to; should be accessed using atomic operations. */
+    uint64_t num_mmapped;
+
     struct libos_lock lock;
     refcount_t ref_count;
 };

--- a/libos/include/libos_vma.h
+++ b/libos/include/libos_vma.h
@@ -130,6 +130,9 @@ int msync_range(uintptr_t begin, uintptr_t end);
 /* Call `msync` for file mappings of `hdl` */
 int msync_handle(struct libos_handle* hdl);
 
+/* Reload file mappings of `hdl` */
+int reload_mmaped_from_file_handle(struct libos_handle* hdl);
+
 void debug_print_all_vmas(void);
 
 /* Returns the peak amount of memory usage */

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -450,18 +450,28 @@ static ssize_t chroot_encrypted_write(struct libos_handle* hdl, const void* buf,
     lock(&hdl->inode->lock);
 
     int ret = encrypted_file_write(enc, buf, count, *pos, &actual_count);
-    if (ret < 0)
-        goto out;
+    if (ret < 0) {
+        unlock(&hdl->inode->lock);
+        return ret;
+    }
 
     assert(actual_count <= count);
     *pos += actual_count;
     if (hdl->inode->size < *pos)
         hdl->inode->size = *pos;
 
-    ret = 0;
-out:
     unlock(&hdl->inode->lock);
-    return ret < 0 ? ret : (ssize_t)actual_count;
+
+    /* If there are any MAP_SHARED mappings for the file, this will read data from `enc`. */
+    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
+        ret = reload_mmaped_from_file_handle(hdl);
+        if (ret < 0) {
+            log_error("reload mmapped regions of file failed: %s", unix_strerror(ret));
+            BUG();
+        }
+    }
+
+    return (ssize_t)actual_count;
 }
 
 static int chroot_encrypted_truncate(struct libos_handle* hdl, file_off_t size) {

--- a/libos/src/fs/tmpfs/fs.c
+++ b/libos/src/fs/tmpfs/fs.c
@@ -259,8 +259,10 @@ static ssize_t tmpfs_write(struct libos_handle* hdl, const void* buf, size_t siz
     struct libos_mem_file* mem = inode->data;
 
     ret = mem_file_write(mem, *pos, buf, size);
-    if (ret < 0)
-        goto out;
+    if (ret < 0) {
+        unlock(&inode->lock);
+        return ret;
+    }
 
     inode->size = mem->size;
 
@@ -268,8 +270,17 @@ static ssize_t tmpfs_write(struct libos_handle* hdl, const void* buf, size_t siz
     inode->mtime = time_us / USEC_IN_SEC;
     /* keep `ret` */
 
-out:
     unlock(&inode->lock);
+
+    /* If there are any MAP_SHARED mappings for the file, this will read data from `hdl`. */
+    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
+        int reload_ret = reload_mmaped_from_file_handle(hdl);
+        if (reload_ret < 0) {
+            log_error("reload mmapped regions of file failed: %s", unix_strerror(reload_ret));
+            BUG();
+        }
+    }
+
     return ret;
 }
 

--- a/libos/test/fs/meson.build
+++ b/libos/test/fs/meson.build
@@ -43,6 +43,7 @@ tests = {
     'open_close': {},
     'open_flags': {},
     'read_write': {},
+    'read_write_mmap': {},
     'seek_tell': {},
     'seek_tell_truncate': {},
     'stat': {},

--- a/libos/test/fs/read_write_mmap.c
+++ b/libos/test/fs/read_write_mmap.c
@@ -1,0 +1,96 @@
+#include "common.h"
+
+static void read_write_mmap(const char* file_path) {
+    const size_t size = 1024 * 1024;
+    int fd = open_output_fd(file_path, /*rdwr=*/true);
+    printf("open(%s) RW (mmap) OK\n", file_path);
+
+    if (ftruncate(fd, size) == -1) {
+        close(fd);
+        fatal_error("ftruncate\n");
+    }
+
+    void* buf_write = alloc_buffer(size);
+    void* buf_read = alloc_buffer(size);
+
+    void* m = mmap_fd(file_path, fd, PROT_READ | PROT_WRITE, 0, size);
+    printf("mmap_fd(%zu) OK\n", size);
+    fill_random(m, size);
+    int ret = msync(m, size, MS_SYNC);
+    if (ret < 0) {
+        close(fd);
+        fatal_error("msync\n");
+    }
+
+    read_fd(file_path, fd, buf_read, size);
+    printf("read(%s) 1 RW (mmap) OK\n", file_path);
+    if (memcmp(m, buf_read, size) != 0)
+        fatal_error("Read data via read() is different from what was written in the mapping\n");
+
+    fill_random(buf_write, size);
+    seek_fd(file_path, fd, 0, SEEK_SET);
+    printf("seek(%s) 1 RW (mmap) OK\n", file_path);
+    write_fd(file_path, fd, buf_write, size);
+    printf("write(%s) RW (mmap) OK\n", file_path);
+    seek_fd(file_path, fd, 0, SEEK_SET);
+    printf("seek(%s) 2 RW (mmap) OK\n", file_path);
+    read_fd(file_path, fd, buf_read, size);
+    printf("read(%s) 2 RW (mmap) OK\n", file_path);
+    if (memcmp(buf_write, buf_read, size) != 0)
+        fatal_error("Read data via read() is different from what was written via write()\n");
+    if (memcmp(buf_write, m, size) != 0)
+        fatal_error("Read data in the mapping is different from what was written via write()\n");
+    printf("compare(%s) RW (mmap) OK\n", file_path);
+
+    munmap_fd(file_path, m, size);
+    printf("munmap_fd(%zu) OK\n", size);
+    close_fd(file_path, fd);
+    printf("close(%s) RW (mmap) OK\n", file_path);
+    free(buf_write);
+    free(buf_read);
+}
+
+static void read_write_mmap_different_fds(const char* file_path) {
+    const size_t size = 1024 * 1024;
+    int fd1 = open_output_fd(file_path, /*rdwr=*/true);
+    printf("open(%s) RW fd1 (mmap) OK\n", file_path);
+
+    if (ftruncate(fd1, size) == -1) {
+        close(fd1);
+        fatal_error("ftruncate fd1\n");
+    }
+
+    int fd2 = open_output_fd(file_path, /*rdwr=*/true);
+    printf("open(%s) RW fd2 OK\n", file_path);
+
+    void* m = mmap_fd(file_path, fd1, PROT_READ, 0, size);
+    printf("mmap_fd(%zu) fd1 OK\n", size);
+
+    void* buf_write = alloc_buffer(size);
+    fill_random(buf_write, size);
+    write_fd(file_path, fd2, buf_write, size);
+    printf("write(%s) RW fd2 OK\n", file_path);
+
+    if (memcmp(m, buf_write, size) != 0)
+        fatal_error("Read data from the mapping is different from what was written via write() by "
+                    "another fd of the same file\n");
+
+    munmap_fd(file_path, m, size);
+    printf("munmap_fd(%zu) fd1 OK\n", size);
+    close_fd(file_path, fd1);
+    printf("close(%s) RW fd1 (mmap) OK\n", file_path);
+    close_fd(file_path, fd2);
+    printf("close(%s) RW fd2 OK\n", file_path);
+    free(buf_write);
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2)
+        fatal_error("Usage: %s <file_path>\n", argv[0]);
+
+    setup();
+    read_write_mmap(argv[1]);
+    read_write_mmap_different_fds(argv[1]);
+
+    return 0;
+}

--- a/libos/test/fs/test_enc.py
+++ b/libos/test/fs/test_enc.py
@@ -91,6 +91,33 @@ class TC_50_EncryptedFiles(test_fs.TC_00_FileSystem):
         self.verify_open_close(stdout, stderr, output_path, 'output')
         self.assertTrue(os.path.isfile(output_path))
 
+    # overrides TC_00_FileSystem to not skip Gramine-SGX
+    def test_111_read_write_mmap(self):
+        file_path = os.path.join(self.OUTPUT_DIR, 'test_111') # new file to be created
+        stdout, stderr = self.run_binary(['read_write_mmap', file_path])
+        size = '1048576'
+        self.assertNotIn('ERROR: ', stderr)
+        self.assertTrue(os.path.isfile(file_path))
+
+        self.assertIn('open(' + file_path + ') RW (mmap) OK', stdout)
+        self.assertIn('mmap_fd(' + size + ') OK', stdout)
+        self.assertIn('read(' + file_path + ') 1 RW (mmap) OK', stdout)
+        self.assertIn('seek(' + file_path + ') 1 RW (mmap) OK', stdout)
+        self.assertIn('write(' + file_path + ') RW (mmap) OK', stdout)
+        self.assertIn('seek(' + file_path + ') 2 RW (mmap) OK', stdout)
+        self.assertIn('read(' + file_path + ') 2 RW (mmap) OK', stdout)
+        self.assertIn('compare(' + file_path + ') RW (mmap) OK', stdout)
+        self.assertIn('munmap_fd(' + size + ') OK', stdout)
+        self.assertIn('close(' + file_path + ') RW (mmap) OK', stdout)
+
+        self.assertIn('open(' + file_path + ') RW fd1 (mmap) OK', stdout)
+        self.assertIn('open(' + file_path + ') RW fd2 OK', stdout)
+        self.assertIn('mmap_fd(' + size + ') fd1 OK', stdout)
+        self.assertIn('write(' + file_path + ') RW fd2 OK', stdout)
+        self.assertIn('munmap_fd(' + size + ') fd1 OK', stdout)
+        self.assertIn('close(' + file_path + ') RW fd1 (mmap) OK', stdout)
+        self.assertIn('close(' + file_path + ') RW fd2 OK', stdout)
+
     # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
     def test_115_seek_tell(self):
         # the test binary expects a path to read-only (existing) file and two paths to files that

--- a/libos/test/fs/test_tmpfs.py
+++ b/libos/test/fs/test_tmpfs.py
@@ -46,6 +46,32 @@ class TC_10_Tmpfs(test_fs.TC_00_FileSystem):
         self.assertIn('compare(' + file_path + ') RW OK', stdout)
         self.assertIn('close(' + file_path + ') RW OK', stdout)
 
+    # overrides TC_00_FileSystem to not skip Gramine-SGX and to skip verification of file existence
+    def test_111_read_write_mmap(self):
+        file_path = os.path.join(self.OUTPUT_DIR, 'test_111') # new file to be created
+        stdout, stderr = self.run_binary(['read_write_mmap', file_path])
+        size = '1048576'
+        self.assertNotIn('ERROR: ', stderr)
+
+        self.assertIn('open(' + file_path + ') RW (mmap) OK', stdout)
+        self.assertIn('mmap_fd(' + size + ') OK', stdout)
+        self.assertIn('read(' + file_path + ') 1 RW (mmap) OK', stdout)
+        self.assertIn('seek(' + file_path + ') 1 RW (mmap) OK', stdout)
+        self.assertIn('write(' + file_path + ') RW (mmap) OK', stdout)
+        self.assertIn('seek(' + file_path + ') 2 RW (mmap) OK', stdout)
+        self.assertIn('read(' + file_path + ') 2 RW (mmap) OK', stdout)
+        self.assertIn('compare(' + file_path + ') RW (mmap) OK', stdout)
+        self.assertIn('munmap_fd(' + size + ') OK', stdout)
+        self.assertIn('close(' + file_path + ') RW (mmap) OK', stdout)
+
+        self.assertIn('open(' + file_path + ') RW fd1 (mmap) OK', stdout)
+        self.assertIn('open(' + file_path + ') RW fd2 OK', stdout)
+        self.assertIn('mmap_fd(' + size + ') fd1 OK', stdout)
+        self.assertIn('write(' + file_path + ') RW fd2 OK', stdout)
+        self.assertIn('munmap_fd(' + size + ') fd1 OK', stdout)
+        self.assertIn('close(' + file_path + ') RW fd1 (mmap) OK', stdout)
+        self.assertIn('close(' + file_path + ') RW fd2 OK', stdout)
+
     @unittest.skip("impossible to do setup on tmpfs with python only")
     def test_115_seek_tell(self):
         test_fs.TC_00_FileSystem.test_115_seek_tell(self)

--- a/libos/test/fs/tests.toml
+++ b/libos/test/fs/tests.toml
@@ -14,6 +14,7 @@ manifests = [
   "open_close",
   "open_flags",
   "read_write",
+  "read_write_mmap",
   "seek_tell",
   "seek_tell_truncate",
   "stat",


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously, Gramine didn't propagate changes to a mmaped encrypted file back to the memory. This is unexpected for apps that use both mmap and read/write on the same file (e.g., etcd-io/bbolt has such implementation to write data via `write()` and read it via the mmaped memory).

This commit introduces overwriting of affected mmapped regions on encrypted file writes. To reduce performance penalty in normal cases (where apps use either `write()` or `mmap()`), this commit also creates a new field in the file handle to record the number of mmaped regions of this file. We hence simply check on this field to determine whether to perform the updates to make the overhead negligible if none mmapped.

Fixes https://github.com/gramineproject/gramine/issues/1432 and https://github.com/gramineproject/gramine/discussions/1591.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Newly introduced test + CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1523)
<!-- Reviewable:end -->
