### PR TITLE
[PAL/Linux-SGX] Fix an error log on `[vdso]` when profile is enabled

### DIFF
--- a/pal/src/host/linux-sgx/host_profile.c
+++ b/pal/src/host/linux-sgx/host_profile.c
@@ -314,8 +314,16 @@ void sgx_profile_report_elf(const char* filename, void* addr) {
     if (!strcmp(filename, ""))
         filename = get_main_exec_path();
 
-    if (!strcmp(filename, "[vdso_libos]"))
+    if (!strcmp(filename, "[vdso]") || !strcmp(filename, "[vdso_libos]")) {
+        /*
+         * Our SGX profiler currently does not support reporting perf events in vDSO binaries:
+         * host-Linux `[vdso]` and enclave-LibOS `[vdso_libos]`. It is hard to find these vDSO
+         * binaries: the former is embedded in host Linux and the latter is embedded in LibOS
+         * `libsysdb.so` binary. The assumption is that vDSO is never a perf bottleneck in SGX
+         * environments, so we don't lose much precision in our profiler.
+         */
         return;
+    }
 
     // Convert filename to absolute path - some tools (e.g. libunwind in 'perf report') refuse to
     // process relative paths.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine's embedded profiler already skips the internal Gramine vDSO library. However, we forgot to skip the host-Linux vDSO library, which resulted in a benign but annoying error message: the underlying ELF file couldn't be found by profiler, so it complained about non-existing path.

See https://github.com/gramineproject/gramine/pull/1285#issuecomment-1873809020 for explanations.

## How to test this PR? <!-- (if applicable) -->

Just try out some workload with `sgx.profile.enable = "main"`. I tried with Blender.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1695)
<!-- Reviewable:end -->
