### PR TITLE
[LibOS] Remove assertion in `parse_mmap_flags()`

### DIFF
--- a/libos/src/libos_parser.c
+++ b/libos/src/libos_parser.c
@@ -688,14 +688,21 @@ static int parse_flags(struct print_buf* buf, int flags, const struct flag_table
 static void parse_open_flags(struct print_buf* buf, va_list* ap) {
     int flags = va_arg(*ap, int);
 
-    if (flags & O_WRONLY) {
-        buf_puts(buf, "O_WRONLY");
-        flags &= ~O_WRONLY;
-    } else if (flags & O_RDWR) {
-        buf_puts(buf, "O_RDWR");
-        flags &= ~O_RDWR;
-    } else {
-        buf_puts(buf, "O_RDONLY");
+    switch (flags & O_ACCMODE) {
+        case O_RDONLY:
+            buf_puts(buf, "O_RDONLY");
+            flags &= ~O_RDONLY;
+            break;
+        case O_WRONLY:
+            buf_puts(buf, "O_WRONLY");
+            flags &= ~O_WRONLY;
+            break;
+        case O_RDWR:
+            buf_puts(buf, "O_RDWR");
+            flags &= ~O_RDWR;
+            break;
+        default:
+            break;
     }
 
     if (flags & O_APPEND) {
@@ -833,8 +840,7 @@ static void parse_mmap_flags(struct print_buf* buf, va_list* ap) {
     } else if (flags & MAP_SHARED) {
         buf_puts(buf, "MAP_SHARED");
         flags &= ~MAP_SHARED;
-    } else {
-        assert(flags & MAP_PRIVATE);
+    } else if (flags & MAP_PRIVATE) {
         buf_puts(buf, "MAP_PRIVATE");
         flags &= ~MAP_PRIVATE;
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
In case of invalid MAP_TYPE flags in mmap requests (e.g., no or wrong mapping type specified), previously Gramine simply ran into assertion fails when parsing them in debug mode.

Instead, Gramine should parse the flags and fail with the same error on syscall handling as Linux does (on incorrect flags).

Fixes https://github.com/gramineproject/gramine/issues/1516.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1524)
<!-- Reviewable:end -->
