### PR TITLE
[PAL/Linux,Linux-SGX] Convert `ENOTCONN` to `PAL_ERROR_NOTCONNECTION`

### DIFF
--- a/pal/src/host/linux-sgx/pal_linux_error.h
+++ b/pal/src/host/linux-sgx/pal_linux_error.h
@@ -45,6 +45,8 @@ static int unix_to_pal_error_positive(int unix_errno) {
         case ECONNRESET:
         case ECONNREFUSED:
             return PAL_ERROR_CONNFAILED;
+        case ENOTCONN:
+            return PAL_ERROR_NOTCONNECTION;
         case EPIPE:
             return PAL_ERROR_CONNFAILED_PIPE;
         case EAFNOSUPPORT:

--- a/pal/src/host/linux/pal_linux_error.h
+++ b/pal/src/host/linux/pal_linux_error.h
@@ -45,6 +45,8 @@ static int unix_to_pal_error_positive(int unix_errno) {
         case ECONNRESET:
         case ECONNREFUSED:
             return PAL_ERROR_CONNFAILED;
+        case ENOTCONN:
+            return PAL_ERROR_NOTCONNECTION;
         case EPIPE:
             return PAL_ERROR_CONNFAILED_PIPE;
         case EAFNOSUPPORT:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, both PALs forgot to convert `ENOTCONN` into an (already-existing) `PAL_ERROR_NOTCONNECTION` error code. This led to `ENOTCONN` host-Linux errors being transformed into `EACCES` for the application. This in turn confused some applications, most notably Python's `ssl.py` method `SSLSocket::_create()`.

Fixes #1694. See there for my analysis.

## How to test this PR? <!-- (if applicable) -->

Do the same as in #1694.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1696)
<!-- Reviewable:end -->
