### PR TITLE
[tools] common/util.h: Make INFO and DBG print to stderr

### DIFF
--- a/libos/test/fs/test_enc.py
+++ b/libos/test/fs/test_enc.py
@@ -67,8 +67,8 @@ class TC_50_EncryptedFiles(test_fs.TC_00_FileSystem):
         # test random key generation
         key_path = os.path.join(self.TEST_DIR, 'tmpkey')
         args = ['gen-key', '-w', key_path]
-        stdout, _ = self.__pf_crypt(args)
-        self.assertIn('Wrap key saved to: ' + key_path, stdout)
+        _, stderr = self.__pf_crypt(args)
+        self.assertIn('Wrap key saved to: ' + key_path, stderr)
         self.assertEqual(os.path.getsize(key_path), 16)
         os.remove(key_path)
 

--- a/tools/sgx/common/util.h
+++ b/tools/sgx/common/util.h
@@ -30,12 +30,12 @@ extern endianness_t g_endianness;
 #define DBG(fmt, ...)                                 \
     do {                                              \
         if (g_verbose)                                \
-            dprintf(g_stdout_fd, fmt, ##__VA_ARGS__); \
+            dprintf(g_stderr_fd, fmt, ##__VA_ARGS__); \
     } while (0)
 
 #define INFO(fmt, ...)                            \
     do {                                          \
-        dprintf(g_stdout_fd, fmt, ##__VA_ARGS__); \
+        dprintf(g_stderr_fd, fmt, ##__VA_ARGS__); \
     } while (0)
 
 #define ERROR(fmt, ...)                                                \


### PR DESCRIPTION
See commit message.

## Description of the changes <!-- (reasons and measures) -->

So I'm writing a tool that relies of `ra_tls_verify_*` libraries and it turns out that I need to write some output to stdout. The verifier library garbles the output.

## How to test this PR? <!-- (if applicable) -->

Write an attestor, run it, check that status info from `libra_tls_*` is not being printed to stdout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1624)
<!-- Reviewable:end -->
