### PR TITLE
[tools] Add `gramine-direct --version` and `gramine-sgx --version`

### DIFF
--- a/Documentation/manpages/gramine.rst
+++ b/Documentation/manpages/gramine.rst
@@ -20,6 +20,13 @@ Description
 This is the main way to invoke Gramine. The first argument is the name of the
 application (that is, name of the manifest file *without* ``.manifest``).
 
+Options
+=======
+
+.. option:: --version
+
+   Show version and exit.
+
 Environment variables
 =====================
 

--- a/scripts/meson-render-script.py
+++ b/scripts/meson-render-script.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2023 Intel Corporation
+#                    Wojtek Porczyk <woju@invisiblethingslab.com>
+#
+
+import argparse
+import functools
+import os
+import string
+
+# NOTE: do not include the usual <invalid> group, since we don't want to
+# fail on e-mail addresses in the header
+class MesonTemplate(string.Template):
+    pattern = '''
+        @(?:
+            (?P<escaped>@) |
+            (?P<named>[A-Za-z0-9_]+)@ |
+            (?P<braced>[A-Za-z0-9_]+)@
+        )
+    '''
+
+_parser = argparse.ArgumentParser()
+_parser.add_argument('-m', '--mode', metavar='MODE',
+    type=functools.partial(int, base=8),
+    help='set permission mode (as in chmod)',
+)
+_parser.add_argument('-f', '--config', metavar='PATH',
+    action='append',
+    type=argparse.FileType('r'),
+    help='read file with KEY=VALUE defines (see -D), one per line'
+)
+_parser.add_argument('-D', '--define', metavar='KEY=VALUE',
+    action='append',
+    default=[],
+    help='define a substitution for the template',
+)
+_parser.add_argument('infile', metavar='IN',
+    nargs='?',
+    type=argparse.FileType('r'),
+    default='-',
+    help='input file or "-" for stdin'
+)
+_parser.add_argument('outfile', metavar='OUT',
+    type=argparse.FileType('w'),
+    nargs='?',
+    default='-',
+    help='output file or "-" for stdout'
+)
+
+def main(args=None):
+    args = _parser.parse_args(args)
+    template = MesonTemplate(args.infile.read())
+    substs = {}
+
+    for file in args.config:
+        for line in file:
+            if line[0] in '\n#':
+                continue
+            k, v = line.rstrip('\n').split('=')
+            substs[k] = v
+
+    for value in args.define:
+        try:
+            k, v = value.split('=', 1)
+        except ValueError:
+            k, v = value, True
+        substs[k] = v
+
+    args.outfile.write(template.substitute(substs))
+    args.outfile.flush()
+
+    if args.mode is not None:
+        if not os.path.exists(args.outfile.name):
+            # it might not exist if it's "<stdout>"
+            _parser.error('cannot set mode on pipe')
+        os.chmod(args.outfile.name, args.mode)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -3,6 +3,7 @@ foreach script : [
     'gen-pal-map.py',
     'get-python-platlib.py',
     'meson-clang-format.sh',
+    'meson-render-script.py',
 ]
     set_variable('@0@_prog'.format(script.split('.')[0].underscorify()),
         find_program(script))

--- a/tools/gramine.in
+++ b/tools/gramine.in
@@ -37,6 +37,11 @@ if [ "$PERF" == "1" ]; then
     PREFIX=(perf stat)
 fi
 
+if [ "$1" == "--version" ]; then
+    echo "Gramine @VERSION@ (@VCS_TAG@)"
+    exit 0
+fi
+
 while [ "$1" != "" ];
 do
     if [ "$APPLICATION" == "" ]; then

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,22 +1,33 @@
-conf = configuration_data()
-conf.set_quoted('IN_GIT', '')
-conf.set_quoted('PREFIX', get_option('prefix'))
-conf.set_quoted('BINDIR', get_option('bindir'))
+gramine_vcs_tag = vcs_tag(
+    command: ['git', 'rev-parse', '--verify', 'HEAD'],
+    input: 'vcs_tag.in',
+    output: 'vcs_tag',
+)
+
+common_render_defines = [
+    '--config', gramine_vcs_tag,
+    '-D', 'VERSION=@0@'.format(meson.project_version()),
+    '-D', 'PREFIX=@0@'.format(get_option('prefix')),
+    '-D', 'BINDIR=@0@'.format(get_option('bindir')),
+]
 
 if direct
     hostpalpath_direct = get_option('prefix') / pkglibdir / 'direct'
