### PR TITLE
[LibOS] Defer put_handle on thread exit for handles with async events

### DIFF
--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -224,7 +224,7 @@ struct libos_handle {
 /* allocating / manage handle */
 struct libos_handle* get_new_handle(void);
 void get_handle(struct libos_handle* hdl);
-void put_handle(struct libos_handle* hdl);
+refcount_t put_handle(struct libos_handle* hdl);
 
 /* Set handle to non-blocking or blocking mode. */
 int set_handle_nonblocking(struct libos_handle* hdl, bool on);

--- a/libos/include/libos_utils.h
+++ b/libos/include/libos_utils.h
@@ -55,6 +55,7 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
 int init_async_worker(void);
 int64_t install_async_event(PAL_HANDLE object, unsigned long time,
                             void (*callback)(IDTYPE caller, void* arg), void* arg);
+int maybe_uninstall_async_event(struct libos_handle* hdl);
 struct libos_thread* terminate_async_worker(void);
 
 extern const toml_table_t* g_manifest_root;

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -505,7 +505,7 @@ static int clear_flock_locks(struct libos_handle* hdl) {
     return 0;
 }
 
-void put_handle(struct libos_handle* hdl) {
+refcount_t put_handle(struct libos_handle* hdl) {
     refcount_t ref_count = refcount_dec(&hdl->ref_count);
 
     if (!ref_count) {
@@ -536,6 +536,7 @@ void put_handle(struct libos_handle* hdl) {
 
         destroy_handle(hdl);
     }
+    return ref_count;
 }
 
 int get_file_size(struct libos_handle* hdl, uint64_t* size) {

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -706,7 +706,8 @@ static int walk_handle_map_writable(int (*callback)(struct libos_fd_handle*,
 
 static int detach_fd(struct libos_fd_handle* fd_hdl, struct libos_handle_map* map) {
     struct libos_handle* hdl = __detach_fd_handle(fd_hdl, NULL, map);
-    put_handle(hdl);
+    if (!maybe_uninstall_async_event(hdl))
+        put_handle(hdl);
     return 0;
 }
 

--- a/libos/src/libos_async.c
+++ b/libos/src/libos_async.c
@@ -156,9 +156,13 @@ static void clean_async_list(void) {
     struct async_event* tmp, *n;
     LISTP_FOR_EACH_ENTRY_SAFE(tmp, n, &async_list, list) {
         if (tmp->hdl_to_put) {
-            put_handle(tmp->hdl_to_put);
-            LISTP_DEL(tmp, &async_list, list);
-            free(tmp);
+            if (put_handle(tmp->hdl_to_put) == 0) {
+                /* no more users */
+                LISTP_DEL(tmp, &async_list, list);
+                free(tmp);
+            } else {
+                tmp->hdl_to_put = 0;
+            }
         }
     }
 }

--- a/libos/test/regression/async_task_shutdown.c
+++ b/libos/test/regression/async_task_shutdown.c
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 IBM Corporation
+ *                    Stefan Berger <stefanb@linux.ibm.com>
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+
+int main(void) {
+    int pipefd[2];
+    int pid;
+    int n;
+
+    /* A derivative of a syzbot test case that starts the async thread with the
+     * ioctl(fd, FIOASYNC). During thread_exit() the file descriptors were
+     * detached, which included the freeing of a PAL_HANDLE that the async
+     * thread was still using even after it had been freed triggering an assert.
+     */
+
+    pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "fork() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (pid > 0) {
+        /* parent */
+        int status = 0;
+        while (waitpid(-1, &status, __WALL) != pid) {
+        }
+        return WEXITSTATUS(status);
+    } else {
+        n = pipe(pipefd);
+        if (n < 0) {
+            fprintf(stderr, "pipe() failed: %s\n", strerror(errno));
+            return 1;
+        }
+        n = ioctl(pipefd[1], FIOASYNC, 0);
+        if (n < 0) {
+            fprintf(stderr, "fctnl() failed: %s\n", strerror(errno));
+           return 1;
+        }
+        return 0;
+    }
+}

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -3,6 +3,7 @@ fs = import('fs')
 tests = {
     'abort': {},
     'abort_multithread': {},
+    'async_task_shutdown': {},
     'bootstrap': {},
     'bootstrap_pie': {
         'pie': true,

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -992,6 +992,11 @@ class TC_30_Syscall(RegressionTestCase):
                 os.remove('tmp/flock_file2')
         self.assertIn('TEST OK', stdout)
 
+    def test_150_async_task_shutdown(self):
+        for i in range(0, 200):
+            _, stderr = self.run_binary(['async_task_shutdown'])
+            self.assertNotIn('assert failed', stderr)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -3,6 +3,7 @@ binary_dir = "@GRAMINE_PKGLIBDIR@/tests/libos/regression"
 manifests = [
   "argv_from_file",
   "argv_from_manifest",
+  "async_task_shutdown",
   "abort",
   "abort_multithread",
   "bootstrap",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -5,6 +5,7 @@ libc = "musl"
 manifests = [
   "argv_from_file",
   "argv_from_manifest",
+  "async_task_shutdown",
   "abort",
   "abort_multithread",
   "bootstrap",


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR fixes issue #1525 where a PAL_HANDLE was freed even though this PAL_HANDLE had an async event associated with it. Now all PAL_HANDLEs in the thread_exit -> detach_all_fds -> detach_fd path are checked for whether they have an async event associated and if so they are queued for the async worker thread to perform the put_handle on, otherwise the put_handle is called immediately.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

A LibOS regression test case is provided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1585)
<!-- Reviewable:end -->
