### PR TITLE
[tools] Disallow nested Gramine invocation

### DIFF
--- a/tools/gramine.in
+++ b/tools/gramine.in
@@ -15,6 +15,12 @@ APPLICATION=
 ENVS=()
 PREFIX=()
 
+if [ -d "/dev/attestation/keys" ]; then
+    echo "Gramine ($0) seems to be executed in a Gramine environment (not a host environment)." >&2
+    echo "Such nested execution is impossible; please check your deployment scripts for bugs." >&2
+    exit 2
+fi
+
 if [ "$GDB" == "1" ]; then
     PREFIX=("gdb" "-q")
     if [ -n "$INSIDE_EMACS" ]; then


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

In certain cases, and with bugs in the Gramine build & deployment scripts, we may end up in Gramine invoking itself (via bash). Since inner Gramine executable prints hard-to-diagnose error messages in this case, this commit proactively checks if Gramine executes in the Gramine environment (by checking for `/dev/attestation/keys/` dir existence), and prints a human-readable error if it detects such env.

Fixes #1666.

## How to test this PR? <!-- (if applicable) -->

Test manually using our Bash example:

1. Create a soft link to `gramine-direct` in the Bash example dir, for simplicity:
```
cd CI-Examples/bash/
ln -s /home/dimakuv/gramineproject/gramine/built-debug/bin/gramine-direct .
```

2. Apply the following git diff:
```diff
diff --git a/CI-Examples/bash/manifest.template b/CI-Examples/bash/manifest.template
@@ -2,12 +2,13 @@
 # including ls, cat, cp, date, and rm.

 loader.entrypoint = "file:{{ gramine.libos }}"
-libos.entrypoint = "{{ execdir }}/bash"
+libos.entrypoint = "gramine-direct"

-loader.log_level = "{{ log_level }}"
+#loader.log_level = "{{ log_level }}"
+loader.log_level = "all"

 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
-loader.env.PATH = "{{ execdir }}"
+loader.env.PATH = "{{ execdir }}:/usr/{{ execdir }}"

 loader.insecure__use_cmdline_argv = true

@@ -16,6 +17,10 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr/lib", uri = "file:/usr/lib" },
   { path = "{{ execdir }}", uri = "file:{{ execdir }}" },
+  { path = "/usr/{{ execdir }}", uri = "file:/usr/{{ execdir }}" },
+  # REPLACE BELOW PATH MANUALLY
+  { path = "/home/dimakuv/gramineproject/gramine/built-debug", uri = "file:/home/dimakuv/gramineproject/gramine/built-debug" },
+  { path = "/gramine-direct", uri = "file:gramine-direct" },
 ]

 sgx.debug = true
@@ -26,9 +31,11 @@ sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ execdir }}/",
+  "file:/usr/{{ execdir }}/",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
+  "file:gramine-direct",
 ]

 sgx.allowed_files = [
```

3. Run this without this PR and with this PR:
   - Without this PR:
      ```
      $ gramine-direct bash bash
      Emulating a raw system/supervisor call. This degrades performance, consider patching your application to use Gramine syscall API.
      $ echo $?
      6 
      ```
   - With this PR:
      ```
      $ gramine-direct bash bash
      Gramine (gramine-direct) seems to be executed in a Gramine environment (not a host environment).
      Such nested execution is impossible; please check your deployment scripts for bugs.
      ```
   - (same for SGX version.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1668)
<!-- Reviewable:end -->
