### PR TITLE
[PAL] Refactor splitting of typed URI into type, URI and ops

### DIFF
--- a/common/include/api.h
+++ b/common/include/api.h
@@ -386,8 +386,21 @@ int buf_flush(struct print_buf* buf);
 #define URI_PREFIX_EVENTFD  URI_TYPE_EVENTFD URI_PREFIX_SEPARATOR
 #define URI_PREFIX_FILE     URI_TYPE_FILE URI_PREFIX_SEPARATOR
 
-#define URI_PREFIX_DEV_LEN  (static_strlen(URI_PREFIX_DEV))
-#define URI_PREFIX_FILE_LEN (static_strlen(URI_PREFIX_FILE))
+#define URI_PREFIX_DIR_LEN      (static_strlen(URI_PREFIX_DIR))
+#define URI_PREFIX_PIPE_LEN     (static_strlen(URI_PREFIX_PIPE))
+#define URI_PREFIX_PIPE_SRV_LEN (static_strlen(URI_PREFIX_PIPE_SRV))
+#define URI_PREFIX_CONSOLE_LEN  (static_strlen(URI_PREFIX_CONSOLE))
+#define URI_PREFIX_DEV_LEN      (static_strlen(URI_PREFIX_DEV))
+#define URI_PREFIX_EVENTFD_LEN  (static_strlen(URI_PREFIX_EVENTFD))
+#define URI_PREFIX_FILE_LEN     (static_strlen(URI_PREFIX_FILE))
+
+#define URI_PREFIX_MAX_LEN (MAX(URI_PREFIX_DIR_LEN,                           \
+                                MAX(URI_PREFIX_PIPE_LEN,                      \
+                                    MAX(URI_PREFIX_PIPE_SRV_LEN,              \
+                                        MAX(URI_PREFIX_CONSOLE_LEN,           \
+                                            MAX(URI_PREFIX_DEV_LEN,           \
+                                                MAX(URI_PREFIX_EVENTFD_LEN,   \
+                                                    URI_PREFIX_FILE_LEN)))))))
 
 #define TIME_US_IN_S 1000000ul
 #define TIME_US_IN_MS 1000ul

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -329,7 +329,7 @@ typedef uint32_t pal_stream_options_t; /* bitfield */
 /*!
  * \brief Open/create a stream resource specified by `uri`.
  *
- * \param uri          The URI of the stream to be opened/created.
+ * \param typed_uri    The URI of the stream to be opened/created, prefixed with the type.
  * \param access       See #pal_access.
  * \param share_flags  A combination of the `PAL_SHARE_*` flags.
  * \param create       See #pal_create_mode.
@@ -349,7 +349,7 @@ typedef uint32_t pal_stream_options_t; /* bitfield */
  *   processes. The server side of a pipe can accept any number of connections. If `pipe:` is given
  *   as the URI (i.e., without a name), it will open an anonymous bidirectional pipe.
  */
-int PalStreamOpen(const char* uri, enum pal_access access, pal_share_flags_t share_flags,
+int PalStreamOpen(const char* typed_uri, enum pal_access access, pal_share_flags_t share_flags,
                   enum pal_create_mode create, pal_stream_options_t options, PAL_HANDLE* handle);
 
 /*!
@@ -491,7 +491,7 @@ typedef struct _PAL_STREAM_ATTR {
  *
  * This API only applies for URIs such as `%file:...`, `dir:...`, and `dev:...`.
  */
-int PalStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr);
+int PalStreamAttributesQuery(const char* typed_uri, PAL_STREAM_ATTR* attr);
 
 /*!
  * \brief Query the attributes of an open stream.
@@ -511,7 +511,7 @@ int PalStreamAttributesSetByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr);
 /*!
  * \brief This API changes the name of an open stream.
  */
-int PalStreamChangeName(PAL_HANDLE handle, const char* uri);
+int PalStreamChangeName(PAL_HANDLE handle, const char* typed_uri);
 
 struct pal_socket_addr {
     enum pal_socket_domain domain;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously PAL code had a function `parse_stream_uri()` that returned the type, URI and corresponding handle operations based on the typed URI input. This function had confusing signature and semantics. This commit renames it to `split_uri_and_find_ops()` and makes it explicit that the input URI is a type-prefixed URI.

Fixes #1586. **NOTE**: I didn't make the `find_path_in_uri()` a generic func because it would become too complex. So I kept the `find_path_in_uri()` function as local to that file, and instead simply refactored the `parse_stream_uri()` code.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1607)
<!-- Reviewable:end -->
