### PR TITLE
[PAL,LibOS] Use `sys.` for `check_invalid_pointers` and `insecure__disable_aslr`

### DIFF
--- a/Documentation/devel/onboarding.rst
+++ b/Documentation/devel/onboarding.rst
@@ -264,7 +264,7 @@ fine on native Linux but fails under Gramine::
    - Analyze the manifest file carefully. If you suspect problems with
      environment variables, see if it works with ``loader.insecure__use_host_env
      = true``. If you observe that memory addresses change constantly and hinder
-     your debugging, set ``loader.insecure__disable_aslr = true``. But don't use
+     your debugging, set ``sys.insecure__disable_aslr = true``. But don't use
      these two options in production; use them only for debugging and analysis!
 
    - Analyze FS mount points (``fs.mounts``) in the manifest file carefully.

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -266,7 +266,7 @@ Disabling ASLR
 
 ::
 
-    loader.insecure__disable_aslr = [true|false]
+    sys.insecure__disable_aslr = [true|false]
     (Default: false)
 
 This specifies whether to disable Address Space Layout Randomization (ASLR).
@@ -278,7 +278,7 @@ Check invalid pointers
 
 ::
 
-    libos.check_invalid_pointers = [true|false]
+    sys.check_invalid_pointers = [true|false]
     (Default: true)
 
 This specifies whether to enable checks of invalid pointers on syscall
@@ -1298,3 +1298,25 @@ SGX EXINFO (deprecated syntax)
 This syntax specified whether a user application can retrieve faulting address
 in signal handler in case of a page fault. This syntax was renamed to
 ``sgx.use_exinfo``. The default value was ``false``.
+
+
+Deprecated options
+------------------
+
+Disabling ASLR
+^^^^^^^^^^^^^^
+
+::
+
+    loader.insecure__disable_aslr = [true|false]
+
+This syntax was renamed to ``sys.insecure__disable_aslr``.
+
+Check invalid pointers
+^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    libos.check_invalid_pointers = [true|false]
+
+This syntax was renamed to ``sys.check_invalid_pointers``.

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -452,7 +452,7 @@ option ``loader.log_level = "none"``.
 There are several manifest options that may improve performance of some
 workloads. The manifest options include:
 
-- ``libos.check_invalid_pointers = false`` -- disable checks of invalid pointers
+- ``sys.check_invalid_pointers = false`` -- disable checks of invalid pointers
   on system call invocations. Most real-world applications never provide invalid
   arguments to system calls, so there is no need in additional checks.
 - ``sgx.preheat_enclave = true`` -- pre-fault all enclave pages during enclave

--- a/libos/src/bookkeep/libos_signal.c
+++ b/libos/src/bookkeep/libos_signal.c
@@ -541,10 +541,24 @@ int init_signal_handling(void) {
         return -EINVAL;
     }
 
-    ret = toml_bool_in(g_manifest_root, "libos.check_invalid_pointers", /*defaultval=*/true,
-                       &g_check_invalid_ptrs);
+    /* TODO: Keep only `sys.check_invalid_pointers` parsing starting from v1.8 */
+    bool sys_check_invalid_pointers_exists = false;
+    toml_table_t* manifest_sys = toml_table_in(g_manifest_root, "sys");
+    if (manifest_sys) {
+        toml_raw_t manifest_pointers_raw = toml_raw_in(manifest_sys, "check_invalid_pointers");
+        if (manifest_pointers_raw)
+            sys_check_invalid_pointers_exists = true;
+    }
+
+    if (sys_check_invalid_pointers_exists) {
+        ret = toml_bool_in(g_manifest_root, "sys.check_invalid_pointers", /*defaultval=*/true,
+                           &g_check_invalid_ptrs);
+    } else {
+        ret = toml_bool_in(g_manifest_root, "libos.check_invalid_pointers", /*defaultval=*/true,
+                           &g_check_invalid_ptrs);
+    }
     if (ret < 0) {
-        log_error("Cannot parse 'libos.check_invalid_pointers' (the value must be `true` or "
+        log_error("Cannot parse 'sys.check_invalid_pointers' (the value must be `true` or "
                   "`false`)");
         return -EINVAL;
     }

--- a/libos/test/regression/large_mmap.manifest.template
+++ b/libos/test/regression/large_mmap.manifest.template
@@ -5,7 +5,7 @@ loader.env.LD_LIBRARY_PATH = "/lib"
 
 # application allocates 2GB and 4GB memory regions which may occasionally fail
 # in an SGX enclave restricted to 8GB of virtual space if ASLR is enabled
-loader.insecure__disable_aslr = true
+sys.insecure__disable_aslr = true
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },

--- a/libos/test/regression/openmp.manifest.template
+++ b/libos/test/regression/openmp.manifest.template
@@ -12,9 +12,9 @@ sys.enable_sigterm_injection = true
 # `sgx.preheat_enclave` is invalid with EDMM
 sgx.preheat_enclave = {{ 'false' if env.get('EDMM', '0') == '1' else 'true' }}
 
-# Note that `libos.check_invalid_pointers` cannot be disabled, because LLVM's OpenMP depends on it
+# Note that `sys.check_invalid_pointers` cannot be disabled, because LLVM's OpenMP depends on it
 # (by calling `sched_setaffinity` with NULL and expecting it to return either -EFAULT or -ENOSYS)
-# libos.check_invalid_pointers = false
+# sys.check_invalid_pointers = false
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },

--- a/libos/test/regression/toml_parsing.manifest.template
+++ b/libos/test/regression/toml_parsing.manifest.template
@@ -13,7 +13,7 @@ fs.mounts = [
 ]
 
 # the manifest option below added only so that this feature has any test coverage
-libos.check_invalid_pointers = false
+sys.check_invalid_pointers = false
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -445,8 +445,22 @@ static int print_warnings_on_insecure_configs(PAL_HANDLE parent_process) {
     if (ret < 0)
         goto out;
 
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "loader.insecure__disable_aslr",
-                       /*defaultval=*/false, &disable_aslr);
+    /* TODO: Keep only `sys.insecure__disable_aslr` parsing starting from v1.8 */
+    bool sys_disable_aslr_exists = false;
+    toml_table_t* manifest_sys = toml_table_in(g_pal_public_state.manifest_root, "sys");
+    if (manifest_sys) {
+        toml_raw_t manifest_aslr_raw = toml_raw_in(manifest_sys, "insecure__disable_aslr");
+        if (manifest_aslr_raw)
+            sys_disable_aslr_exists = true;
+    }
+
+   if (sys_disable_aslr_exists) {
+        ret = toml_bool_in(g_pal_public_state.manifest_root, "sys.insecure__disable_aslr",
+                           /*defaultval=*/false, &disable_aslr);
+    } else {
+        ret = toml_bool_in(g_pal_public_state.manifest_root, "loader.insecure__disable_aslr",
+                           /*defaultval=*/false, &disable_aslr);
+    }
     if (ret < 0)
         goto out;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine had these manifest options:
- `libos.check_invalid_pointers`
- `loader.insecure__disable_aslr`

All other similar (boolean) options have the `sys.` prefix, and this is non-uniform and confusing for manifest writers. So this commit unifies this syntax.

If folks agree that it's a good change, then I'll do the same for (if required):
- [ ]  Examples repo,
- [ ] GSC repo.

## How to test this PR? <!-- (if applicable) -->

Made changes to CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1717)
<!-- Reviewable:end -->
