### PR TITLE
[common] Introduce pre-allocated node free list for encrypted files

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -1021,6 +1021,20 @@ Gramine:
    in the application is insecure. If you need to derive encryption keys from
    such a "doubly-used" key, you must apply a KDF.
 
+Encrypted files free list node limit
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    fs.limit.encrypted_files_node_free_list = [NUM]
+    (Default: 0)
+
+This syntax specifies a limit on the number of nodes in the pre-allocated
+encrypted files free list, as a performance optimization that trades space for
+time. By default, this optimization is disabled as the limit should be
+application-specific.
+
 .. _untrusted-shared-memory:
 
 Untrusted shared memory

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -1021,6 +1021,8 @@ Gramine:
    in the application is insecure. If you need to derive encryption keys from
    such a "doubly-used" key, you must apply a KDF.
 
+.. _encrypted-files-free-list-node-limit:
+
 Encrypted files optimization: free list node limit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -1021,17 +1021,16 @@ Gramine:
    in the application is insecure. If you need to derive encryption keys from
    such a "doubly-used" key, you must apply a KDF.
 
-Encrypted files free list node limit
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Encrypted files optimization: free list node limit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
-    fs.limit.encrypted_files_node_free_list = [NUM]
+    fs.limits.encrypted_files_free_list_nodes = [NUM]
     (Default: 0)
 
 This syntax specifies a limit on the number of nodes in the pre-allocated
-encrypted files free list, as a performance optimization that trades space for
+encrypted files free list, as a performance optimization that trades memory for
 time. By default, this optimization is disabled as the limit should be
 application-specific.
 

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -305,6 +305,17 @@ in Gramine:
    all IPC is transparently encrypted/decrypted using the TLS-PSK with AES-GCM
    crypto.
 
+Optimizations for file I/O
+--------------------------
+
+Allocation of the Encrypted FS file nodes (e.g., MHT nodes, data nodes) can be
+one source of overhead for certain workloads (e.g., RocksDB compaction). To
+address this performance bottleneck, instead of using alloc/free directly on
+file nodes, Gramine provides an optional free list of pre-allocacted nodes as an
+optimization that trades memory for time. This optimization is by default
+disabled, but can be enabled and tuned according to the needs of the application
+via the manifest option ``fs.limits.encrypted_files_node_free_list``.
+
 .. _choice_of_sgx_machine:
 
 Choice of SGX machine

--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -308,13 +308,20 @@ in Gramine:
 Optimizations for file I/O
 --------------------------
 
-Allocation of the Encrypted FS file nodes (e.g., MHT nodes, data nodes) can be
-one source of overhead for certain workloads (e.g., RocksDB compaction). To
-address this performance bottleneck, instead of using alloc/free directly on
-file nodes, Gramine provides an optional free list of pre-allocacted nodes as an
-optimization that trades memory for time. This optimization is by default
-disabled, but can be enabled and tuned according to the needs of the application
-via the manifest option ``fs.limits.encrypted_files_node_free_list``.
+An encrypted file is split into equally-sized chunks (nodes). The first node is
+the file metadata node, and the other nodes are stored as a variant of Merkle
+Hash Tree (MHT). In this MHT variant, MHT nodes host the crypto metadata like
+the encryption keys and MACs of the child nodes; data nodes host the actual
+encrypted data and are linked to MHT nodes.
+
+Allocation of the file nodes can be one source of overhead for certain workloads
+(e.g., RocksDB compaction). To address this performance bottleneck, instead of
+using alloc/free directly on file nodes, Gramine provides an optional free list
+of pre-allocated nodes as an optimization that trades memory for time. This
+optimization is by default disabled, but can be enabled and tuned according to
+the needs of the application via the manifest option
+``fs.limits.encrypted_files_node_free_list``. See
+:ref:`encrypted-files-free-list-node-limit` for more information.
 
 .. _choice_of_sgx_machine:
 

