### PR TITLE
[LibOS,PAL] Rename `PalObjectClose()` to `PalObjectDestroy()`

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -327,7 +327,7 @@ Objects
 .. doxygenfunction:: PalStreamsWaitEvents
    :project: pal
 
-.. doxygenfunction:: PalObjectClose
+.. doxygenfunction:: PalObjectDestroy
    :project: pal
 
 Miscellaneous

--- a/libos/include/libos_lock.h
+++ b/libos/include/libos_lock.h
@@ -28,7 +28,7 @@ static inline bool create_lock(struct libos_lock* l) {
 }
 
 static inline void destroy_lock(struct libos_lock* l) {
-    PalObjectClose(l->lock); // TODO: handle errors
+    PalObjectDestroy(l->lock);
     clear_lock(l);
 }
 

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -522,7 +522,7 @@ void put_handle(struct libos_handle* hdl) {
         free(hdl->uri);
 
         if (hdl->pal_handle) {
-            PalObjectClose(hdl->pal_handle); // TODO: handle errors
+            PalObjectDestroy(hdl->pal_handle);
             hdl->pal_handle = NULL;
         }
 

--- a/libos/src/bookkeep/libos_thread.c
+++ b/libos/src/bookkeep/libos_thread.c
@@ -383,7 +383,7 @@ void put_thread(struct libos_thread* thread) {
         free(thread->groups_info.groups);
 
         if (thread->pal_handle && thread->pal_handle != g_pal_public_state->first_thread)
-            PalObjectClose(thread->pal_handle);
+            PalObjectDestroy(thread->pal_handle);
 
         if (thread->handle_map) {
             put_handle_map(thread->handle_map);
@@ -398,7 +398,7 @@ void put_thread(struct libos_thread* thread) {
         /* `signal_altstack` is provided by the user, no need for a clean up. */
 
         if (thread->scheduler_event) {
-            PalObjectClose(thread->scheduler_event);
+            PalObjectDestroy(thread->scheduler_event);
         }
 
         /* `wake_queue` is only meaningful when `thread` is part of some wake up queue (is just

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -263,7 +263,7 @@ static int chroot_encrypted_mkdir(struct libos_dentry* dent, mode_t perm) {
         ret = pal_to_unix_errno(ret);
         goto out;
     }
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
 
     inode->type = S_IFDIR;
     inode->perm = perm;
@@ -297,7 +297,7 @@ static int chroot_encrypted_unlink(struct libos_dentry* dent) {
     }
 
     ret = PalStreamDelete(palhdl, PAL_DELETE_ALL);
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
         goto out;
@@ -356,7 +356,7 @@ static int chroot_encrypted_chmod(struct libos_dentry* dent, mode_t perm) {
     mode_t host_perm = HOST_PERM(perm);
     PAL_STREAM_ATTR attr = {.share_flags = host_perm};
     ret = PalStreamAttributesSetByHandle(palhdl, &attr);
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
         goto out;

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -224,7 +224,7 @@ static int chroot_do_open(struct libos_handle* hdl, struct libos_dentry* dent, m
         hdl->pos = 0;
         hdl->pal_handle = palhdl;
     } else {
-        PalObjectClose(palhdl);
+        PalObjectDestroy(palhdl);
     }
     ret = 0;
 
@@ -386,7 +386,7 @@ int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void*
 
 out:
     free(buf);
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
     return ret;
 }
 
@@ -402,7 +402,7 @@ int chroot_unlink(struct libos_dentry* dent) {
         return ret;
 
     ret = PalStreamDelete(palhdl, PAL_DELETE_ALL);
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
     if (ret < 0)
         return pal_to_unix_errno(ret);
 
@@ -426,7 +426,7 @@ static int chroot_rename(struct libos_dentry* old, struct libos_dentry* new) {
         goto out;
 
     ret = PalStreamChangeName(palhdl, new_uri);
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
         goto out;
@@ -452,7 +452,7 @@ static int chroot_chmod(struct libos_dentry* dent, mode_t perm) {
     mode_t host_perm = HOST_PERM(perm);
     PAL_STREAM_ATTR attr = {.share_flags = host_perm};
     ret = PalStreamAttributesSetByHandle(palhdl, &attr);
-    PalObjectClose(palhdl);
+    PalObjectDestroy(palhdl);
     if (ret < 0)
         return pal_to_unix_errno(ret);
 

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -211,7 +211,7 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
 out:
     free(normpath);
     if (ret < 0)
-        PalObjectClose(pal_handle);
+        PalObjectDestroy(pal_handle);
     return ret;
 }
 
@@ -242,7 +242,7 @@ static void encrypted_file_internal_close(struct libos_encrypted_file* enc) {
     }
 
     enc->pf = NULL;
-    PalObjectClose(enc->pal_handle);
+    PalObjectDestroy(enc->pal_handle);
     enc->pal_handle = NULL;
     return;
 }

--- a/libos/src/fs/libos_fs_lock.c
+++ b/libos/src/fs/libos_fs_lock.c
@@ -618,7 +618,7 @@ int file_lock_set(struct libos_dentry* dent, struct libos_file_lock* file_lock, 
 out:
     unlock(&g_fs_lock_lock);
     if (event)
-        PalObjectClose(event);
+        PalObjectDestroy(event);
     return ret;
 }
 

--- a/libos/src/fs/socket/fs.c
+++ b/libos/src/fs/socket/fs.c
@@ -23,7 +23,7 @@ static int close(struct libos_handle* handle) {
     free(handle->info.sock.peek.buf);
     /* No need for atomics - we are releasing the last reference, nothing can access it anymore. */
     if (handle->info.sock.pal_handle) {
-        PalObjectClose(handle->info.sock.pal_handle);
+        PalObjectDestroy(handle->info.sock.pal_handle);
     }
     return 0;
 }

--- a/libos/src/ipc/libos_ipc.c
+++ b/libos/src/ipc/libos_ipc.c
@@ -82,7 +82,7 @@ static void put_ipc_connection(struct libos_ipc_connection* conn) {
     refcount_t ref_count = refcount_dec(&conn->ref_count);
 
     if (!ref_count) {
-        PalObjectClose(conn->handle);
+        PalObjectDestroy(conn->handle);
         destroy_lock(&conn->lock);
         free(conn);
     }
@@ -157,7 +157,7 @@ out:
             destroy_lock(&conn->lock);
         }
         if (conn->handle) {
-            PalObjectClose(conn->handle);
+            PalObjectDestroy(conn->handle);
         }
         free(conn);
     }
@@ -311,7 +311,7 @@ out:
     avl_tree_delete(&g_msg_waiters_tree, &waiter.node);
     unlock(&g_msg_waiters_tree_lock);
     free(waiter.response_data);
-    PalObjectClose(waiter.event);
+    PalObjectDestroy(waiter.event);
     return ret;
 }
 

--- a/libos/src/ipc/libos_ipc_worker.c
+++ b/libos/src/ipc/libos_ipc_worker.c
@@ -110,7 +110,7 @@ static void del_ipc_connection(struct libos_ipc_connection* conn) {
     LISTP_DEL(conn, &g_ipc_connections, list);
     g_ipc_connections_cnt--;
 
-    PalObjectClose(conn->handle);
+    PalObjectDestroy(conn->handle);
 
     free(conn);
 }
@@ -320,7 +320,7 @@ static noreturn void ipc_worker_main(void) {
             ret = read_exact(new_handle, &new_id, sizeof(new_id));
             if (ret < 0) {
                 log_error(LOG_PREFIX "receiving id failed: %s", unix_strerror(ret));
-                PalObjectClose(new_handle);
+                PalObjectDestroy(new_handle);
             } else {
                 ret = add_ipc_connection(new_handle, new_id);
                 if (ret < 0) {
@@ -417,6 +417,6 @@ void terminate_ipc_worker(void) {
 
     put_thread(g_worker_thread);
     g_worker_thread = NULL;
-    PalObjectClose(g_self_ipc_handle);
+    PalObjectDestroy(g_self_ipc_handle);
     g_self_ipc_handle = NULL;
 }

--- a/libos/src/libos_checkpoint.c
+++ b/libos/src/libos_checkpoint.c
@@ -659,7 +659,7 @@ out:
     }
 
     if (pal_process)
-        PalObjectClose(pal_process);
+        PalObjectDestroy(pal_process);
 
     if (ret < 0) {
         log_error("process creation failed");

--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -37,7 +37,7 @@ int create_pollable_event(struct libos_pollable_event* event) {
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         log_error("PalStreamWaitForClient failed: %s", pal_strerror(ret));
-        PalObjectClose(write_handle);
+        PalObjectDestroy(write_handle);
         ret = pal_to_unix_errno(ret);
         goto out;
     }
@@ -50,10 +50,10 @@ int create_pollable_event(struct libos_pollable_event* event) {
 
 out:;
     int tmp_ret = pal_to_unix_errno(PalStreamDelete(srv_handle, PAL_DELETE_ALL));
-    PalObjectClose(srv_handle);
+    PalObjectDestroy(srv_handle);
     if (!ret && tmp_ret) {
-        PalObjectClose(read_handle);
-        PalObjectClose(write_handle);
+        PalObjectDestroy(read_handle);
+        PalObjectDestroy(write_handle);
         /* Clearing just for sanity. */
         event->read_handle = NULL;
         event->write_handle = NULL;
@@ -62,8 +62,8 @@ out:;
 }
 
 void destroy_pollable_event(struct libos_pollable_event* event) {
-    PalObjectClose(event->read_handle);
-    PalObjectClose(event->write_handle);
+    PalObjectDestroy(event->read_handle);
+    PalObjectDestroy(event->write_handle);
 }
 
 int set_pollable_event(struct libos_pollable_event* event) {

--- a/libos/src/libos_rwlock.c
+++ b/libos/src/libos_rwlock.c
@@ -13,13 +13,13 @@ bool rwlock_create(struct libos_rwlock* l) {
         return false;
     }
     if (PalEventCreate(&l->writer_wait, /*init_signaled=*/false, /*auto_clear=*/true) < 0) {
-        PalObjectClose(l->readers_wait);
+        PalObjectDestroy(l->readers_wait);
         return false;
     }
     l->waiting_readers = 0;
     if (!create_lock(&l->writers_lock)) {
-        PalObjectClose(l->readers_wait);
-        PalObjectClose(l->writer_wait);
+        PalObjectDestroy(l->readers_wait);
+        PalObjectDestroy(l->writer_wait);
         return false;
     }
     return true;
@@ -30,8 +30,8 @@ void rwlock_destroy(struct libos_rwlock* l) {
     assert(l->departing_readers == 0);
     assert(l->waiting_readers == 0);
 
-    PalObjectClose(l->readers_wait);
-    PalObjectClose(l->writer_wait);
+    PalObjectDestroy(l->readers_wait);
+    PalObjectDestroy(l->writer_wait);
     destroy_lock(&l->writers_lock);
 }
 

--- a/libos/src/net/ip.c
+++ b/libos/src/net/ip.c
@@ -179,7 +179,7 @@ static int accept(struct libos_handle* handle, bool is_nonblocking,
                                                                handle->info.sock.protocol,
                                                                is_nonblocking);
     if (!client_handle) {
-        PalObjectClose(client_pal_handle);
+        PalObjectDestroy(client_pal_handle);
         return -ENOMEM;
     }
 

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -190,7 +190,7 @@ static int accept(struct libos_handle* handle, bool is_nonblocking,
                                                                handle->info.sock.protocol,
                                                                is_nonblocking);
     if (!client_handle) {
-        PalObjectClose(client_pal_handle);
+        PalObjectDestroy(client_pal_handle);
         return -ENOMEM;
     }
 

--- a/libos/src/sync/libos_sync_client.c
+++ b/libos/src/sync/libos_sync_client.c
@@ -52,7 +52,7 @@ static void put_sync_handle(struct sync_handle* handle) {
         free(handle->data);
         destroy_lock(&handle->use_lock);
         destroy_lock(&handle->prop_lock);
-        PalObjectClose(handle->event);
+        PalObjectDestroy(handle->event);
         free(handle);
     }
 }
@@ -199,7 +199,7 @@ err:
     if (lock_created(&handle->prop_lock))
         destroy_lock(&handle->prop_lock);
     if (handle->event)
-        PalObjectClose(handle->event);
+        PalObjectDestroy(handle->event);
     return ret;
 }
 

--- a/libos/src/sys/libos_clone.c
+++ b/libos/src/sys/libos_clone.c
@@ -474,8 +474,8 @@ long libos_syscall_clone(unsigned long flags, unsigned long user_stack_addr, int
     while (!__atomic_load_n(&new_args.is_thread_initialized, __ATOMIC_ACQUIRE)) {
         CPU_RELAX();
     }
-    PalObjectClose(new_args.initialize_event);
-    PalObjectClose(new_args.create_event);
+    PalObjectDestroy(new_args.initialize_event);
+    PalObjectDestroy(new_args.create_event);
 
     put_thread(thread);
     return tid;
@@ -484,9 +484,9 @@ clone_thread_failed:
     if (new_args.thread)
         put_thread(new_args.thread);
     if (new_args.create_event)
-        PalObjectClose(new_args.create_event);
+        PalObjectDestroy(new_args.create_event);
     if (new_args.initialize_event)
-        PalObjectClose(new_args.initialize_event);
+        PalObjectDestroy(new_args.initialize_event);
 failed:
     put_thread(thread);
     return ret;

--- a/libos/src/sys/libos_pipe.c
+++ b/libos/src/sys/libos_pipe.c
@@ -80,12 +80,12 @@ static int create_pipes(struct libos_handle* srv, struct libos_handle* cli, int 
 
 out:;
     int tmp_ret = PalStreamDelete(hdl0, PAL_DELETE_ALL);
-    PalObjectClose(hdl0);
+    PalObjectDestroy(hdl0);
     if (ret || tmp_ret) {
         if (hdl1)
-            PalObjectClose(hdl1);
+            PalObjectDestroy(hdl1);
         if (hdl2)
-            PalObjectClose(hdl2);
+            PalObjectDestroy(hdl2);
 
         free(srv->uri);
         srv->uri = NULL;

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -99,8 +99,6 @@ enum {
     PAL_HANDLE_TYPE_BOUND,
 };
 
-#define PAL_IDX_POISON         ((PAL_IDX)-1) /* PAL identifier poison value */
-
 /********** PAL APIs **********/
 
 struct pal_dns_host_conf_addr {
@@ -826,9 +824,9 @@ int PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_
                          pal_wait_flags_t* ret_events, uint64_t* timeout_us);
 
 /*!
- * \brief Close (deallocate) a PAL handle.
+ * \brief Close and deallocate a PAL handle.
  */
-void PalObjectClose(PAL_HANDLE object_handle);
+void PalObjectDestroy(PAL_HANDLE handle);
 
 /*
  * MISC

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -48,11 +48,14 @@ struct handle_ops {
     int64_t (*read)(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
     int64_t (*write)(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
 
-    /* 'close' and 'delete' is used by PalObjectClose and PalStreamDelete, 'close' will close the
-     * stream, while 'delete' actually destroy the stream, such as deleting a file or shutting
-     * down a socket */
-    int (*close)(PAL_HANDLE handle);
+    /* 'delete' is used by PalStreamDelete: for files and dirs it corresponds to unlinking, for
+     * sockets it corresponds to shutting down a socket connection. */
     int (*delete)(PAL_HANDLE handle, enum pal_delete_mode delete_mode);
+
+    /* 'destroy' is used by PalObjectDestroy: it closes all associated resources on the host (e.g.
+     * closes the host FD), frees all sub-objects of the PAL handle (e.g. a filename string) and
+     * finally frees the PAL handle object itself */
+    void (*destroy)(PAL_HANDLE handle);
 
     /*
      * 'map' and 'unmap' will map or unmap the handle into memory space, it's not necessary mapped
@@ -216,7 +219,7 @@ int _PalVirtualMemoryFree(void* addr, uint64_t size);
 int _PalVirtualMemoryProtect(void* addr, uint64_t size, pal_prot_flags_t prot);
 
 /* PalObject calls */
-int _PalObjectClose(PAL_HANDLE object_handle);
+void _PalObjectDestroy(PAL_HANDLE object_handle);
 int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags_t* events,
                           pal_wait_flags_t* ret_events, uint64_t* timeout_us);
 

--- a/pal/regression/Directory.c
+++ b/pal/regression/Directory.c
@@ -27,7 +27,7 @@ int main(int argc, char** argv, char** envp) {
                     pal_printf("Read Directory: %s\n", c);
         }
 
-        PalObjectClose(dir1);
+        PalObjectDestroy(dir1);
     }
 
     PAL_HANDLE dir2 = NULL;
@@ -35,7 +35,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_CREATE_NEVER, /*options=*/0, &dir2);
     if (ret >= 0 && dir2) {
         pal_printf("Directory Open Test 2 OK\n");
-        PalObjectClose(dir2);
+        PalObjectDestroy(dir2);
     }
 
     PAL_HANDLE dir3 = NULL;
@@ -43,7 +43,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_CREATE_NEVER, /*options=*/0, &dir3);
     if (ret >= 0 && dir3) {
         pal_printf("Directory Open Test 3 OK\n");
-        PalObjectClose(dir3);
+        PalObjectDestroy(dir3);
     }
 
     PAL_STREAM_ATTR attr2;
@@ -60,7 +60,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_CREATE_ALWAYS, /*options=*/0, &dir4);
     if (ret >= 0 && dir4) {
         pal_printf("Directory Creation Test 1 OK\n");
-        PalObjectClose(dir4);
+        PalObjectDestroy(dir4);
     }
 
     PAL_HANDLE dir5 = NULL;
@@ -68,7 +68,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_SHARE_OWNER_R | PAL_SHARE_OWNER_W | PAL_SHARE_OWNER_X,
                         PAL_CREATE_ALWAYS, /*options=*/0, &dir5);
     if (ret >= 0) {
-        PalObjectClose(dir5);
+        PalObjectDestroy(dir5);
     } else {
         pal_printf("Directory Creation Test 2 OK\n");
     }
@@ -79,7 +79,7 @@ int main(int argc, char** argv, char** envp) {
                         &dir6);
     if (ret >= 0 && dir6) {
         pal_printf("Directory Creation Test 3 OK\n");
-        PalObjectClose(dir6);
+        PalObjectDestroy(dir6);
     }
 
     PAL_HANDLE dir7 = NULL;
@@ -91,7 +91,7 @@ int main(int argc, char** argv, char** envp) {
             pal_printf("PalStreamDelete failed\n");
             return 1;
         }
-        PalObjectClose(dir7);
+        PalObjectDestroy(dir7);
     }
 
     PAL_HANDLE dir8 = NULL;
