### PR TITLE
[LibOS] Remove duplicated `dent->inode->perm` assignment in `chmod()`

### DIFF
--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -341,7 +341,6 @@ static int chroot_encrypted_chmod(struct libos_dentry* dent, mode_t perm) {
     assert(dent->inode);
 
     char* uri = NULL;
-    lock(&dent->inode->lock);
 
     int ret = chroot_dentry_uri(dent, dent->inode->type, &uri);
     if (ret < 0)
@@ -362,11 +361,9 @@ static int chroot_encrypted_chmod(struct libos_dentry* dent, mode_t perm) {
         ret = pal_to_unix_errno(ret);
         goto out;
     }
-    dent->inode->perm = perm;
     ret = 0;
 
 out:
-    unlock(&dent->inode->lock);
     free(uri);
     return ret;
 }

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -452,28 +452,19 @@ static int chroot_chmod(struct libos_dentry* dent, mode_t perm) {
 
     int ret;
 
-    lock(&dent->inode->lock);
-
     PAL_HANDLE palhdl;
     ret = chroot_temp_open(dent, dent->inode->type, &palhdl);
     if (ret < 0)
-        goto out;
+        return ret;
 
     mode_t host_perm = HOST_PERM(perm);
     PAL_STREAM_ATTR attr = {.share_flags = host_perm};
     ret = PalStreamAttributesSetByHandle(palhdl, &attr);
     PalObjectClose(palhdl);
-    if (ret < 0) {
-        ret = pal_to_unix_errno(ret);
-        goto out;
-    }
+    if (ret < 0)
+        return pal_to_unix_errno(ret);
 
-    dent->inode->perm = perm;
-    ret = 0;
-
-out:
-    unlock(&dent->inode->lock);
-    return ret;
+    return 0;
 }
 
 struct libos_fs_ops chroot_fs_ops = {


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

The `chmod()` callback is supposed to perform PAL-level (host-level) file permission change. The description of this callback explicitly states that "on success, the caller should update `dent->inode->perm`". Thus, the assignment inside the callback is redundant.

See the description of the callback: https://github.com/gramineproject/gramine/blob/8f65e6ad7444410d576a63fd0e5f443ced82830c/libos/include/libos_fs.h#L376-L387

## How to test this PR? <!-- (if applicable) -->

N/A. No functional change, just removed duplicate code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1542)
<!-- Reviewable:end -->
