### PR TITLE
[PAL,LibOS] Replace `malloc_copy()` with `alloc_and_copy()`

### DIFF
--- a/libos/include/libos_utils.h
+++ b/libos/include/libos_utils.h
@@ -28,7 +28,6 @@ int init_slab(void);
 
 void* malloc(size_t size);
 void free(void* mem);
-void* malloc_copy(const void* mem, size_t size);
 
 /* ELF binary loading */
 struct link_map;

--- a/libos/src/libos_malloc.c
+++ b/libos/src/libos_malloc.c
@@ -135,14 +135,6 @@ void* realloc(void* ptr, size_t new_size) {
 }
 #endif
 
-// Copies data from `mem` to a newly allocated buffer of a specified size.
-void* malloc_copy(const void* mem, size_t size) {
-    void* buff = malloc(size);
-    if (buff)
-        memcpy(buff, mem, size);
-    return buff;
-}
-
 void free(void* mem) {
     if (memory_migrated(mem)) {
         return;

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -288,7 +288,6 @@ void pal_disable_early_memory_bookkeeping(void);
 
 void init_slab_mgr(void);
 void* malloc(size_t size);
-void* malloc_copy(const void* mem, size_t size);
 void* calloc(size_t num, size_t size);
 void free(void* mem);
 

--- a/pal/src/pal_streams.c
+++ b/pal/src/pal_streams.c
@@ -100,7 +100,7 @@ static int parse_stream_uri(const char** uri, char** prefix, struct handle_ops**
     *uri = p;
 
     if (prefix) {
-        *prefix = malloc_copy(u, p - u);
+        *prefix = alloc_and_copy(u, p - u);
         if (!*prefix)
             return -PAL_ERROR_NOMEM;
         /* We don't want ':' in prefix, replacing that with nullbyte which also ends the string. */

--- a/pal/src/slab.c
+++ b/pal/src/slab.c
@@ -83,16 +83,6 @@ void* malloc(size_t size) {
     return ptr;
 }
 
-// Copies data from `mem` to a newly allocated buffer of a specified size.
-void* malloc_copy(const void* mem, size_t size) {
-    void* nmem = malloc(size);
-
-    if (nmem)
-        memcpy(nmem, mem, size);
-
-    return nmem;
-}
-
 void* calloc(size_t num, size_t size) {
     size_t total;
     if (__builtin_mul_overflow(num, size, &total))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine had two generic functions doing the same thing. Remove one of them.

I added the `alloc_and_copy()` function in commit https://github.com/gramineproject/gramine/commit/872a14ecb48f79b6c64838adc26bfd18197b4d8e. I didn't notice that we already have `malloc_copy()`. Now let's remove the latter (as the former is cleaner).

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1606)
<!-- Reviewable:end -->
