### PR TITLE
[LibOS] Fail if address in `arch_prctl()` is inaccessible

### DIFF
--- a/libos/src/arch/x86_64/libos_arch_prctl.c
+++ b/libos/src/arch/x86_64/libos_arch_prctl.c
@@ -36,6 +36,9 @@ long libos_syscall_arch_prctl(int code, unsigned long addr) {
             return 0;
 
         case ARCH_GET_FS:
+            if (!is_user_memory_writable((unsigned long*)addr, sizeof(unsigned long))) {
+                return -EFAULT;
+            }
             return pal_to_unix_errno(PalSegmentBaseGet(PAL_SEGMENT_FS, (unsigned long*)addr));
 
         /* Emulate ARCH_GET_XCOMP_SUPP, ARCH_GET_XCOMP_PERM, ARCH_REQ_XCOMP_PERM by querying CPUID,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The check was missing. Reported by Scott Constable.

## How to test this PR? <!-- (if applicable) -->

N/A. Trivial.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1543)
<!-- Reviewable:end -->