--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -515,7 +515,7 @@ pf_status_t pf_init_node_free_list(size_t limit_nodes) {
         struct pf_node_item* item = calloc(1, sizeof(struct pf_node_item));
         if (item == NULL) {
             log_error("Not enough memory for the encrypted files node free list. Please consider "
-                      "dicreasing the free list node limit via the manifest option "
+                      "decreasing the free list node limit via the manifest option "
                       "'fs.limits.encrypted_files_free_list_nodes'.");
             return PF_STATUS_NO_MEMORY;
         }

--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -572,8 +572,7 @@ static void ipf_free_node_item(struct pf_node_item* item) {
 static void ipf_free_node_item_from_data(file_node_t* data_ptr) {
     assert(data_ptr);
 
-    struct pf_node_item* item =
-        (struct pf_node_item*)((char*)data_ptr - offsetof(struct pf_node_item, file_node));
+    struct pf_node_item* item = container_of(data_ptr, struct pf_node_item, file_node);
 
     ipf_free_node_item(item);
 }

--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -304,3 +304,13 @@ pf_status_t pf_get_handle(pf_context_t* pf, pf_handle_t* handle);
  * \returns PF status.
  */
 pf_status_t pf_flush(pf_context_t* pf);
+
+/*!
+ * \brief Initialize the free list of file nodes for a PF.
+ *
+ * \param limit_node_free_list  Limit number of nodes for the PF free list.
+ *
+ * \returns PF status.
+ */
+
+pf_status_t pf_init_node_free_list(size_t limit_node_free_list);

--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -308,9 +308,11 @@ pf_status_t pf_flush(pf_context_t* pf);
 /*!
  * \brief Initialize the free list of file nodes for a PF.
  *
- * \param limit_node_free_list  Limit number of nodes for the PF free list.
+ * \param limit_nodes  Limit number of nodes for the PF free list.
  *
  * \returns PF status.
+ *
+ * Note that calling this function is optional -- if it's not called then no free list of file nodes
+ * will be created (i.e., this optimization will be disabled).
  */
-
-pf_status_t pf_init_node_free_list(size_t limit_node_free_list);
+pf_status_t pf_init_node_free_list(size_t limit_nodes);

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -276,20 +276,19 @@ int init_encrypted_files(void) {
 
     toml_table_t* manifest_fs = toml_table_in(g_manifest_root, "fs");
 
-    int64_t limit_node_free_list_int64;
-    ret = toml_int_in(manifest_fs, "limit.encrypted_files_node_free_list", /*defaultval=*/0,
-                      &limit_node_free_list_int64);
+    int64_t limit_nodes_int64;
+    ret = toml_int_in(manifest_fs, "limits.encrypted_files_free_list_nodes", /*defaultval=*/0,
+                      &limit_nodes_int64);
     if (ret < 0) {
-        log_error("Cannot parse 'limit.encrypted_files_node_free_list'");
+        log_error("Cannot parse 'limits.encrypted_files_free_list_nodes'!");
         return -EINVAL;
     }
-    if (limit_node_free_list_int64 < 0) {
-        log_error("'limit.encrypted_files_node_free_list' = %ld is negative",
-                  limit_node_free_list_int64);
+    if (limit_nodes_int64 < 0) {
+        log_error("Invalid 'limits.encrypted_files_free_list_nodes' value!");
         return -EINVAL;
     }
 
-    ret = pf_init_node_free_list((size_t)limit_node_free_list_int64);
+    ret = pf_init_node_free_list((size_t)limit_nodes_int64);
     if (ret < 0)
         return ret;
 

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -283,11 +283,11 @@ int init_encrypted_files(void) {
     ret = toml_int_in(manifest_fs, "limits.encrypted_files_free_list_nodes", /*defaultval=*/0,
                       &limit_nodes_int64);
     if (ret < 0) {
-        log_error("Cannot parse 'limits.encrypted_files_free_list_nodes'!");
+        log_error("Cannot parse 'fs.limits.encrypted_files_free_list_nodes'!");
         return -EINVAL;
     }
     if (limit_nodes_int64 < 0) {
-        log_error("Invalid 'limits.encrypted_files_free_list_nodes' value!");
+        log_error("Invalid 'fs.limits.encrypted_files_free_list_nodes' value!");
         return -EINVAL;
     }
 

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -274,7 +274,10 @@ int init_encrypted_files(void) {
 
     int ret;
 
+    assert(g_manifest_root);
     toml_table_t* manifest_fs = toml_table_in(g_manifest_root, "fs");
+    if (!manifest_fs)
+        return -EINVAL;
 
     int64_t limit_nodes_int64;
     ret = toml_int_in(manifest_fs, "limits.encrypted_files_free_list_nodes", /*defaultval=*/0,

--- a/tools/sgx/common/pf_util.c
+++ b/tools/sgx/common/pf_util.c
@@ -217,8 +217,17 @@ static void cb_debug(const char* msg) {
     DBG("%s\n", msg);
 }
 
+/* The encrypted files related tools (gramine-sgx-pf-crypt, gramine-sgx-pf-tamper) are not
+ * performance-sensitive so we set the limit of the node free list to 0 which by default disables
+ * the node free list optimization. */
+#define LIMIT_ENCRYPTED_FILES_NODE_FREE_LIST 0
+
 /* Initialize protected files for native environment */
 int pf_init(void) {
+    int ret = pf_init_node_free_list(LIMIT_ENCRYPTED_FILES_NODE_FREE_LIST);
+    if (ret < 0)
+        return ret;
+
     return pf_set_linux_callbacks(cb_debug);
 }
 

--- a/tools/sgx/common/pf_util.c
+++ b/tools/sgx/common/pf_util.c
@@ -217,17 +217,8 @@ static void cb_debug(const char* msg) {
     DBG("%s\n", msg);
 }
 
-/* The encrypted files related tools (gramine-sgx-pf-crypt, gramine-sgx-pf-tamper) are not
- * performance-sensitive so we set the limit of the node free list to 0 which by default disables
- * the node free list optimization. */
-#define LIMIT_ENCRYPTED_FILES_NODE_FREE_LIST 0
-
 /* Initialize protected files for native environment */
 int pf_init(void) {
-    int ret = pf_init_node_free_list(LIMIT_ENCRYPTED_FILES_NODE_FREE_LIST);
-    if (ret < 0)
-        return ret;
-
     return pf_set_linux_callbacks(cb_debug);
 }
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Allocation of the Encrypted FS file nodes (e.g., MHT nodes, data nodes) was found to be a performance bottleneck for certain workloads (e.g., RocksDB compaction).

Therefore, instead of using alloc/free directly on file nodes, this commit introduces a free list of pre-allocacted nodes reserved specifically for their usage, as a performance optimization that trades space for time. A new manifest option has been added to allow users to set and adjust the free list limit based on their applications.

Fixes https://github.com/gramineproject/gramine/issues/1714.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI and RocksDB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1723)
<!-- Reviewable:end -->
