### PR TITLE
Fix Coverity issues

### DIFF
--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -203,7 +203,6 @@ static void ipf_init_root_mht(file_node_t* mht) {
 static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf) {
     bool ret = false;
     file_node_t** mht_array = NULL;
-    file_node_t* file_mht_node;
     pf_status_t status;
     void* data = lruc_get_first(pf->cache);
 
@@ -232,8 +231,8 @@ static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf) {
                     goto out;
                 }
 
-                file_mht_node = data_node->parent;
 #ifdef DEBUG
+                file_node_t* file_mht_node = data_node->parent;
                 // this loop should do nothing, add it here just to be safe
                 while (file_mht_node->node_number != 0) {
                     assert(file_mht_node->need_writing == true);
@@ -268,7 +267,7 @@ static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf) {
     uint64_t dirty_idx = 0;
     while (data != NULL) {
         if (((file_node_t*)data)->type == FILE_MHT_NODE_TYPE) {
-            file_mht_node = (file_node_t*)data;
+            file_node_t* file_mht_node = (file_node_t*)data;
 
             if (file_mht_node->need_writing)
                 mht_array[dirty_idx++] = file_mht_node;
@@ -282,7 +281,7 @@ static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf) {
 
     // update the gmacs in the parents from last node to first (bottom layers first)
     for (dirty_idx = dirty_count; dirty_idx > 0; dirty_idx--) {
-        file_mht_node = mht_array[dirty_idx - 1];
+        file_node_t* file_mht_node = mht_array[dirty_idx - 1];
 
         gcm_crypto_data_t* gcm_crypto_data =
             &file_mht_node->parent->decrypted.mht

--- a/libos/src/sys/libos_poll.c
+++ b/libos/src/sys/libos_poll.c
@@ -376,7 +376,7 @@ out:
 
 long libos_syscall_select(int nfds, struct linux_fd_set* read_set, struct linux_fd_set* write_set,
                           struct linux_fd_set* except_set, struct __kernel_timeval* tv) {
-    if (nfds < 0 || (uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE) || nfds > INT_MAX)
+    if (nfds < 0 || (uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE))
         return -EINVAL;
 
     /* Each of `read_set`, `write_set` and `except_set` is an array of linux_fd_set items; each
@@ -427,7 +427,7 @@ struct sigset_argpack {
 long libos_syscall_pselect6(int nfds, struct linux_fd_set* read_set, struct linux_fd_set* write_set,
                             struct linux_fd_set* except_set, struct __kernel_timespec* tsp,
                             void* _sigmask_argpack) {
-    if (nfds < 0 || (uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE) || nfds > INT_MAX)
+    if (nfds < 0 || (uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE))
         return -EINVAL;
 
     /* for explanation on calculations below, see libos_syscall_select() */

--- a/pal/src/host/linux/pal_streams.c
+++ b/pal/src/host/linux/pal_streams.c
@@ -206,10 +206,6 @@ int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo) {
     message_hdr.msg_iovlen = 1;
 
     ret = DO_SYSCALL(sendmsg, fd, &message_hdr, 0);
-    if (ret < 0) {
-        free(hdl_data);
-        return unix_to_pal_error(ret);
-    }
 
     free(hdl_data);
     return ret < 0 ? unix_to_pal_error(ret) : 0;

--- a/python/graminelibos/gen_jinja_env.py
+++ b/python/graminelibos/gen_jinja_env.py
@@ -91,7 +91,11 @@ def add_globals_misc(env):
     env.globals['ldd'] = ldd
 
 def make_env():
-    env = jinja2.Environment(undefined=jinja2.StrictUndefined, keep_trailing_newline=True)
+
+    # Jinja's autoescape feature escapes HTML sequences but we're rendering TOML, hence explicitly
+    # setting autoescape to False
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined, keep_trailing_newline=True,
+                             autoescape=False)
     add_globals_from_gramine(env)
     add_globals_from_python(env)
     add_globals_misc(env)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

PR fixes Coverity issues described below:
CID 3400413: Operands don't affect result (CONSTANT_EXPRESSION_RESULT)
result_independent_of_operands nfds > 2147483647 is always false regardless of the values of its operands. This occurs as the logical second operand of "||". Code:https://github.com/gramineproject/gramine/blob/c114403801d9faed97148cdf0394477965b35ffa/libos/src/sys/libos_poll.c#L430


CID 3400412: Operands don't affect result (CONSTANT_EXPRESSION_RESULT)
result_independent_of_operands nfds > 2147483647 is always false regardless of the values of its operands. This occurs as the logical second operand of "||". Code: https://github.com/gramineproject/gramine/blob/c114403801d9faed97148cdf0394477965b35ffa/libos/src/sys/libos_poll.c#L379


CID 328009: Logically dead code
The indicated dead code may have performed some action; that action will never occur. In _PalSendHandle: Code can never be reached because of a logical contradiction (CWE-561). Code: https://github.com/gramineproject/gramine/blob/c114403801d9faed97148cdf0394477965b35ffa/pal/src/host/linux/pal_streams.c#L209-L212


CID 328084: Jinja2 autoescape disabled
Disabling Jinja2 autoescape protections allows an attacker to write untrusted data to the template which, when rendered, can result in cross-site scripting (XSS) attacks. Code: https://github.com/gramineproject/gramine/blob/c114403801d9faed97148cdf0394477965b35ffa/python/graminelibos/gen_jinja_env.py#L94


CID 327977: (#1 of 1): Unused value (UNUSED_VALUE)
assigned_pointer Assigning value from data_node->parent to file_mht_node here, but that stored value is overwritten before it can be used. In make_env: Jinja2 autoescape protection is disabled. (CWE-79). Code: https://github.com/gramineproject/gramine/blob/c114403801d9faed97148cdf0394477965b35ffa/common/src/protected_files/protected_files.c#L235C17-L235C30

## How to test this PR? <!-- (if applicable) -->

Jenkins test should be fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1622)
<!-- Reviewable:end -->
