### PR TITLE
[Pal/Linux-SGX] Add `sgx.insecure__allow_memfaults_without_exinfo` manifest option

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -797,11 +797,29 @@ SGX EXINFO
     sgx.use_exinfo = [true|false]
     (Default: false)
 
+    sgx.insecure__allow_memfaults_without_exinfo = [true|false]
+    (Default: false)
+
 If ``sgx.use_exinfo`` is set, user application can retrieve faulting address in
-signal handler in case of a page fault. Otherwise (set to ``false``), the
-faulting address will always be provided as ``0``. The default is ``false``
-because some frameworks/runtimes could otherwise print the callstack and
-variables/registers on exceptions, potentially leaking data.
+signal handler in case of page/general protection faults (#PF and #GP).
+Otherwise (set to ``false``), the behavior depends on
+``sgx.insecure__allow_memfaults_without_exinfo``:
+
+- If ``sgx.insecure__allow_memfaults_without_exinfo`` is unset (default), then
+  Gramine terminates with an error, to prevent a possible attack.
+- Otherwise the exception is allowed and Gramine forwards it to the application,
+  and the faulting address is provided as ``0``.
+
+The default value for ``sgx.use_exinfo`` is ``false`` because some
+frameworks/runtimes could otherwise print the callstack and variables/registers
+on exceptions, potentially leaking data.
+
+.. note::
+   The option ``sgx.insecure__allow_memfaults_without_exinfo`` is provided only
+   to allow debugging/testing on old CPUs that do not support the EXINFO
+   feature. Without EXINFO support, a malicious host may attack the application
+   by injecting a memory fault. This option is thus insecure and must not be
+   used in production environments! It will be removed in near future.
 
 Optional CPU features (AVX, AVX512, AMX, MPX, PKRU)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -34,6 +34,7 @@ extern struct pal_linuxsgx_state {
     /* enclave information */
     bool enclave_initialized;        /* thread creation ECALL is allowed only after this is set */
     bool edmm_enabled;
+    bool memfaults_without_exinfo_allowed;
     sgx_target_info_t qe_targetinfo; /* received from untrusted host, use carefully */
     sgx_report_body_t enclave_info;  /* cached self-report result, trusted */
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commits ["[PAL/Linux-SGX] Disallow memfault handling with no faulting address reported"](https://github.com/gramineproject/gramine/commit/9f80c4245a8a852a2d6ac30c81840c94db447305) and ["[PAL/Linux-SGX] Cross-verify SW signals vs HW exceptions"](https://github.com/gramineproject/gramine/commit/a390e33e16ed374a40de2344562a937f289be2e1) hardened Gramine's exception handling in the SGX PAL. In particular, memory faults (#PF and #GP) became allowed only when the SGX EXINFO feature is available on the CPU and is enabled in the manifest (via `sgx.use_exinfo`). Otherwise Gramine immediately terminated the SGX enclave.

However, some applications (Java runtimes in particular) rely on exception handling of memory faults, even if the related MADDR (faulting address) and ERRCD (error code) have dummy zero values. The two mentioned commits effectively forbade such applications from running on older CPUs that don't have EXINFO. This is unfortunate because frequently, the development/testing machines have old SGX CPUs.

To work around the problem of old CPUs, this PR introduces the `sgx.insecure__allow_memfaults_without_exinfo` manifest option, that restores the previous (insecure) Gramine behavior. **This is only a temporary solution; it will be removed in near future.**

Fixes #1587.

For more context, see:
- https://github.com/gramineproject/gramine/issues/1561
- https://github.com/gramineproject/gramine/pull/1570
- https://github.com/gramineproject/gramine/issues/1514
- https://github.com/gramineproject/gramine/discussions/1704
- https://github.com/gramineproject/gramine/discussions/1740

## How to test this PR? <!-- (if applicable) -->

Try e.g. some Java workloads on old CPUs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1744)
<!-- Reviewable:end -->
