### PR TITLE
[LibOS] Move `chroot` specific `truncate` to generic FS operations

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -943,6 +943,7 @@ int generic_emulated_mmap(struct libos_handle* hdl, void* addr, size_t size, int
                           uint64_t offset);
 int generic_emulated_msync(struct libos_handle* hdl, void* addr, size_t size, int prot, int flags,
                            uint64_t offset);
+int generic_truncate(struct libos_handle* hdl, file_off_t size);
 
 int synthetic_setup_dentry(struct libos_dentry* dent, mode_t type, mode_t perm);
 

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -338,22 +338,6 @@ static int chroot_mmap(struct libos_handle* hdl, void* addr, size_t size, int pr
     return 0;
 }
 
-static int chroot_truncate(struct libos_handle* hdl, file_off_t size) {
-    assert(hdl->type == TYPE_CHROOT);
-
-    int ret;
-
-    lock(&hdl->inode->lock);
-    ret = PalStreamSetLength(hdl->pal_handle, size);
-    if (ret == 0) {
-        hdl->inode->size = size;
-    } else {
-        ret = pal_to_unix_errno(ret);
-    }
-    unlock(&hdl->inode->lock);
-    return ret;
-}
-
 int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void* arg) {
     int ret;
     PAL_HANDLE palhdl;
@@ -503,7 +487,7 @@ struct libos_fs_ops chroot_fs_ops = {
      * breaks for such device-specific cases */
     .seek       = &generic_inode_seek,
     .hstat      = &generic_inode_hstat,
-    .truncate   = &chroot_truncate,
+    .truncate   = &generic_truncate,
     .poll       = &generic_inode_poll,
 };
 

--- a/libos/src/fs/libos_fs_util.c
+++ b/libos/src/fs/libos_fs_util.c
@@ -234,3 +234,15 @@ out:
     }
     return ret;
 }
+
+int generic_truncate(struct libos_handle* hdl, file_off_t size) {
+    lock(&hdl->inode->lock);
+    int ret = PalStreamSetLength(hdl->pal_handle, size);
+    if (ret == 0) {
+        hdl->inode->size = size;
+    } else {
+        ret = pal_to_unix_errno(ret);
+    }
+    unlock(&hdl->inode->lock);
+    return ret;
+}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
`generic_truncate` can be used for other file system types (shared memory filesystem in #827).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1529)
<!-- Reviewable:end -->
