### PR TITLE
[Python,CI-Examples] Hide `loader.entrypoint` manifest option

### DIFF
--- a/CI-Examples/bash/manifest.template
+++ b/CI-Examples/bash/manifest.template
@@ -4,7 +4,6 @@
 # This is a general manifest template for running Bash and core utility programs,
 # including ls, cat, cp, date, and rm.
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/bash"
 
 loader.log_level = "{{ log_level }}"
@@ -27,7 +26,6 @@ sgx.enclave_size = "512M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ execdir }}/",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/blender/blender.manifest.template
+++ b/CI-Examples/blender/blender.manifest.template
@@ -3,7 +3,6 @@
 
 # Blender manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/blender/blender"
 
 loader.log_level = "{{ log_level }}"
@@ -30,7 +29,6 @@ sgx.enclave_size = "2048M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '64' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ blender_dir }}/blender",
   "file:{{ blender_dir }}/lib/",
   "file:{{ gramine.runtimedir() }}/",

--- a/CI-Examples/busybox/busybox.manifest.template
+++ b/CI-Examples/busybox/busybox.manifest.template
@@ -3,7 +3,6 @@
 
 # Busybox manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/busybox"
 
 loader.log_level = "{{ log_level }}"
@@ -33,5 +32,4 @@ sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 sgx.trusted_files = [
   "file:busybox",
   "file:{{ gramine.runtimedir() }}/",
-  "file:{{ gramine.libos }}",
 ]

--- a/CI-Examples/helloworld/helloworld.manifest.template
+++ b/CI-Examples/helloworld/helloworld.manifest.template
@@ -3,7 +3,6 @@
 
 # Hello World manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/helloworld"
 loader.log_level = "{{ log_level }}"
 
@@ -18,7 +17,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:helloworld",
   "file:{{ gramine.runtimedir() }}/",
 ]

--- a/CI-Examples/lighttpd/lighttpd.manifest.template
+++ b/CI-Examples/lighttpd/lighttpd.manifest.template
@@ -3,7 +3,6 @@
 
 # lighttpd manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/sbin/lighttpd"
 
 loader.log_level = "{{ log_level }}"
@@ -28,7 +27,6 @@ sgx.enclave_size = "256M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '3' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ install_dir }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/memcached/memcached.manifest.template
+++ b/CI-Examples/memcached/memcached.manifest.template
@@ -3,7 +3,6 @@
 
 # Memcached manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/memcached"
 
 loader.log_level = "{{ log_level }}"
@@ -40,5 +39,4 @@ sgx.trusted_files = [
   "file:memcached",
   "file:{{ gramine.runtimedir() }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:{{ gramine.libos }}",
 ]

--- a/CI-Examples/nginx/nginx.manifest.template
+++ b/CI-Examples/nginx/nginx.manifest.template
@@ -3,7 +3,6 @@
 
 # Nginx manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/sbin/nginx"
 
 loader.log_level = "{{ log_level }}"
@@ -34,7 +33,6 @@ sgx.enclave_size = "512M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ install_dir }}/sbin/nginx",
   "file:{{ install_dir }}/conf/",
   "file:{{ install_dir }}/html/",

--- a/CI-Examples/python/python.manifest.template
+++ b/CI-Examples/python/python.manifest.template
@@ -3,7 +3,6 @@
 
 # Python3 manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "{{ log_level }}"
@@ -45,7 +44,6 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/ra-tls-mbedtls/client.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/client.manifest.template
@@ -3,7 +3,6 @@
 
 # Client manifest file
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
@@ -33,7 +32,6 @@ sgx.enclave_size = "512M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
   "file:/usr/local/lib/",

--- a/CI-Examples/ra-tls-mbedtls/server.manifest.template
+++ b/CI-Examples/ra-tls-mbedtls/server.manifest.template
@@ -3,7 +3,6 @@
 
 # RA-TLS manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/server"
 
 loader.log_level = "{{ log_level }}"
@@ -30,7 +29,6 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:server",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/ra-tls-nginx/nginx.manifest.template
+++ b/CI-Examples/ra-tls-nginx/nginx.manifest.template
@@ -1,7 +1,6 @@
 # Copyright (C) 2023 Gramine contributors
 # SPDX-License-Identifier: BSD-3-Clause
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 loader.argv = [
     "gramine-ratls", "/tmp/crt.pem", "/tmp/key.pem", "--",
     "/usr/sbin/nginx", "-p", "/etc/nginx", "-c", "nginx.conf",
@@ -51,7 +50,6 @@ sys.enable_sigterm_injection = true
 sgx.debug = true
 
 sgx.trusted_files = [
-    "file:{{ gramine.libos }}",
     "file:{{ gramine.runtimedir() }}/",
 
     "file:{{ entrypoint }}",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov/client.manifest.template
@@ -3,7 +3,6 @@
 
 # Secret Provisioning manifest file example (client)
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
@@ -30,7 +29,6 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_minimal/client.manifest.template
@@ -3,7 +3,6 @@
 
 # Secret Provisioning manifest file example (minimal client)
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
@@ -34,7 +33,6 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
+++ b/CI-Examples/ra-tls-secret-prov/secret_prov_pf/client.manifest.template
@@ -3,7 +3,6 @@
 
 # Secret Provisioning manifest file example (Protected Files client)
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/client"
 
 loader.log_level = "{{ log_level }}"
@@ -36,7 +35,6 @@ sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:client",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/redis/redis-server.manifest.template
+++ b/CI-Examples/redis/redis-server.manifest.template
@@ -5,10 +5,6 @@
 
 ################################## GRAMINE ####################################
 
-# PAL entrypoint (points to the LibOS layer library of Gramine). There is
-# currently only one implementation, so it is always set to libsysdb.so.
-loader.entrypoint = "file:{{ gramine.libos }}"
-
 # Entrypoint binary which Gramine invokes.
 libos.entrypoint = "/redis-server"
 
@@ -115,7 +111,6 @@ sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}
 # If hashes match, this file is trusted and allowed to be loaded and used. Note
 # that this happens on the deployment machine.
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:redis-server",
   "file:{{ gramine.runtimedir() }}/",
 ]

