### PR TITLE
[LibOS,PAL] Fix wrong handling of sysfs NUMA nodes when nodes are offline

### DIFF
--- a/pal/include/arch/x86_64/pal_topology.h
+++ b/pal/include/arch/x86_64/pal_topology.h
@@ -111,6 +111,7 @@ struct pal_topo_info {
     struct pal_numa_node_info* numa_nodes;
 
     /* Has `numa_nodes_cnt * numa_nodes_cnt` elements.
-     * numa_distance_matrix[i*numa_nodes_cnt + j] is NUMA distance from node i to node j. */
+     * numa_distance_matrix[i*numa_nodes_cnt + j] is NUMA distance from node i to node j.
+     * If node i or node j is offline, then NUMA distance is zero. */
     size_t* numa_distance_matrix;
 };


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->


Previously, Gramine iterated through all NUMA nodes within the range obtained from the host's `/sys/devices/system/node/possible` file to get `cpulist` and `distance`. It also used the count of possible nodes to parse the `distance` between nodes. However, there is no `/sys/devices/system/node/nodeX` directory when a node is not online. Also, `/sys/devices/system/node/nodeX/distance` lists distances between online nodes only (jumping over offline nodes). This can lead to failures when Gramine tries to read values of `cpulist` and `distance` pseudo-files from the directory. Plus a correct parsing of `distance` should consider only online nodes.

**This is version 2 of #1454.** @mkow asked to keep an original definition of the `distances` array for NUMA nodes inside Gramine, and this PR reflects this. Since the change is rather drastic from the original #1454 code, I chose to create it as a separate PR.

Fixes #1452. For more context and discussions, see #1452 and #1454.

## How to test this PR? <!-- (if applicable) -->

Manually on weird NUMA platforms...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1545)
<!-- Reviewable:end -->
