### PR TITLE
[PAL/Linux-SGX] Thread initialization error handling fixes

### DIFF
--- a/pal/src/host/linux-sgx/host_thread.c
+++ b/pal/src/host/linux-sgx/host_thread.c
@@ -195,10 +195,6 @@ int pal_thread_init(void* tcbptr) {
     unmap_tcs();
     ret = 0;
 out:
-#ifdef ASAN
-    asan_unpoison_region((uintptr_t)tcb->stack, THREAD_STACK_SIZE + ALT_STACK_SIZE);
-#endif
-    DO_SYSCALL(munmap, tcb->stack, THREAD_STACK_SIZE + ALT_STACK_SIZE);
     return ret;
 }
 

--- a/pal/src/host/linux-sgx/host_thread.c
+++ b/pal/src/host/linux-sgx/host_thread.c
@@ -189,12 +189,16 @@ int pal_thread_init(void* tcbptr) {
         return 0;
     }
 
+    __atomic_store_n(tcb->start_status_ptr, 0, __ATOMIC_RELAXED);
+
     /* not-first (child) thread, start it */
     ecall_thread_start();
 
     unmap_tcs();
     ret = 0;
 out:
+    if (ret != 0)
+        __atomic_store_n(tcb->start_status_ptr, ret, __ATOMIC_RELAXED);
     return ret;
 }
 
@@ -271,8 +275,9 @@ int clone_thread(void) {
     /* align child_stack to 16 */
     child_stack_top = ALIGN_DOWN_PTR(child_stack_top, 16);
 
-    // TODO: pal_thread_init() may fail during initialization (e.g. on TCS exhaustion), we should
-    // check its result (but this happens asynchronously, so it's not trivial to do).
+    int start_status = 1;
+    tcb->start_status_ptr = &start_status;
+
     ret = clone(pal_thread_init, child_stack_top,
                 CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_THREAD | CLONE_SIGHAND,
                 tcb, /*parent_tid=*/NULL, /*tls=*/NULL, /*child_tid=*/NULL, thread_exit);
@@ -281,7 +286,11 @@ int clone_thread(void) {
         DO_SYSCALL(munmap, stack, THREAD_STACK_SIZE + ALT_STACK_SIZE);
         return ret;
     }
-    return 0;
+
+    while ((ret = __atomic_load_n(&start_status, __ATOMIC_RELAXED)) == 1)
+        CPU_RELAX();
+
+    return ret;
 }
 
 int get_tid_from_tcs(void* tcs) {

--- a/pal/src/host/linux-sgx/pal_tcb.h
+++ b/pal/src/host/linux-sgx/pal_tcb.h
@@ -104,6 +104,7 @@ typedef struct pal_host_tcb {
     atomic_ulong async_signal_cnt; /* # of async signals, corresponds to # of SIGINT/SIGCONT/.. */
     uint64_t profile_sample_time;  /* last time sgx_profile_sample() recorded a sample */
     int32_t last_async_event;      /* last async signal, reported to the enclave on ocall return */
+    int* start_status_ptr;         /* pointer to return value of clone_thread */
 } PAL_HOST_TCB;
 
 extern void pal_host_tcb_init(PAL_HOST_TCB* tcb, void* stack, void* alt_stack);


### PR DESCRIPTION
## Description of the changes

A TODO within the code is fixed, adding proper error reporting in host-side `clone_thread`.  Additionally, a segfault in error handling is fixed.

## How to test this PR?

This PR fixes a test added by #1451.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1645)
<!-- Reviewable:end -->
