### PR TITLE
[LibOS] Have async thread set a callback on libos_handle to take it off the list before it is freed. [v2]

### DIFF
--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -134,6 +134,8 @@ struct libos_epoll_handle {
     size_t last_returned_index;
 };
 
+typedef void (*libos_handle_free_callback_t)(struct libos_handle* handle);
+
 struct libos_handle {
     enum libos_handle_type type;
     bool is_dir;
@@ -155,6 +157,7 @@ struct libos_handle {
     bool created_by_process;
 
     refcount_t ref_count;
+    libos_handle_free_callback_t free_callback;
 
     struct libos_fs* fs;
     struct libos_dentry* dentry;
@@ -225,6 +228,16 @@ struct libos_handle {
 struct libos_handle* get_new_handle(void);
 void get_handle(struct libos_handle* hdl);
 void put_handle(struct libos_handle* hdl);
+
+/* Callback to call before freeing libos_handle */
+static inline libos_handle_free_callback_t
+set_handle_free_callback(struct libos_handle* hdl,
+                         libos_handle_free_callback_t cb)
+{
+    libos_handle_free_callback_t ret = hdl->free_callback;
+    hdl->free_callback = cb;
+    return ret;
+}
 
 /* Set handle to non-blocking or blocking mode. */
 int set_handle_nonblocking(struct libos_handle* hdl, bool on);

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -157,7 +157,7 @@ struct libos_handle {
     bool created_by_process;
 
     refcount_t ref_count;
-    libos_handle_free_callback_t free_callback;
+    libos_handle_free_callback_t free_in_async_helper_thread_callback;
 
     struct libos_fs* fs;
     struct libos_dentry* dentry;
@@ -230,13 +230,9 @@ void get_handle(struct libos_handle* hdl);
 void put_handle(struct libos_handle* hdl);
 
 /* Callback to call before freeing libos_handle */
-static inline libos_handle_free_callback_t
-set_handle_free_callback(struct libos_handle* hdl,
-                         libos_handle_free_callback_t cb)
-{
-    libos_handle_free_callback_t ret = hdl->free_callback;
-    hdl->free_callback = cb;
-    return ret;
+static inline void set_handle_free_callback(struct libos_handle* hdl,
+                                            libos_handle_free_callback_t cb) {
+    hdl->free_in_async_helper_thread_callback = cb;
 }
 
 /* Set handle to non-blocking or blocking mode. */

--- a/libos/include/libos_utils.h
+++ b/libos/include/libos_utils.h
@@ -53,7 +53,7 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
 
 /* Asynchronous event support */
 int init_async_worker(void);
-int64_t install_async_event(PAL_HANDLE object, unsigned long time,
+int64_t install_async_event(struct libos_handle* hdl, unsigned long time,
                             void (*callback)(IDTYPE caller, void* arg), void* arg);
 struct libos_thread* terminate_async_worker(void);
 

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -512,8 +512,8 @@ void put_handle(struct libos_handle* hdl) {
         assert(hdl->epoll_items_count == 0);
         assert(LISTP_EMPTY(&hdl->epoll_items));
 
-        if (hdl->free_callback) {
-            hdl->free_callback(hdl);
+        if (hdl->free_in_async_helper_thread_callback) {
+            hdl->free_in_async_helper_thread_callback(hdl);
         }
 
         if (hdl->is_dir) {

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -512,6 +512,10 @@ void put_handle(struct libos_handle* hdl) {
         assert(hdl->epoll_items_count == 0);
         assert(LISTP_EMPTY(&hdl->epoll_items));
 
+        if (hdl->free_callback) {
+            hdl->free_callback(hdl);
+        }
+
         if (hdl->is_dir) {
             clear_directory_handle(hdl);
         }

--- a/libos/src/libos_async.c
+++ b/libos/src/libos_async.c
@@ -25,6 +25,7 @@ struct async_event {
     void* arg;
     PAL_HANDLE object;       /* handle (async IO) to wait on */
     uint64_t expire_time_us; /* alarm/timer to wait on */
+    struct libos_handle* hdl;
 };
 DEFINE_LISTP(async_event);
 static LISTP_TYPE(async_event) async_list;
@@ -39,6 +40,28 @@ static struct libos_lock async_worker_lock;
 static struct libos_pollable_event install_new_event;
 
 static int create_async_worker(void);
+
+/* Remove a PAL_HANDLE from the list of monitored handles.
+ * This function will be called before the libos_handle is freed.
+ */
+static void remove_pal_handle(struct libos_handle* hdl) {
+    lock(&async_worker_lock);
+    if (async_worker_state == WORKER_NOTALIVE)
+        goto exit;
+
+    struct async_event* tmp, *n;
+    LISTP_FOR_EACH_ENTRY_SAFE(tmp, n, &async_list, list) {
+        if (tmp->object == hdl->pal_handle) {
+            LISTP_DEL(tmp, &async_list, list);
+            free(tmp);
+            break;
+        }
+    }
+
+exit:
+    unlock(&async_worker_lock);
+}
+
 
 /* Threads register async events like alarm(), setitimer(), ioctl(FIOASYNC)
  * using this function. These events are enqueued in async_list and delivered
@@ -55,10 +78,10 @@ static int create_async_worker(void);
  * Function returns remaining usecs for alarm/timer events (same as alarm())
  * or 0 for async IO events. On error, it returns a negated error code.
  */
-int64_t install_async_event(PAL_HANDLE object, uint64_t time_us,
+int64_t install_async_event(struct libos_handle *hdl, uint64_t time_us,
                             void (*callback)(IDTYPE caller, void* arg), void* arg) {
-    /* if event happens on object, time_us must be zero */
-    assert(!object || (object && !time_us));
+    /* if event happens on libos_handle, time must be zero */
+    assert(!hdl || (hdl && !time_us));
 
     uint64_t now_us = 0;
     int ret = PalSystemTimeQuery(&now_us);
@@ -73,11 +96,14 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time_us,
         return -ENOMEM;
     }
 
+    PAL_HANDLE object = hdl ? hdl->pal_handle : NULL;
+
     event->callback       = callback;
     event->arg            = arg;
     event->caller         = get_cur_tid();
     event->object         = object;
     event->expire_time_us = time_us ? now_us + time_us : 0;
+    event->hdl            = hdl;
 
     lock(&async_worker_lock);
 
@@ -93,6 +119,8 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time_us,
                     max_prev_expire_time_us = tmp->expire_time_us;
 
                 LISTP_DEL(tmp, &async_list, list);
+                if (tmp->hdl)
+                    assert(set_handle_free_callback(tmp->hdl, NULL) == remove_pal_handle);
                 free(tmp);
             }
         }
@@ -105,6 +133,9 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time_us,
             return max_prev_expire_time_us - now_us;
         }
     }
+
+    if (event->hdl)
+        assert(set_handle_free_callback(event->hdl, remove_pal_handle) == NULL);
 
     INIT_LIST_HEAD(event, list);
     LISTP_ADD_TAIL(event, &async_list, list);

--- a/libos/src/sys/libos_ioctl.c
+++ b/libos/src/sys/libos_ioctl.c
@@ -104,7 +104,7 @@ long libos_syscall_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
             rwlock_write_unlock(&handle_map->lock);
             break;
         case FIOASYNC:
-            ret = install_async_event(hdl->pal_handle, 0, &signal_io, NULL);
+            ret = install_async_event(hdl, 0, &signal_io, NULL);
             break;
         case FIONREAD: {
             if (!is_user_memory_writable((void*)arg, sizeof(int))) {

--- a/libos/test/regression/async_task_shutdown.c
+++ b/libos/test/regression/async_task_shutdown.c
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2023 IBM Corporation
+ *                    Stefan Berger <stefanb@linux.ibm.com>
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+
+int main(void) {
+    int pipefd[2];
+    int pid;
+    int n;
+
+    /* A derivative of a syzbot test case that starts the async thread with the
+     * ioctl(fd, FIOASYNC). During thread_exit() the file descriptors were
+     * detached, which included the freeing of a PAL_HANDLE that the async
+     * thread was still using even after it had been freed triggering an assert.
+     */
+
+    pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "fork() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (pid > 0) {
+        /* parent */
+        int status = 0;
+        while (waitpid(-1, &status, __WALL) != pid) {
+        }
+        return WEXITSTATUS(status);
+    } else {
+        n = pipe(pipefd);
+        if (n < 0) {
+            fprintf(stderr, "pipe() failed: %s\n", strerror(errno));
+            return 1;
+        }
+        n = ioctl(pipefd[1], FIOASYNC, 0);
+        if (n < 0) {
+            fprintf(stderr, "ioctl(FIOASYNC) failed: %s\n", strerror(errno));
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -3,6 +3,7 @@ fs = import('fs')
 tests = {
     'abort': {},
     'abort_multithread': {},
+    'async_task_shutdown': {},
     'bootstrap': {},
     'bootstrap_pie': {
         'pie': true,

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1000,6 +1000,11 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['itimer'])
         self.assertIn("TEST OK", stdout)
 
+    def test_160_async_task_shutdown(self):
+        for i in range(0, 200):
+            _, stderr = self.run_binary(['async_task_shutdown'])
+            self.assertNotIn('assert failed', stderr)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -3,6 +3,7 @@ binary_dir = "@GRAMINE_PKGLIBDIR@/tests/libos/regression"
 manifests = [
   "argv_from_file",
   "argv_from_manifest",
+  "async_task_shutdown",
   "abort",
   "abort_multithread",
   "bootstrap",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -5,6 +5,7 @@ libc = "musl"
 manifests = [
   "argv_from_file",
   "argv_from_manifest",
+  "async_task_shutdown",
   "abort",
   "abort_multithread",
   "bootstrap",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR fixes issue https://github.com/gramineproject/gramine/issues/1525 where a PAL_HANDLE was freed even though this PAL_HANDLE still had an async event associated with it.  The solution I am using now is to add support for a callback to libos_handle where that callback is called before the libos_handle is freed once its reference counter has reached 0, thus avoiding the issue. The callback will be set for as long as the async thread has a libos_handle on its list and once it is removed from the list the callback will be set to NULL. 

This PR is improvement to https://github.com/gramineproject/gramine/pull/1585

## How to test this PR? <!-- (if applicable) -->

A test case is provided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1721)
<!-- Reviewable:end -->
