### PR TITLE
[CI-Examples] Add the BSD-3-clause license to all examples

### DIFF
--- a/CI-Examples/bash/Makefile
+++ b/CI-Examples/bash/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)

--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # This is a general manifest template for running Bash and core utility programs,
 # including ls, cat, cp, date, and rm.
 

--- a/CI-Examples/bash/scripts/bash_test.sh
+++ b/CI-Examples/bash/scripts/bash_test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 times=$1
 [ "$times" -gt 0 ] 2>/dev/null || times=300
 

--- a/CI-Examples/blender/Makefile
+++ b/CI-Examples/blender/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # assumes this makefile lies in cwd
 PWD := $(shell pwd)
 

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Blender manifest example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/blender/test_all_scenes.sh
+++ b/CI-Examples/blender/test_all_scenes.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 set -e
 
 if test -n "$SGX"

--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 SRCDIR = src

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Busybox manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/common_tools/benchmark-http.sh
+++ b/CI-Examples/common_tools/benchmark-http.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # On Ubuntu, this script requires wrk2 tool installed for the wrk binary.
 #
 # Run like: ./benchmark-http.sh host:port

--- a/CI-Examples/common_tools/download
+++ b/CI-Examples/common_tools/download
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 set -eu -o pipefail
 
 declare -a urls

--- a/CI-Examples/helloworld/Makefile
+++ b/CI-Examples/helloworld/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 CFLAGS = -Wall -Wextra
 
 ifeq ($(DEBUG),1)