-    conf_gramine_direct = configuration_data()
-    conf_gramine_direct.merge_from(conf)
-    conf_gramine_direct.set('SGX', 0)
-    conf_gramine_direct.set_quoted('HOST_PAL_PATH', hostpalpath_direct)
-    conf_gramine_direct.set_quoted('LIBPAL_PATH', hostpalpath_direct / 'libpal.so')
-    conf_gramine_direct.set_quoted('PAL_CMD', hostpalpath_direct / 'loader')
-    conf_gramine_direct.set_quoted('CONFIG_SGX_DRIVER', '')
-
-    configure_file(
+    custom_target('gramine-direct',
+        command: [meson_render_script_prog,
+            '--mode', '755',
+            common_render_defines,
+            '-D', 'SGX=0',
+            '-D', 'HOST_PAL_PATH=@0@'.format(hostpalpath_direct),
+            '-D', 'LIBPAL_PATH=@0@'.format(hostpalpath_direct / 'libpal.so'),
+            '-D', 'PAL_CMD=@0@'.format(hostpalpath_direct / 'loader'),
+            '-D', 'CONFIG_SGX_DRIVER=',
+            '@INPUT@',
+            '@OUTPUT@',
+        ],
         input: 'gramine.in',
         output: 'gramine-direct',
-        configuration: conf_gramine_direct,
+        install: true,
         install_dir: get_option('bindir'),
     )
 endif
@@ -25,18 +36,22 @@ if sgx
     subdir('sgx')
 
     hostpalpath_linux_sgx = get_option('prefix') / pkglibdir / 'sgx'
-    conf_gramine_sgx = configuration_data()
-    conf_gramine_sgx.merge_from(conf)
-    conf_gramine_sgx.set('SGX', 1)
-    conf_gramine_sgx.set_quoted('HOST_PAL_PATH', hostpalpath_linux_sgx)
-    conf_gramine_sgx.set_quoted('LIBPAL_PATH', hostpalpath_linux_sgx / 'libpal.so')
-    conf_gramine_sgx.set_quoted('PAL_CMD', get_option('prefix') / pkglibdir / 'sgx' / 'loader')
-    conf_gramine_sgx.set_quoted('CONFIG_SGX_DRIVER', sgx_driver)
 
-    configure_file(
+    custom_target('gramine-sgx',
+        command: [meson_render_script_prog,
+            '--mode', '755',
+            common_render_defines,
+            '-D', 'SGX=1',
+            '-D', 'HOST_PAL_PATH=@0@'.format(hostpalpath_linux_sgx),
+            '-D', 'LIBPAL_PATH=@0@'.format(hostpalpath_linux_sgx / 'libpal.so'),
+            '-D', 'PAL_CMD=@0@'.format(get_option('prefix') / pkglibdir / 'sgx' / 'loader'),
+            '-D', 'CONFIG_SGX_DRIVER=@0@'.format(sgx_driver),
+            '@INPUT@',
+            '@OUTPUT@',
+        ],
         input: 'gramine.in',
         output: 'gramine-sgx',
-        configuration: conf_gramine_sgx,
+        install: true,
         install_dir: get_option('bindir'),
     )
 endif

--- a/tools/vcs_tag.in
+++ b/tools/vcs_tag.in
@@ -1,0 +1,1 @@
+VCS_TAG=@VCS_TAG@


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Alternative to #1270. Changed:
- adds generic script for rendering templates, which can also chmod the resulting file
- version output is `Gramine X.Y (COMMIT)`
- added manpage entry for `--version` 

## How to test this PR? <!-- (if applicable) -->

```sh
gramine-direct --version
gramine-sgx --version
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1632)
<!-- Reviewable:end -->