@@ -109,7 +109,7 @@ int main(int argc, char** argv, char** envp) {
             pal_printf("PalStreamDelete failed: %d\n", ret);
             return 1;
         }
-        PalObjectClose(dir8);
+        PalObjectDestroy(dir8);
     }
 
     return 0;

--- a/pal/regression/File.c
+++ b/pal/regression/File.c
@@ -89,7 +89,7 @@ int main(int argc, char** argv, char** envp) {
             pal_printf("Map Test 1 & 2: Failed to map buffer\n");
         }
 
-        PalObjectClose(file1);
+        PalObjectDestroy(file1);
     }
 
     PAL_HANDLE file2 = NULL;
@@ -97,7 +97,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_CREATE_NEVER, /*options=*/0, &file2);
     if (ret >= 0 && file2) {
         pal_printf("File Open Test 2 OK\n");
-        PalObjectClose(file2);
+        PalObjectDestroy(file2);
     }
 
     PAL_HANDLE file3 = NULL;
@@ -105,7 +105,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_CREATE_NEVER, /*options=*/0, &file3);
     if (ret >= 0 && file3) {
         pal_printf("File Open Test 3 OK\n");
-        PalObjectClose(file3);
+        PalObjectDestroy(file3);
     }
 
     PAL_STREAM_ATTR attr2;