--- a/CI-Examples/helloworld/helloworld.c
+++ b/CI-Examples/helloworld/helloworld.c
@@ -1,3 +1,6 @@
+/* Copyright (C) 2023 Gramine contributors
+ * SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 int main(void) {

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Hello World manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/lighttpd/Makefile
+++ b/CI-Examples/lighttpd/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)

--- a/CI-Examples/lighttpd/lighttpd-generic.conf
+++ b/CI-Examples/lighttpd/lighttpd-generic.conf
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 server.event-handler = "select"
 #server.event-handler = "linux-sysepoll"
 server.max-connections = 1024

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # lighttpd manifest example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/memcached/Makefile
+++ b/CI-Examples/memcached/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 SRCDIR = src

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Memcached manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/nginx/Makefile
+++ b/CI-Examples/nginx/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)

--- a/CI-Examples/nginx/nginx-gramine.conf.template
+++ b/CI-Examples/nginx/nginx-gramine.conf.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # This configuration file is based on nginx.conf.default from Nginx v1.16.1.
 #
 # The following changes are made:

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Nginx manifest example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/nginx/ssl/ca_config.conf
+++ b/CI-Examples/nginx/ssl/ca_config.conf
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 [ req ]
 default_bits       = 4096
 default_md         = sha512

--- a/CI-Examples/python/Makefile
+++ b/CI-Examples/python/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Python3 manifest example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/python/run-tests.sh
+++ b/CI-Examples/python/run-tests.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 set -e
 
 if test -n "$SGX"

--- a/CI-Examples/python/scripts/dummy-web-server.py
+++ b/CI-Examples/python/scripts/dummy-web-server.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 

--- a/CI-Examples/python/scripts/helloworld.py
+++ b/CI-Examples/python/scripts/helloworld.py
@@ -1,3 +1,6 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 print("Hello World")

--- a/CI-Examples/python/scripts/sgx-quote.py
+++ b/CI-Examples/python/scripts/sgx-quote.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import sys
 

--- a/CI-Examples/python/scripts/sgx-report.py
+++ b/CI-Examples/python/scripts/sgx-report.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import sys
 

--- a/CI-Examples/python/scripts/test-http.py
+++ b/CI-Examples/python/scripts/test-http.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 import urllib.request
 

--- a/CI-Examples/python/scripts/test-numpy.py
+++ b/CI-Examples/python/scripts/test-numpy.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 import timeit
 
 import numpy

--- a/CI-Examples/python/scripts/test-scipy.py
+++ b/CI-Examples/python/scripts/test-scipy.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 import timeit
 
 setup = """\

--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Client manifest file
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # RA-TLS manifest file example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/ra-tls-mbedtls/ssl/ca_config.conf
+++ b/CI-Examples/ra-tls-mbedtls/ssl/ca_config.conf
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 [ req ]
 default_bits       = 4096
 default_md         = sha512

--- a/CI-Examples/ra-tls-nginx/Makefile
+++ b/CI-Examples/ra-tls-nginx/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 RA_TYPE ?= dcap
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 

--- a/CI-Examples/ra-tls-nginx/nginx.conf
+++ b/CI-Examples/ra-tls-nginx/nginx.conf
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 error_log stderr warn;
 pid /tmp/nginx.pid;
 daemon off;

--- a/CI-Examples/ra-tls-nginx/nginx.manifest.template
+++ b/CI-Examples/ra-tls-nginx/nginx.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 loader.argv = [
     "gramine-ratls", "/tmp/crt.pem", "/tmp/key.pem", "--",

--- a/CI-Examples/ra-tls-nginx/run.sh
+++ b/CI-Examples/ra-tls-nginx/run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 set -e
 
 gramine-sgx nginx &

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)

--- a/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Secret Provisioning manifest file example (client)
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Secret Provisioning manifest file example (minimal client)
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Secret Provisioning manifest file example (Protected Files client)
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/ra-tls-secret-prov/ssl/ca_config.conf
+++ b/CI-Examples/ra-tls-secret-prov/ssl/ca_config.conf
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 [ req ]
 default_bits       = 4096
 default_md         = sha512

--- a/CI-Examples/redis/Makefile
+++ b/CI-Examples/redis/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Build Redis as follows:
 #
 # - make               -- create non-SGX no-debug-log manifest

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Redis manifest file example
 
 ################################## GRAMINE ####################################

--- a/CI-Examples/rust/Cargo.toml
+++ b/CI-Examples/rust/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 [package]
 name = "rust-hyper-http-server"
 version = "0.1.0"

--- a/CI-Examples/rust/Makefile
+++ b/CI-Examples/rust/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 SELF_EXE = target/release/rust-hyper-http-server

--- a/CI-Examples/rust/rust-hyper-http-server.manifest.template
+++ b/CI-Examples/rust/rust-hyper-http-server.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Rust manifest example
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/rust/src/main.rs
+++ b/CI-Examples/rust/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2023 Gramine contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use hyper::{Body, Request, Response, Server};

--- a/CI-Examples/sqlite/Makefile
+++ b/CI-Examples/sqlite/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2023 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 # This is a general manifest template for running SQLite.
 
 loader.entrypoint = "file:{{ gramine.libos }}"

--- a/CI-Examples/sqlite/scripts/create.sql
+++ b/CI-Examples/sqlite/scripts/create.sql
@@ -1,3 +1,6 @@
+/* Copyright (C) 2023 Gramine contributors
+ * SPDX-License-Identifier: BSD-3-Clause */
+
 DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab (

--- a/CI-Examples/sqlite/scripts/select.sql
+++ b/CI-Examples/sqlite/scripts/select.sql
@@ -1,1 +1,4 @@
+/* Copyright (C) 2023 Gramine contributors
+ * SPDX-License-Identifier: BSD-3-Clause */
+
 SELECT id, str FROM tab ORDER BY id DESC;

--- a/CI-Examples/sqlite/scripts/update.sql
+++ b/CI-Examples/sqlite/scripts/update.sql
@@ -1,1 +1,4 @@
+/* Copyright (C) 2023 Gramine contributors
+ * SPDX-License-Identifier: BSD-3-Clause */
+
 UPDATE tab SET str = 'row ' || id;

--- a/LICENSE.addendum.txt
+++ b/LICENSE.addendum.txt
@@ -1,5 +1,8 @@
 Gramine itself is licensed under the LGPL-3.0-or-later.
 
+Examples (the `CI-Examples` subdirectory) are licensed under BSD-3-Clause,
+except for several C files. See each file for its license.
+
 Gramine also includes the following third party sources (and licenses):
 * cJSON - MIT
 * curl/libcurl - MIT derivative


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

To make the licensing of examples explicit, we mark all Makefiles, manifest templates, config files, Python scripts, etc. with a BSD-3-clause license.

For motivation and discussion, see #1644.

## How to test this PR? <!-- (if applicable) -->

N/A.