### PR TITLE
[python] Remove unneeded attrs in `get_mrenclave_and_manifest()`

### DIFF
--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -452,21 +452,13 @@ def get_mrenclave_and_manifest(manifest_path, libpal, verbose=False):
         'enclave_size': parse_size(manifest_sgx['enclave_size']),
         'edmm_enable': manifest_sgx.get('edmm_enable', False),
         'max_threads': manifest_sgx['max_threads'],
-        'isv_prod_id': manifest_sgx['isvprodid'],
-        'isv_svn': manifest_sgx['isvsvn'],
     }
-    attr['flags'], attr['xfrms'], attr['misc_select'] = get_enclave_attributes(manifest_sgx)
 
     if verbose:
-        print('Attributes:')
+        print('Attributes (required for enclave measurement):')
         print(f'    size:        {attr["enclave_size"]:#x}')
         print(f'    edmm:        {attr["edmm_enable"]}')
         print(f'    max_threads: {attr["max_threads"]}')
-        print(f'    isv_prod_id: {attr["isv_prod_id"]}')
-        print(f'    isv_svn:     {attr["isv_svn"]}')
-        print(f'    attr.flags:  {attr["flags"]:#x}')
-        print(f'    attr.xfrm:   {attr["xfrms"]:#x}')
-        print(f'    misc_select: {attr["misc_select"]:#x}')
 
         print('SGX remote attestation:')
         attestation_type = manifest_sgx.get('remote_attestation', 'none')


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The only enclave attributes required for the SGX enclave measurement are the enclave size and the number of enclave threads. Other attributes such as ISV_PROD_ID, ISV_SVN, XFRM are not included in the measurement.

This commit is extracted from https://github.com/gramineproject/gramine/pull/881.

## How to test this PR? <!-- (if applicable) -->

E.g., manually build the Helloworld example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1550)
<!-- Reviewable:end -->
