### PR TITLE
[LibOS] Add "unused" attribute to variable `read_from_in`

### DIFF
--- a/libos/src/sys/libos_file.c
+++ b/libos/src/sys/libos_file.c
@@ -426,7 +426,10 @@ long libos_syscall_sendfile(int out_fd, int in_fd, off_t* offset, size_t count) 
     long ret;
     char* buf = NULL;
 
-    size_t read_from_in  = 0;
+    /* "unused" to silence newer Clang; we keep this variable as it may be helpful once we improve
+     * the `sendfile()` implementation, see one of the TODOs below */
+    __attribute__((unused)) size_t read_from_in = 0;
+
     size_t copied_to_out = 0;
 
     if (offset && !is_user_memory_writable(offset, sizeof(*offset)))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The variable is indeed unused but may be helpful once we improve `sendfile()` implementation. Newer Clang (e.g. v14) complains about this unused variable, so let's silence Clang by adding the attribute.

## How to test this PR? <!-- (if applicable) -->

Try with Clang v14 (on Ubuntu 22.04) and with `meson setup ... --werror`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1685)
<!-- Reviewable:end -->
