### PR TITLE
[LibOS] Allow any context restore and handle SI_KERNEL

### DIFF
--- a/libos/src/arch/x86_64/libos_context.c
+++ b/libos/src/arch/x86_64/libos_context.c
@@ -110,7 +110,6 @@ void libos_xstate_save(void* xstate_extended) {
 #endif
 
 __attribute__((used)) static int is_xstate_extended(const struct libos_xstate* xstate) {
-    assert(IS_ALIGNED_PTR(xstate, LIBOS_XSTATE_ALIGN));
 
     if (!g_libos_xsave_enabled) {
         return 0;

--- a/libos/test/regression/fail_with_rt_sigreturn.c
+++ b/libos/test/regression/fail_with_rt_sigreturn.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 IBM Corporation
+ *                    Stefan Berger <stefanb@linux.ibm.com>
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+
+int main(void) {
+    int pid;
+
+    /* A derivative of a syzbot test case that causes a failure in a child
+     * process calling rt_sigreturn.
+     */
+
+    pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "fork() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (pid > 0) {
+        /* parent */
+        int status = 0;
+        while (waitpid(-1, &status, __WALL) != pid) {
+        }
+        if (status == 139) {
+            printf("TEST OK\n");
+        } else {
+            printf("Got status %d but expected 130\n", status);
+        }
+        return WEXITSTATUS(status);
+    } else {
+        syscall(__NR_rt_sigreturn, NULL);
+    }
+}

--- a/libos/test/regression/fail_with_rt_sigreturn.c
+++ b/libos/test/regression/fail_with_rt_sigreturn.c
@@ -26,13 +26,15 @@ int main(void) {
         int status = 0;
         while (waitpid(-1, &status, __WALL) != pid) {
         }
-        if (status == 139) {
+        int exp_status = SI_KERNEL + SIGSEGV; /* 139 */
+        if (status == exp_status) {
             printf("TEST OK\n");
         } else {
-            printf("Got status %d but expected 130\n", status);
+            printf("Got status %d but expected %d\n", status, exp_status);
         }
         return WEXITSTATUS(status);
     } else {
-        syscall(__NR_rt_sigreturn, NULL);
+        syscall(__NR_rt_sigreturn);
+        /* unreachable */
     }
 }

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -29,6 +29,7 @@ tests = {
     'exec_victim': {},
     'exit': {},
     'exit_group': {},
+    'fail_with_rt_sigreturn': {},
     'fcntl_lock': {},
     'fcntl_lock_child_only': {},
     'fdleak': {},

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -992,6 +992,10 @@ class TC_30_Syscall(RegressionTestCase):
                 os.remove('tmp/flock_file2')
         self.assertIn('TEST OK', stdout)
 
+    def test_150_fail_with_rtsigreturn(self):
+        stdout, _ = self.run_binary(['fail_with_rt_sigreturn'])
+        self.assertIn('TEST OK', stdout)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -30,6 +30,7 @@ manifests = [
   "exec_victim",
   "exit",
   "exit_group",
+  "fail_with_rt_sigreturn",
   "fcntl_lock",
   "fcntl_lock_child_only",
   "fdleak",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -32,6 +32,7 @@ manifests = [
   "exec_victim",
   "exit",
   "exit_group",
+  "fail_with_rt_sigreturn",
   "fcntl_lock",
   "fcntl_lock_child_only",
   "fdleak",


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

Fix issue in #1515.

The question with the changes is whether it is more helpful for us to have these asserts in there or to get the correct result. 

It now shows this in debug mode:

```
(libos_signal.c:317:internal_fault) [P2:T2:fail_with_rt_sigreturn] debug: process in kernel: Internal memory fault at 0x00000000 (libsysdb.so+0x9632a (addr = 0x7ffffff4932a), VMID = 2, TID = 2)
(libos_signal.c:58:sighandler_kill) [P2:T2:fail_with_rt_sigreturn] debug: killed by signal 11
```

Here we try to restore some context from address 0x0 and this fails as expected... We should let it restore any context and fail on bad pointers.

With this patch we now also get the correct result in `status` from `wait(...,&status,...);`. It is now `status=139` and without this patch it would be `status = 30`.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Use the provided test case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1589)
<!-- Reviewable:end -->
