### PR TITLE
[PAL/Linux-SGX] Remove redundant `_PalHandleExternalEvent()`

### DIFF
--- a/pal/src/host/linux-sgx/enclave_entry.S
+++ b/pal/src/host/linux-sgx/enclave_entry.S
@@ -267,7 +267,7 @@ enclave_entry:
     # Instead if we're in such situation, we emulate it as if RIP reached to the safe point,
     # .Lcssa0_ocall_return_after_stack_restore. In other words, the stage-1 handler jumps to the
     # regular returning-from-OCALL flow (CSSA=0) with RSI=<external event> which forces that flow
-    # to call _PalHandleExternalEvent() before proceeding with normal enclave code.
+    # to call _PalExceptionHandler() before proceeding with normal enclave code.
     #
     # Ocall sequence:
     #  1. call sgx_ocall()
@@ -278,7 +278,7 @@ enclave_entry:
     #  6. .Lcssa0_ocall_return:
     #  7. (RSP, SGX_STACK) = (SGX_STACK, 0): restore trusted stack
     #  8. .Lcssa0_ocall_return_after_stack_restore:
-    #  9. call _PalHandleExternalEvent() if interrupted
+    #  9. call _PalExceptionHandler() if interrupted
     # 10. return from sgx_ocall() to the caller
     #
     # It is also required that sgx_ocall() be atomic wrt async exception. When host async signal
@@ -321,7 +321,7 @@ enclave_entry:
     # CASE A. We are right-before EEXIT for ocall in between [.Lcssa0_ocall_eexit_prepare,
     #         .Lcssa0_ocall_eexit_done) -- skip EEXIT as if ocall returned EINTR.
     #
-    # If there is a registered signal handler for the current exception, _PalHandleExternalEvent()
+    # If there is a registered signal handler for the current exception, _PalExceptionHandler()
     # will be called (and thus we need to save RDI = <external event>) before returning from ocall.
 
     movq $-EINTR, SGX_GPR_RDI(%rbx)    # return value for .Lcssa0_ocall_return
@@ -340,7 +340,7 @@ enclave_entry:
     #
     # Set RSI = <external event> and move RIP to .Lcssa0_ocall_return_after_stack_restore, such
     # that regular returning-from-OCALL flow (CSSA=0) will notice the external event and will call
-    # _PalHandleExternalEvent() to handle the exception.
+    # _PalExceptionHandler() to handle the exception.
     #
     # Note that either we fell-through from Case A and RDI was already set to the -EINTR return
     # value, or we are indeed in Case C and RDI already contains the successful OCALL result.
@@ -755,7 +755,8 @@ sgx_ocall:
     jmp _restore_sgx_context
 
 2:
-    # there was some event, call _PalHandleExternalEvent(event, uc, xregs_state)
+    # there was some external event, call the exception handler
+    # _PalExceptionHandler(/*trusted_exit_info=*/0, event, uc, xregs_state, /*exinfo=*/NULL)
 
     # clear the Alignment Check flag to prevent #AC-fault side channel
     pushfq
@@ -766,10 +767,12 @@ sgx_ocall:
     leaq g_xsave_reset_state(%rip), %rdi
     callq restore_xregs
 
-    movq %rsi, %rdi                         # external event (1st arg)
-    movq %rsp, %rsi                         # SGX context    (2nd arg)
-    leaq SGX_CPU_CONTEXT_SIZE(%rsp), %rdx   # xregs_state    (3rd arg)
-    callq _PalHandleExternalEvent
+    movq $0,   %rdi                         # trusted EXITINFO  (1st arg), not used
+    movq %rsi, %rsi                         # external event    (2nd arg), to be explicit
+    movq %rsp, %rdx                         # SGX context       (3rd arg)
+    leaq SGX_CPU_CONTEXT_SIZE(%rsp), %rcx   # xregs_state       (4th arg)
+    movq $0,   %r8                          # pointer to EXINFO (5th arg), not used
+    callq _PalExceptionHandler
     FAIL_LOOP                               # cannot be reached
 
 

--- a/pal/src/host/linux-sgx/pal_exception.c
+++ b/pal/src/host/linux-sgx/pal_exception.c
@@ -434,30 +434,3 @@ void _PalExceptionHandler(uint32_t trusted_exit_info_,
 
     restore_pal_context(uc, &ctx);
 }
-
-/* TODO: remove this function (SGX signal handling needs to be revisited)
- * actually what is the point of this function?
- * Tracked in https://github.com/gramineproject/gramine/issues/84. */
-noreturn void _PalHandleExternalEvent(long event_, sgx_cpu_context_t* uc,
-                                      PAL_XREGS_STATE* xregs_state) {
-    assert(IS_ALIGNED_PTR(xregs_state, PAL_XSTATE_ALIGN));
-    enum pal_event event = event_;
-
-    if (event != PAL_EVENT_QUIT && event != PAL_EVENT_INTERRUPTED) {
-        log_error("Illegal exception reported by untrusted PAL: %d", event);
-        _PalProcessExit(1);
-    }
-
-    PAL_CONTEXT ctx;
-    save_pal_context(&ctx, uc, xregs_state);
-
-    pal_event_handler_t upcall = _PalGetExceptionHandler(event);
-    if (upcall) {
-        (*upcall)(ADDR_IN_PAL(uc->rip), /*addr=*/0, &ctx);
-    }
-
-    /* modification to PAL_CONTEXT is discarded; it is assumed that LibOS won't change context
-     * (GPRs, FP registers) if RIP is in PAL.
-     */
-    restore_sgx_context(uc, xregs_state);
-}

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -98,9 +98,6 @@ noreturn void _restore_sgx_context(sgx_cpu_context_t* uc, PAL_XREGS_STATE* xsave
 void _PalExceptionHandler(uint32_t trusted_exit_info_,
                           uint32_t untrusted_external_event, sgx_cpu_context_t* uc,
                           PAL_XREGS_STATE* xregs_state, sgx_arch_exinfo_t* exinfo);
-/* `event_` is actually of `enum pal_event` type, but we call it from assembly, so we need to know
- * its underlying type. */
-void _PalHandleExternalEvent(long event_, sgx_cpu_context_t* uc, PAL_XREGS_STATE* xregs_state);
 
 void init_tsc(void);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `_PalExceptionHandler()` function is a superset of the removed func.

## How to test this PR? <!-- (if applicable) -->

CI is enough. No functional changes, just removing dead code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1571)
<!-- Reviewable:end -->