@@ -128,7 +128,7 @@ int main(int argc, char** argv, char** envp) {
                         PAL_SHARE_OWNER_R | PAL_SHARE_OWNER_W, PAL_CREATE_ALWAYS, /*options=*/0,
                         &file5);
     if (ret >= 0) {
-        PalObjectClose(file5);
+        PalObjectDestroy(file5);
     } else {
         pal_printf("File Creation Test 2 OK\n");
     }
@@ -139,7 +139,7 @@ int main(int argc, char** argv, char** envp) {
                         &file6);
     if (ret >= 0 && file6) {
         pal_printf("File Creation Test 3 OK\n");
-        PalObjectClose(file6);
+        PalObjectDestroy(file6);
     }
 
     if (file4) {
@@ -167,7 +167,7 @@ int main(int argc, char** argv, char** envp) {
         }
 
     fail_writing:
-        PalObjectClose(file4);
+        PalObjectDestroy(file4);
         if (ret < 0) {
             return 1;
         }
@@ -182,7 +182,7 @@ int main(int argc, char** argv, char** envp) {
             pal_printf("PalStreamDelete failed\n");
             return 1;
         }
-        PalObjectClose(file7);
+        PalObjectDestroy(file7);
     }
 
     return 0;

--- a/pal/regression/File2.c
+++ b/pal/regression/File2.c
@@ -24,7 +24,7 @@ int main(int argc, char** argv, char** envp) {
         return 1;
     }
 
