### PR TITLE
[python] Fix encoding of the passphrase

### DIFF
--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -592,7 +592,7 @@ def get_tbssigstruct(manifest_path, date, libpal=SGX_LIBPAL, verbose=False):
     help='optional passphrase to decrypt the key')
 def sign_with_file(ctx, key, passphrase):
     try:
-        private_key = load_private_key_from_pem_file(key, passphrase)
+        private_key = load_private_key_from_pem_file(key, passphrase and passphrase.encode())
     except InvalidKeyError as e:
         ctx.fail(str(e))
 
@@ -674,7 +674,7 @@ def sign_with_private_key_from_pem_file(data, file, passphrase=None):
     Args:
         data (bytes): Data to calculate the signature over.
         file (file-like): File-like object, from which one can read RSA private key.
-        passphrase (str or None): Optional passphrase.
+        passphrase (bytes or None): Optional passphrase.
 
     Returns:
         (int, int, int): Tuple of exponent, modulus and signature respectively.
@@ -700,7 +700,7 @@ def sign_with_private_key_from_pem_path(data, path, passphrase=None):
     Args:
         data (bytes): Data to calculate the signature over.
         path (path-like): Path to a file with RSA private key.
-        passphrase (str or None): Optional passphrase.
+        passphrase (bytes or None): Optional passphrase.
 
     Returns:
         (int, int, int): Tuple of exponent, modulus and signature respectively.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
see commit message

## How to test this PR?

Get an encrypted PEM RSA-3072 key, then attempt to sign an enclave with:
```sh
gramine-sgx-sign --passphrase ...
```

Before this PR, there is probably this error:
```
  File "/usr/lib/python3/dist-packages/cryptography/utils.py", line 36, in _check_byteslike
    memoryview(value)
TypeError: memoryview: a bytes-like object is required, not 'str'

TypeError: password must be bytes-like
```

After this PR, signing should complete without error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1581)
<!-- Reviewable:end -->
