### PR TITLE
[tools/pf_crypt] Allow in-place (same file) encrypt/decrypt

### DIFF
--- a/tools/sgx/pf_crypt/pf_crypt.c
+++ b/tools/sgx/pf_crypt/pf_crypt.c
@@ -58,8 +58,13 @@ int main(int argc, char* argv[]) {
     char* mode = NULL;
     bool verify = false;
 
+    if (argc == 1) {
+        usage(argv[0]);
+        exit(1);
+    }
+
     while (true) {
-        this_option = getopt_long(argc, argv, "i:o:p:w:Vvh", g_options, NULL);
+        this_option = getopt_long(argc, argv, "i:o:w:Vvh", g_options, NULL);
         if (this_option == -1)
             break;
 
@@ -83,14 +88,14 @@ int main(int argc, char* argv[]) {
                 usage(argv[0]);
                 exit(0);
             default:
-                ERROR("Unknown option: %c\n", this_option);
-                usage(argv[0]);
+                /* note that getopt_long() already prints the error `invalid option ...` */
+                ERROR("Use '%s --help' to see possible options.\n", argv[0]);
+                goto out;
         }
     }
 
     if (optind >= argc) {
         ERROR("Mode not specified\n");
-        usage(argv[0]);
         goto out;
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `gramine-sgx-pf-crypt` tool didn't support in-place encryption/decryption of a file -- it produced garbage during encryption and failed during decryption. This commit fixes this, by using a temporary file as an intermediate storage.

Detected in this discussion: https://github.com/gramineproject/gramine/discussions/1610#discussioncomment-7324380

## How to test this PR? <!-- (if applicable) -->

E.g. like this manually (this was done from the Gramine repo root dir):
```bash
$ gramine-sgx-pf-crypt gen-key -w bla.key


##### WITHOUT THIS PR
$ gramine-sgx-pf-crypt encrypt --input README.rst --output README.rst --wrap-key bla.key
Encrypting: README.rst -> README.rst

$ gramine-sgx-pf-crypt decrypt --input README.rst --output README.rst --wrap-key bla.key
Decrypting: README.rst -> README.rst
linux_read: EOF
pf_decrypt_file: Read from protected file failed (offset 0, size 4096): File is corrupted


##### WITH THIS PR
$ gramine-sgx-pf-crypt encrypt --input README.rst --output README.rst --wrap-key bla.key
Encrypting: README.rst -> README.rst

$ gramine-sgx-pf-crypt decrypt --input README.rst --output README.rst --wrap-key bla.key
Decrypting: README.rst -> README.rst

$ head README.rst
*****************************************
Gramine Library OS with Intel SGX Support
*****************************************
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1631)
<!-- Reviewable:end -->
