### PR TITLE
[LibOS] Re-register async event when a periodic itimer expires

### DIFF
--- a/libos/src/sys/libos_alarm.c
+++ b/libos/src/sys/libos_alarm.c
@@ -65,8 +65,13 @@ static void signal_itimer(IDTYPE caller, void* arg) {
     }
 
     g_real_itimer.timeout += g_real_itimer.reset;
-    g_real_itimer.reset = 0;
+    uint64_t next_timeout = g_real_itimer.timeout;
+    uint64_t next_reset = g_real_itimer.reset;
+
     spinlock_unlock(&g_real_itimer_lock);
+
+    if (next_reset)
+        install_async_event(/*object=*/NULL, next_reset, &signal_itimer, (void*)(next_timeout));
 
     signal_current_proc(SIGALRM);
 }

--- a/libos/test/regression/itimer.c
+++ b/libos/test/regression/itimer.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation
+ *                    Kailun Qin <kailun.qin@intel.com>
+ */
+
+/* Test for syscalls that gets/sets value of an interval timer (`getitimer()`, `setitimer()`). */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <signal.h>
+#include <sys/time.h>
+
+#include "common.h"
+
+#define EXPECTED_ITIMER_COUNT 5
+
+int g_itimer_count = 0;
+
+static void itimer_handler(int signum) {
+    ++g_itimer_count;
+
+    if (g_itimer_count >= EXPECTED_ITIMER_COUNT) {
+        struct itimerval timer = {0};
+        CHECK(setitimer(ITIMER_REAL, &timer, NULL));
+    }
+}
+
+int main(void) {
+    struct sigaction sa = {0};
+    sa.sa_handler = itimer_handler;
+    CHECK(sigaction(SIGALRM, &sa, NULL));
+
+    /* configure the timer to expire after 1 sec, and then every 1 sec */
+    struct itimerval timer = {
+        .it_value.tv_sec     = 1,
+        .it_value.tv_usec    = 0,
+        .it_interval.tv_sec  = 1,
+        .it_interval.tv_usec = 0,
+    };
+
+    setitimer(ITIMER_REAL, &timer, NULL);
+
+    struct itimerval current_timer;
+    getitimer(ITIMER_REAL, &current_timer);
+    if (current_timer.it_interval.tv_sec != 1 || current_timer.it_interval.tv_usec != 0)
+        errx(1, "getitimer: unexpected values");
+
+    while (1) {
+        if (g_itimer_count >= EXPECTED_ITIMER_COUNT) {
+            break;
+        }
+    }
+
+    if (g_itimer_count != EXPECTED_ITIMER_COUNT)
+        errx(1, "expected itimer count = %d, but got only %d", EXPECTED_ITIMER_COUNT,
+             g_itimer_count);
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -57,6 +57,7 @@ tests = {
     'host_root_fs': {},
     'hostname': {},
     'init_fail': {},
+    'itimer': {},
     'keys': {},
     'kill_all': {},
     'large_dir_read': {},

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -992,6 +992,10 @@ class TC_30_Syscall(RegressionTestCase):
                 os.remove('tmp/flock_file2')
         self.assertIn('TEST OK', stdout)
 
+    def test_150_itimer(self):
+        stdout, _ = self.run_binary(['itimer'])
+        self.assertIn("TEST OK", stdout)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -59,6 +59,7 @@ manifests = [
   "hostname_extra_runtime_conf",
   "host_root_fs",
   "init_fail",
+  "itimer",
   "keys",
   "kill_all",
   "large_dir_read",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -61,6 +61,7 @@ manifests = [
   "hostname_extra_runtime_conf",
   "host_root_fs",
   "init_fail",
+  "itimer",
   "keys",
   "kill_all",
   "large_dir_read",


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously, the async event was registered only once on `setitimer()` syscall and the event's callback blindly reset the interval to 0 when an interval timer expired. This broke the functionality of a periodic itimer which fired once rather than periodically.

This commit fixes the above issue by re-regitering an async event in the itimer event callback if periodic. A LibOS regression test is added.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI + newly added regression test.
