### PR TITLE
[LibOS] Update time attributes in `struct stat` on file status query

### DIFF
--- a/libos/src/fs/libos_fs_util.c
+++ b/libos/src/fs/libos_fs_util.c
@@ -64,6 +64,9 @@ static int generic_istat(struct libos_inode* inode, struct stat* buf) {
     buf->st_size = inode->size;
     buf->st_uid  = inode->uid;
     buf->st_gid  = inode->gid;
+    buf->st_atime = inode->atime;
+    buf->st_mtime = inode->mtime;
+    buf->st_ctime = inode->ctime;
 
     /* Some programs (e.g. some tests from LTP) require this value. We've picked some random,
      * pretty looking constant - exact value should not affect anything (perhaps except


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Update time attributes in `struct stat` on file status query. This is required to support Gunicorn workload in gramine. This workload calls `fstat` on `tmpfs` files and uses the `st_ctime` field of `struct stat`.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1539)
<!-- Reviewable:end -->
