### PR TITLE
[LibOS] Fix a few user-pointer checking bugs in syscalls

### DIFF
--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -86,7 +86,8 @@ struct libos_thread {
 
     /* child tid */
     int* set_child_tid;
-    int* clear_child_tid;    /* LibOS zeroes it to notify parent that thread exited */
+    int* clear_child_tid;    /* LibOS zeroes it to notify parent that thread exited.
+                              * Be careful - unverified user pointer! */
     int clear_child_tid_pal; /* PAL zeroes it to notify LibOS that thread exited */
 
     /* Thread signal mask. Should be accessed with `this_thread->lock` held. Must not be modified
@@ -114,7 +115,7 @@ struct libos_thread {
     stack_t signal_altstack;
 
     /* futex robust list */
-    struct robust_list_head* robust_list;
+    struct robust_list_head* robust_list; // careful - unverified user pointer!
 
     PAL_HANDLE scheduler_event;
 

--- a/libos/src/sys/libos_access.c
+++ b/libos/src/sys/libos_access.c
@@ -17,9 +17,6 @@ long libos_syscall_access(const char* file, mode_t mode) {
 }
 
 long libos_syscall_faccessat(int dfd, const char* filename, mode_t mode) {
-    if (!filename)
-        return -EINVAL;
-
     if (!is_user_string_readable(filename))
         return -EFAULT;
 

--- a/libos/src/sys/libos_alarm.c
+++ b/libos/src/sys/libos_alarm.c
@@ -80,8 +80,9 @@ long libos_syscall_setitimer(int which, struct __kernel_itimerval* value,
     if (which != ITIMER_REAL)
         return -ENOSYS;
 
-    if (!value)
-        return -EFAULT;
+    /* Technically, as of v6.5.2, Linux supports value==NULL with a special meaning (setting timer
+     * to 0), but it throws a warning that it will be removed in the future versions, so we probably
+     * don't have to implement it. */
     if (!is_user_memory_readable(value, sizeof(*value)))
         return -EFAULT;
     if (ovalue && !is_user_memory_writable(ovalue, sizeof(*ovalue)))
@@ -131,8 +132,6 @@ long libos_syscall_getitimer(int which, struct __kernel_itimerval* value) {
     if (which != ITIMER_REAL)
         return -ENOSYS;
 
-    if (!value)
-        return -EFAULT;
     if (!is_user_memory_writable(value, sizeof(*value)))
         return -EFAULT;
 

--- a/libos/src/sys/libos_getcwd.c
+++ b/libos/src/sys/libos_getcwd.c
@@ -20,9 +20,6 @@
 #endif
 
 long libos_syscall_getcwd(char* buf, size_t buf_size) {
-    if (!buf || !buf_size)
-        return -EINVAL;
-
     if (!is_user_memory_writable(buf, buf_size))
         return -EFAULT;
 

--- a/libos/src/sys/libos_getpid.c
+++ b/libos/src/sys/libos_getpid.c
@@ -28,7 +28,7 @@ long libos_syscall_getppid(void) {
 long libos_syscall_set_tid_address(int* tidptr) {
     struct libos_thread* cur = get_cur_thread();
     lock(&cur->lock);
-    cur->clear_child_tid = tidptr;
+    cur->clear_child_tid = tidptr; // will be lazy-verified (before writing to it)
     unlock(&cur->lock);
     return cur->tid;
 }

--- a/libos/src/sys/libos_mmap.c
+++ b/libos/src/sys/libos_mmap.c
@@ -371,9 +371,9 @@ long libos_syscall_munmap(void* _addr, size_t length) {
     return 0;
 }
 
-/* This emulation of mincore() always tells that pages are _NOT_ in RAM
- * pessimistically due to lack of a good way to know it.
- * Possibly it may cause performance(or other) issue due to this lying.
+/* This emulation of mincore() always pessimistically tells that pages are _NOT_ in RAM due to lack
+ * of a good way to know it.
+ * This lying may possibly cause performance (or other) issues.
  */
 long libos_syscall_mincore(void* addr, size_t len, unsigned char* vec) {
     if (!IS_ALLOC_ALIGNED_PTR(addr))

--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -1349,7 +1349,7 @@ long libos_syscall_getsockopt(int fd, int level, int optname, char* optval, int*
         goto out;
     }
 
-    if (!is_user_memory_writable(optlen, sizeof(*optlen))) {
+    if (!is_user_memory_readable(optlen, sizeof(*optlen))) {
         ret = -EFAULT;
         goto out;
     }
@@ -1385,6 +1385,10 @@ long libos_syscall_getsockopt(int fd, int level, int optname, char* optval, int*
     unlock(&sock->lock);
 
     if (ret == 0) {
+        if (!is_user_memory_writable(optlen, sizeof(*optlen))) {
+            ret = -EFAULT;
+            goto out;
+        }
         *optlen = len;
     }
 

--- a/libos/src/sys/libos_time.c
+++ b/libos/src/sys/libos_time.c
@@ -11,23 +11,29 @@
 #include "pal.h"
 
 long libos_syscall_gettimeofday(struct __kernel_timeval* tv, struct __kernel_timezone* tz) {
-    if (!tv)
-        return -EINVAL;
+    if (tv) {
+        if (!is_user_memory_writable(tv, sizeof(*tv)))
+            return -EFAULT;
 
-    if (!is_user_memory_writable(tv, sizeof(*tv)))
-        return -EFAULT;
+        uint64_t time = 0;
+        int ret = PalSystemTimeQuery(&time);
+        if (ret < 0) {
+            return pal_to_unix_errno(ret);
+        }
 
-    if (tz && !is_user_memory_writable(tz, sizeof(*tz)))
-        return -EFAULT;
-
-    uint64_t time = 0;
-    int ret = PalSystemTimeQuery(&time);
-    if (ret < 0) {
-        return pal_to_unix_errno(ret);
+        tv->tv_sec  = time / 1000000;
+        tv->tv_usec = time % 1000000;
     }
 
-    tv->tv_sec  = time / 1000000;
-    tv->tv_usec = time % 1000000;
+    if (tz) {
+        if (!is_user_memory_writable(tz, sizeof(*tz)))
+            return -EFAULT;
+
+        /* Not implemented, return zeros. */
+        tz->tz_minuteswest = 0;
+        tz->tz_dsttime = 0;
+    }
+
     return 0;
 }
 
@@ -52,9 +58,6 @@ long libos_syscall_time(time_t* tloc) {
 long libos_syscall_clock_gettime(clockid_t which_clock, struct timespec* tp) {
     /* all clocks are the same */
     if (!(0 <= which_clock && which_clock < MAX_CLOCKS))
-        return -EINVAL;
-
-    if (!tp)
         return -EINVAL;
 
     if (!is_user_memory_writable(tp, sizeof(*tp)))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Inspired by #1543, I went through all the syscalls implementations and verified if they actually check user pointers.

Additionally fixes a bug in gettimeofday() implementation which left timezone struct uninitialized.

## How to test this PR? <!-- (if applicable) -->

CI, mostly LTP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1544)
<!-- Reviewable:end -->
