### PR TITLE
[LibOS] Set file handle to NULL after each shebang search iteration

### DIFF
--- a/libos/src/libos_rtld.c
+++ b/libos/src/libos_rtld.c
@@ -799,6 +799,7 @@ int load_and_check_exec(const char* path, const char* const* argv, struct libos_
         free(*curr_argv);
         free(curr_argv);
         put_handle(file);
+        file = NULL;
 
         curr_argv = new_argv;
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Otherwise, this could lead to a "double `put_handle()`" problem when the shebang script depth exceeded the limit.

Fixes https://github.com/gramineproject/gramine/issues/1526.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1558)
<!-- Reviewable:end -->
