### PR TITLE
[Docs] Explain that `loader.argv` must contain `argv[0]`

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -131,7 +131,10 @@ If you want your application to use commandline arguments, you must choose one
 of the three mutually exclusive options:
 
 - set ``loader.insecure__use_cmdline_argv`` (insecure in almost all cases),
-- put commandline arguments into ``loader.argv`` array,
+- put commandline arguments into ``loader.argv`` array (note that the first
+  argument is typically the program name and the actual arguments start with
+  the second array item; see `this link
+  <https://unix.stackexchange.com/questions/315812>`__ for an explanation),
 - point ``loader.argv_src_file`` to a file
   containing output of :ref:`gramine-argv-serializer<gramine-argv-serializer>`.
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Non-programming users do not know this quirk that `argv[0]` is typically a program name, and that actual commandline arguments start with the second item (`argv[1]`).

## How to test this PR? <!-- (if applicable) -->

Documentation check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1608)
<!-- Reviewable:end -->
