### PR TITLE
[CI] Remove pylint from checks

### DIFF
--- a/.ci/lib/stage-lint.jenkinsfile
+++ b/.ci/lib/stage-lint.jenkinsfile
@@ -1,7 +1,6 @@
 stage('lint') {
     sh '''
         ./scripts/gitignore-check-files
-        ./.ci/run-pylint -f text
         ./.ci/run-shellcheck
     '''
 }

--- a/.ci/run-shellcheck
+++ b/.ci/run-shellcheck
@@ -14,5 +14,5 @@ LC_ALL=C.UTF-8 shellcheck "$@" \
     scripts/clean-check-test-copy \
     scripts/download \
     scripts/gitignore-test \
-    .ci/run-pylint \
+    scripts/run-pylint \
     .ci/run-shellcheck

--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     pkg-config \
     protobuf-c-compiler \
     protobuf-compiler \
-    pylint3 \
     python \
     python3-apport \
     python3-apt \

--- a/.ci/ubuntu22.04.dockerfile
+++ b/.ci/ubuntu22.04.dockerfile
@@ -46,7 +46,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     pkg-config \
     protobuf-c-compiler \
     protobuf-compiler \
-    pylint \
     python3 \
     python3-apport \
     python3-apt \

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1264,8 +1264,6 @@ class TC_50_GDB(RegressionTestCase):
         return match.group(1).strip()
 
     def test_000_gdb_backtrace(self):
-        # pylint: disable=fixme
-        #
         # To run this test manually, use:
         # GDB=1 GDB_SCRIPT=debug.gdb gramine-{direct|sgx} debug
         #

--- a/scripts/run-pylint
+++ b/scripts/run-pylint
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Currently not used in CI due to a high ratio of questionable findings to meaningful ones and
+# incompatible changes between pylint versions.
+# It is still recommended to use it and check the results manually when doing bigger changes in
+# Python codebase. It's just not suitable as a CI check.
+
 set -e
 
 cd "$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

pylint turned out to not be suitable as a CI check due to its instability between versions and a large amount of questionable findings.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1658)
<!-- Reviewable:end -->
