### PR TITLE
Fix Coverity issues

### DIFF
--- a/libos/src/libos_pollable_event.c
+++ b/libos/src/libos_pollable_event.c
@@ -97,7 +97,7 @@ int clear_pollable_event(struct libos_pollable_event* event) {
     do {
         char buf[0x100];
         size_t size = sizeof(buf);
-        int ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf);
+        ret = PalStreamRead(event->read_handle, /*offset=*/0, &size, buf);
         ret = pal_to_unix_errno(ret);
         if (ret == 0 && size == 0) {
             ret = -EINVAL;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

PR fixes Coverity issue described below:

CID 328056: Infinite loop
The loop does not have a normal termination condition, so will continue until an abnormal condition arises.

In clear_pollable_event: Infinite loop with unsatisfiable exit condition (CWE-835)

loop_bottom Bottom of the loop.
loop_condition If ret == -4 is initially true then it will remain true

https://github.com/gramineproject/gramine/blob/master/libos/src/libos_pollable_event.c#L74-L86

## How to test this PR? <!-- (if applicable) -->

Sanity run should do the job?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1651)
<!-- Reviewable:end -->