-    PalObjectClose(out);
+    PalObjectDestroy(out);
 
     PAL_HANDLE in = NULL;
     ret = PalStreamOpen(FILE_URI, PAL_ACCESS_RDONLY, /*share_flags=*/0, PAL_CREATE_NEVER,

--- a/pal/regression/HelloWorld.c
+++ b/pal/regression/HelloWorld.c
@@ -23,6 +23,6 @@ int main(int argc, char** argv, char** envp) {
         return 1;
     }
 
-    PalObjectClose(out);
+    PalObjectDestroy(out);
     return 0;
 }

--- a/pal/regression/Pie.c
+++ b/pal/regression/Pie.c
@@ -23,6 +23,6 @@ int main(int argc, char** argv, char** envp) {
         return 1;
     }
 
-    PalObjectClose(out);
+    PalObjectDestroy(out);
     return 0;
 }

--- a/pal/regression/Process4.c
+++ b/pal/regression/Process4.c
@@ -36,15 +36,15 @@ int main(int argc, char** argv) {
         if (ret < 0)
             pal_printf("Can't create process\n");
 
-        PalObjectClose(proc);
+        PalObjectDestroy(proc);
 
         PAL_HANDLE pipe = NULL;
         ret = PalStreamWaitForClient(pipe_srv, &pipe, /*options=*/0);
         if (ret < 0) {
             pal_printf("PalStreamWaitForClient failed: %d\n", ret);
         }
-        PalObjectClose(pipe);
-        PalObjectClose(pipe_srv);
+        PalObjectDestroy(pipe);
+        PalObjectDestroy(pipe_srv);
     } else {
         count = atoi(argv[1]);
 
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
             if (ret < 0)
                 pal_printf("Can't create process\n");
 
-            PalObjectClose(proc);
+            PalObjectDestroy(proc);
         } else {
             uint64_t end = 0;
             if (PalSystemTimeQuery(&end) < 0) {
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
                 pal_printf("Failed to open pipe: %d\n", ret);
                 return 1;
             }
-            PalObjectClose(pipe);
+            PalObjectDestroy(pipe);
         }
     }
 

--- a/pal/regression/Symbols.c
+++ b/pal/regression/Symbols.c
@@ -47,7 +47,7 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(PalEventClear);
     PRINT_SYMBOL(PalEventWait);
 
