### PR TITLE
[LibOS,Pal,common,tools] Improved protected files performance

### DIFF
--- a/common/src/protected_files/protected_files_format.h
+++ b/common/src/protected_files/protected_files_format.h
@@ -94,12 +94,6 @@ typedef struct _data_node {
 
 static_assert(sizeof(data_node_t) == PF_NODE_SIZE, "sizeof(data_node_t)");
 
-typedef struct _encrypted_node {
-    uint8_t cipher[PF_NODE_SIZE];
-} encrypted_node_t;
-
-static_assert(sizeof(encrypted_node_t) == PF_NODE_SIZE, "sizeof(encrypted_node_t)");
-
 #define MAX_PAGES_IN_CACHE 48
 
 typedef enum {
@@ -119,10 +113,7 @@ typedef struct _file_node {
     struct _file_node* parent;
     bool need_writing;
     bool new_node;
-    struct {
-        uint64_t physical_node_number;
-        encrypted_node_t encrypted; // the actual data from the disk
-    };
+    uint64_t physical_node_number;
     union { // decrypted data
         mht_node_t mht;
         data_node_t data;

--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -19,6 +19,7 @@ struct pf_context {
     metadata_encrypted_t encrypted_part_plain; // encrypted part of metadata node, decrypted
     file_node_t root_mht; // the root of the mht is always needed (for files bigger than 3KB)
     pf_handle_t file;
+    void* addr;
     pf_file_mode_t mode;
     uint64_t real_file_size;
     bool need_writing;

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -373,7 +373,7 @@ static int chroot_encrypted_fchmod(struct libos_handle* hdl, mode_t perm) {
 
     struct libos_encrypted_file* enc = hdl->inode->data;
     mode_t host_perm = HOST_PERM(perm);
-    PAL_STREAM_ATTR attr = {.share_flags = host_perm};
+    PAL_STREAM_ATTR attr = {.share_flags = host_perm, .addr = (void*)-1};
     int ret = PalStreamAttributesSetByHandle(enc->pal_handle, &attr);
     if (ret < 0)
         return pal_to_unix_errno(ret);

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -20,72 +20,24 @@ static LISTP_TYPE(libos_encrypted_files_key) g_keys = LISTP_INIT;
 /* Protects the `g_keys` list, but also individual keys, since they can be updated */
 static struct libos_lock g_keys_lock;
 
-static pf_status_t cb_read(pf_handle_t handle, void* buffer, uint64_t offset, size_t size) {
+static pf_status_t cb_truncate(pf_handle_t handle, uint64_t size, void** ret_addr) {
+    int ret;
     PAL_HANDLE pal_handle = (PAL_HANDLE)handle;
 
-    size_t buffer_offset = 0;
-    size_t remaining = size;
-
-    while (remaining > 0) {
-        size_t count = remaining;
-        int ret = PalStreamRead(pal_handle, offset + buffer_offset, &count, buffer + buffer_offset);
-        if (ret == -PAL_ERROR_INTERRUPTED)
-            continue;
-
-        if (ret < 0) {
-            log_warning("PalStreamRead failed: %s", pal_strerror(ret));
-            return PF_STATUS_CALLBACK_FAILED;
-        }
-
-        if (count == 0) {
-            log_warning("EOF");
-            return PF_STATUS_CALLBACK_FAILED;
-        }
-
-        assert(count <= remaining);
-        remaining -= count;
-        buffer_offset += count;
-    }
-    return PF_STATUS_SUCCESS;
-}
-
-static pf_status_t cb_write(pf_handle_t handle, const void* buffer, uint64_t offset, size_t size) {
-    PAL_HANDLE pal_handle = (PAL_HANDLE)handle;
-
-    size_t buffer_offset = 0;
-    size_t remaining = size;
-
-    while (remaining > 0) {
-        size_t count = remaining;
-        int ret = PalStreamWrite(pal_handle, offset + buffer_offset, &count,
-                                 (void*)(buffer + buffer_offset));
-        if (ret == -PAL_ERROR_INTERRUPTED)
-            continue;
-
-        if (ret < 0) {
-            log_warning("PalStreamWrite failed: %s", pal_strerror(ret));
-            return PF_STATUS_CALLBACK_FAILED;
-        }
-
-        if (count == 0) {
-            log_warning("EOF");
-            return PF_STATUS_CALLBACK_FAILED;
-        }
-
-        assert(count <= remaining);
-        remaining -= count;
-        buffer_offset += count;
-    }
-    return PF_STATUS_SUCCESS;
-}
-
-static pf_status_t cb_truncate(pf_handle_t handle, uint64_t size) {
-    PAL_HANDLE pal_handle = (PAL_HANDLE)handle;
-
-    int ret = PalStreamSetLength(pal_handle, size);
+    ret = PalStreamSetLength(pal_handle, size);
     if (ret < 0) {
         log_warning("PalStreamSetLength failed: %s", pal_strerror(ret));
         return PF_STATUS_CALLBACK_FAILED;
+    }
+
+    if (ret_addr) {
+        PAL_STREAM_ATTR pal_attr;
+        ret = PalStreamAttributesQueryByHandle(pal_handle, &pal_attr);
+        if (ret < 0) {
+            log_warning("PalStreamAttributesQueryByHandle failed: %s", pal_strerror(ret));
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+        *ret_addr = pal_attr.addr;
     }
 
     return PF_STATUS_SUCCESS;
@@ -157,7 +109,7 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
     if (!pal_handle) {
         enum pal_create_mode create_mode = create ? PAL_CREATE_ALWAYS : PAL_CREATE_NEVER;
         ret = PalStreamOpen(enc->uri, PAL_ACCESS_RDWR, share_flags, create_mode,
-                            PAL_OPTION_PASSTHROUGH, &pal_handle);
+                            PAL_OPTION_PASSTHROUGH | PAL_OPTION_ENCRYPTED_FILE, &pal_handle);
         if (ret < 0) {
             log_warning("PalStreamOpen failed: %s", pal_strerror(ret));
             return pal_to_unix_errno(ret);
@@ -172,6 +124,7 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
         goto out;
     }
     size_t size = pal_attr.pending_size;
+    void* addr = pal_attr.addr;
 
     assert(strstartswith(enc->uri, URI_PREFIX_FILE));
     const char* path = enc->uri + static_strlen(URI_PREFIX_FILE);
@@ -196,7 +149,7 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
         ret = -EACCES;
         goto out;
     }
-    pf_status_t pfs = pf_open(pal_handle, normpath, size, PF_FILE_MODE_READ | PF_FILE_MODE_WRITE,
+    pf_status_t pfs = pf_open(pal_handle, normpath, size, addr, PF_FILE_MODE_READ | PF_FILE_MODE_WRITE,
                               create, &enc->key->pf_key, &pf);
     unlock(&g_keys_lock);
     if (PF_FAILURE(pfs)) {
@@ -272,9 +225,8 @@ int init_encrypted_files(void) {
     if (!create_lock(&g_keys_lock))
         return -ENOMEM;
 
-    pf_set_callbacks(&cb_read, &cb_write, &cb_truncate,
-                     &cb_aes_cmac, &cb_aes_gcm_encrypt, &cb_aes_gcm_decrypt,
-                     &cb_random, cb_debug_ptr);
+    pf_set_callbacks(&cb_truncate, &cb_aes_cmac, &cb_aes_gcm_encrypt,
+                     &cb_aes_gcm_decrypt, &cb_random, cb_debug_ptr);
 
     int ret;
 
@@ -782,7 +734,28 @@ BEGIN_RS_FUNC(encrypted_file) {
     assert(!enc->pf);
     if (enc->use_count > 0) {
         assert(enc->pal_handle);
-        int ret = encrypted_file_internal_open(enc, enc->pal_handle, /*create=*/false,
+
+        /* Recreate file map: set handle->file.addr to NULL and call PalStreamSetLength */
+        int ret;
+        PAL_STREAM_ATTR pal_attr;
+        ret = PalStreamAttributesQueryByHandle(enc->pal_handle, &pal_attr);
+        if (ret < 0) {
+            log_warning("PalStreamAttributesQueryByHandle failed: %s", pal_strerror(ret));
+            return pal_to_unix_errno(ret);
+        }
+        pal_attr.addr = NULL;
+        ret = PalStreamAttributesSetByHandle(enc->pal_handle, &pal_attr);
+        if (ret < 0) {
+            log_warning("PalStreamAttributesQueryByHandle failed: %s", pal_strerror(ret));
+            return pal_to_unix_errno(ret);
+        }
+        ret = PalStreamSetLength(enc->pal_handle, pal_attr.pending_size);
+        if (ret < 0) {
+            log_warning("PalStreamSetLength failed: %s", pal_strerror(ret));
+            return pal_to_unix_errno(ret);
+        }
+
+        ret = encrypted_file_internal_open(enc, enc->pal_handle, /*create=*/false,
                                                /*share_flags=*/0);
         if (ret < 0)
             return ret;

--- a/pal/include/host/linux-common/pal_flags_conv.h
+++ b/pal/include/host/linux-common/pal_flags_conv.h
@@ -60,6 +60,6 @@ static inline int PAL_CREATE_TO_LINUX_OPEN(enum pal_create_mode create) {
 }
 
 static inline int PAL_OPTION_TO_LINUX_OPEN(pal_stream_options_t options) {
-    assert(WITHIN_MASK(options, PAL_OPTION_NONBLOCK | PAL_OPTION_PASSTHROUGH));
+    assert(WITHIN_MASK(options, PAL_OPTION_MASK));
     return options & PAL_OPTION_NONBLOCK ? O_NONBLOCK : 0;
 }

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -326,7 +326,8 @@ typedef uint32_t pal_stream_options_t; /* bitfield */
 #define PAL_OPTION_EFD_SEMAPHORE   0x1 /*!< specific to `eventfd` syscall */
 #define PAL_OPTION_NONBLOCK        0x2
 #define PAL_OPTION_PASSTHROUGH     0x4 /*!< Disregard `sgx.{allowed,trusted}_files` */
-#define PAL_OPTION_MASK            0x7
+#define PAL_OPTION_ENCRYPTED_FILE  0x8 /*!< Open encrypted file */
+#define PAL_OPTION_MASK            0xf
 
 /*!
  * \brief Open/create a stream resource specified by `uri`.
@@ -467,6 +468,7 @@ typedef struct _PAL_STREAM_ATTR {
     bool nonblocking;
     pal_share_flags_t share_flags;
     size_t pending_size;
+    void* addr;
     union {
         struct {
             uint64_t linger;

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -50,6 +50,8 @@ typedef struct {
             PAL_IDX fd;
             char* realpath;
             size_t total;
+            bool encrypted;                 /* flag to indicate encrypted files */
+            void* addr;                     /* mapped address, used only for encrypted files */
             /* below fields are used only for trusted files */
             sgx_chunk_hash_t* chunk_hashes; /* array of hashes of file chunks */
             void* umem;                     /* valid only when chunk_hashes != NULL */

--- a/pal/src/host/linux/pal_host.h
+++ b/pal/src/host/linux/pal_host.h
@@ -35,7 +35,10 @@ typedef struct {
         struct {
             PAL_IDX fd;
             char* realpath;
-            bool seekable; /* regular files are seekable, FIFO pipes are not */
+            bool encrypted; /* flag to indicate encrypted files */
+            void* addr;     /* mapped address, used only for encrypted files */
+            size_t total;   /* file size, used only for encrypted files */
+            bool seekable;  /* regular files are seekable, FIFO pipes are not */
         } file;
 
         struct {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Fixes #1599 

### LibOS
- Removed `cb_read`, `cb_write` callback. Add `cb_truncate` callback to truncate and remap file when file size changed.
- Redo the file map in the `rs_encrypted_file` function.

### Pal
- Add additional pal option flag `PAL_OPTION_ENCRYPTED_FILE` to indicate opening an encrypted file when using `PalStreamOpen`. 
- Add a flag `encrypted` and a pointer `addr` storing mapping address to the fields of `PAL_HANDLE`.
- Add pointer `addr` in `PAL_STREAM_ATTR`.
- In `file_open`, map the file and store address in `addr` field. Unmap the file in `file_destory`. Remap the file in `file_setlength`.
- Set and get `addr` field in `file_attrsetbyhdl` and `file_attrquerybyhdl`.

### common
Improve performance of `protected files` with the following changes:
- Replace reading/writing a single node with directly `memcpy` from/to the mapping address.
- Removed `encrypted` part inside `file_node_t` structure. The encrypted content is directly retrived from the file mapped memory.

### tools
Modify `pf_util` similar to the changes in LibOS and Pal.

### Performance test
In release mode, read is around 60% faster, and write is around 35% faster.

**Read**
<html>
<body">

File Size | 10KB | 100KB | 1MB | 10MB | 100MB | 1GB
-- | -- | -- | -- | -- | -- | --
Original(KB/s） | 96242 | 80569 | 81528 | 81259 | 80615 | 80004
Improved(KB/s) | 145229 | 134960 | 131873 | 130959 | 130208 | 129321
Percentage | 150.90% | 167.51% | 161.75% | 161.16% | 161.52% | 161.64%

</body>
</html>

**Write**
<html>
<body>

File Size | 10KB | 100KB | 1MB | 10MB | 100MB | 1GB
-- | -- | -- | -- | -- | -- | --
Original(KB/s） | 23699 | 26575 | 35626 | 40681 | 40257 | 39478
Improved(KB/s) | 34842 | 35779 | 50670 | 54829 | 54454 | 51478
Percentage | 147.02% | 134.63% | 142.23% | 134.78% | 135.27% | 130.40%

</body>
</html>



## How to test this PR? <!-- (if applicable) -->

Using LibOS and Pal regression test. `gramine-sgx-pf-crypt` and `gramine-sgx-pf-tamper` can be used to test `pf_util`. 

Performance test result is from [iozone](https://www.iozone.org/) using `fread/fwrite`.
