### PR TITLE
[tests] Add `sgx.use_exinfo` to LTP manifest template

### DIFF
--- a/libos/test/ltp/manifest.template
+++ b/libos/test/ltp/manifest.template
@@ -25,6 +25,9 @@ sys.stack.size = "4M"
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# for tests that require SIGSEGV handling (e.g., setrlimit01, mmap03)
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.allowed_files = [
   "file:/tmp",
 ]


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Fixes https://github.com/gramineproject/gramine/issues/1561.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
LTP tests w/ EDMM enabled (specifically setrlimit01, mmap03).
