### PR TITLE
[LibOS] Allow `madvise(MADV_DONTNEED)` on non-writable mappings

### DIFF
--- a/Documentation/devel/features.md
+++ b/Documentation/devel/features.md
@@ -1728,7 +1728,6 @@ applications that would use these flags. In case of SGX backend, `mprotect()` be
 `madvise()` implements only a minimal subset of functionality:
 - `MADV_DONTNEED` is partially supported:
   - resetting writable file-backed mappings is not implemented;
-  - zeroing non-writable mappings is not implemented;
   - all other cases are implemented.
 - `MADV_NORMAL`, `MADV_RANDOM`, `MADV_SEQUENTIAL`, `MADV_WILLNEED`, `MADV_FREE`,
   `MADV_SOFT_OFFLINE`, `MADV_MERGEABLE`, `MADV_UNMERGEABLE`, `MADV_HUGEPAGE`, `MADV_NOHUGEPAGE` are

--- a/libos/src/bookkeep/libos_vma.c
+++ b/libos/src/bookkeep/libos_vma.c
@@ -1326,14 +1326,32 @@ static bool madvise_dontneed_visitor(struct libos_vma* vma, void* visitor_arg) {
         return true;
     }
 
-    if (!(vma->prot & PROT_WRITE)) {
-        ctx->error = -ENOSYS; // Zeroing non-writable mappings is not yet implemented.
-        return false;
-    }
-
     uintptr_t zero_start = MAX(ctx->begin, vma->begin);
     uintptr_t zero_end = MIN(ctx->end, vma->end);
+
+    pal_prot_flags_t pal_prot = LINUX_PROT_TO_PAL(vma->prot, vma->flags);
+    pal_prot_flags_t pal_prot_writable = pal_prot | PAL_PROT_WRITE;
+
+    if (pal_prot != pal_prot_writable) {
+        /* make the area writable so that it can be memset-to-zero */
+        int ret = PalVirtualMemoryProtect((void*)zero_start, zero_end - zero_start,
+                                          pal_prot_writable);
+        if (ret < 0) {
+            ctx->error = pal_to_unix_errno(ret);
+            return false;
+        }
+    }
+
     memset((void*)zero_start, 0, zero_end - zero_start);
+
+    if (pal_prot != pal_prot_writable) {
+        /* the area was made writable above; restore the original permissions */
+        int ret = PalVirtualMemoryProtect((void*)zero_start, zero_end - zero_start, pal_prot);
+        if (ret < 0) {
+            log_error("restoring original permissions failed: %s", pal_strerror(ret));
+            BUG();
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, it was not implemented though there is no blocker for this (only need to temporarily change permissions on the mapping to be writable). This fixes Node.js v20 workloads.

Fixes #1469.

## How to test this PR? <!-- (if applicable) -->

Added a LibOS test.

Also, test Node.js v20:

- Without PR:
```
gramineproject/examples/nodejs$ gramine-direct ./nodejs helloworld.js
# Fatal error in , line 0
# Check failed: 0 == ret.

gramineproject/examples/nodejs$ gramine-sgx ./nodejs helloworld.js
# Fatal error in , line 0
# Check failed: 0 == ret.
```

- With PR:
```
gramineproject/examples/nodejs$ gramine-direct ./nodejs helloworld.js
Hello World

gramineproject/examples/nodejs$ gramine-sgx ./nodejs helloworld.js
Hello World
```

To install Node.js v20 on Ubuntu 20.04, you can use this hacky approach: https://joshtronic.com/2023/04/23/how-to-install-nodejs-20-on-ubuntu-2004-lts/. Note that the binary was renamed from `nodejs` to `node`, so when running our Node.js example, to not modify the manifest template file, simply create a symlink: `ln -s /usr/bin/node /usr/bin/nodejs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1692)
<!-- Reviewable:end -->
