### PR TITLE
`gramine-manifest-check` tool

### DIFF
--- a/.ci/ubuntu20.04.dockerfile
+++ b/.ci/ubuntu20.04.dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-pytest-xdist \
     python3-scipy \
     python3-sphinx-rtd-theme \
+    python3-voluptuous \
     shellcheck \
     sphinx-doc \
     sqlite3 \

--- a/.ci/ubuntu22.04.dockerfile
+++ b/.ci/ubuntu22.04.dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-pytest-xdist \
     python3-scipy \
     python3-sphinx-rtd-theme \
+    python3-voluptuous \
     shellcheck \
     sphinx-doc \
     sqlite3 \

--- a/CI-Examples/helloworld/Makefile
+++ b/CI-Examples/helloworld/Makefile
@@ -25,6 +25,7 @@ helloworld.manifest: helloworld.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		$< $@
+	gramine-manifest-check $@
 
 # gramine-sgx-sign generates both a .sig file and a .manifest.sgx file. This is somewhat
 # hard to express properly in Make. The simple solution would be to use
@@ -47,6 +48,7 @@ sgx_sign: helloworld.manifest helloworld
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx
+	gramine-manifest-check $<.sgx
 
 ifeq ($(SGX),)
 GRAMINE = gramine-direct

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -147,6 +147,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'click': ('https://click.palletsprojects.com/en/latest', None),
     'cryptography': ('https://cryptography.io/en/latest', None),
+    'voluptuous': ('https://alecthomas.github.io/voluptuous/docs/_build/html', None),
 }
 
 # -- Options for HTML output -------------------------------------------------
