### PR TITLE
[CI-Examples] Update version of Memcached

### DIFF
--- a/CI-Examples/memcached/Makefile
+++ b/CI-Examples/memcached/Makefile
@@ -1,12 +1,12 @@
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 SRCDIR = src
-MEMCACHED_SRC ?= memcached-1.5.21.tar.gz
+MEMCACHED_SRC ?= memcached-1.6.21.tar.gz
 MEMCACHED_MIRRORS ?= \
     https://memcached.org/files \
     https://packages.gramineproject.io/distfiles
 
-MEMCACHED_SHA256 ?= e3d10c06db755b220f43d26d3b68d15ebf737a69c7663529b504ab047efe92f4
+MEMCACHED_SHA256 ?= c788980efc417dd5d93c442b1c8b8769fb2018896c29de3887d22a2f143da2ee
 
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug

--- a/CI-Examples/memcached/README.md
+++ b/CI-Examples/memcached/README.md
@@ -1,7 +1,7 @@
 # Memcached
 
 This directory contains the Makefile and the template manifest for the most
-recent version of Memcached as of this writing (v1.5.21).
+recent version of Memcached as of this writing (v1.6.21).
 
 # Prerequisites
 

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -15,6 +15,10 @@ loader.env.LD_LIBRARY_PATH = "/lib:/usr/{{ arch_libdir }}"
 loader.uid = 1000
 loader.gid = 1000
 
+# Memcached requires `eventfd` for worker thread notifications, starting from v1.6.11. If you have a
+# Memcached version older than that, we recommend to remove this insecure manifest option.
+sys.insecure__allow_eventfd = true
+
 sys.enable_sigterm_injection = true
 
 fs.mounts = [


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previous version of Memcached (v1.5.21) failed on Ubuntu 22.04 and GCC 11.4.0 with a build error:

    ‘sigignore’ is deprecated: Use the signal function instead

This was fixed in v1.6.7. So let's update Memcached to the latest available version (v1.6.21 as of Oct 2023). This latest version uses eventfd, so we also update the manifest template.

### Details

The exact error:
```
gcc -DHAVE_CONFIG_H -I.  -DNDEBUG   -g -O2 -pthread -pthread -Wall -Werror -pedantic \
    -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls \
    -MT memcached-memcached.o -MD -MP -MF .deps/memcached-memcached.Tpo -c -o memcached-memcached.o
memcached.c: In function ‘main’:
memcached.c:9531:9: error: ‘sigignore’ is deprecated: Use the signal function instead [-Werror=deprecated-declarations]
```

The exact GCC version:
```
$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
```

The GitHub thread where this bug is described: https://github.com/memcached/memcached/issues/707

The Release Notes where this bug was fixed: https://github.com/memcached/memcached/wiki/ReleaseNotes167#fixes

The Release Notes where `eventfd` was added: https://github.com/memcached/memcached/wiki/ReleaseNotes1611#fixes

## How to test this PR? <!-- (if applicable) -->

This was found while testing Memcached on an Ubuntu 22.04 machine with GCC 11.4.0. So try that out manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1582)
<!-- Reviewable:end -->
