### PR TITLE
[python] Fix CLI option synonym handling for old click

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,7 @@ Depends:
  libprotobuf-c1,
  python3,
  python3 (>= 3.10) | python3-pkg-resources,
- python3-click,
+ python3-click (>= 6.7),
  python3-cryptography,
  python3-jinja2,
  python3-pyelftools,

--- a/gramine.spec
+++ b/gramine.spec
@@ -28,7 +28,7 @@ BuildRequires: python3-recommonmark
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
 
-Requires: python3-click
+Requires: python3-click >= 6.7
 Requires: python3-cryptography
 Requires: python3-jinja2
 Requires: python3-protobuf

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -35,7 +35,7 @@ makedepends="
     py3-pytest
     "
 depends="
-    py3-click
+    py3-click>=6.7
     py3-cryptography
     py3-elftools
     py3-jinja2

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -550,7 +550,10 @@ def get_tbssigstruct(manifest_path, date, libpal=SGX_LIBPAL, verbose=False):
     type=click.File('rb'),
     default=os.fspath(SGX_RSA_KEY_PATH),
     help='specify signing key (.pem) file')
-@click.option('--passphrase', '--password', '-p', metavar='PASSPHRASE',
+# Explicit 'passphrase' below is for compatibility with click < 6.8 (supported on .el8),
+# see https://github.com/pallets/click/issues/793 for more info.
+# TODO after deprecating .el8: remove this workaround
+@click.option('--passphrase', '--password', '-p', 'passphrase', metavar='PASSPHRASE',
     help='optional passphrase to decrypt the key')
 def sign_with_file(ctx, key, passphrase):
     try:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See the commit message.

## How to test this PR? <!-- (if applicable) -->

Run any scenario up to `gramine-sgx-sign` (which should not fail) on all supported distros. Executing the enclave is not necessary.

## Control statements

Fixes: #1532

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1540)
<!-- Reviewable:end -->