@@ -185,6 +186,7 @@ man_pages = [
     ('manpages/gramine', 'gramine-sgx', 'Gramine', [author], 1),
     ('manpages/gramine-argv-serializer', 'gramine-argv-serializer', 'Serialize command line arguments', [author], 1),
     ('manpages/gramine-manifest', 'gramine-manifest', 'Gramine manifest preprocessor', [author], 1),
+    ('manpages/gramine-manifest-check', 'gramine-manifest-check', 'Gramine manifest schema validator', [author], 1),
     ('manpages/gramine-ratls', 'gramine-ratls', 'RA-TLS wrapper', [author], 1),
     ('manpages/gramine-sgx-gen-private-key', 'gramine-sgx-gen-private-key', 'Gramine SGX key generator', [author], 1),
     ('manpages/gramine-sgx-get-token', 'gramine-sgx-get-token', 'Gramine SGX Token generator', [author], 1),

--- a/Documentation/manpages/gramine-manifest-check.rst
+++ b/Documentation/manpages/gramine-manifest-check.rst
@@ -1,0 +1,28 @@
+.. program:: gramine-manifest-check
+.. _gramine-manifest-check:
+
+======================================================================
+:program:`gramine-manifest-check` -- Gramine manifest schema validator
+======================================================================
+
+Synopsis
+========
+
+:command:`gramine-manifest-check` [*MANIFEST-FILE*]
+
+Description
+===========
+
+The program :program:`gramine-manifest-check` is used to check manifests for
+compliance with builtin manifest schema.
+
+If the manifest contains entries that are not parsed by Gramine itself (possibly
+misspelled real options) or does not contain mandatory options,
+:program:`gramine-manifest-check` exits non-zero and short diagnostics
+describing the path into data structure will be output to standard error.
+If the manifest is OK, nothing is printed and the tool exits with return code 0.
+
+Note that options that are allowed and/or mandatory for default LibOS
+implementation (``libsysdb.so``) are considered allowed/mandatory in schema.
+Therefore, if you have another LibOS implementation (like it happens in PAL
+test suite), the check may be wrong.

--- a/Documentation/manpages/gramine-manifest-check.rst
+++ b/Documentation/manpages/gramine-manifest-check.rst
@@ -26,3 +26,7 @@ Note that options that are allowed and/or mandatory for default LibOS
 implementation (``libsysdb.so``) are considered allowed/mandatory in schema.
 Therefore, if you have another LibOS implementation (like it happens in PAL
 test suite), the check may be wrong.
+
+By default the check is already performed in :program:`gramine-manifest` (see
+:option:`gramine-manifest --check`). This standalone tool may be useful for
+example to validate existing manifests when updating Gramine version.

--- a/Documentation/manpages/gramine-manifest.rst
+++ b/Documentation/manpages/gramine-manifest.rst
@@ -23,6 +23,23 @@ Command line arguments
 
    Have a |~| variable available in the template.
 
+.. option:: --check
+
+   After rendering manifest from template, perform validation against manifest
+   schema to check for unknown manifest entries and/or missing mandatory
+   options. See :doc:`gramine-manifest-check` for more details.
+
+   The check is enabled by default. This option serves to re-enable the check
+   after :option:`--no-check`.
+
+   For the 1.7 release, only a |~| warning is issued and
+   :program:`gramine-manifest` proceeds to write the faulty manifest. In version
+   1.8 this will be a |~| hard error.
+
+.. option:: --no-check
+
+   Disable schema validation, as described above in :option:`--check`.
+
 Functions and constants available in templates
 ==============================================
 

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -19,3 +19,6 @@ tomli==2.0.*
 
 # https://tracker.debian.org/pkg/python-tomli-w
 tomli-w==1.0.*
+
+# https://tracker.debian.org/pkg/voluptuous
+voluptuous==0.12.*

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends: debhelper-compat (= 13),
  python3-sphinx-rtd-theme,
  python3-tomli (>= 1.1.0),
  python3-tomli-w (>= 0.4.0),
+ python3-voluptuous,
 #libunwind8,
 #python3-pytest,
 Standards-Version: 4.1.3
@@ -43,6 +44,7 @@ Depends:
  python3-pyelftools,
  python3-tomli (>= 1.1.0),
  python3-tomli-w (>= 0.4.0),
+ python3-voluptuous,
 Recommends:
  gramine-ratls-dcap,
  gramine-ratls-epid,

--- a/gramine.spec
+++ b/gramine.spec
@@ -43,6 +43,7 @@ Requires: python3-protobuf
 Requires: python3-pyelftools
 Requires: python3-tomli >= 1.1.0
 Requires: python3-tomli-w >= 0.4.0
+Requires: python3-voluptuous
 
 %global debug_package %{nil}
 %global __meson_auto_features disabled

--- a/libos/test/regression/fork_disallowed.manifest.template
+++ b/libos/test/regression/fork_disallowed.manifest.template
@@ -14,7 +14,6 @@ fs.mounts = [
 # must print a warning: "The app tried to create a subprocess, but this is disabled"
 sys.disallow_subprocesses = true
 
-sgx.nonpie_binary = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -41,6 +41,7 @@ depends="
     py3-jinja2
     py3-tomli
     py3-tomli-w
+    py3-voluptuous
     "
 source="$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$_real_pkgver/"

--- a/pal/regression/tests.toml
+++ b/pal/regression/tests.toml
@@ -1,5 +1,11 @@
 binary_dir = "@GRAMINE_PKGLIBDIR@/tests/pal"
 
+# Disable checking manifest for conformance with official schema (`gramine-manifest --no-check`).
+# Official schema includes mandatory manifest entries for official libos (libsysdb.so), but what we
+# do here is, we run libos replacements and manifests for those don't include entries that are
+# normally required by libsysdb. Therefore we need to disable schema checking.
+gramine-manifest-no-check = true
+
 manifests = [
   "..Bootstrap",
   "avl_tree_test",

--- a/python/gramine-manifest
+++ b/python/gramine-manifest
@@ -4,6 +4,7 @@
 #                    Borys Popławski <borysp@invisiblethingslab.com>
 
 import click
+import voluptuous
 
 from graminelibos import Manifest
 
@@ -20,13 +21,25 @@ def validate_define(_ctx, _param, values):
 @click.command()
 @click.option('--string', '-c')
 @click.option('--define', '-D', multiple=True, callback=validate_define)
+@click.option('--check/--no-check', default=True,
+    help='check the manifest for correctness against builtin schema')
 @click.argument('infile', type=click.File('r'), required=False)
 @click.argument('outfile', type=click.File('wb'), default='-')
-def main(string, define, infile, outfile):
+@click.pass_context
+def main(ctx, string, define, infile, outfile, check):
     if not bool(string) ^ bool(infile):
         click.get_current_context().fail('specify exactly one of (infile, -c)')
     template = infile.read() if infile else string
     manifest = Manifest.from_template(template, define)
+
+    if check:
+        try:
+            manifest.check()
+        except voluptuous.MultipleInvalid as err:
+            click.echo(f'WARNING: error in manifest (after rendering): {err!s}', err=True)
+            # TODO after 1.7: make this a hard error
+            #ctx.exit(1)
+
     manifest.dump(outfile)
 
 if __name__ == '__main__':

--- a/python/gramine-manifest-check
+++ b/python/gramine-manifest-check
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Intel Corporation
+#                    Wojtek Porczyk <woju@invisiblethingslab.com>
+
+import sys
+
+import click
+import voluptuous
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+from graminelibos.manifest_check import GramineManifestSchema
+
+@click.command()
+@click.argument('file', type=click.File('rb'), default='-')
+@click.pass_context
+def main(ctx, file):
+    with file:
+        try:
+            data = tomllib.load(file)
+        except tomllib.TOMLDecodeError as err:
+            ctx.fail(f'error parsing manifest: {err!s}')
+    try:
+        GramineManifestSchema(data)
+    except voluptuous.MultipleInvalid as err:
+        print(f'error in manifest: {err!s}')
+        ctx.exit(1)
+
+if __name__ == '__main__':
+    main() # pylint: disable=no-value-for-parameter

--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -20,6 +20,7 @@ import tomli
 import tomli_w
 
 from . import _env
+from .manifest_check import GramineManifestSchema
 
 DEFAULT_ENCLAVE_SIZE_NO_EDMM = '256M'
 DEFAULT_ENCLAVE_SIZE_WITH_EDMM = '1024G'  # 1TB; note that DebugInfo is at 1TB and ASan at 1.5TB
@@ -382,6 +383,15 @@ class Manifest:
 
     def dump(self, f):
         tomli_w.dump(self._manifest, f)
+
+    def check(self):
+        """Check the manifest against builtin schema
+
+        Raises:
+            voluptuous.error.MultipleInvalid: when check fails
+        """
+
+        return GramineManifestSchema(self._manifest)
 
     def expand_all_trusted_files(self, chroot=None):
         """Expand all trusted files entries.

--- a/python/graminelibos/manifest_check.py
+++ b/python/graminelibos/manifest_check.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Intel Corporation
+#                    Wojtek Porczyk <woju@invisiblethingslab.com>
+
+from voluptuous import (
+    Any,
+    Required,
+    Schema,
+)
+
+# size (number + suffix)
+# TODO: write a better validator
+_size = str
+
+# masks for sgx.seal_key.*_mask fields
+# TODO: write a better validator
+_mask64 = str
+_mask32 = str
+
+# TODO: write a better validator
+_uri = str
+
+# fs.root and fs.mounts[] are almost the same, but fs.root does not contain path= key
+_fs_base = (
+    {
+        'type': 'chroot',
+        Required('uri'): _uri,
+    },
+    {
+        Required('type'): 'encrypted',
+        Required('uri'): _uri,
+        'key_name': str,
+    },
+    {
+        Required('type'): 'tmpfs',
+        'uri': str, # not _uri, this field is ignored by Gramine
+    },
+    {
+        Required('type'): 'untrusted_shm',
+        Required('uri'): _uri,
+    },
+)
+
+_fs_root = Any(*_fs_base)
+_fs_mount = Any(*({**d, Required('path'): str} for d in _fs_base))
+
+GramineManifestSchema = Schema({
+    Required('fs'): {
+        Required('mounts'): [_fs_mount],
+        'root': _fs_root,
+        'start_dir': str,
+        'insecure__keys': {str: str},
+    },
+
+    Required('libos'): {
+        Required('entrypoint'): str,
+        'check_invalid_pointers': bool,
+    },
+
+    Required('loader'): {
+        Required('entrypoint'): str,
+        'argv': [str],
+        'argv_src_file': str,
+        'env': {str: Any(str, {'value': str}, {'passthrough': True})},
+        'env_src_file': str,
+        'gid': int,
+        'insecure__use_cmdline_argv': bool,
+        'insecure__use_host_env': bool,
+        'insecure__disable_aslr': bool,
+        'log_file': str,
+        'log_level': Any('none', 'error', 'warning', 'debug', 'trace', 'all'),
+        'uid': int,
+    },
+
+    'sgx': {
+        'allowed_files': [str],
+        'cpu_features': {
+            Any('avx', 'avx512', 'amx'): Any('unspecified', 'disabled', 'required'),
+            Any('mpx', 'pkru'): Any('disabled', 'required'),
+        },
+        'debug': bool,
+        'edmm_enable': bool,
+        'enable_stats': bool,
+        'enclave_size': _size,
+        'file_check_policy': Any('strict', 'allow_all_but_log'),
+        'insecure__allow_memfaults_without_exinfo': bool,
+        'insecure__rpc_thread_num': int,
+        'isvprodid': int,
+        'isvsvn': int,
+        'max_threads': int,
+        'preheat_enclave': bool,
+        'profile': {
+            'enable': Any('none', 'main', 'all'),
+            'mode': Any('aex', 'ocall_inner', 'ocall_outer'),
+            'with_stack': bool,
+            'frequency': int,
+        },
+        'ra_client_linkable': bool,
+        'ra_client_spid': str,
+        'remote_attestation': Any('none', 'dcap', 'epid'),
+        'require_amx': bool,        # deprecated
+        'require_avx': bool,        # deprecated
+        'require_avx512': bool,     # deprecated
+        'require_exinfo': bool,     # deprecated
+        'require_mpx': bool,        # deprecated
+        'require_pkru': bool,       # deprecated
+        'seal_key': {
+            'flags_mask': _mask64,
+            'xfrm_mask': _mask64,
+            'misc_mask': _mask32,
+        },
+        # TODO: validator for sha256
+        'trusted_files': [Any(str, {'uri': _uri, 'sha256': str})],
+        'use_exinfo': bool,
+        'vtune_profile': bool,
+    },
+
+    'sys': {
+        'allowed_ioctls': [{
+            Required('request_code'): int,
+            'struct': str,
+        }],
+        'brk': {'max_size': _size},
+        'disallow_subprocesses': bool,
+        'enable_extra_runtime_domain_names_conf': bool,
+        'enable_sigterm_injection': bool,
+        'experimental__enable_flock': bool,
+        'insecure__allow_eventfd': bool,
+
+        # Description of this thing will be both very hard to write, and mostly useless, since
+        # majority of errors will be semantic (wrong offsets), not syntactic. We'll leave it almost
+        # not validated.
+        'ioctl_structs': {str: object},
+
+        'stack': {'size': _size},
+    },
+})

--- a/python/graminelibos/meson.build
+++ b/python/graminelibos/meson.build
@@ -15,6 +15,7 @@ python_src = [
     init_py,
     'gen_jinja_env.py',
     'manifest.py',
+    'manifest_check.py',
 ]
 
 if enable_tests

--- a/python/graminelibos/util_tests.py
+++ b/python/graminelibos/util_tests.py
@@ -67,6 +67,8 @@ class TestConfig:
 
         self.libc = data.get('libc', 'glibc')
 
+        self.no_check = data.get('gramine-manifest-no-check', False)
+
         self.arch_libdir = _CONFIG_SYSLIBDIR
 
         # Used by LTP, for `libstdbuf.so`
@@ -126,6 +128,7 @@ class TestConfig:
                      '-Dentrypoint=$ENTRYPOINT '
                      '-Dbinary_dir=$BINARY_DIR '
                      '-Dlibc=$GRAMINE_LIBC '
+                    f'{"--no-check " if self.no_check else ""}'
                      '$in $out'),
             description='manifest: $out'
         )

--- a/python/meson.build
+++ b/python/meson.build
@@ -4,6 +4,7 @@ subdir('graminelibos.dist-info')
 install_data([
     'gramine-gen-depend',
     'gramine-manifest',
+    'gramine-manifest-check',
 ], install_dir: get_option('bindir'))
 
 if enable_tests


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Linter for gramine manifest. Parser in the actual application is permissive, silently ignores unknown keys in manifest. This optional tool will warn about unknown options (probably mistyped real things!).

Fixes: #1336

## How to test this PR? <!-- (if applicable) -->

Go get any manifest (and/or manifest.sgx) and feed it to this tool. If there's no output and 0 exit code, then manifest should be OK. If the manifest is not OK, exit code should be != 0 and some explanation should be written to stdout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1726)
<!-- Reviewable:end -->
