### PR TITLE
[python] Fix encoding of the passphrase yet again

### DIFF
--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -591,8 +591,10 @@ def get_tbssigstruct(manifest_path, date, libpal=SGX_LIBPAL, verbose=False):
 @click.option('--passphrase', '--password', '-p', 'passphrase', metavar='PASSPHRASE',
     help='optional passphrase to decrypt the key')
 def sign_with_file(ctx, key, passphrase):
+    if passphrase is not None:
+        passphrase = passphrase.encode()
     try:
-        private_key = load_private_key_from_pem_file(key, passphrase and passphrase.encode())
+        private_key = load_private_key_from_pem_file(key, passphrase)
     except InvalidKeyError as e:
         ctx.fail(str(e))
 


### PR DESCRIPTION
This fixes mistake in #1581. Relevant to gramineproject/gsc#173.

## How to test this PR? <!-- (if applicable) -->

- `gramine-sgx-sign` (no `--passphrase`)
- `gramine-sgx-sign --passphrase abc` (non-empty `--passphrase`)
- `gramine-sgx-sign --passphrase ''` (empty, but set `--passphrase`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1611)
<!-- Reviewable:end -->
