### PR TITLE
[LibOS] Implement a checkpoint rwlock to protect access to 'resources'

### DIFF
--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -262,3 +262,13 @@ int init_stack(const char* const* argv, const char* const* envp, char*** out_arg
  * The implementation of this function depends on the used architecture.
  */
 noreturn void call_elf_entry(elf_addr_t entry, void* argp);
+
+/*!
+ * \brief Callback function invoked by PAL
+ */
+void libos_pal_callback(enum pal_callback_type pct);
+
+/*!
+ * \brief Get the PAL callback function depending on currently active thread
+ */
+pal_callback_t get_pct(void);

--- a/libos/include/libos_lock.h
+++ b/libos/include/libos_lock.h
@@ -35,7 +35,7 @@ static inline void destroy_lock(struct libos_lock* l) {
 static inline void lock(struct libos_lock* l) {
     assert(l->lock);
 
-    while (PalEventWait(l->lock, /*timeout=*/NULL, NULL) < 0)
+    while (PalEventWait(l->lock, /*timeout=*/NULL, get_pct()) < 0)
         /* nop */;
 
     l->owner = get_cur_tid();

--- a/libos/include/libos_lock.h
+++ b/libos/include/libos_lock.h
@@ -35,7 +35,7 @@ static inline void destroy_lock(struct libos_lock* l) {
 static inline void lock(struct libos_lock* l) {
     assert(l->lock);
 
-    while (PalEventWait(l->lock, /*timeout=*/NULL) < 0)
+    while (PalEventWait(l->lock, /*timeout=*/NULL, NULL) < 0)
         /* nop */;
 
     l->owner = get_cur_tid();

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -136,6 +136,10 @@ struct libos_thread {
 
     refcount_t ref_count;
     struct libos_lock lock;
+
+    unsigned int state;
+#define THR_STATE_IN_SYSCALL   (1 << 0)
+#define THR_STATE_MIGRATING    (1 << 1)
 };
 
 struct libos_thread_queue {

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -230,7 +230,7 @@ static inline int thread_wait(uint64_t* timeout_us, bool ignore_pending_signals)
         return -EINTR;
     }
 
-    int ret = PalEventWait(cur_thread->scheduler_event, timeout_us);
+    int ret = PalEventWait(cur_thread->scheduler_event, timeout_us, NULL);
     return ret == -PAL_ERROR_TRYAGAIN ? -ETIMEDOUT : pal_to_unix_errno(ret);
 }
 

--- a/libos/include/libos_thread.h
+++ b/libos/include/libos_thread.h
@@ -234,7 +234,7 @@ static inline int thread_wait(uint64_t* timeout_us, bool ignore_pending_signals)
         return -EINTR;
     }
 
-    int ret = PalEventWait(cur_thread->scheduler_event, timeout_us, NULL);
+    int ret = PalEventWait(cur_thread->scheduler_event, timeout_us, get_pct());
     return ret == -PAL_ERROR_TRYAGAIN ? -ETIMEDOUT : pal_to_unix_errno(ret);
 }
 

--- a/libos/src/arch/x86_64/libos_context.c
+++ b/libos/src/arch/x86_64/libos_context.c
@@ -10,6 +10,7 @@
 #include <stdalign.h>
 #include <stdnoreturn.h>
 
+#include "libos_checkpoint.h"
 #include "libos_context.h"
 #include "libos_entry.h"
 #include "libos_internal.h"

--- a/libos/src/bookkeep/libos_signal.c
+++ b/libos/src/bookkeep/libos_signal.c
@@ -725,6 +725,9 @@ bool handle_signal(PAL_CONTEXT* context) {
            || pal_context_get_ip(context) == (uint64_t)&libos_syscall_entry);
 
     if (__atomic_load_n(&current->time_to_die, __ATOMIC_ACQUIRE)) {
+        if (get_pct()) {
+            CHECKPOINT_RUNLOCK;
+        }
         thread_exit(/*error_code=*/0, /*term_signal=*/0);
     }
 

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -273,7 +273,7 @@ static int chroot_mkdir(struct libos_dentry* dent, mode_t perm) {
 static int chroot_flush(struct libos_handle* hdl) {
     assert(hdl->type == TYPE_CHROOT);
 
-    int ret = PalStreamFlush(hdl->pal_handle, NULL);
+    int ret = PalStreamFlush(hdl->pal_handle, get_pct());
     return pal_to_unix_errno(ret);
 }
 
@@ -281,7 +281,7 @@ static ssize_t chroot_read(struct libos_handle* hdl, void* buf, size_t count, fi
     assert(hdl->type == TYPE_CHROOT);
 
     size_t actual_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, *pos, &actual_count, buf, NULL);
+    int ret = PalStreamRead(hdl->pal_handle, *pos, &actual_count, buf, get_pct());
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -297,7 +297,7 @@ static ssize_t chroot_write(struct libos_handle* hdl, const void* buf, size_t co
     assert(hdl->type == TYPE_CHROOT);
 
     size_t actual_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, *pos, &actual_count, (void*)buf, NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, *pos, &actual_count, (void*)buf, get_pct());
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -348,7 +348,7 @@ int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void*
 
     while (true) {
         size_t read_size = buf_size;
-        ret = PalStreamRead(palhdl, /*offset=*/0, &read_size, buf, NULL);
+        ret = PalStreamRead(palhdl, /*offset=*/0, &read_size, buf, get_pct());
         if (ret < 0) {
             ret = pal_to_unix_errno(ret);
             goto out;

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -273,7 +273,7 @@ static int chroot_mkdir(struct libos_dentry* dent, mode_t perm) {
 static int chroot_flush(struct libos_handle* hdl) {
     assert(hdl->type == TYPE_CHROOT);
 
-    int ret = PalStreamFlush(hdl->pal_handle);
+    int ret = PalStreamFlush(hdl->pal_handle, NULL);
     return pal_to_unix_errno(ret);
 }
 
@@ -281,7 +281,7 @@ static ssize_t chroot_read(struct libos_handle* hdl, void* buf, size_t count, fi
     assert(hdl->type == TYPE_CHROOT);
 
     size_t actual_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, *pos, &actual_count, buf);
+    int ret = PalStreamRead(hdl->pal_handle, *pos, &actual_count, buf, NULL);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -297,7 +297,7 @@ static ssize_t chroot_write(struct libos_handle* hdl, const void* buf, size_t co
     assert(hdl->type == TYPE_CHROOT);
 
     size_t actual_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, *pos, &actual_count, (void*)buf);
+    int ret = PalStreamWrite(hdl->pal_handle, *pos, &actual_count, (void*)buf, NULL);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -348,7 +348,7 @@ int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void*
 
     while (true) {
         size_t read_size = buf_size;
-        ret = PalStreamRead(palhdl, /*offset=*/0, &read_size, buf);
+        ret = PalStreamRead(palhdl, /*offset=*/0, &read_size, buf, NULL);
         if (ret < 0) {
             ret = pal_to_unix_errno(ret);
             goto out;

--- a/libos/src/fs/dev/fs.c
+++ b/libos/src/fs/dev/fs.c
@@ -79,7 +79,7 @@ static int dev_tty_open(struct libos_handle* hdl, struct libos_dentry* dent, int
 
 static ssize_t dev_tty_read(struct libos_handle* hdl, void* buf, size_t count) {
     size_t actual_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, /*offset=*/0, &actual_count, buf);
+    int ret = PalStreamRead(hdl->pal_handle, /*offset=*/0, &actual_count, buf, NULL);
     if (ret < 0)
         return pal_to_unix_errno(ret);
 
@@ -89,7 +89,7 @@ static ssize_t dev_tty_read(struct libos_handle* hdl, void* buf, size_t count) {
 
 static ssize_t dev_tty_write(struct libos_handle* hdl, const void* buf, size_t count) {
     size_t actual_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, /*offset=*/0, &actual_count, (void*)buf);
+    int ret = PalStreamWrite(hdl->pal_handle, /*offset=*/0, &actual_count, (void*)buf, NULL);
     if (ret < 0)
         return pal_to_unix_errno(ret);
 
@@ -98,7 +98,7 @@ static ssize_t dev_tty_write(struct libos_handle* hdl, const void* buf, size_t c
 }
 
 static int dev_tty_flush(struct libos_handle* hdl) {
-    int ret = PalStreamFlush(hdl->pal_handle);
+    int ret = PalStreamFlush(hdl->pal_handle, NULL);
     return pal_to_unix_errno(ret);
 }
 

--- a/libos/src/fs/dev/fs.c
+++ b/libos/src/fs/dev/fs.c
@@ -79,7 +79,7 @@ static int dev_tty_open(struct libos_handle* hdl, struct libos_dentry* dent, int
 
 static ssize_t dev_tty_read(struct libos_handle* hdl, void* buf, size_t count) {
     size_t actual_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, /*offset=*/0, &actual_count, buf, NULL);
+    int ret = PalStreamRead(hdl->pal_handle, /*offset=*/0, &actual_count, buf, get_pct());
     if (ret < 0)
         return pal_to_unix_errno(ret);
 
@@ -89,7 +89,7 @@ static ssize_t dev_tty_read(struct libos_handle* hdl, void* buf, size_t count) {
 
 static ssize_t dev_tty_write(struct libos_handle* hdl, const void* buf, size_t count) {
     size_t actual_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, /*offset=*/0, &actual_count, (void*)buf, NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, /*offset=*/0, &actual_count, (void*)buf, get_pct());
     if (ret < 0)
         return pal_to_unix_errno(ret);
 
@@ -98,7 +98,7 @@ static ssize_t dev_tty_write(struct libos_handle* hdl, const void* buf, size_t c
 }
 
 static int dev_tty_flush(struct libos_handle* hdl) {
-    int ret = PalStreamFlush(hdl->pal_handle, NULL);
+    int ret = PalStreamFlush(hdl->pal_handle, get_pct());
     return pal_to_unix_errno(ret);
 }
 

--- a/libos/src/fs/eventfd/fs.c
+++ b/libos/src/fs/eventfd/fs.c
@@ -19,7 +19,7 @@ static ssize_t eventfd_read(struct libos_handle* hdl, void* buf, size_t count, f
         return -EINVAL;
 
     size_t orig_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, NULL);
+    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, get_pct());
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/true, ret == 0 ? count < orig_count : false);
     if (ret < 0) {
@@ -37,7 +37,7 @@ static ssize_t eventfd_write(struct libos_handle* hdl, const void* buf, size_t c
         return -EINVAL;
 
     size_t orig_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, get_pct());
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/false, ret == 0 ? count < orig_count : false);
     if (ret < 0) {

--- a/libos/src/fs/eventfd/fs.c
+++ b/libos/src/fs/eventfd/fs.c
@@ -19,7 +19,7 @@ static ssize_t eventfd_read(struct libos_handle* hdl, void* buf, size_t count, f
         return -EINVAL;
 
     size_t orig_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf);
+    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, NULL);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/true, ret == 0 ? count < orig_count : false);
     if (ret < 0) {
@@ -37,7 +37,7 @@ static ssize_t eventfd_write(struct libos_handle* hdl, const void* buf, size_t c
         return -EINVAL;
 
     size_t orig_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf);
+    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, NULL);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/false, ret == 0 ? count < orig_count : false);
     if (ret < 0) {

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -28,7 +28,8 @@ static pf_status_t cb_read(pf_handle_t handle, void* buffer, uint64_t offset, si
 
     while (remaining > 0) {
         size_t count = remaining;
-        int ret = PalStreamRead(pal_handle, offset + buffer_offset, &count, buffer + buffer_offset);
+        int ret = PalStreamRead(pal_handle, offset + buffer_offset, &count, buffer + buffer_offset,
+                                NULL);
         if (ret == -PAL_ERROR_INTERRUPTED)
             continue;
 
@@ -58,7 +59,7 @@ static pf_status_t cb_write(pf_handle_t handle, const void* buffer, uint64_t off
     while (remaining > 0) {
         size_t count = remaining;
         int ret = PalStreamWrite(pal_handle, offset + buffer_offset, &count,
-                                 (void*)(buffer + buffer_offset));
+                                 (void*)(buffer + buffer_offset), NULL);
         if (ret == -PAL_ERROR_INTERRUPTED)
             continue;
 

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -29,7 +29,7 @@ static pf_status_t cb_read(pf_handle_t handle, void* buffer, uint64_t offset, si
     while (remaining > 0) {
         size_t count = remaining;
         int ret = PalStreamRead(pal_handle, offset + buffer_offset, &count, buffer + buffer_offset,
-                                NULL);
+                                get_pct());
         if (ret == -PAL_ERROR_INTERRUPTED)
             continue;
 
@@ -59,7 +59,7 @@ static pf_status_t cb_write(pf_handle_t handle, const void* buffer, uint64_t off
     while (remaining > 0) {
         size_t count = remaining;
         int ret = PalStreamWrite(pal_handle, offset + buffer_offset, &count,
-                                 (void*)(buffer + buffer_offset), NULL);
+                                 (void*)(buffer + buffer_offset), get_pct());
         if (ret == -PAL_ERROR_INTERRUPTED)
             continue;
 

--- a/libos/src/fs/pipe/fs.c
+++ b/libos/src/fs/pipe/fs.c
@@ -91,7 +91,7 @@ static ssize_t pipe_read(struct libos_handle* hdl, void* buf, size_t count, file
         return -EACCES;
 
     size_t orig_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf);
+    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, NULL);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/true, ret == 0 ? count < orig_count : false);
     if (ret < 0) {
@@ -110,7 +110,7 @@ static ssize_t pipe_write(struct libos_handle* hdl, const void* buf, size_t coun
         return -EACCES;
 
     size_t orig_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf);
+    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, NULL);
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/false, ret == 0 ? count < orig_count : false);
     if (ret < 0) {

--- a/libos/src/fs/pipe/fs.c
+++ b/libos/src/fs/pipe/fs.c
@@ -91,7 +91,7 @@ static ssize_t pipe_read(struct libos_handle* hdl, void* buf, size_t count, file
         return -EACCES;
 
     size_t orig_count = count;
-    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, NULL);
+    int ret = PalStreamRead(hdl->pal_handle, 0, &count, buf, get_pct());
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/true, ret == 0 ? count < orig_count : false);
     if (ret < 0) {
@@ -110,7 +110,7 @@ static ssize_t pipe_write(struct libos_handle* hdl, const void* buf, size_t coun
         return -EACCES;
 
     size_t orig_count = count;
-    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, NULL);
+    int ret = PalStreamWrite(hdl->pal_handle, 0, &count, (void*)buf, get_pct());
     ret = pal_to_unix_errno(ret);
     maybe_epoll_et_trigger(hdl, ret, /*in=*/false, ret == 0 ? count < orig_count : false);
     if (ret < 0) {

--- a/libos/src/ipc/libos_ipc.c
+++ b/libos/src/ipc/libos_ipc.c
@@ -258,7 +258,7 @@ static int wait_for_response(struct ipc_msg_waiter* waiter) {
 
     int ret = 0;
     do {
-        ret = PalEventWait(waiter->event, /*timeout=*/NULL);
+        ret = PalEventWait(waiter->event, /*timeout=*/NULL, NULL);
     } while (ret == -PAL_ERROR_INTERRUPTED);
 
     log_debug("Waiting finished: %s", pal_strerror(ret));

--- a/libos/src/ipc/libos_ipc_worker.c
+++ b/libos/src/ipc/libos_ipc_worker.c
@@ -136,7 +136,7 @@ static int receive_ipc_messages(struct libos_ipc_connection* conn) {
         /* Receive at least the message header. */
         while (size < sizeof(buf.msg_header)) {
             size_t tmp_size = sizeof(buf) - size;
-            int ret = PalStreamRead(conn->handle, /*offset=*/0, &tmp_size, buf.buf + size);
+            int ret = PalStreamRead(conn->handle, /*offset=*/0, &tmp_size, buf.buf + size, NULL);
             if (ret < 0) {
                 if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                     continue;
@@ -309,7 +309,7 @@ static noreturn void ipc_worker_main(void) {
             do {
                 /* Although IPC worker thread does not handle any signals (hence it should never be
                  * interrupted), lets handle it for uniformity with the rest of the code. */
-                ret = PalStreamWaitForClient(g_self_ipc_handle, &new_handle, /*options=*/0);
+                ret = PalStreamWaitForClient(g_self_ipc_handle, &new_handle, /*options=*/0, NULL);
             } while (ret == -PAL_ERROR_INTERRUPTED);
             if (ret < 0) {
                 log_error(LOG_PREFIX "PalStreamWaitForClient failed: %s", pal_strerror(ret));

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -371,6 +371,8 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     g_pal_public_state = PalGetPalPublicState();
     assert(g_pal_public_state);
 
+    rwlock_create(&checkpoint_lock);
+
     g_log_level = g_pal_public_state->log_level;
 
     /* create the initial TCB, libos can not be run without a tcb */
@@ -507,6 +509,7 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     libos_tcb_t* cur_tcb = libos_get_tcb();
 
     if (cur_tcb->context.regs) {
+        CHECKPOINT_RLOCK; /* matches return_from_syscall */
         restore_child_context_after_clone(&cur_tcb->context);
         /* UNREACHABLE */
     }

--- a/libos/src/libos_object.c
+++ b/libos/src/libos_object.c
@@ -1,10 +1,11 @@
 #include "libos_internal.h"
+#include "libos_thread.h"
 #include "pal.h"
 
 int event_wait_with_retry(PAL_HANDLE handle) {
     int ret;
     do {
-        ret = PalEventWait(handle, /*timeout=*/NULL, NULL);
+        ret = PalEventWait(handle, /*timeout=*/NULL, get_pct());
     } while (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN);
 
     if (ret < 0) {

--- a/libos/src/libos_object.c
+++ b/libos/src/libos_object.c
@@ -4,7 +4,7 @@
 int event_wait_with_retry(PAL_HANDLE handle) {
     int ret;
     do {
-        ret = PalEventWait(handle, /*timeout=*/NULL);
+        ret = PalEventWait(handle, /*timeout=*/NULL, NULL);
     } while (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN);
 
     if (ret < 0) {

--- a/libos/src/libos_pal.c
+++ b/libos/src/libos_pal.c
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 IBM Corporation */
+
+#include "libos_checkpoint.h"
+#include "libos_internal.h"
+#include "pal.h"
+
+pal_callback_t get_pct(void) {
+    struct libos_thread* thread = get_cur_thread();
+    if (!thread || is_internal(thread))
+        return NULL;
+    if ((thread->state & (THR_STATE_IN_SYSCALL | THR_STATE_MIGRATING)) == THR_STATE_IN_SYSCALL)
+        return libos_pal_callback;
+    return NULL;
+}
+
+void libos_pal_callback(enum pal_callback_type pct) {
+    switch(pct) {
+    case PAL_CALLBACK_BEFORE_SYSCALL:
+        CHECKPOINT_RUNLOCK;
+        break;
+    case PAL_CALLBACK_AFTER_SYSCALL:
+        CHECKPOINT_RLOCK;
+        break;
+    }
+}

--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -33,7 +33,7 @@ int create_pollable_event(struct libos_pollable_event* event) {
 
     PAL_HANDLE read_handle;
     do {
-        ret = PalStreamWaitForClient(srv_handle, &read_handle, PAL_OPTION_NONBLOCK);
+        ret = PalStreamWaitForClient(srv_handle, &read_handle, PAL_OPTION_NONBLOCK, NULL);
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         log_error("PalStreamWaitForClient failed: %s", pal_strerror(ret));
@@ -74,7 +74,7 @@ int set_pollable_event(struct libos_pollable_event* event) {
     do {
         char c = 0;
         size_t size = sizeof(c);
-        ret = PalStreamWrite(event->write_handle, /*offset=*/0, &size, &c);
+        ret = PalStreamWrite(event->write_handle, /*offset=*/0, &size, &c, NULL);
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;
@@ -97,7 +97,7 @@ int clear_pollable_event(struct libos_pollable_event* event) {
     do {
         char buf[0x100];
         size_t size = sizeof(buf);
-        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf);
+        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf, NULL);
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;

--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -33,7 +33,8 @@ int create_pollable_event(struct libos_pollable_event* event) {
 
     PAL_HANDLE read_handle;
     do {
-        ret = PalStreamWaitForClient(srv_handle, &read_handle, PAL_OPTION_NONBLOCK, NULL);
+        ret = PalStreamWaitForClient(srv_handle, &read_handle, PAL_OPTION_NONBLOCK,
+                                     get_pct());
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         log_error("PalStreamWaitForClient failed: %s", pal_strerror(ret));
@@ -74,7 +75,7 @@ int set_pollable_event(struct libos_pollable_event* event) {
     do {
         char c = 0;
         size_t size = sizeof(c);
-        ret = PalStreamWrite(event->write_handle, /*offset=*/0, &size, &c, NULL);
+        ret = PalStreamWrite(event->write_handle, /*offset=*/0, &size, &c, get_pct());
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;
@@ -97,7 +98,7 @@ int clear_pollable_event(struct libos_pollable_event* event) {
     do {
         char buf[0x100];
         size_t size = sizeof(buf);
-        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf, NULL);
+        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf, get_pct());
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;

--- a/libos/src/libos_rwlock.c
+++ b/libos/src/libos_rwlock.c
@@ -36,7 +36,7 @@ void rwlock_destroy(struct libos_rwlock* l) {
 }
 
 void rwlock_read_lock_slow_path(struct libos_rwlock* l) {
-    while (PalEventWait(l->readers_wait, /*timeout=*/NULL) < 0)
+    while (PalEventWait(l->readers_wait, /*timeout=*/NULL, NULL) < 0)
         /* nop */;
     size_t waiting_readers = __atomic_sub_fetch(&l->waiting_readers, 1, __ATOMIC_RELAXED);
     if (waiting_readers == 0) {
@@ -62,7 +62,7 @@ void rwlock_write_lock(struct libos_rwlock* l) {
         int64_t departing = __atomic_add_fetch(&l->departing_readers, state, __ATOMIC_RELAXED);
         if (departing != 0) {
             assert(departing > 0);
-            while (PalEventWait(l->writer_wait, /*timeout=*/NULL) < 0)
+            while (PalEventWait(l->writer_wait, /*timeout=*/NULL, NULL) < 0)
                 /* nop */;
         }
         /* This prevents code hoisting. */
@@ -81,7 +81,7 @@ void rwlock_write_unlock(struct libos_rwlock* l) {
         PalEventSet(l->readers_wait);
 
         /* Wait for all waiting readers to actually wake up... */
-        while (PalEventWait(l->writer_wait, /*timeout=*/NULL) < 0)
+        while (PalEventWait(l->writer_wait, /*timeout=*/NULL, NULL) < 0)
             /* nop */;
 
         /* ...and unset the event. */

--- a/libos/src/libos_rwlock.c
+++ b/libos/src/libos_rwlock.c
@@ -36,7 +36,7 @@ void rwlock_destroy(struct libos_rwlock* l) {
 }
 
 void rwlock_read_lock_slow_path(struct libos_rwlock* l) {
-    while (PalEventWait(l->readers_wait, /*timeout=*/NULL, NULL) < 0)
+    while (PalEventWait(l->readers_wait, /*timeout=*/NULL, libos_pal_callback) < 0)
         /* nop */;
     size_t waiting_readers = __atomic_sub_fetch(&l->waiting_readers, 1, __ATOMIC_RELAXED);
     if (waiting_readers == 0) {
@@ -62,7 +62,7 @@ void rwlock_write_lock(struct libos_rwlock* l) {
         int64_t departing = __atomic_add_fetch(&l->departing_readers, state, __ATOMIC_RELAXED);
         if (departing != 0) {
             assert(departing > 0);
-            while (PalEventWait(l->writer_wait, /*timeout=*/NULL, NULL) < 0)
+            while (PalEventWait(l->writer_wait, /*timeout=*/NULL, libos_pal_callback) < 0)
                 /* nop */;
         }
         /* This prevents code hoisting. */
@@ -81,7 +81,7 @@ void rwlock_write_unlock(struct libos_rwlock* l) {
         PalEventSet(l->readers_wait);
 
         /* Wait for all waiting readers to actually wake up... */
-        while (PalEventWait(l->writer_wait, /*timeout=*/NULL, NULL) < 0)
+        while (PalEventWait(l->writer_wait, /*timeout=*/NULL, libos_pal_callback) < 0)
             /* nop */;
 
         /* ...and unset the event. */

--- a/libos/src/libos_utils.c
+++ b/libos/src/libos_utils.c
@@ -11,7 +11,7 @@ int read_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t read = 0;
     while (read < size) {
         size_t tmp_read = size - read;
-        int ret = PalStreamRead(handle, /*offset=*/0, &tmp_read, (char*)buf + read);
+        int ret = PalStreamRead(handle, /*offset=*/0, &tmp_read, (char*)buf + read, NULL);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 continue;
@@ -29,7 +29,7 @@ int write_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t written = 0;
     while (written < size) {
         size_t tmp_written = size - written;
-        int ret = PalStreamWrite(handle, /*offset=*/0, &tmp_written, (char*)buf + written);
+        int ret = PalStreamWrite(handle, /*offset=*/0, &tmp_written, (char*)buf + written, NULL);
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 continue;

--- a/libos/src/libos_utils.c
+++ b/libos/src/libos_utils.c
@@ -11,7 +11,7 @@ int read_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t read = 0;
     while (read < size) {
         size_t tmp_read = size - read;
-        int ret = PalStreamRead(handle, /*offset=*/0, &tmp_read, (char*)buf + read, NULL);
+        int ret = PalStreamRead(handle, /*offset=*/0, &tmp_read, (char*)buf + read, get_pct());
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 continue;
@@ -29,7 +29,8 @@ int write_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t written = 0;
     while (written < size) {
         size_t tmp_written = size - written;
-        int ret = PalStreamWrite(handle, /*offset=*/0, &tmp_written, (char*)buf + written, NULL);
+        int ret = PalStreamWrite(handle, /*offset=*/0, &tmp_written, (char*)buf + written,
+                                 get_pct());
         if (ret < 0) {
             if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
                 continue;

--- a/libos/src/meson.build
+++ b/libos/src/meson.build
@@ -60,6 +60,7 @@ libos_sources = files(
     'libos_init.c',
     'libos_malloc.c',
     'libos_object.c',
+    'libos_pal.c',
     'libos_parser.c',
     'libos_pollable_event.c',
     'libos_rtld.c',

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -180,7 +180,7 @@ static int accept(struct libos_handle* handle, bool is_nonblocking,
     /* Since this socket is listening, it must have a PAL handle. */
     assert(pal_handle);
     PAL_HANDLE client_pal_handle;
-    int ret = PalStreamWaitForClient(pal_handle, &client_pal_handle, options);
+    int ret = PalStreamWaitForClient(pal_handle, &client_pal_handle, options, NULL);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }
@@ -313,7 +313,8 @@ static int getsockopt(struct libos_handle* handle, int level, int optname, void*
 
 static int maybe_force_nonblocking_wrapper(bool force_nonblocking, struct libos_handle* handle,
                                            PAL_HANDLE pal_handle,
-                                           int (*func)(PAL_HANDLE, uint64_t, size_t*, void*),
+                                           int (*func)(PAL_HANDLE, uint64_t, size_t*, void*,
+                                                       pal_callback_t),
                                            void* buf, size_t* size) {
     /*
      * There are 3 kinds of operations that can race here:
@@ -360,7 +361,7 @@ static int maybe_force_nonblocking_wrapper(bool force_nonblocking, struct libos_
     }
 
 again:
-    ret = func(pal_handle, /*offset=*/0, size, buf);
+    ret = func(pal_handle, /*offset=*/0, size, buf, NULL);
     if (ret < 0) {
         ret = (ret == -PAL_ERROR_TOOLONG) ? -EMSGSIZE : pal_to_unix_errno(ret);
         if (ret == -EAGAIN && !force_nonblocking) {

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -361,7 +361,7 @@ static int maybe_force_nonblocking_wrapper(bool force_nonblocking, struct libos_
     }
 
 again:
-    ret = func(pal_handle, /*offset=*/0, size, buf, NULL);
+    ret = func(pal_handle, /*offset=*/0, size, buf, get_pct());
     if (ret < 0) {
         ret = (ret == -PAL_ERROR_TOOLONG) ? -EMSGSIZE : pal_to_unix_errno(ret);
         if (ret == -EAGAIN && !force_nonblocking) {

--- a/libos/src/sys/libos_clone.c
+++ b/libos/src/sys/libos_clone.c
@@ -43,6 +43,9 @@ static int clone_implementation_wrapper(void* arg_) {
     libos_tcb_init();
     set_cur_thread(my_thread);
 
+    CHECKPOINT_RLOCK; /* matches return_from_syscall */
+    my_thread->state = THR_STATE_IN_SYSCALL;
+
     /* only now we can call LibOS/PAL functions because they require a set-up TCB;
      * do not move the below functions before libos_tcb_init/set_cur_thread()! */
     int ret = event_wait_with_retry(arg->create_event);

--- a/libos/src/sys/libos_eventfd.c
+++ b/libos/src/sys/libos_eventfd.c
@@ -55,7 +55,7 @@ static int create_eventfd(PAL_HANDLE* efd, uint64_t initial_count, int flags) {
 
     /* set the initial count */
     size_t write_size = sizeof(initial_count);
-    ret = PalStreamWrite(hdl, /*offset=*/0, &write_size, &initial_count);
+    ret = PalStreamWrite(hdl, /*offset=*/0, &write_size, &initial_count, NULL);
     if (ret < 0) {
         log_error("eventfd: failed to set initial count");
         return pal_to_unix_errno(ret);

--- a/libos/src/sys/libos_exit.c
+++ b/libos/src/sys/libos_exit.c
@@ -6,6 +6,7 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
+#include "libos_checkpoint.h"
 #include "libos_fs_lock.h"
 #include "libos_handle.h"
 #include "libos_ipc.h"
@@ -16,6 +17,13 @@
 #include "libos_thread.h"
 #include "libos_utils.h"
 #include "pal.h"
+
+static noreturn void libos_exit_on_syscall_emu(bool thread, unsigned long exit_param) {
+    CHECKPOINT_RUNLOCK;
+    if (thread)
+        PalThreadExit((int *)exit_param);
+    PalProcessExit(exit_param);
+}
 
 static noreturn void libos_clean_and_exit(int exit_code) {
     /*
@@ -59,7 +67,8 @@ static noreturn void libos_clean_and_exit(int exit_code) {
 
     /* TODO: We exit whole libos, but there are some objects that might need cleanup - we should do
      * a proper cleanup of everything. */
-    PalProcessExit(exit_code);
+    CHECKPOINT_LOCK_END;
+    libos_exit_on_syscall_emu(false, exit_code);
 }
 
 noreturn void thread_exit(int error_code, int term_signal) {
@@ -98,6 +107,8 @@ noreturn void thread_exit(int error_code, int term_signal) {
              * TODO: "Rewire" the identity of the non-main thread inside Gramine, similarly to how
              *       Linux does it.
              */
+            CHECKPOINT_RUNLOCK;
+            cur_thread->state &= ~THR_STATE_IN_SYSCALL;
             thread_prepare_wait();
             while (true)
                 thread_wait(/*timeout_us=*/NULL, /*ignore_pending_signals=*/true);
@@ -123,11 +134,11 @@ noreturn void thread_exit(int error_code, int term_signal) {
             /* `cleanup_thread` did not get this reference, clean it. We have to be careful, as
              * this is most likely the last reference and will free this `cur_thread`. */
             put_thread(cur_thread);
-            PalThreadExit(NULL);
+            libos_exit_on_syscall_emu(true, (unsigned long)NULL);
             /* UNREACHABLE */
         }
 
-        PalThreadExit(&cur_thread->clear_child_tid_pal);
+        libos_exit_on_syscall_emu(true, (unsigned long)&cur_thread->clear_child_tid_pal);
         /* UNREACHABLE */
     }
 
@@ -160,6 +171,7 @@ static int mark_thread_to_die(struct libos_thread* thread, void* arg) {
     /* Now let's kick `thread`, so that it notices (in `handle_signal`) the flag `time_to_die`
      * set above (but only if we really set that flag). */
     if (need_wakeup) {
+        CHECKPOINT_RLOCK;
         thread_wakeup(thread);
         (void)PalThreadResume(thread->pal_handle); // There is nothing we can do on errors.
     }

--- a/libos/src/sys/libos_pipe.c
+++ b/libos/src/sys/libos_pipe.c
@@ -43,7 +43,7 @@ static int create_pipes(struct libos_handle* srv, struct libos_handle* cli, int 
     }
 
     do {
-        ret = PalStreamWaitForClient(hdl0, &hdl1, /*options=*/0);
+        ret = PalStreamWaitForClient(hdl0, &hdl1, /*options=*/0, NULL);
     } while (ret == -PAL_ERROR_INTERRUPTED);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -368,7 +368,8 @@ int PalStreamOpen(const char* uri, enum pal_access access, pal_share_flags_t sha
  *
  * This API is only available for handles that are opened with `pipe.srv:...`.
  */
-int PalStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_options_t options);
+int PalStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_options_t options,
+                           pal_callback_t pct);
 
 /*!
  * \brief Read data from an open stream.
@@ -385,7 +386,8 @@ int PalStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client, pal_stream_opt
  * If \p handle is a directory, PalStreamRead fills the buffer with the null-terminated names of the
  * directory entries.
  */
-int PalStreamRead(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer);
+int PalStreamRead(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer,
+                  pal_callback_t pct);
 
 /*!
  * \brief Write data to an open stream.
@@ -399,7 +401,8 @@ int PalStreamRead(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffe
  *
  * \returns 0 on success, negative error code on failure.
  */
-int PalStreamWrite(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer);
+int PalStreamWrite(PAL_HANDLE handle, uint64_t offset, size_t* count, void* buffer,
+                   pal_callback_t pct);
 
 enum pal_delete_mode {
     PAL_DELETE_ALL,  /*!< delete the whole resource / shut down both directions */
@@ -442,7 +445,7 @@ int PalStreamSetLength(PAL_HANDLE handle, uint64_t length);
  *
  * \returns 0 on success, negative error code on failure.
  */
-int PalStreamFlush(PAL_HANDLE handle);
+int PalStreamFlush(PAL_HANDLE handle, pal_callback_t pct);
 
 /*!
  * \brief Send a PAL handle to a process.

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -54,6 +54,13 @@ enum pal_socket_type {
     PAL_SOCKET_UDP,
 };
 
+enum pal_callback_type {
+    PAL_CALLBACK_BEFORE_SYSCALL,
+    PAL_CALLBACK_AFTER_SYSCALL,
+};
+
+typedef void (*pal_callback_t)(enum pal_callback_type pct);
+
 #ifdef IN_PAL
 
 typedef struct {
@@ -797,7 +804,7 @@ void PalEventClear(PAL_HANDLE handle);
  *
  * This function has acquire semantics and synchronizes with #PalEventSet.
  */
-int PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us);
+int PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us, pal_callback_t pc);
 
 typedef uint32_t pal_wait_flags_t; /* bitfield */
 #define PAL_WAIT_READ     1

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -45,8 +45,10 @@ struct handle_ops {
 
     /* 'read' and 'write' is used by PalStreamRead and PalStreamWrite, so they have exactly same
      * prototype as them. */
-    int64_t (*read)(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
-    int64_t (*write)(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
+    int64_t (*read)(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer,
+                    pal_callback_t pct);
+    int64_t (*write)(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer,
+                     pal_callback_t pct);
 
     /* 'delete' is used by PalStreamDelete: for files and dirs it corresponds to unlinking, for
      * sockets it corresponds to shutting down a socket connection. */
@@ -74,7 +76,8 @@ struct handle_ops {
     int (*flush)(PAL_HANDLE handle);
 
     /* 'waitforclient' is used by PalStreamWaitforClient. It accepts an connection */
-    int (*waitforclient)(PAL_HANDLE server, PAL_HANDLE* client, pal_stream_options_t options);
+    int (*waitforclient)(PAL_HANDLE server, PAL_HANDLE* client, pal_stream_options_t options,
+                         pal_callback_t pct);
 
     /* 'attrquery' is used by PalStreamAttributesQuery. It queries the attributes of a stream */
     int (*attrquery)(const char* type, const char* uri, PAL_STREAM_ATTR* attr);
@@ -171,14 +174,16 @@ int _PalStreamOpen(PAL_HANDLE* handle, const char* uri, enum pal_access access,
                    pal_share_flags_t share, enum pal_create_mode create,
                    pal_stream_options_t options);
 int _PalStreamDelete(PAL_HANDLE handle, enum pal_delete_mode delete_mode);
-int64_t _PalStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buf);
-int64_t _PalStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buf);
+int64_t _PalStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buf,
+                       pal_callback_t pct);
+int64_t _PalStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buf,
+                        pal_callback_t pct);
 int _PalStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr);
 int _PalStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
 int _PalStreamMap(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,
                   uint64_t size);
 int64_t _PalStreamSetLength(PAL_HANDLE handle, uint64_t length);
-int _PalStreamFlush(PAL_HANDLE handle);
+int _PalStreamFlush(PAL_HANDLE handle, pal_callback_t pct);
 int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo);
 int _PalReceiveHandle(PAL_HANDLE source_process, PAL_HANDLE* out_cargo);
 

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -211,7 +211,7 @@ int _PalThreadGetCpuAffinity(PAL_HANDLE thread, unsigned long* cpu_mask, size_t 
 int _PalEventCreate(PAL_HANDLE* handle_ptr, bool init_signaled, bool auto_clear);
 void _PalEventSet(PAL_HANDLE handle);
 void _PalEventClear(PAL_HANDLE handle);
-int _PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us);
+int _PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us, pal_callback_t pc);
 
 /* PalVirtualMemory calls */
 int _PalVirtualMemoryAlloc(void* addr, uint64_t size, pal_prot_flags_t prot);

--- a/pal/regression/Directory.c
+++ b/pal/regression/Directory.c
@@ -20,7 +20,7 @@ int main(int argc, char** argv, char** envp) {
         }
 
         size_t bytes = sizeof(buffer);
-        ret = PalStreamRead(dir1, 0, &bytes, buffer);
+        ret = PalStreamRead(dir1, 0, &bytes, buffer, NULL);
         if (ret >= 0 && bytes) {
             for (char* c = buffer; c < buffer + bytes; c += strlen(c) + 1)
                 if (strlen(c))

--- a/pal/regression/Event.c
+++ b/pal/regression/Event.c
@@ -28,7 +28,7 @@ static noreturn int thread_func(void* arg) {
     wait_for(&g_ready, 2);
 
     uint64_t timeout = TIME_US_IN_S;
-    int ret = PalEventWait(sleep_handle, &timeout);
+    int ret = PalEventWait(sleep_handle, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN || timeout != 0) {
         pal_printf("Error: unexpected short sleep, remaining time: %lu\n", timeout);
         PalProcessExit(1);
@@ -44,13 +44,13 @@ int main(void) {
     CHECK(PalEventCreate(&event, /*init_signaled=*/true, /*auto_clear=*/true));
 
     /* Event is already set, should not sleep. */
-    CHECK(PalEventWait(event, /*timeout=*/NULL));
+    CHECK(PalEventWait(event, /*timeout=*/NULL, NULL));
 
     uint64_t start = 0;
     CHECK(PalSystemTimeQuery(&start));
     /* Sleep for one second. */
     uint64_t timeout = TIME_US_IN_S;
-    int ret = PalEventWait(event, &timeout);
+    int ret = PalEventWait(event, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN) {
         CHECK(-1);
     }
@@ -74,7 +74,7 @@ int main(void) {
     set(&g_ready, 2);
 
     CHECK(PalSystemTimeQuery(&start));
-    CHECK(PalEventWait(event, /*timeout=*/NULL));
+    CHECK(PalEventWait(event, /*timeout=*/NULL, NULL));
     CHECK(PalSystemTimeQuery(&end));
 
     if (end < start) {

--- a/pal/regression/File.c
+++ b/pal/regression/File.c
@@ -32,19 +32,19 @@ int main(int argc, char** argv, char** envp) {
 
         /* test file read */
         size_t size = sizeof(buffer1);
-        ret = PalStreamRead(file1, 0, &size, buffer1);
+        ret = PalStreamRead(file1, 0, &size, buffer1, NULL);
         if (ret == 0 && size == sizeof(buffer1)) {
             print_hex("Read Test 1 (0th - 40th): %s\n", buffer1, size);
         }
 
         size = sizeof(buffer1);
-        ret = PalStreamRead(file1, 0, &size, buffer1);
+        ret = PalStreamRead(file1, 0, &size, buffer1, NULL);
         if (ret == 0 && size == sizeof(buffer1)) {
             print_hex("Read Test 2 (0th - 40th): %s\n", buffer1, size);
         }
 
         size = sizeof(buffer2);
-        ret = PalStreamRead(file1, 200, &size, buffer2);
+        ret = PalStreamRead(file1, 200, &size, buffer2, NULL);
         if (ret == 0 && size == sizeof(buffer2)) {
             print_hex("Read Test 3 (200th - 240th): %s\n", buffer2, size);
         }
@@ -146,17 +146,17 @@ int main(int argc, char** argv, char** envp) {
         /* test file writing */
 
         size_t size = sizeof(buffer1);
-        ret = PalStreamWrite(file4, 0, &size, buffer1);
+        ret = PalStreamWrite(file4, 0, &size, buffer1, NULL);
         if (ret < 0)
             goto fail_writing;
 
         size = sizeof(buffer2);
-        ret = PalStreamWrite(file4, 0, &size, buffer2);
+        ret = PalStreamWrite(file4, 0, &size, buffer2, NULL);
         if (ret < 0)
             goto fail_writing;
 
         size = sizeof(buffer1);
-        ret = PalStreamWrite(file4, 200, &size, buffer1);
+        ret = PalStreamWrite(file4, 200, &size, buffer1, NULL);
         if (ret < 0)
             goto fail_writing;
 

--- a/pal/regression/File2.c
+++ b/pal/regression/File2.c
@@ -18,7 +18,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     size_t bytes = sizeof(str) - 1;
-    ret = PalStreamWrite(out, 0, &bytes, str);
+    ret = PalStreamWrite(out, 0, &bytes, str, NULL);
     if (ret < 0 || bytes != sizeof(str) - 1) {
         pal_printf("second PalStreamWrite failed\n");
         return 1;
@@ -36,7 +36,7 @@ int main(int argc, char** argv, char** envp) {
 
     bytes = sizeof(str);
     memset(str, 0, bytes);
-    ret = PalStreamRead(in, 0, &bytes, str);
+    ret = PalStreamRead(in, 0, &bytes, str, NULL);
     if (ret < 0) {
         pal_printf("PalStreamRead failed\n");
         return 1;

--- a/pal/regression/HelloWorld.c
+++ b/pal/regression/HelloWorld.c
@@ -16,7 +16,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     size_t bytes = sizeof(str) - 1;
-    ret = PalStreamWrite(out, 0, &bytes, str);
+    ret = PalStreamWrite(out, 0, &bytes, str, NULL);
 
     if (ret < 0 || bytes != sizeof(str) - 1) {
         pal_printf("PalStreamWrite failed\n");

--- a/pal/regression/Misc.c
+++ b/pal/regression/Misc.c
@@ -34,7 +34,7 @@ int main(int argc, const char** argv, const char** envp) {
     }
 
     uint64_t timeout = 10000;
-    int ret = PalEventWait(sleep_handle, &timeout);
+    int ret = PalEventWait(sleep_handle, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN) {
         pal_printf("PalEventWait failed\n");
         return 1;
@@ -58,7 +58,7 @@ int main(int argc, const char** argv, const char** envp) {
     }
 
     timeout = 3000000;
-    ret = PalEventWait(sleep_handle, &timeout);
+    ret = PalEventWait(sleep_handle, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN) {
         pal_printf("PalEventWait failed\n");
         return 1;

--- a/pal/regression/Pie.c
+++ b/pal/regression/Pie.c
@@ -16,7 +16,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     size_t bytes = sizeof(str) - 1;
-    ret = PalStreamWrite(out, 0, &bytes, str);
+    ret = PalStreamWrite(out, 0, &bytes, str, NULL);
 
     if (ret < 0 || bytes != sizeof(str) - 1) {
         pal_printf("PalStreamWrite failed\n");

--- a/pal/regression/Pipe.c
+++ b/pal/regression/Pipe.c
@@ -34,28 +34,28 @@ int main(int argc, char** argv, char** envp) {
 
         if (ret >= 0 && pipe2) {
             PAL_HANDLE pipe3 = NULL;
-            ret = PalStreamWaitForClient(pipe1, &pipe3, /*options=*/0);
+            ret = PalStreamWaitForClient(pipe1, &pipe3, /*options=*/0, NULL);
 
             if (ret >= 0 && pipe3) {
                 pal_printf("Pipe Connection 1 OK\n");
 
                 size_t size = sizeof(buffer1);
-                ret = PalStreamWrite(pipe3, 0, &size, buffer1);
+                ret = PalStreamWrite(pipe3, 0, &size, buffer1, NULL);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Write 1 OK\n");
 
                 size = sizeof(buffer3);
-                ret = PalStreamRead(pipe2, 0, &size, buffer3);
+                ret = PalStreamRead(pipe2, 0, &size, buffer3, NULL);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Read 1: %s\n", buffer3);
 
                 size = sizeof(buffer2);
-                ret = PalStreamWrite(pipe2, 0, &size, buffer2);
+                ret = PalStreamWrite(pipe2, 0, &size, buffer2, NULL);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Write 2 OK\n");
 
                 size = sizeof(buffer4);
-                ret = PalStreamRead(pipe3, 0, &size, buffer4);
+                ret = PalStreamRead(pipe3, 0, &size, buffer4, NULL);
                 if (ret == 0 && size > 0)
                     pal_printf("Pipe Read 2: %s\n", buffer4);
             }

--- a/pal/regression/Process.c
+++ b/pal/regression/Process.c
@@ -18,15 +18,15 @@ int main(int argc, char** argv, char** envp) {
         }
 
         size = sizeof(buffer1);
-        PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1);
+        PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1, NULL);
 
         size = sizeof(buffer1);
-        ret = PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1);
+        ret = PalStreamWrite(PalGetPalPublicState()->parent_process, 0, &size, buffer1, NULL);
         if (ret == 0 && size > 0)
             pal_printf("Process Write 1 OK\n");
 
         size = sizeof(buffer4);
-        ret = PalStreamRead(PalGetPalPublicState()->parent_process, 0, &size, buffer4);
+        ret = PalStreamRead(PalGetPalPublicState()->parent_process, 0, &size, buffer4, NULL);
         if (ret == 0 && size > 0)
             pal_printf("Process Read 2: %s\n", buffer4);
 
@@ -42,19 +42,19 @@ int main(int argc, char** argv, char** envp) {
             if (ret == 0 && children[i]) {
                 pal_printf("Process created %d\n", i + 1);
                 size = sizeof(buffer4);
-                PalStreamRead(children[i], 0, &size, buffer4);
+                PalStreamRead(children[i], 0, &size, buffer4, NULL);
             }
         }
 
         for (int i = 0; i < 3; i++)
             if (children[i]) {
                 size = sizeof(buffer3);
-                ret = PalStreamRead(children[i], 0, &size, buffer3);
+                ret = PalStreamRead(children[i], 0, &size, buffer3, NULL);
                 if (ret == 0 && size > 0)
                     pal_printf("Process Read 1: %s\n", buffer3);
 
                 size = sizeof(buffer2);
-                ret = PalStreamWrite(children[i], 0, &size, buffer2);
+                ret = PalStreamWrite(children[i], 0, &size, buffer2, NULL);
                 if (ret == 0 && size > 0)
                     pal_printf("Process Write 2 OK\n");
             }

--- a/pal/regression/Process4.c
+++ b/pal/regression/Process4.c
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
         PalObjectDestroy(proc);
 
         PAL_HANDLE pipe = NULL;
-        ret = PalStreamWaitForClient(pipe_srv, &pipe, /*options=*/0);
+        ret = PalStreamWaitForClient(pipe_srv, &pipe, /*options=*/0, NULL);
         if (ret < 0) {
             pal_printf("PalStreamWaitForClient failed: %d\n", ret);
         }

--- a/pal/regression/Thread2.c
+++ b/pal/regression/Thread2.c
@@ -69,7 +69,7 @@ int main(void) {
     // 1 s should be enough even on a very busy system to start a thread and
     // then exit it again including all cleanup.
     uint64_t timeout = 1000000;
-    ret = PalEventWait(sleep_handle, &timeout);
+    ret = PalEventWait(sleep_handle, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN) {
         pal_printf("PalEventWait failed\n");
         return 1;
@@ -87,7 +87,7 @@ int main(void) {
     }
 
     timeout = 1000000;
-    ret = PalEventWait(sleep_handle, &timeout);
+    ret = PalEventWait(sleep_handle, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN) {
         pal_printf("PalEventWait failed\n");
         return 1;
@@ -105,7 +105,7 @@ int main(void) {
     }
 
     timeout = 1000000;
-    ret = PalEventWait(sleep_handle, &timeout);
+    ret = PalEventWait(sleep_handle, &timeout, NULL);
     if (ret != -PAL_ERROR_TRYAGAIN) {
         pal_printf("PalEventWait failed\n");
         return 1;

--- a/pal/regression/send_handle.c
+++ b/pal/regression/send_handle.c
@@ -15,7 +15,7 @@ static void write_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
             case PAL_TYPE_FILE:
             case PAL_TYPE_PIPE:
             case PAL_TYPE_PIPECLI:
-                CHECK(PalStreamWrite(handle, 0, &this_size, buf + i));
+                CHECK(PalStreamWrite(handle, 0, &this_size, buf + i, NULL));
                 break;
             case PAL_TYPE_SOCKET:;
                 struct iovec iov = {
@@ -43,7 +43,7 @@ static void read_all(PAL_HANDLE handle, int type, char* buf, size_t size) {
         switch (type) {
             case PAL_TYPE_FILE:
             case PAL_TYPE_PIPE:
-                CHECK(PalStreamRead(handle, 0, &this_size, buf + i));
+                CHECK(PalStreamRead(handle, 0, &this_size, buf + i, NULL));
                 break;
             case PAL_TYPE_SOCKET:;
                 struct iovec iov = {
@@ -156,7 +156,7 @@ static void do_child(void) {
     /* pipe.srv handle */
     CHECK(PalReceiveHandle(PalGetPalPublicState()->parent_process, &handle));
     PAL_HANDLE client_handle;
-    CHECK(PalStreamWaitForClient(handle, &client_handle, /*options=*/0));
+    CHECK(PalStreamWaitForClient(handle, &client_handle, /*options=*/0, NULL));
     PalObjectDestroy(handle);
     write_msg(client_handle, PAL_TYPE_PIPECLI);
     PalObjectDestroy(client_handle);

--- a/pal/src/host/linux/pal_console.c
+++ b/pal/src/host/linux/pal_console.c
@@ -46,7 +46,8 @@ static int console_open(PAL_HANDLE* handle, const char* type, const char* uri,
     return 0;
 }
 
-static int64_t console_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
+static int64_t console_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer,
+                            pal_callback_t pct) {
     assert(handle->hdr.type == PAL_TYPE_CONSOLE);
 
     if (offset)
@@ -55,11 +56,16 @@ static int64_t console_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, v
     if (!(handle->flags & PAL_HANDLE_FD_READABLE))
         return -PAL_ERROR_DENIED;
 
+    if (pct)
+        pct(PAL_CALLBACK_BEFORE_SYSCALL);
     int64_t bytes = DO_SYSCALL(read, handle->console.fd, buffer, size);
+    if (pct)
+        pct(PAL_CALLBACK_AFTER_SYSCALL);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 
-static int64_t console_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
+static int64_t console_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer,
+                             pal_callback_t pct) {
     assert(handle->hdr.type == PAL_TYPE_CONSOLE);
 
     if (offset)
@@ -68,7 +74,11 @@ static int64_t console_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, 
     if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
         return -PAL_ERROR_DENIED;
 
+    if (pct)
+        pct(PAL_CALLBACK_BEFORE_SYSCALL);
     int64_t bytes = DO_SYSCALL(write, handle->console.fd, buffer, size);
+    if (pct)
+        pct(PAL_CALLBACK_AFTER_SYSCALL);
     return bytes < 0 ? unix_to_pal_error(bytes) : bytes;
 }
 

--- a/pal/src/host/linux/pal_eventfd.c
+++ b/pal/src/host/linux/pal_eventfd.c
@@ -65,7 +65,8 @@ static int eventfd_pal_open(PAL_HANDLE* handle, const char* type, const char* ur
     return 0;
 }
 
-static int64_t eventfd_pal_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void* buffer) {
+static int64_t eventfd_pal_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void* buffer,
+                                pal_callback_t pct) {
     if (offset)
         return -PAL_ERROR_INVAL;
 
@@ -75,7 +76,11 @@ static int64_t eventfd_pal_read(PAL_HANDLE handle, uint64_t offset, uint64_t len
     if (len < sizeof(uint64_t))
         return -PAL_ERROR_INVAL;
 
+    if (pct)
+        pct(PAL_CALLBACK_BEFORE_SYSCALL);
     int64_t bytes = DO_SYSCALL(read, handle->eventfd.fd, buffer, len);
+    if (pct)
+        pct(PAL_CALLBACK_AFTER_SYSCALL);
 
     if (bytes < 0)
         return unix_to_pal_error(bytes);
@@ -84,7 +89,7 @@ static int64_t eventfd_pal_read(PAL_HANDLE handle, uint64_t offset, uint64_t len
 }
 
 static int64_t eventfd_pal_write(PAL_HANDLE handle, uint64_t offset, uint64_t len,
-                                 const void* buffer) {
+                                 const void* buffer, pal_callback_t pct) {
     if (offset)
         return -PAL_ERROR_INVAL;
 
@@ -94,7 +99,11 @@ static int64_t eventfd_pal_write(PAL_HANDLE handle, uint64_t offset, uint64_t le
     if (len < sizeof(uint64_t))
         return -PAL_ERROR_INVAL;
 
+    if (pct)
+        pct(PAL_CALLBACK_BEFORE_SYSCALL);
     int64_t bytes = DO_SYSCALL(write, handle->eventfd.fd, buffer, len);
+    if (pct)
+        pct(PAL_CALLBACK_AFTER_SYSCALL);
     if (bytes < 0)
         return unix_to_pal_error(bytes);
 

--- a/pal/src/host/linux/pal_process.c
+++ b/pal/src/host/linux/pal_process.c
@@ -286,11 +286,16 @@ noreturn void _PalProcessExit(int exitcode) {
     die_or_inf_loop();
 }
 
-static int64_t proc_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer) {
+static int64_t proc_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer,
+                         pal_callback_t pct) {
     if (offset)
         return -PAL_ERROR_INVAL;
 
+    if (pct)
+        pct(PAL_CALLBACK_BEFORE_SYSCALL);
     int64_t bytes = DO_SYSCALL(read, handle->process.stream, buffer, count);
+    if (pct)
+        pct(PAL_CALLBACK_AFTER_SYSCALL);
 
     if (bytes < 0)
         switch (bytes) {
@@ -305,11 +310,16 @@ static int64_t proc_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
     return bytes;
 }
 
-static int64_t proc_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer) {
+static int64_t proc_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer,
+                          pal_callback_t pct) {
     if (offset)
         return -PAL_ERROR_INVAL;
 
+    if (pct)
+        pct(PAL_CALLBACK_BEFORE_SYSCALL);
     int64_t bytes = DO_SYSCALL(write, handle->process.stream, buffer, count);
+    if (pct)
+        pct(PAL_CALLBACK_AFTER_SYSCALL);
 
     if (bytes < 0)
         switch (bytes) {

--- a/pal/src/pal_events.c
+++ b/pal/src/pal_events.c
@@ -22,7 +22,7 @@ void PalEventClear(PAL_HANDLE handle) {
     _PalEventClear(handle);
 }
 
-int PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
+int PalEventWait(PAL_HANDLE handle, uint64_t* timeout_us, pal_callback_t pc) {
     assert(handle && handle->hdr.type == PAL_TYPE_EVENT);
-    return _PalEventWait(handle, timeout_us);
+    return _PalEventWait(handle, timeout_us, pc);
 }

--- a/pal/src/pal_main.c
+++ b/pal/src/pal_main.c
@@ -325,7 +325,7 @@ static int load_cstring_array(const char* uri, const char*** res) {
         ret = -PAL_ERROR_NOMEM;
         goto out_fail;
     }
-    ret = _PalStreamRead(hdl, 0, file_size, buf);
+    ret = _PalStreamRead(hdl, 0, file_size, buf, NULL);
     if (ret < 0)
         goto out_fail;
     if (file_size > 0 && buf[file_size - 1] != '\0') {

--- a/pal/src/pal_rtld.c
+++ b/pal/src/pal_rtld.c
@@ -648,7 +648,7 @@ int load_entrypoint(const char* uri) {
     if (ret < 0)
         return ret;
 
-    ret = _PalStreamRead(handle, 0, sizeof(buf), buf);
+    ret = _PalStreamRead(handle, 0, sizeof(buf), buf, NULL);
     if (ret < 0) {
         log_error("Reading ELF file failed");
         goto out;


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Implement a checkpoint rwlock that protects the access to resources, such as PAL_HANDLEs and mmmap'ed memory regions, while a process  performs a checkpoint due to fork(). While the checkpoint is ongoing other threads must not touch the resources.

Lock the read lock when
- starting to emulate a syscall
- for openmp testcase: a new thread has been created
- for 'other' testcase: don't lock

Unlock the read lock when
- leaving the emulation of a systcall
- upon execve

For debugging purposes allow enablement of an atomic counter that is increased when a read lock is taken and decreased when the read lock is released.

Fixes: #1156 
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Run existing test cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1592)
<!-- Reviewable:end -->