--- a/CI-Examples/rust/rust-hyper-http-server.manifest.template
+++ b/CI-Examples/rust/rust-hyper-http-server.manifest.template
@@ -3,7 +3,6 @@
 
 # Rust manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ self_exe }}"
 loader.log_level = "{{ log_level }}"
 
@@ -24,7 +23,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ self_exe }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/CI-Examples/sqlite/manifest.template
+++ b/CI-Examples/sqlite/manifest.template
@@ -3,7 +3,6 @@
 
 # This is a general manifest template for running SQLite.
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/sqlite3"
 
 loader.log_level = "{{ log_level }}"
@@ -35,7 +34,6 @@ sgx.enclave_size = "256M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ execdir }}/sqlite3",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -70,10 +70,12 @@ Loader entrypoint
 ::
 
    loader.entrypoint = "[URI]"
+   (Default: "<path to libsysdb.so>")
 
 This specifies the LibOS component that Gramine will load and run before loading
-the first executable of the user application. Currently, there is only one LibOS
-implementation: ``libsysdb.so``.
+the first executable of the user application. **Note**: currently, there is only
+one LibOS implementation: ``libsysdb.so``, and there is no need to specify this
+option explicitly.
 
 Note that the loader (the PAL binary) loads the LibOS binary specified in
 ``loader.entrypoint`` and passes control to this binary. Next, the LibOS binary

--- a/Documentation/manpages/gramine-manifest.rst
+++ b/Documentation/manpages/gramine-manifest.rst
@@ -104,12 +104,12 @@ Example
 
 .. code-block:: jinja
 
-   loader.entrypoint = "file:{{ gramine.libos }}"
    libos.entrypoint = "{{ entrypoint }}"
    loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
    fs.mounts = [
      { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+     { path = "/{{ entrypoint }}", uri = "file:{{ entrypoint }}" },
    ]
 
    sgx.trusted_files = [

--- a/Documentation/manpages/gramine-ratls.rst
+++ b/Documentation/manpages/gramine-ratls.rst
@@ -53,7 +53,6 @@ utility:
 
 .. code-block:: jinja
 
-    loader.entrypoint = "file:{{ gramine.libos }}"
     loader.argv = [
         "gramine-ratls", "/tmp/crt.der", "/tmp/key.der",
         "cat", "/tmp/crt.der",
@@ -74,7 +73,6 @@ utility:
     sgx.debug = true
 
     sgx.trusted_files = [
-        "file:{{ gramine.libos }}",
         "file:/usr/bin/gramine-ratls",
         "file:{{ gramine.runtimedir() }}/",
         "file:/bin/cat",

--- a/Documentation/tutorials/pytorch/index.rst
+++ b/Documentation/tutorials/pytorch/index.rst
@@ -248,7 +248,6 @@ First, here are the following SGX-specific lines in the manifest template::
 
    sgx.trusted_files = [
      "file:{{ entrypoint }}",
-     "file:{{ gramine.libos }}",
      "file:{{ gramine.runtimedir() }}/",
       ...
    ]

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -343,6 +343,13 @@ class Manifest:
             else:
                 raise ManifestError(f'Unknown trusted file format: {tf!r}')
 
+        # for convenience, users are not required to specify `loader.entrypoint` and
+        # `sgx.trusted_files = [ <loader.entrypoint file name> ]`; replace with the default LibOS
+        loader = manifest.setdefault('loader', {})
+        if 'entrypoint' not in loader:
+            loader['entrypoint'] = f'file:{_env.globals["gramine"]["libos"]}'
+            trusted_files.append({'uri': loader['entrypoint']})
+
         sgx['trusted_files'] = trusted_files
 
         self._manifest = manifest


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

For end users, the `loader.entrypoint` manifest option is always the LibOS binary. Similarly, `sgx.trusted_files` must always contain the LibOS binary.

To preserve special cases like PAL tests (where `loader.entrypoint` points to the PAL test binary), we allow special `loader.entrypoint`. In this case, the LibOS binary is not appended to `sgx.trusted_files`.

### Rationale

I was asked too many times by casual users what the hell this is. I don't see any point in not allowing this info to go implicit.

So, it's a small user-friendliness improvement.

### TODOs

If folks agree that it's a good change, then I'll do the same for:
- [x]  Examples repo,
- [x] GSC repo -- actually no need, since GSC templates are not user-facing.

## How to test this PR? <!-- (if applicable) -->

Changes CI-Examples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1716)
<!-- Reviewable:end -->
