### PR TITLE
[PAL] Adjust get_topopology_info for more general case

### DIFF
--- a/pal/src/host/linux-common/topo_info.c
+++ b/pal/src/host/linux-common/topo_info.c
@@ -220,6 +220,11 @@ static int get_ranges_end(size_t ind, void* _arg) {
     return 0;
 }
 
+static int get_ranges_count(size_t ind, void* _arg) {
+    *(size_t*)_arg += 1;
+    return 0;
+}
+
 static int set_thread_online(size_t ind, void* _threads) {
     struct pal_cpu_thread_info* threads = (struct pal_cpu_thread_info*)_threads;
     threads[ind].is_online = true;
@@ -289,7 +294,11 @@ int get_topology_info(struct pal_topo_info* topo_info) {
     if (ret < 0)
         return ret;
     size_t nodes_cnt = 0;
-    ret = iterate_ranges_from_file("/sys/devices/system/node/possible", get_ranges_end, &nodes_cnt);
+    ret = iterate_ranges_from_file("/sys/devices/system/node/online", get_ranges_count, &nodes_cnt);
+    if (ret < 0)
+        return ret;
+    size_t nodes_max = 0;
+    ret = iterate_ranges_from_file("/sys/devices/system/node/possible", get_ranges_end, &nodes_max);
     if (ret < 0)
         return ret;
 
@@ -300,8 +309,8 @@ int get_topology_info(struct pal_topo_info* topo_info) {
     struct pal_cpu_core_info* cores = malloc(threads_cnt * sizeof(*cores)); // overapproximate the count
     size_t sockets_cnt = 0;
     struct pal_socket_info* sockets = malloc(threads_cnt * sizeof(*sockets)); // overapproximate the count
-    struct pal_numa_node_info* numa_nodes = malloc(nodes_cnt * sizeof(*numa_nodes));
-    size_t* distances = malloc(nodes_cnt * nodes_cnt * sizeof(*distances));
+    struct pal_numa_node_info* numa_nodes = malloc(nodes_max * sizeof(*numa_nodes));
+    size_t* distances = malloc(nodes_max * nodes_max * sizeof(*distances));
     if (!threads || !caches || !cores || !sockets || !numa_nodes || !distances) {
         ret = -ENOMEM;
         goto fail;
@@ -316,7 +325,7 @@ int get_topology_info(struct pal_topo_info* topo_info) {
             threads[i].ids_of_caches[j] = (size_t)-1;
         }
     }
-    for (size_t i = 0; i < nodes_cnt; i++)
+    for (size_t i = 0; i < nodes_max; i++)
         numa_nodes[i].is_online = false;
 
     ret = iterate_ranges_from_file("/sys/devices/system/cpu/online", set_thread_online, threads);
@@ -400,7 +409,7 @@ int get_topology_info(struct pal_topo_info* topo_info) {
      *            0        ,    0    ,        0
      *     node 2 -> node 0,    0    , node 2 -> node 2 ]
      */
-    memset(distances, 0, nodes_cnt * nodes_cnt * sizeof(*distances));
+    memset(distances, 0, nodes_max * nodes_max * sizeof(*distances));
     for (size_t i = 0; i < nodes_cnt; i++) {
         if (!numa_nodes[i].is_online)
             continue;

--- a/pal/src/host/linux-common/topo_info.c
+++ b/pal/src/host/linux-common/topo_info.c
@@ -60,11 +60,22 @@ static int get_hw_resource_value(const char* filename, size_t* out_value) {
     return 0;
 }
 
+static ssize_t get_next_online_numa_node(struct pal_numa_node_info* numa_nodes, size_t nodes_max,
+                                         size_t sidx) {
+    while (!numa_nodes[sidx].is_online) {
+        sidx++;
+        if (sidx >= nodes_max)
+            return -1;
+    }
+    return sidx;
+}
+
 /* Read a space-separated list of numbers in the format used by
  * `/sys/devices/system/node/node<i>/distance`, and write the result to the online nodes from
  * `numa_nodes`. */
 static int read_distances_from_file(const char* path, size_t* out_arr,
-                                    struct pal_numa_node_info* numa_nodes, size_t nodes_cnt) {
+                                    struct pal_numa_node_info* numa_nodes, size_t nodes_max,
+                                    size_t nodes_cnt) {
     char buf[PAL_SYSFS_BUF_FILESZ];
     int ret = read_file_buffer(path, buf, sizeof(buf) - 1);
     if (ret < 0)
@@ -75,10 +86,14 @@ static int read_distances_from_file(const char* path, size_t* out_arr,
     const char* end;
     char last_separator = ' ';
     size_t node_i = 0;
-    for (size_t input_i = 0; /* no condition */; input_i++) {
+    ssize_t sidx = 0;
+    for (size_t input_i = 0; /* no condition */; input_i++, sidx++) {
         /* Find next online node (only these are listed in `distance` file). */
-        while (node_i < nodes_cnt && !numa_nodes[node_i].is_online)
-            node_i++;
+        if (node_i < nodes_cnt) {
+            sidx = get_next_online_numa_node(numa_nodes, nodes_max, sidx);
+            if (sidx < 0)
+                return -EINVAL;
+        }
         if (node_i == nodes_cnt)
             break;
         if (last_separator != ' ')
@@ -376,11 +391,15 @@ int get_topology_info(struct pal_topo_info* topo_info) {
         }
     }
 
-    for (size_t i = 0; i < nodes_cnt; i++) {
-        if (!numa_nodes[i].is_online)
-            continue;
+    ssize_t sidx = 0;
+    for (size_t i = 0; i < nodes_cnt; i++, sidx++) {
+        sidx = get_next_online_numa_node(numa_nodes, nodes_max, sidx);
+        if (sidx < 0) {
+            ret = -EINVAL;
+            goto fail;
+        }
 
-        snprintf(path, sizeof(path), "/sys/devices/system/node/node%zu/cpulist", i);
+        snprintf(path, sizeof(path), "/sys/devices/system/node/node%zu/cpulist", sidx);
         ret = iterate_ranges_from_file(path, set_node_id, &(struct set_node_id_args){
             .threads = threads,
             .cores = cores,
@@ -410,15 +429,20 @@ int get_topology_info(struct pal_topo_info* topo_info) {
      *     node 2 -> node 0,    0    , node 2 -> node 2 ]
      */
     memset(distances, 0, nodes_max * nodes_max * sizeof(*distances));
-    for (size_t i = 0; i < nodes_cnt; i++) {
-        if (!numa_nodes[i].is_online)
-            continue;
+    sidx = 0;
+    for (size_t i = 0; i < nodes_cnt; i++, sidx++) {
+        sidx = get_next_online_numa_node(numa_nodes, nodes_max, sidx);
+        if (sidx < 0) {
+            ret = -EINVAL;
+            goto fail;
+        }
 
         /* populate row i of `distances`, setting only online nodes */
-        ret = snprintf(path, sizeof(path), "/sys/devices/system/node/node%zu/distance", i);
+        ret = snprintf(path, sizeof(path), "/sys/devices/system/node/node%zu/distance", sidx);
         if (ret < 0)
             goto fail;
-        ret = read_distances_from_file(path, distances + i * nodes_cnt, numa_nodes, nodes_cnt);
+        ret = read_distances_from_file(path, distances + i * nodes_max, numa_nodes, nodes_max,
+                                       nodes_cnt);
         if (ret < 0)
             goto fail;
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The recent changes in get_topology_info still have bugs that make it fail to work on some of my
ppc64 machines where one of them for example has possible NUMA nodes '0,8' and online
NUMA nodes are also '0,8'.

The proposed changes implement a more general solution than what is there right now.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

I can test this on my ppc64 machine but on other machines it depends on the NUMA node configuration and what is shown in sysfs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1556)
<!-- Reviewable:end -->
