### PR TITLE
[glibc] Apply fixes of CVEs

### DIFF
--- a/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-4527.patch
+++ b/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-4527.patch
@@ -1,0 +1,13 @@
+diff --git a/resolv/nss_dns/dns-host.c b/resolv/nss_dns/dns-host.c
+index 1d60c51f5e0ec1aa146872e3af5a4909a7660f57..5d0ab30de6e9da6b1d08b8e7d85bdbfc0e8fa567 100644 (file)
+--- a/resolv/nss_dns/dns-host.c
++++ b/resolv/nss_dns/dns-host.c
+@@ -427,7 +427,7 @@ _nss_dns_gethostbyname4_r (const char *name, struct gaih_addrtuple **pat,
+     {
+       n = __res_context_search (ctx, name, C_IN, T_A,
+ 				dns_packet_buffer, sizeof (dns_packet_buffer),
+-				NULL, NULL, NULL, NULL, NULL);
++				&alt_dns_packet_buffer, NULL, NULL, NULL, NULL);
+       if (n >= 0)
+ 	status = gaih_getanswer_noaaaa (alt_dns_packet_buffer, n,
+ 					&abuf, pat, errnop, herrnop, ttlp);

--- a/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-4806.patch
+++ b/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-4806.patch
@@ -1,0 +1,84 @@
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 0356b622be6dda5e6ac9bf70c9813cc1351a0b81..b2236b105c1651201bdfe0e80b5a4995c90acd84 100644 (file)
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -120,6 +120,7 @@ struct gaih_result
+ {
+   struct gaih_addrtuple *at;
+   char *canon;
++  char *h_name;
+   bool free_at;
+   bool got_ipv6;
+ };
+@@ -165,6 +166,7 @@ gaih_result_reset (struct gaih_result *res)
+   if (res->free_at)
+     free (res->at);
+   free (res->canon);
++  free (res->h_name);
+   memset (res, 0, sizeof (*res));
+ }
+ 
+@@ -203,9 +205,8 @@ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+   return 0;
+ }
+ 
+-/* Convert struct hostent to a list of struct gaih_addrtuple objects.  h_name
+-   is not copied, and the struct hostent object must not be deallocated
+-   prematurely.  The new addresses are appended to the tuple array in RES.  */
++/* Convert struct hostent to a list of struct gaih_addrtuple objects.  The new
++   addresses are appended to the tuple array in RES.  */
+ static bool
+ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+ 				   struct hostent *h, struct gaih_result *res)
+@@ -238,6 +239,15 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+   res->at = array;
+   res->free_at = true;
+ 
++  /* Duplicate h_name because it may get reclaimed when the underlying storage
++     is freed.  */
++  if (res->h_name == NULL)
++    {
++      res->h_name = __strdup (h->h_name);
++      if (res->h_name == NULL)
++	return false;
++    }
++
+   /* Update the next pointers on reallocation.  */
+   for (size_t i = 0; i < old; i++)
+     array[i].next = array + i + 1;
+@@ -262,7 +272,6 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+ 	}
+       array[i].next = array + i + 1;
+     }
+-  array[0].name = h->h_name;
+   array[count - 1].next = NULL;
+ 
+   return true;
+@@ -324,15 +333,15 @@ gethosts (nss_gethostbyname3_r fct, int family, const char *name,
+    memory allocation failure.  The returned string is allocated on the
+    heap; the caller has to free it.  */
+ static char *
+-getcanonname (nss_action_list nip, struct gaih_addrtuple *at, const char *name)
++getcanonname (nss_action_list nip, const char *hname, const char *name)
+ {
+   nss_getcanonname_r *cfct = __nss_lookup_function (nip, "getcanonname_r");
+   char *s = (char *) name;
+   if (cfct != NULL)
+     {
+       char buf[256];
+-      if (DL_CALL_FCT (cfct, (at->name ?: name, buf, sizeof (buf),
+-			      &s, &errno, &h_errno)) != NSS_STATUS_SUCCESS)
++      if (DL_CALL_FCT (cfct, (hname ?: name, buf, sizeof (buf), &s, &errno,
++			      &h_errno)) != NSS_STATUS_SUCCESS)
+ 	/* If the canonical name cannot be determined, use the passed
+ 	   string.  */
+ 	s = (char *) name;
+@@ -771,7 +780,7 @@ get_nss_addresses (const char *name, const struct addrinfo *req,
+ 		  if ((req->ai_flags & AI_CANONNAME) != 0
+ 		      && res->canon == NULL)
+ 		    {
+-		      char *canonbuf = getcanonname (nip, res->at, name);
++		      char *canonbuf = getcanonname (nip, res->h_name, name);
+ 		      if (canonbuf == NULL)
+ 			{
+ 			  __resolv_context_put (res_ctx);

--- a/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-4911.patch
+++ b/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-4911.patch
@@ -1,0 +1,36 @@
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 62b7332d95b61ce3428040522271f6e93e9d53ed..cae67efa0aacb9984c49874dcb95f170ecd1d86d 100644 (file)
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -180,11 +180,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -244,9 +240,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ 
+ /* Enable the glibc.malloc.check tunable in SETUID/SETGID programs only when

--- a/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-5156.patch
+++ b/subprojects/packagefiles/glibc-2.38/fix-CVE-2023-5156.patch
@@ -1,0 +1,15 @@
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index b2236b105c1651201bdfe0e80b5a4995c90acd84..13082305d3f89316ae9d685857470835c747f895 100644 (file)
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -1196,9 +1196,7 @@ free_and_return:
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
+-  if (res.free_at)
+-    free (res.at);
+-  free (res.canon);
++  gaih_result_reset (&res);
+ 
+   return result;
+ }

--- a/subprojects/packagefiles/glibc-2.38/meson.build
+++ b/subprojects/packagefiles/glibc-2.38/meson.build
@@ -73,6 +73,29 @@ glibc = custom_target('glibc',
         'glibc-2.38/configure',
         'gramine-syscall.patch',
         'hp-timing.patch',
+        # backporting the fix for CVE-2023-4527; drop when we update to glibc 2.39;
+        # see the following:
+        #  - https://nvd.nist.gov/vuln/detail/CVE-2023-4527
+        #  - https://sourceware.org/bugzilla/show_bug.cgi?id=30842
+        #  - https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=b25508dd774b617f99419bdc3cf2ace4560cd2d6
+        'fix-CVE-2023-4527.patch',
+        # backporting the fix for CVE-2023-4806; drop when we update to glibc 2.39;
+        # see the following:
+        #  - https://nvd.nist.gov/vuln/detail/CVE-2023-4806
+        #  - https://sourceware.org/bugzilla/show_bug.cgi?id=30843
+        #  - https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=00ae4f10b504bc4564e9f22f00907093f1ab9338
+        'fix-CVE-2023-4806.patch',
+        # backporting the fix for CVE-2023-4911; drop when we update to glibc 2.39;
+        # see the following:
+        #  - https://nvd.nist.gov/vuln/detail/CVE-2023-4911
+        #  - https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=750a45a783906a19591fb8ff6b7841470f1f5701
+        'fix-CVE-2023-4911.patch',
+        # backporting the fix for CVE-2023-5156; drop when we update to glibc 2.39;
+        # see the following:
+        #  - https://nvd.nist.gov/vuln/detail/CVE-2023-5156
+        #  - https://sourceware.org/bugzilla/show_bug.cgi?id=30884
+        #  - https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=5ee59ca371b99984232d7584fe2b1a758b4421d3
+        'fix-CVE-2023-5156.patch',
     ],
 
     output: glibc_output,


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Glibc 2.38 release does not contain the fixes of some CVEs, specifically CVE-2023-4527, CVE-2023-4806, CVE-2023-4911 and CVE-2023-5156. Thus Gramine need to apply the fixes, which are taken from the corresponding glibc commits.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1628)
<!-- Reviewable:end -->