-    PRINT_SYMBOL(PalObjectClose);
+    PRINT_SYMBOL(PalObjectDestroy);
 
     PRINT_SYMBOL(PalSystemTimeQuery);
     PRINT_SYMBOL(PalRandomBitsRead);

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -96,12 +96,12 @@ static void do_parent(void) {
     CHECK(PalStreamOpen("pipe.srv:1", PAL_ACCESS_RDWR, /*share_flags=*/0, PAL_CREATE_IGNORED,
                         /*options=*/0, &handle));
     CHECK(PalSendHandle(child_process, handle));
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     CHECK(PalStreamOpen("pipe:1", PAL_ACCESS_RDWR, /*share_flags=*/0, PAL_CREATE_IGNORED,
                         /*options=*/0, &handle));
     recv_and_check(handle, PAL_TYPE_PIPE);
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     /* TCP socket */
     CHECK(PalSocketCreate(PAL_IPV4, PAL_SOCKET_TCP, /*options=*/0, &handle));
@@ -116,12 +116,12 @@ static void do_parent(void) {
     CHECK(PalSocketBind(handle, &addr));
     CHECK(PalSocketListen(handle, /*backlog=*/3));
     CHECK(PalSendHandle(child_process, handle));
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     CHECK(PalSocketCreate(PAL_IPV4, PAL_SOCKET_TCP, /*options=*/0, &handle));
     CHECK(PalSocketConnect(handle, &addr, /*local_addr=*/NULL));
     recv_and_check(handle, PAL_TYPE_SOCKET);
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     /* UDP IPv6 socket */
     CHECK(PalSocketCreate(PAL_IPV6, PAL_SOCKET_UDP, /*options=*/0, &handle));
@@ -135,19 +135,19 @@ static void do_parent(void) {
     set_reuseaddr(handle);
     CHECK(PalSocketBind(handle, &addr));
     CHECK(PalSendHandle(child_process, handle));
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     CHECK(PalSocketCreate(PAL_IPV6, PAL_SOCKET_UDP, /*options=*/0, &handle));
     CHECK(PalSocketConnect(handle, &addr, /*local_addr=*/NULL));
     write_msg(handle, PAL_TYPE_SOCKET);
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     /* file handle */
     CHECK(PalStreamOpen("file:to_send.tmp", PAL_ACCESS_RDWR, /*share_flags=*/0600, PAL_CREATE_TRY,
                         /*options=*/0, &handle));
     write_msg(handle, PAL_TYPE_FILE);
     CHECK(PalSendHandle(child_process, handle));
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 }
 
 static void do_child(void) {
@@ -157,27 +157,27 @@ static void do_child(void) {
     CHECK(PalReceiveHandle(PalGetPalPublicState()->parent_process, &handle));
     PAL_HANDLE client_handle;
     CHECK(PalStreamWaitForClient(handle, &client_handle, /*options=*/0));
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
     write_msg(client_handle, PAL_TYPE_PIPECLI);
-    PalObjectClose(client_handle);
+    PalObjectDestroy(client_handle);
 
     /* TCP socket */
     CHECK(PalReceiveHandle(PalGetPalPublicState()->parent_process, &handle));
     CHECK(PalSocketAccept(handle, /*options=*/0, &client_handle, /*out_client_addr=*/NULL,
                           /*out_local_addr=*/NULL));
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
     write_msg(client_handle, PAL_TYPE_SOCKET);
-    PalObjectClose(client_handle);
+    PalObjectDestroy(client_handle);
 
     /* UDP IPv6 socket */
     CHECK(PalReceiveHandle(PalGetPalPublicState()->parent_process, &handle));
     recv_and_check(handle, PAL_TYPE_SOCKET);
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 
     /* file handle */
     CHECK(PalReceiveHandle(PalGetPalPublicState()->parent_process, &handle));
     recv_and_check(handle, PAL_TYPE_FILE);
-    PalObjectClose(handle);
+    PalObjectDestroy(handle);
 }
 
 int main(int argc, char* argv[]) {

--- a/pal/regression/test_pal.py
+++ b/pal/regression/test_pal.py
@@ -168,7 +168,7 @@ class TC_02_Symbols(RegressionTestCase):
         'PalEventClear',
         'PalEventWait',
         'PalStreamsWaitEvents',
-        'PalObjectClose',
+        'PalObjectDestroy',
         'PalSystemTimeQuery',
         'PalRandomBitsRead',
     ]

--- a/pal/src/host/linux-sgx/pal_console.c
+++ b/pal/src/host/linux-sgx/pal_console.c
@@ -53,7 +53,7 @@ static int64_t console_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, v
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->flags & PAL_HANDLE_FD_READABLE) || handle->console.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_READABLE))
         return -PAL_ERROR_DENIED;
 
     int64_t bytes = ocall_read(handle->console.fd, buffer, size);
@@ -66,25 +66,25 @@ static int64_t console_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, 
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE) || handle->console.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
     int64_t bytes = ocall_write(handle->console.fd, buffer, size);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 
-static int console_close(PAL_HANDLE handle) {
+static void console_destroy(PAL_HANDLE handle) {
     assert(handle->hdr.type == PAL_TYPE_CONSOLE);
 
     /* do not close host stdin/stdout, to allow Gramine itself to use them (e.g. for logs) */
-    handle->console.fd = PAL_IDX_POISON;
-    return 0;
+
+    free(handle);
 }
 
 static int console_flush(PAL_HANDLE handle) {
     assert(handle->hdr.type == PAL_TYPE_CONSOLE);
 
-    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE) || handle->console.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
     int ret = ocall_fsync(handle->console.fd);
@@ -95,6 +95,6 @@ struct handle_ops g_console_ops = {
     .open           = &console_open,
     .read           = &console_read,
     .write          = &console_write,
-    .close          = &console_close,
+    .destroy        = &console_destroy,
     .flush          = &console_flush,
 };

--- a/pal/src/host/linux-sgx/pal_devices.c
+++ b/pal/src/host/linux-sgx/pal_devices.c
@@ -75,7 +75,7 @@ static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void*
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->flags & PAL_HANDLE_FD_READABLE) || handle->dev.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_READABLE))
         return -PAL_ERROR_DENIED;
 
     ssize_t bytes = ocall_read(handle->dev.fd, buffer, size);
@@ -88,34 +88,30 @@ static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, cons
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE) || handle->dev.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
     ssize_t bytes = ocall_write(handle->dev.fd, buffer, size);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 
