### PR TITLE
[PAL] Enforce that device files are in the list of `sgx.allowed_files`

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -878,6 +878,8 @@ of SGX sealing should use these masks. In particular, these masks allow to
 specify a subset of enclave/machine attributes to be used in sealing key
 derivation. Moreover, these masks themselves are used in sealing key derivation.
 
+.. _allowed_files:
+
 Allowed files
 ^^^^^^^^^^^^^
 
@@ -888,15 +890,21 @@ Allowed files
       "[URI]",
     ]
 
-This syntax specifies the files that are allowed to be created or loaded into
-the enclave unconditionally. In other words, allowed files can be opened for
-reading/writing and can be created if they do not exist already. Allowed files
-are not cryptographically hashed and are thus not protected.
+This syntax specifies the files/directories (with the ``file:`` prefix) and
+devices (with the ``dev:`` prefix) that are allowed to be created or opened in
+the enclave unconditionally. In other words, allowed files, directories and
+devices can be opened for reading/writing and can be created if they do not
+exist already. Allowed files are not cryptographically hashed and are thus not
+protected.
 
 .. warning::
    It is insecure to allow files containing code or critical information;
    developers must not allow files blindly! Instead, use trusted or encrypted
    files.
+
+   Similarly, communication with allowed devices is pass-through and thus
+   potentially insecure by itself. It is the responsibility of the app developer
+   to correctly communicate with devices, with security implications in mind.
 
 Trusted files
 ^^^^^^^^^^^^^
@@ -1008,16 +1016,17 @@ File check policy
     (Default: "strict")
 
 This syntax specifies the file check policy, determining the behavior of
-authentication when opening files. By default, only files explicitly listed as
-``trusted_files`` or ``allowed_files`` declared in the manifest are allowed for
-access.
+authentication when opening files or devices. By default, only files explicitly
+listed as ``trusted_files`` and files or devices explicitly listed as
+``allowed_files`` are allowed for access.
 
-If the file check policy is ``allow_all_but_log``, all files other than trusted
-and allowed are allowed for access, and Gramine emits a warning message for
-every such file. Effectively, this policy operates on all unknown files as if
-they were listed as ``allowed_files``. (However, this policy still does not
-allow writing/creating files specified as trusted.) This policy is a convenient
-way to determine the set of files that the ported application uses.
+If the file check policy is ``allow_all_but_log``, all files and devices other
+than trusted and allowed are allowed for access, and Gramine emits a warning
+message for every such file/device. Effectively, this policy operates on all
+unknown files and devices as if they were listed as ``allowed_files``. (However,
+this policy still does not allow writing/creating files specified as trusted.)
+This policy is a convenient way to determine the set of files that the ported
+application uses.
 
 Attestation and quotes
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -275,6 +275,7 @@ char* alloc_substr(const char* start, size_t len);
 char* alloc_concat(const char* a, size_t a_len, const char* b, size_t b_len);
 char* alloc_concat3(const char* a, size_t a_len, const char* b, size_t b_len,
                     const char* c, size_t c_len);
+void* alloc_and_copy(const void* src, size_t size);
 
 /* Libc memory allocation functions */
 void* malloc(size_t size);
@@ -385,6 +386,7 @@ int buf_flush(struct print_buf* buf);
 #define URI_PREFIX_EVENTFD  URI_TYPE_EVENTFD URI_PREFIX_SEPARATOR
 #define URI_PREFIX_FILE     URI_TYPE_FILE URI_PREFIX_SEPARATOR
 
+#define URI_PREFIX_DEV_LEN  (static_strlen(URI_PREFIX_DEV))
 #define URI_PREFIX_FILE_LEN (static_strlen(URI_PREFIX_FILE))
 
 #define TIME_US_IN_S 1000000ul

--- a/common/src/string/util.c
+++ b/common/src/string/util.c
@@ -40,3 +40,11 @@ char* alloc_concat3(const char* a, size_t a_len, const char* b, size_t b_len,
     buf[a_len + b_len + c_len] = '\0';
     return buf;
 }
+
+void* alloc_and_copy(const void* src, size_t size) {
+    void* dst = malloc(size);
+    if (!dst)
+        return NULL;
+    memcpy(dst, src, size);
+    return dst;
+}

