### PR TITLE
[tests] test_sgx_sign: fix incompatibility with old pytest

### DIFF
--- a/tests/test_sgx_sign.py
+++ b/tests/test_sgx_sign.py
@@ -11,11 +11,13 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 @pytest.fixture
-def tmp_rsa_key(tmp_path):
+def tmp_rsa_key(tmpdir):
     from graminelibos.sgx_sign import (SGX_RSA_KEY_SIZE, SGX_RSA_PUBLIC_EXPONENT,
         _cryptography_backend)
     def gen_rsa_key(passphrase=None, key_size=SGX_RSA_KEY_SIZE):
-        key_path = tmp_path / 'key.pem'
+        # TODO: use `tmp_path` fixture after we drop support for distros (RHEL 8, CentOS Stream 8)
+        # that have old pytest version (< 3.9.0) installed
+        key_path = tmpdir.join('key.pem')
         with open(key_path, 'wb') as pfile:
             key = rsa.generate_private_key(public_exponent=SGX_RSA_PUBLIC_EXPONENT,
                 key_size=key_size, backend=_cryptography_backend)


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
`tmp_path` fixture requires pytest version 3.9.0+. However, RHEL 8 and CentOS Stream 8 install pytest 3.4.2 by default.

This commit fixes the incompatibility issue by using `tmpdir` fixture instead.

Fixes https://github.com/gramineproject/gramine/issues/1661.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

`python3 -m pytest -v --junit-xml tests.xml tests/` w/ both older and newer pytest versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1662)
<!-- Reviewable:end -->
