### PR TITLE
[LibOS] Fix handling of oldpath == newpath in rename syscall

### DIFF
--- a/libos/src/sys/libos_file.c
+++ b/libos/src/sys/libos_file.c
@@ -377,6 +377,10 @@ long libos_syscall_renameat(int olddirfd, const char* oldpath, int newdirfd, con
 
     lock(&g_dcache_lock);
 
+    if (strcmp(oldpath, newpath) == 0) {
+        goto out;
+    }
+
     if (*oldpath != '/' && (ret = get_dirfd_dentry(olddirfd, &old_dir_dent)) < 0) {
         goto out;
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Gramine implementation of rename system call is failing if the old and new  path are same. 
Seen this issue while graminizing the harshulthakur/voice:latestforgsc  docker image.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
 1. create a regular file, eg: touch /home/intel/test.txt
 2. Graminize and run the below sample python code 
```python
import os
file = input('Enter a file name: ')
path = os.replace(file, file)
print("File %s is renamed successfully" % file)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1627)
<!-- Reviewable:end -->
