### PR TITLE
[PAL] Return `0` on success in `PalStreamSetLength()`

### DIFF
--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -67,8 +67,8 @@ struct handle_ops {
     int (*map)(PAL_HANDLE handle, void* address, pal_prot_flags_t prot, uint64_t offset,
                uint64_t size);
 
-    /* 'setlength' is used by PalStreamFlush. It truncate the stream to certain size. */
-    int64_t (*setlength)(PAL_HANDLE handle, uint64_t length);
+    /* 'setlength' is used by PalStreamFlush. It truncates the stream to certain size. */
+    int (*setlength)(PAL_HANDLE handle, uint64_t length);
 
     /* 'flush' is used by PalStreamFlush. It syncs the stream to the device */
     int (*flush)(PAL_HANDLE handle);
@@ -177,7 +177,7 @@ int _PalStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr);
 int _PalStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
 int _PalStreamMap(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,
                   uint64_t size);
-int64_t _PalStreamSetLength(PAL_HANDLE handle, uint64_t length);
+int _PalStreamSetLength(PAL_HANDLE handle, uint64_t length);
 int _PalStreamFlush(PAL_HANDLE handle);
 int _PalSendHandle(PAL_HANDLE target_process, PAL_HANDLE cargo);
 int _PalReceiveHandle(PAL_HANDLE source_process, PAL_HANDLE* out_cargo);

--- a/pal/src/host/linux-sgx/pal_devices.c
+++ b/pal/src/host/linux-sgx/pal_devices.c
@@ -148,11 +148,11 @@ static int dev_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
-static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+static int dev_setlength(PAL_HANDLE handle, uint64_t length) {
     assert(handle->hdr.type == PAL_TYPE_DEV);
 
     int ret = ocall_ftruncate(handle->dev.fd, length);
-    return ret < 0 ? unix_to_pal_error(ret) : (int64_t)length;
+    return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 
 static int dev_flush(PAL_HANDLE handle) {

--- a/pal/src/host/linux-sgx/pal_files.c
+++ b/pal/src/host/linux-sgx/pal_files.c
@@ -382,13 +382,13 @@ out:
 }
 
 /* 'setlength' operation for file stream. */
-static int64_t file_setlength(PAL_HANDLE handle, uint64_t length) {
+static int file_setlength(PAL_HANDLE handle, uint64_t length) {
     int ret = ocall_ftruncate(handle->file.fd, length);
     if (ret < 0)
         return unix_to_pal_error(ret);
 
     handle->file.total = length;
-    return (int64_t)length;
+    return 0;
 }
 
 /* 'flush' operation for file stream. */

--- a/pal/src/host/linux/pal_devices.c
+++ b/pal/src/host/linux/pal_devices.c
@@ -133,11 +133,11 @@ static int dev_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
-static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+static int dev_setlength(PAL_HANDLE handle, uint64_t length) {
     assert(handle->hdr.type == PAL_TYPE_DEV);
 
     int ret = DO_SYSCALL(ftruncate, handle->dev.fd, length);
-    return ret < 0 ? unix_to_pal_error(ret) : (int64_t)length;
+    return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 
 static int dev_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t offset,

--- a/pal/src/host/linux/pal_files.c
+++ b/pal/src/host/linux/pal_files.c
@@ -153,14 +153,14 @@ static int file_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64
 }
 
 /* 'setlength' operation for file stream. */
-static int64_t file_setlength(PAL_HANDLE handle, uint64_t length) {
+static int file_setlength(PAL_HANDLE handle, uint64_t length) {
     int ret = DO_SYSCALL(ftruncate, handle->file.fd, length);
 
     if (ret < 0)
         return (ret == -EINVAL || ret == -EBADF) ? -PAL_ERROR_BADHANDLE
                                                  : -PAL_ERROR_DENIED;
 
-    return (int64_t)length;
+    return 0;
 }
 
 /* 'flush' operation for file stream. */

--- a/pal/src/host/skeleton/pal_devices.c
+++ b/pal/src/host/skeleton/pal_devices.c
@@ -32,7 +32,7 @@ static int dev_delete(PAL_HANDLE handle, enum pal_delete_mode delete_mode) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int64_t dev_setlength(PAL_HANDLE handle, uint64_t length) {
+static int dev_setlength(PAL_HANDLE handle, uint64_t length) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/pal/src/host/skeleton/pal_files.c
+++ b/pal/src/host/skeleton/pal_files.c
@@ -43,7 +43,7 @@ static int file_map(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64
 }
 
 /* 'setlength' operation for file stream. */
-static int64_t file_setlength(PAL_HANDLE handle, uint64_t length) {
+static int file_setlength(PAL_HANDLE handle, uint64_t length) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/pal/src/pal_streams.c
+++ b/pal/src/pal_streams.c
@@ -310,9 +310,7 @@ int PalStreamMap(PAL_HANDLE handle, void* addr, pal_prot_flags_t prot, uint64_t 
     return _PalStreamMap(handle, addr, prot, offset, size);
 }
 
-/* _PalStreamSetLength for internal use. This function truncate the stream to certain length. This
- *  call might not be support for certain streams */
-int64_t _PalStreamSetLength(PAL_HANDLE handle, uint64_t length) {
+int _PalStreamSetLength(PAL_HANDLE handle, uint64_t length) {
     const struct handle_ops* ops = HANDLE_OPS(handle);
 
     if (!ops)
@@ -328,15 +326,7 @@ int PalStreamSetLength(PAL_HANDLE handle, uint64_t length) {
     if (!handle) {
         return -PAL_ERROR_INVAL;
     }
-
-    int64_t ret = _PalStreamSetLength(handle, length);
-
-    if (ret < 0) {
-        return ret;
-    }
-
-    assert((uint64_t)ret == length);
-    return 0;
+    return _PalStreamSetLength(handle, length);
 }
 
 /* _PalStreamFlush for internal use. This function sync up the handle with devices. Some streams may


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, there was a bug of returning a supplied length. However, the PAL API explicitly states that this function returns 0 on success, and LibOS relied on this behavior.

## How to test this PR? <!-- (if applicable) -->

I found it while working on my new PAL, on the `Event` regression test: https://github.com/gramineproject/gramine/blob/a3694193649f8dccc9cb6eb349d092e65b686c5c/pal/regression/File.c#L164

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1687)
<!-- Reviewable:end -->