-static int dev_close(PAL_HANDLE handle) {
+static void dev_destroy(PAL_HANDLE handle) {
     assert(handle->hdr.type == PAL_TYPE_DEV);
 
-    if (handle->dev.fd != PAL_IDX_POISON) {
-        int ret = ocall_close(handle->dev.fd);
-        if (ret < 0)
-            return unix_to_pal_error(ret);
+    int ret = ocall_close(handle->dev.fd);
+    if (ret < 0) {
+        log_error("closing dev host fd %d failed: %s", handle->dev.fd, unix_strerror(ret));
+        /* We cannot do anything about it anyway... */
     }
-    handle->dev.fd = PAL_IDX_POISON;
-    return 0;
+
+    free(handle);
 }
 
 static int dev_flush(PAL_HANDLE handle) {
     assert(handle->hdr.type == PAL_TYPE_DEV);
 
-    if (handle->dev.fd != PAL_IDX_POISON) {
-        int ret = ocall_fsync(handle->dev.fd);
-        if (ret < 0)
-            return unix_to_pal_error(ret);
-    }
-    return 0;
+    int ret = ocall_fsync(handle->dev.fd);
+    return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
@@ -161,7 +157,7 @@ struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
-    .close          = &dev_close,
+    .destroy        = &dev_destroy,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,
@@ -176,9 +172,6 @@ int _PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int*
         fd = handle->sock.fd;
     else
         return -PAL_ERROR_INVAL;
-
-    if ((PAL_IDX)fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
 
     /* find this IOCTL request in the manifest */
     toml_table_t* manifest_sys = toml_table_in(g_pal_public_state.manifest_root, "sys");

--- a/pal/src/host/linux-sgx/pal_eventfd.c
+++ b/pal/src/host/linux-sgx/pal_eventfd.c
@@ -103,9 +103,6 @@ static int64_t eventfd_pal_write(PAL_HANDLE handle, uint64_t offset, uint64_t le
 static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int ret;
 
-    if (handle->eventfd.fd == PAL_IDX_POISON)
-        return -PAL_ERROR_BADHANDLE;
-
     attr->handle_type  = handle->hdr.type;
     attr->nonblocking  = handle->eventfd.nonblocking;
 
@@ -119,22 +116,22 @@ static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) 
     return 0;
 }
 
-static int eventfd_pal_close(PAL_HANDLE handle) {
-    if (handle->hdr.type == PAL_TYPE_EVENTFD) {
-        if (handle->eventfd.fd != PAL_IDX_POISON) {
-            ocall_close(handle->eventfd.fd);
-            handle->eventfd.fd = PAL_IDX_POISON;
-        }
-        return 0;
+static void eventfd_pal_destroy(PAL_HANDLE handle) {
+    assert(handle->hdr.type == PAL_TYPE_EVENTFD);
+
+    int ret = ocall_close(handle->eventfd.fd);
+    if (ret < 0) {
+        log_error("closing eventfd host fd %d failed: %s", handle->eventfd.fd, unix_strerror(ret));
+        /* We cannot do anything about it anyway... */
     }
 
-    return 0;
+    free(handle);
 }
 
 struct handle_ops g_eventfd_ops = {
     .open           = &eventfd_pal_open,
     .read           = &eventfd_pal_read,
     .write          = &eventfd_pal_write,
-    .close          = &eventfd_pal_close,
+    .destroy        = &eventfd_pal_destroy,
     .attrquerybyhdl = &eventfd_pal_attrquerybyhdl,
 };

--- a/pal/src/host/linux-sgx/pal_events.c
+++ b/pal/src/host/linux-sgx/pal_events.c
@@ -201,11 +201,13 @@ int _PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
     }
 }
 
-static int event_close(PAL_HANDLE handle) {
+static void event_destroy(PAL_HANDLE handle) {
+    assert(handle->hdr.type == PAL_TYPE_EVENT);
+
     free_untrusted_futex_word(handle->event.signaled_untrusted);
-    return 0;
+    free(handle);
 }
 
 struct handle_ops g_event_ops = {
-    .close = event_close,
+    .destroy = event_destroy,
 };

--- a/pal/src/host/linux-sgx/pal_object.c
+++ b/pal/src/host/linux-sgx/pal_object.c
@@ -37,8 +37,7 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
     for (size_t i = 0; i < count; i++) {
         PAL_HANDLE handle = handle_array[i];
         /* If `handle` does not have a host fd, just ignore it. */
-        if (handle && (handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))
-                && handle->generic.fd != PAL_IDX_POISON) {
+        if (handle && (handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))) {
             short fdevents = 0;
             if (events[i] & PAL_WAIT_READ) {
                 fdevents |= POLLIN;
@@ -77,8 +76,7 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
         ret_events[i] = 0;
 
         PAL_HANDLE handle = handle_array[i];
-        if (!handle || !(handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))
-                || handle->generic.fd == PAL_IDX_POISON) {
+        if (!handle || !(handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))) {
             /* We skipped this fd. */
             continue;
         }

--- a/pal/src/host/linux-sgx/pal_sockets.c
+++ b/pal/src/host/linux-sgx/pal_sockets.c
@@ -149,13 +149,16 @@ int _PalSocketCreate(enum pal_socket_domain domain, enum pal_socket_type type,
     return 0;
 }
 
-static int close(PAL_HANDLE handle) {
+static void destroy(PAL_HANDLE handle) {
+    assert(handle->hdr.type == PAL_TYPE_SOCKET);
+
     int ret = ocall_close(handle->sock.fd);
     if (ret < 0) {
-        log_error("closing socket fd failed: %s", unix_strerror(ret));
+        log_error("closing socket host fd %d failed: %s", handle->sock.fd, unix_strerror(ret));
         /* We cannot do anything about it anyway... */
     }
-    return 0;
+
+    free(handle);
 }
 
 static int bind(PAL_HANDLE handle, struct pal_socket_addr* addr) {
@@ -229,12 +232,12 @@ static int tcp_accept(PAL_HANDLE handle, pal_stream_options_t options, PAL_HANDL
 
     int ret = verify_ip_addr(client->sock.domain, &client_addr, client_addrlen);
     if (ret < 0) {
-        _PalObjectClose(client);
+        _PalObjectDestroy(client);
         return ret;
     }
     ret = verify_ip_addr(client->sock.domain, &local_addr, local_addrlen);
     if (ret < 0) {
-        _PalObjectClose(client);
+        _PalObjectDestroy(client);
         return ret;
     }
 
@@ -614,14 +617,14 @@ static struct handle_ops g_tcp_handle_ops = {
     .attrquerybyhdl = attrquerybyhdl,
     .attrsetbyhdl = attrsetbyhdl_tcp,
     .delete = delete_tcp,
-    .close = close,
+    .destroy = destroy,
 };
 
 static struct handle_ops g_udp_handle_ops = {
     .attrquerybyhdl = attrquerybyhdl,
     .attrsetbyhdl = attrsetbyhdl_udp,
     .delete = delete_udp,
-    .close = close,
+    .destroy = destroy,
 };
 
 void fixup_socket_handle_after_deserialization(PAL_HANDLE handle) {

--- a/pal/src/host/linux/pal_devices.c
+++ b/pal/src/host/linux/pal_devices.c
@@ -72,7 +72,7 @@ static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void*
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->flags & PAL_HANDLE_FD_READABLE) || handle->dev.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_READABLE))
         return -PAL_ERROR_DENIED;
 
     int64_t bytes = DO_SYSCALL(read, handle->dev.fd, buffer, size);
@@ -85,34 +85,30 @@ static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, cons
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE) || handle->dev.fd == PAL_IDX_POISON)
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
     int64_t bytes = DO_SYSCALL(write, handle->dev.fd, buffer, size);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 
-static int dev_close(PAL_HANDLE handle) {
+static void dev_destroy(PAL_HANDLE handle) {
     assert(handle->hdr.type == PAL_TYPE_DEV);
 
-    if (handle->dev.fd != PAL_IDX_POISON) {
-        int ret = DO_SYSCALL(close, handle->dev.fd);
-        if (ret < 0)
-            return unix_to_pal_error(ret);
+    int ret = DO_SYSCALL(close, handle->dev.fd);
+    if (ret < 0) {
+        log_error("closing dev host fd %d failed: %s", handle->dev.fd, unix_strerror(ret));
+        /* We cannot do anything about it anyway... */
     }
-    handle->dev.fd = PAL_IDX_POISON;
-    return 0;
+
+    free(handle);
 }
 
 static int dev_flush(PAL_HANDLE handle) {
     assert(handle->hdr.type == PAL_TYPE_DEV);
 
-    if (handle->dev.fd != PAL_IDX_POISON) {
-        int ret = DO_SYSCALL(fsync, handle->dev.fd);
-        if (ret < 0)
-            return unix_to_pal_error(ret);
-    }
-    return 0;
+    int ret = DO_SYSCALL(fsync, handle->dev.fd);
+    return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
@@ -150,7 +146,7 @@ struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
-    .close          = &dev_close,
+    .destroy        = &dev_destroy,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,
@@ -178,9 +174,6 @@ int _PalDeviceIoControl(PAL_HANDLE handle, uint32_t cmd, unsigned long arg, int*
         fd = handle->sock.fd;
     else
         return -PAL_ERROR_INVAL;
-
-    if ((PAL_IDX)fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
 
     /* find this IOCTL request in the manifest */
     toml_table_t* manifest_sys = toml_table_in(g_pal_public_state.manifest_root, "sys");

--- a/pal/src/host/linux/pal_object.c
+++ b/pal/src/host/linux/pal_object.c
@@ -39,8 +39,7 @@ int _PalStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, pal_wait_flags
     for (size_t i = 0; i < count; i++) {
         PAL_HANDLE handle = handle_array[i];
         /* If `handle` does not have a host fd, just ignore it. */
-        if (handle && (handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))
-                && handle->generic.fd != PAL_IDX_POISON) {
+        if (handle && (handle->flags & (PAL_HANDLE_FD_READABLE | PAL_HANDLE_FD_WRITABLE))) {
             short fdevents = 0;
             if (events[i] & PAL_WAIT_READ) {
                 fdevents |= POLLIN;

--- a/pal/src/host/linux/pal_pipes.c
+++ b/pal/src/host/linux/pal_pipes.c
@@ -96,9 +96,6 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_
     if (handle->hdr.type != PAL_TYPE_PIPESRV)
         return -PAL_ERROR_NOTSERVER;
 
-    if (handle->pipe.fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
-
     static_assert(O_NONBLOCK == SOCK_NONBLOCK, "assumed below");
     int flags = PAL_OPTION_TO_LINUX_OPEN(options) | SOCK_CLOEXEC;
     int newfd = DO_SYSCALL(accept4, handle->pipe.fd, NULL, NULL, flags);
@@ -259,18 +256,21 @@ static int64_t pipe_write(PAL_HANDLE handle, uint64_t offset, size_t len, const 
 }
 
 /*!
- * \brief Close pipe.
+ * \brief Destroy pipe (close host FD and free all objects).
  *
  * \param handle  PAL handle of type `pipesrv`, `pipecli`, or `pipe`.
- *
- * \returns 0 on success, negative PAL error code otherwise.
  */
-static int pipe_close(PAL_HANDLE handle) {
-    if (handle->pipe.fd != PAL_IDX_POISON) {
-        DO_SYSCALL(close, handle->pipe.fd);
-        handle->pipe.fd = PAL_IDX_POISON;
+static void pipe_destroy(PAL_HANDLE handle) {
+    assert(handle->hdr.type == PAL_TYPE_PIPESRV || handle->hdr.type == PAL_TYPE_PIPECLI
+            || handle->hdr.type == PAL_TYPE_PIPE);
+
+    int ret = DO_SYSCALL(close, handle->pipe.fd);
+    if (ret < 0) {
+        log_error("closing pipe host fd %d failed: %s", handle->pipe.fd, unix_strerror(ret));
+        /* We cannot do anything about it anyway... */
     }
-    return 0;
+
+    free(handle);
 }
 
 /*!
@@ -297,10 +297,7 @@ static int pipe_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
             return -PAL_ERROR_INVAL;
     }
 
-    if (handle->pipe.fd != PAL_IDX_POISON) {
-        DO_SYSCALL(shutdown, handle->pipe.fd, shutdown);
-    }
-
+    DO_SYSCALL(shutdown, handle->pipe.fd, shutdown);
     return 0;
 }
 
@@ -314,9 +311,6 @@ static int pipe_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
  */
 static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int ret;
-
-    if (handle->pipe.fd == PAL_IDX_POISON)
-        return -PAL_ERROR_BADHANDLE;
 
     attr->handle_type  = handle->hdr.type;
     attr->nonblocking  = handle->pipe.nonblocking;
@@ -346,9 +340,6 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
  * Currently only `nonblocking` attribute can be set.
  */
 static int pipe_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
-    if (handle->pipe.fd == PAL_IDX_POISON)
-        return -PAL_ERROR_BADHANDLE;
-
     bool* nonblocking = &handle->pipe.nonblocking;
 
     if (attr->nonblocking != *nonblocking) {
@@ -367,7 +358,7 @@ struct handle_ops g_pipe_ops = {
     .waitforclient  = &pipe_waitforclient,
     .read           = &pipe_read,
     .write          = &pipe_write,
-    .close          = &pipe_close,
+    .destroy        = &pipe_destroy,
     .delete         = &pipe_delete,
     .attrquerybyhdl = &pipe_attrquerybyhdl,
     .attrsetbyhdl   = &pipe_attrsetbyhdl,

--- a/pal/src/host/skeleton/pal_console.c
+++ b/pal/src/host/skeleton/pal_console.c
@@ -27,8 +27,8 @@ static int64_t console_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, 
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int console_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void console_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 static int console_flush(PAL_HANDLE handle) {
@@ -39,6 +39,6 @@ struct handle_ops g_console_ops = {
     .open           = &console_open,
     .read           = &console_read,
     .write          = &console_write,
-    .close          = &console_close,
+    .destroy        = &console_destroy,
     .flush          = &console_flush,
 };

--- a/pal/src/host/skeleton/pal_devices.c
+++ b/pal/src/host/skeleton/pal_devices.c
@@ -24,8 +24,8 @@ static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, cons
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int dev_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void dev_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 static int dev_flush(PAL_HANDLE handle) {
@@ -44,7 +44,7 @@ struct handle_ops g_dev_ops = {
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
-    .close          = &dev_close,
+    .destroy        = &dev_destroy,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/pal/src/host/skeleton/pal_eventfd.c
+++ b/pal/src/host/skeleton/pal_eventfd.c
@@ -34,14 +34,14 @@ static int eventfd_pal_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) 
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int eventfd_pal_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void eventfd_pal_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 struct handle_ops g_eventfd_ops = {
     .open           = &eventfd_pal_open,
     .read           = &eventfd_pal_read,
     .write          = &eventfd_pal_write,
-    .close          = &eventfd_pal_close,
+    .destroy        = &eventfd_pal_destroy,
     .attrquerybyhdl = &eventfd_pal_attrquerybyhdl,
 };

--- a/pal/src/host/skeleton/pal_events.c
+++ b/pal/src/host/skeleton/pal_events.c
@@ -25,10 +25,10 @@ int _PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int event_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void event_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 struct handle_ops g_event_ops = {
-    .close = event_close,
+    .destroy = event_destroy,
 };

--- a/pal/src/host/skeleton/pal_files.c
+++ b/pal/src/host/skeleton/pal_files.c
@@ -27,9 +27,8 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, co
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'close' operation for file streams */
-static int file_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void file_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 /* 'delete' operation for file streams */
@@ -71,7 +70,7 @@ struct handle_ops g_file_ops = {
     .open           = &file_open,
     .read           = &file_read,
     .write          = &file_write,
-    .close          = &file_close,
+    .destroy        = &file_destroy,
     .delete         = &file_delete,
     .map            = &file_map,
     .setlength      = &file_setlength,
@@ -95,9 +94,8 @@ static int64_t dir_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'close' operation of directory streams */
-static int dir_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void dir_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 /* 'delete' operation of directory streams */
@@ -117,7 +115,7 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
 struct handle_ops g_dir_ops = {
     .open           = &dir_open,
     .read           = &dir_read,
-    .close          = &dir_close,
+    .destroy        = &dir_destroy,
     .delete         = &dir_delete,
     .attrquery      = &file_attrquery,
     .attrquerybyhdl = &dir_attrquerybyhdl,

--- a/pal/src/host/skeleton/pal_pipes.c
+++ b/pal/src/host/skeleton/pal_pipes.c
@@ -44,9 +44,8 @@ static int64_t pipe_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, cons
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'close' operation of pipe stream. */
-static int pipe_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void pipe_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 /* 'delete' operation of pipe stream. */
@@ -59,6 +58,6 @@ struct handle_ops g_pipe_ops = {
     .waitforclient = &pipe_waitforclient,
     .read          = &pipe_read,
     .write         = &pipe_write,
-    .close         = &pipe_close,
+    .destroy       = &pipe_destroy,
     .delete        = &pipe_delete,
 };

--- a/pal/src/host/skeleton/pal_process.c
+++ b/pal/src/host/skeleton/pal_process.c
@@ -31,12 +31,12 @@ static int64_t proc_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, co
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int proc_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+static void proc_destroy(PAL_HANDLE handle) {
+    /* noop */
 }
 
 struct handle_ops g_proc_ops = {
     .read  = &proc_read,
     .write = &proc_write,
-    .close = &proc_close,
+    .destroy = &proc_destroy,
 };

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -351,10 +351,11 @@ static int load_cstring_array(const char* uri, const char*** res) {
                 *(argv_it++) = buf + i + 1;
     }
     *res = array;
-    return _PalObjectClose(hdl);
+    _PalObjectDestroy(hdl);
+    return 0;
 
 out_fail:
-    (void)_PalObjectClose(hdl);
+    _PalObjectDestroy(hdl);
     free(buf);
     free(array);
     return ret;

--- a/pal/src/pal_rtld.c
+++ b/pal/src/pal_rtld.c
@@ -701,7 +701,7 @@ int load_entrypoint(const char* uri) {
 #endif
 
 out:
-    _PalObjectClose(handle);
+    _PalObjectDestroy(handle);
     return ret;
 }
 

--- a/pal/src/pal_symbols
+++ b/pal/src/pal_symbols
@@ -37,7 +37,7 @@ PalProcessExit
 PalSystemTimeQuery
 PalRandomBitsRead
 PalCpuIdRetrieve
-PalObjectClose
+PalObjectDestroy
 PalSetExceptionHandler
 PalSegmentBaseGet
 PalSegmentBaseSet


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previous name didn't make it clear that this PAL API not only closes the associated host resources, but also destroys/frees the PAL handle object itself. Also, this function and all its callbacks are of type `void` now and never return a value (as it's useless anyway).

This PR was a request from @mkow , see #827.

## How to test this PR? <!-- (if applicable) -->

CI is enough, no functional changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1572)
<!-- Reviewable:end -->