--- a/libos/test/regression/device_ioctl.manifest.template
+++ b/libos/test/regression/device_ioctl.manifest.template
@@ -17,6 +17,10 @@ sgx.trusted_files = [
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
 
+sgx.allowed_files = [
+  "dev:/dev/gramine_test_dev",
+]
+
 sys.ioctl_structs.gramine_test_dev_ioctl_write = [
     { size = 8, direction = "out", name = "buf_size" },    # buf_size
     { ptr = [ {size = "buf_size", direction = "out"} ] },  # buf

--- a/libos/test/regression/device_ioctl_fail.manifest.template
+++ b/libos/test/regression/device_ioctl_fail.manifest.template
@@ -19,6 +19,10 @@ sgx.trusted_files = [
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
 
+sgx.allowed_files = [
+  "dev:/dev/gramine_test_dev",
+]
+
 sys.allowed_ioctls = [
   # no allowed IOCTLs to force test failure
 ]

--- a/libos/test/regression/device_ioctl_parse_fail.manifest.template
+++ b/libos/test/regression/device_ioctl_parse_fail.manifest.template
@@ -17,6 +17,10 @@ sgx.trusted_files = [
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
 
+sgx.allowed_files = [
+  "dev:/dev/gramine_test_dev",
+]
+
 # Below IOCTL structs are intentionally modified to test IOCTL parsing (i.e. they don't really make
 # sense). Each IOCTL struct has a single error/limitation that should fail Gramine's IOCTL parser.
 

--- a/libos/test/regression/device_passthrough.manifest.template
+++ b/libos/test/regression/device_passthrough.manifest.template
@@ -17,3 +17,7 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
+
+sgx.allowed_files = [
+  "dev:/dev/zero",
+]

--- a/pal/src/host/linux-sgx/pal_devices.c
+++ b/pal/src/host/linux-sgx/pal_devices.c
@@ -11,6 +11,7 @@
  */
 
 #include "api.h"
+#include "enclave_tf.h"
 #include "ioctls.h"
 #include "pal.h"
 #include "pal_error.h"
@@ -18,6 +19,7 @@
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
+#include "path_utils.h"
 #include "perm.h"
 #include "toml.h"
 #include "toml_utils.h"
@@ -26,6 +28,8 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
                     pal_share_flags_t share, enum pal_create_mode create,
                     pal_stream_options_t options) {
     int ret;
+    char* normpath = NULL;
+
     assert(create != PAL_CREATE_IGNORED);
 
     assert(WITHIN_MASK(share,   PAL_SHARE_MASK));
@@ -53,6 +57,32 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     }
     hdl->dev.fd = ret;
 
+    size_t normpath_size = strlen(uri) + 1;
+    normpath = malloc(normpath_size);
+    if (!normpath) {
+        ret = -PAL_ERROR_NOMEM;
+        goto fail;
+    }
+    ret = get_norm_path(uri, normpath, &normpath_size);
+    if (ret < 0) {
+        log_warning("Could not normalize path (%s): %s", uri, pal_strerror(ret));
+        ret = -PAL_ERROR_DENIED;
+        goto fail;
+    }
+    hdl->dev.realpath = normpath;
+
+    struct trusted_file* tf = get_trusted_or_allowed_file(hdl->dev.realpath);
+    if (!tf || !tf->allowed) {
+        if (get_file_check_policy() != FILE_CHECK_POLICY_ALLOW_ALL_BUT_LOG) {
+            log_warning("Disallowing access to device '%s'; device is not allowed.",
+                        hdl->dev.realpath);
+            ret = -PAL_ERROR_DENIED;
+            goto fail;
+        }
+        log_warning("Allowing access to unknown device '%s' due to file_check_policy settings.",
+                    hdl->dev.realpath);
+    }
+
     if (access == PAL_ACCESS_RDONLY) {
         hdl->flags |= PAL_HANDLE_FD_READABLE;
     } else if (access == PAL_ACCESS_WRONLY) {
@@ -66,6 +96,7 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     return 0;
 fail:
     free(hdl);
+    free(normpath);
     return ret;
 }
 
@@ -105,6 +136,23 @@ static void dev_destroy(PAL_HANDLE handle) {
     }
 
     free(handle);
+}
+
+static int dev_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
+    assert(handle->hdr.type == PAL_TYPE_DEV);
+
+    if (delete_mode != PAL_DELETE_ALL)
+        return -PAL_ERROR_INVAL;
+
+    int ret = ocall_delete(handle->dev.realpath);
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
+}
+
+static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+    assert(handle->hdr.type == PAL_TYPE_DEV);
+
+    int ret = ocall_ftruncate(handle->dev.fd, length);
+    return ret < 0 ? unix_to_pal_error(ret) : (int64_t)length;
 }
 
 static int dev_flush(PAL_HANDLE handle) {
@@ -158,6 +206,8 @@ struct handle_ops g_dev_ops = {
     .read           = &dev_read,
     .write          = &dev_write,
     .destroy        = &dev_destroy,
+    .delete         = &dev_delete,
+    .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -78,6 +78,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
+            char* realpath;
             bool nonblocking;
         } dev;
 

--- a/pal/src/host/linux/pal_devices.c
+++ b/pal/src/host/linux/pal_devices.c
@@ -17,12 +17,15 @@
 #include "pal_flags_conv.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "path_utils.h"
 #include "perm.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum pal_access access,
                     pal_share_flags_t share, enum pal_create_mode create,
                     pal_stream_options_t options) {
     int ret;
+    char* normpath = NULL;
+
     assert(create != PAL_CREATE_IGNORED);
 
     assert(WITHIN_MASK(share,   PAL_SHARE_MASK));
@@ -50,6 +53,20 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     }
     hdl->dev.fd = ret;
 
