### PR TITLE
Fix pylint

### DIFF
--- a/.ci/lib/stage-lint.jenkinsfile
+++ b/.ci/lib/stage-lint.jenkinsfile
@@ -1,10 +1,7 @@
 stage('lint') {
     sh '''
         ./scripts/gitignore-check-files
-        if .ci/isdistro bionic
-        then
-            ./.ci/run-pylint -f text
-        fi
+        ./.ci/run-pylint -f text
         ./.ci/run-shellcheck
     '''
 }

--- a/libos/test/ltp/test_ltp.py
+++ b/libos/test/ltp/test_ltp.py
@@ -212,8 +212,9 @@ def test_ltp(cmd, section):
 
 def test_lint():
     cmd = ['./contrib/conf_lint.py', '--scenario', LTP_SCENARIO, *LTP_CONFIG]
-    p = subprocess.run(cmd)
-    if p.returncode:
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
         pytest.fail('conf_lint.py failed, see stdout for details')
 
 

--- a/python/gramine-sgx-get-token
+++ b/python/gramine-sgx-get-token
@@ -13,7 +13,7 @@ from graminelibos import Sigstruct, get_token, is_oot
 @click.option('--verbose/--quiet', '-v/-q', default=True, help='Display details (on by default)')
 def main(sig, output, verbose):
     if not is_oot():
-        import warnings
+        import warnings # pylint: disable=import-outside-toplevel
         warnings.warn(
             'gramine-sgx-get-token is deprecated on upstream SGX driver, '
             'and calling it will be a hard error in the future',

--- a/python/graminelibos/sgx_get_token.py
+++ b/python/graminelibos/sgx_get_token.py
@@ -50,7 +50,7 @@ def p64(x):
 def connect_aesmd(mrenclave, modulus, flags, xfrms):
     '''Connect with AESMD.'''
 
-    from . import aesm_pb2 # pylint: disable=import-error,no-name-in-module
+    from . import aesm_pb2 # pylint: disable=import-error,no-name-in-module,import-outside-toplevel
 
     req_msg = aesm_pb2.GetTokenReq()
     req_msg.req.signature = mrenclave

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -689,7 +689,7 @@ def sign_with_private_key_from_pem_file(data, file, passphrase=None):
             This function also signs *data*, but the key argument is path to a file, not a file-like
             object.
     """
-    return sign_with_private_key(data, load_pem_private_key_from_file(file, passphrase))
+    return sign_with_private_key(data, load_private_key_from_pem_file(file, passphrase))
 
 
 def sign_with_private_key_from_pem_path(data, path, passphrase=None):
@@ -716,7 +716,7 @@ def sign_with_private_key_from_pem_path(data, path, passphrase=None):
             opened file.
     """
 
-    with open(key, 'rb') as file:
+    with open(path, 'rb') as file:
         return sign_with_private_key_from_pem_file(data, file, passphrase)
 
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

* I think that the variable with the key is called `path` not `key`, this results in the following python error:
```
Traceback (most recent call last):                                                                                                                                                             
  File "/usr/bin/gramine-sgx-sign", line 74, in <module>                                                                                                                                       
    main() # pylint: disable=no-value-for-parameter                                                                                                                                            
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__                                                                                                                  
    return self.main(*args, **kwargs)                                                                                                                                                          
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main                                                                                                                      
    rv = self.invoke(ctx)                                                                                                                                                                      
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke                    
    return ctx.invoke(self.callback, **ctx.params)                                                                                                                                             
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke                     
    return __callback(*args, **kwargs)                                                                                                                                                         
  File "/usr/bin/gramine-sgx-sign", line 48, in main                                                                                                                                           
    sigstruct.sign(sign_with_local_key, key)                                                                                                                                                   
  File "/app/install/lib/python3.11/site-packages/graminelibos/sigstruct.py", line 191, in sign 
    exponent_int, modulus_int, signature_int = do_sign_callback(data, *args, **kwargs)                                                                                                         
  File "/app/install/lib/python3.11/site-packages/graminelibos/sgx_sign.py", line 724, in sign_with_local_key
    return sign_with_private_key_from_pem_path(data, key)                                                                                                                                      
  File "/app/install/lib/python3.11/site-packages/graminelibos/sgx_sign.py", line 717, in sign_with_private_key_from_pem_path                                                                  
    with open(key, 'rb') as file:                                                                                                                                                              
NameError: name 'key' is not defined                                                           
```

* I think that the name of the function is misspelled:
```
Traceback (most recent call last):                                                                                                                                                             
  File "/usr/bin/gramine-sgx-sign", line 74, in <module>                                                                                                                                       
    main() # pylint: disable=no-value-for-parameter                                                                                                                                            
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__                                                                                                                  
    return self.main(*args, **kwargs)                                                          
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main                      
    rv = self.invoke(ctx)                                                                                                                                                                      
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke                                                                                                                    
    return ctx.invoke(self.callback, **ctx.params)                                                                                                                                             
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke                                                                                                                     
    return __callback(*args, **kwargs)                                                                                                                                                         
  File "/usr/bin/gramine-sgx-sign", line 48, in main                                                                                                                                           
    sigstruct.sign(sign_with_local_key, key)                                                                                                                                                   
  File "/app/install/lib/python3.11/site-packages/graminelibos/sigstruct.py", line 191, in sign                                                                                                
    exponent_int, modulus_int, signature_int = do_sign_callback(data, *args, **kwargs)         
  File "/app/install/lib/python3.11/site-packages/graminelibos/sgx_sign.py", line 724, in sign_with_local_key                                                                                  
    return sign_with_private_key_from_pem_path(data, key)                                      
  File "/app/install/lib/python3.11/site-packages/graminelibos/sgx_sign.py", line 718, in sign_with_private_key_from_pem_path                                                                  
    return sign_with_private_key_from_pem_file(data, file, passphrase)                                                                                                                         
  File "/app/install/lib/python3.11/site-packages/graminelibos/sgx_sign.py", line 690, in sign_with_private_key_from_pem_file                                                                  
    return sign_with_private_key(data, load_pem_private_key_from_file(file, passphrase))                                                                                                       
NameError: name 'load_pem_private_key_from_file' is not defined. Did you mean: 'load_private_key_from_pem_file'?                                                                               
```

- pylint doesn't like outside toplevel import
- pylint force us to use `subprocess.run(check=True)` [Link](https://pycodequ.al/docs/pylint-messages/w1510-subprocess-run-check.html)
- Finally bring back CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1613)
<!-- Reviewable:end -->
