### PR TITLE
[python] Add `gramine-sgx-sign --date` option

### DIFF
--- a/Documentation/manpages/gramine-sgx-sign.rst
+++ b/Documentation/manpages/gramine-sgx-sign.rst
@@ -1,9 +1,9 @@
 .. program:: gramine-sgx-sign
 .. _gramine-sgx-sign:
 
-==========================================================
-:program:`gramine-sgx-sign` -- Gramine SIGSTRUCT generator
-==========================================================
+==============================================================
+:program:`gramine-sgx-sign` -- Gramine ``SIGSTRUCT`` generator
+==============================================================
 
 Synopsis
 ========
@@ -36,22 +36,30 @@ Command line arguments
 
     Input manifest file.
 
+.. option:: --date <YYYY-MM-DD>|today
+
+    Set specific date to be put into ``SIGSTRUCT``. If not given, or the value
+    is literal ``today``, then current day according to system calendar is used.
+    Otherwise expects ``<YYYY>-<MM>-<DD>``. The date needs not to be a |~| valid
+    day, it will happily accept ``--date 0000-00-00``, e.g. for reproducible
+    builds.
+
 .. option:: --libpal libpal_path, -l libpal_path
 
     Path to libpal file (main Gramine binary).
 
 .. option:: --sigfile sigfile, -s sigfile
 
-    Path to the output file containing SIGSTRUCT. If not provided,
+    Path to the output file containing ``SIGSTRUCT``. If not provided,
     `manifest_file` will be used with ".manifest" (if present) removed from
     the end and with ".sig" appended.
 
 .. option:: --depfile depfile
 
     Generate a file that describes the dependencies for the output manifest and
-    SIGSTRUCT, i.e. files that should trigger rebuilding if they're modified.
-    The dependency file is in Makefile format, and is suitable for using in
-    build systems (Make, Ninja).
+    ``SIGSTRUCT``, i.e. files that should trigger rebuilding if they're
+    modified. The dependency file is in Makefile format, and is suitable for
+    using in build systems (Make, Ninja).
 
 .. option:: --verbose, -v
 
@@ -64,7 +72,7 @@ Command line arguments
 .. option:: --with <plugin>
 
     Use plugin to perform actual signing. The default plugin is ``file``, which
-    signs the SIGSTRUCT using PEM-encoded local file. The list of available
+    signs the ``SIGSTRUCT`` using PEM-encoded local file. The list of available
     plugins is at the end of :option:`--help` output.
 
     Each plugin may add its own set of options (usually in the form of

--- a/python/gramine-sgx-sign
+++ b/python/gramine-sgx-sign
@@ -1,11 +1,14 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2023 Intel Corporation
 #                    Borys Popławski <borysp@invisiblethingslab.com>
+#                    Wojtek Porczyk <woju@invisiblethingslab.com>
 
 import datetime
+import re
 import sys
 import textwrap
+import typing
 
 import click
 
@@ -32,6 +35,29 @@ def get_sgx_sign_plugin(name):
             return ep.load()
     raise KeyError(name)
 
+class BCDDate(typing.NamedTuple):
+    """Date-compatible object that supports invalid dates (like 0000-00-00)
+    """
+    year: int
+    month: int
+    day: int
+
+class BCDDateParamType(click.ParamType):
+    """Parse "today" or a date-like string YYYY-MM-DD, accepting invalid dates.
+
+    This is needed to support dates like 0000-00-00, which are invalid days, but valid things to put
+    into SIGSTRUCT. Arbitrary values that have hex digits A-F are not currently supported.
+    """
+    name = 'date'
+    _regexp = re.compile(r'(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})')
+    def convert(self, value, param, ctx):
+        if value.casefold() == 'today':
+            value = datetime.date.today().strftime('%Y-%m-%d')
+        match = self._regexp.fullmatch(value)
+        if not match:
+            self.fail('expecting "today" or YYYY-MM-DD')
+        return BCDDate(**{k: int(v) for k, v in match.groupdict().items()})
+
 @click.command(
     context_settings={'ignore_unknown_options': True},
     epilog=textwrap.dedent(f'''
@@ -53,6 +79,9 @@ def get_sgx_sign_plugin(name):
 @click.option('--manifest', '-m', 'manifest_file',
     type=click.File('r', encoding='utf-8'),
     help='Input .manifest file')
+@click.option('--date', '-d',
+    type=BCDDateParamType(), default='today',
+    help='Set DATE field in SIGSTRUCT to this value (YYYY-MM-DD or "today")')
 @click.option('--sigfile', '-s',
     help='Output .sig file')
 @click.option('--depfile',
@@ -65,7 +94,7 @@ def get_sgx_sign_plugin(name):
     nargs=-1,
     type=click.UNPROCESSED)
 @click.pass_context
-def main(ctx, with_, output, libpal, manifest_file, sigfile, depfile, verbose, plugin_args):
+def main(ctx, with_, output, libpal, manifest_file, date, sigfile, depfile, verbose, plugin_args):
     # pylint: disable=too-many-arguments, too-many-locals
 
     ret = get_sgx_sign_plugin(with_)(args=plugin_args, standalone_mode=False)
@@ -108,8 +137,7 @@ def main(ctx, with_, output, libpal, manifest_file, sigfile, depfile, verbose, p
             sigfile = manifest_file.name
         sigfile += '.sig'
 
-    today = datetime.date.today()
-    sigstruct = get_tbssigstruct(output, today, libpal, verbose=verbose)
+    sigstruct = get_tbssigstruct(output, date, libpal, verbose=verbose)
     sigstruct.sign(sign_func)
 
     with open(sigfile, 'wb') as f:

--- a/python/gramine-sgx-sigstruct-view
+++ b/python/gramine-sgx-sigstruct-view
@@ -34,7 +34,7 @@ def main(sigfile, verbose, output_format, output):
         'attribute_flags_mask': hex(sig['attribute_flags_mask']),
         'attribute_xfrm_mask': hex(sig['attribute_xfrm_mask']),
         'misc_mask': hex(sig['misc_mask']),
-        'date': '%d-%02d-%02d' % (sig['date_year'], sig['date_month'], sig['date_day']),
+        'date': f"{sig['date_year']:04}-{sig['date_month']:02}-{sig['date_day']:02}",
         'debug_enclave': bool(sig['attribute_flags'] & 0b10),
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
See commit message.

## How to test this PR? <!-- (if applicable) -->

1) Sign any SGX enclave using `gramine-sgx-sign` without `--date`, see that there is no regression (CI is sufficient for this)
2) Use `gramine-sgx-sign --date today` — should be the same SIGSTRUCT as in (1)
3) Use `gramine-sgx-sign --date YYYY-MM-DD` with valid date (e.g. 2023-10-09 for date of submitting this PR) — should include this date in SIGSTRUCT (you can inspect with `gramine-sgx-sigstruct-view`)
4) Use `gramine-sgx-sign --date 1234-56-78` or `0000-00-00` or any other invalid date — should still pass and include such invalid "date" into SIGSTRUCT.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1598)
<!-- Reviewable:end -->