+    size_t normpath_size = strlen(uri) + 1;
+    normpath = malloc(normpath_size);
+    if (!normpath) {
+        ret = -PAL_ERROR_NOMEM;
+        goto fail;
+    }
+    ret = get_norm_path(uri, normpath, &normpath_size);
+    if (ret < 0) {
+        log_warning("Could not normalize path (%s): %s", uri, pal_strerror(ret));
+        ret = -PAL_ERROR_DENIED;
+        goto fail;
+    }
+    hdl->dev.realpath = normpath;
+
     if (access == PAL_ACCESS_RDONLY) {
         hdl->flags |= PAL_HANDLE_FD_READABLE;
     } else if (access == PAL_ACCESS_WRONLY) {
@@ -63,6 +80,7 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, enum 
     return 0;
 fail:
     free(hdl);
+    free(normpath);
     return ret;
 }
 
@@ -101,7 +119,25 @@ static void dev_destroy(PAL_HANDLE handle) {
         /* We cannot do anything about it anyway... */
     }
 
+    free(handle->dev.realpath);
     free(handle);
+}
+
+static int dev_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
+    assert(handle->hdr.type == PAL_TYPE_DEV);
+
+    if (delete_mode != PAL_DELETE_ALL)
+        return -PAL_ERROR_INVAL;
+
+    int ret = DO_SYSCALL(unlink, handle->dev.realpath);
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
+}
+
+static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+    assert(handle->hdr.type == PAL_TYPE_DEV);
+
+    int ret = DO_SYSCALL(ftruncate, handle->dev.fd, length);
+    return ret < 0 ? unix_to_pal_error(ret) : (int64_t)length;
 }
 
 static int dev_flush(PAL_HANDLE handle) {
@@ -147,6 +183,8 @@ struct handle_ops g_dev_ops = {
     .read           = &dev_read,
     .write          = &dev_write,
     .destroy        = &dev_destroy,
+    .delete         = &dev_delete,
+    .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -55,6 +55,7 @@ typedef struct {
 
         struct {
             PAL_IDX fd;
+            char* realpath;
             bool nonblocking;
         } dev;
 

--- a/pal/src/host/linux/pal_streams.c
+++ b/pal/src/host/linux/pal_streams.c
@@ -44,10 +44,6 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
     /* find a field to serialize (depends on the handle type); note that
      * no handle type has more than one such field, and some have none */
     switch (handle->hdr.type) {
-        case PAL_TYPE_FILE:
-            field = handle->file.realpath;
-            field_size = strlen(handle->file.realpath) + 1;
-            break;
         case PAL_TYPE_PIPE:
         case PAL_TYPE_PIPESRV:
         case PAL_TYPE_PIPECLI:
@@ -57,7 +53,12 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
             /* console (stdin/stdout/stderr) has no fields to serialize */
             break;
         case PAL_TYPE_DEV:
-            /* devices have no fields to serialize */
+            field = handle->dev.realpath;
+            field_size = strlen(handle->dev.realpath) + 1;
+            break;
+        case PAL_TYPE_FILE:
+            field = handle->file.realpath;
+            field_size = strlen(handle->file.realpath) + 1;
             break;
         case PAL_TYPE_DIR:
             field = handle->dir.realpath;
@@ -101,43 +102,36 @@ int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size) {
     memcpy(hdl, data, hdl_size);
 
     /* update handle fields to point to correct contents */
+    assert(hdl_size <= size);
     switch (hdl->hdr.type) {
-        case PAL_TYPE_FILE: {
-            assert(hdl_size < size);
-
-            size_t path_size = size - hdl_size;
-            char* path = malloc(path_size);
-            if (!path) {
-                free(hdl);
-                return -PAL_ERROR_NOMEM;
-            }
-
-            memcpy(path, (const char*)data + hdl_size, path_size);
-
-            hdl->file.realpath = path;
-            break;
-        }
         case PAL_TYPE_PIPE:
         case PAL_TYPE_PIPESRV:
         case PAL_TYPE_PIPECLI:
             break;
         case PAL_TYPE_CONSOLE:
             break;
-        case PAL_TYPE_DEV:
-            break;
-        case PAL_TYPE_DIR: {
-            assert(hdl_size < size);
-
-            size_t path_size = size - hdl_size;
-            char* path = malloc(path_size);
-            if (!path) {
+        case PAL_TYPE_DEV: {
+            hdl->dev.realpath = alloc_and_copy((const char*)data + hdl_size, size - hdl_size);
+            if (!hdl->dev.realpath) {
                 free(hdl);
                 return -PAL_ERROR_NOMEM;
             }
-
-            memcpy(path, (const char*)data + hdl_size, path_size);
-
-            hdl->dir.realpath = path;
+            break;
+        }
+        case PAL_TYPE_FILE: {
+            hdl->file.realpath = alloc_and_copy((const char*)data + hdl_size, size - hdl_size);
+            if (!hdl->file.realpath) {
+                free(hdl);
+                return -PAL_ERROR_NOMEM;
+            }
+            break;
+        }
+        case PAL_TYPE_DIR: {
+            hdl->dir.realpath = alloc_and_copy((const char*)data + hdl_size, size - hdl_size);
+            if (!hdl->dir.realpath) {
+                free(hdl);
+                return -PAL_ERROR_NOMEM;
+            }
             hdl->dir.buf = hdl->dir.ptr = hdl->dir.end = NULL;
             break;
         }

--- a/pal/src/host/skeleton/pal_devices.c
+++ b/pal/src/host/skeleton/pal_devices.c
@@ -28,6 +28,14 @@ static void dev_destroy(PAL_HANDLE handle) {
     /* noop */
 }
 
+static int dev_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
 static int dev_flush(PAL_HANDLE handle) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -45,6 +53,8 @@ struct handle_ops g_dev_ops = {
     .read           = &dev_read,
     .write          = &dev_write,
     .destroy        = &dev_destroy,
+    .delete         = &dev_delete,
+    .setlength      = &dev_setlength,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, device files (like `dev:/dev/zero`) where enabled in Gramine via the FS-mounts syntax in manifest:

    fs.mounts = [ {path = "/dev/zero", uri = "dev:/dev/zero"} ]

However, devices are pass-through; Gramine doesn't add any protections to the app-to-device communication. Therefore, a careless usage of `write(device_fd)` may lead to data leaks and `read(device_fd)` may lead to injection attacks.

To make it more pronounced that Gramine doesn't provide any security guarantees to the device communication, this commit forces to specify devices as `sgx.allowed_files`. This is similar to how Gramine forces to specify device IOCTLs as `sys.allowed_ioctls`. **This is a breaking change!**

At the PAL level, this requires normalizing the device pathname and finding it in the list of allowed files. The device pathname must also be checkpointed and restored in the child processes. Finally, this commit also introduces previously-missing device operations like `unlink` (delete) and `ftruncate` (setlegth).

This was extracted from #827. I based the code in this PR on the code written by @llly, so he is a co-author here.

## How to test this PR? <!-- (if applicable) -->

LibOS tests were modified.

One can manually test different failures in Gramine, using the `device_passthrough` LibOS regression test. Here's the diff for manual tests:
```diff
diff --git a/libos/test/regression/device_passthrough.manifest.template b/libos/test/regression/device_passthrough.manifest.template
@@ -1,5 +1,6 @@
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
+loader.log_level = "warning"

 loader.env.LD_LIBRARY_PATH = "/lib"

@@ -17,3 +18,6 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
+sgx.allowed_files = [ "dev:/dev/zero" ]
+# sgx.file_check_policy = "allow_all_but_log"
```

- Log level set to `warning` just to see the failure messages in Gramine.
- Comment out `sgx.allowed_files` to see how Gramine refuses to open the device (+ a warning).
- Uncomment `sgx.file_check_policy` to see how Gramine allows to open the device but prints a warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1577)
<!-- Reviewable:end -->
