### PR TITLE
[LibOS] Remove unnecessary check in itimer event callback

### DIFF
--- a/libos/src/sys/libos_alarm.c
+++ b/libos/src/sys/libos_alarm.c
@@ -56,13 +56,9 @@ static spinlock_t g_real_itimer_lock = INIT_SPINLOCK_UNLOCKED;
 static void signal_itimer(IDTYPE caller, void* arg) {
     // XXX: Can we simplify this code or streamline with the other callback?
     __UNUSED(caller);
+    __UNUSED(arg);
 
     spinlock_lock(&g_real_itimer_lock);
-
-    if (g_real_itimer.timeout != (unsigned long)arg) {
-        spinlock_unlock(&g_real_itimer_lock);
-        return;
-    }
 
     g_real_itimer.timeout += g_real_itimer.reset;
     g_real_itimer.reset = 0;
@@ -105,8 +101,7 @@ long libos_syscall_setitimer(int which, struct __kernel_itimerval* value,
                                : 0;
     uint64_t current_reset = g_real_itimer.reset;
 
-    int64_t install_ret = install_async_event(NULL, next_value, &signal_itimer,
-                                              (void*)(setup_time + next_value));
+    int64_t install_ret = install_async_event(NULL, next_value, &signal_itimer, /*arg=*/NULL);
 
     if (install_ret < 0) {
         spinlock_unlock(&g_real_itimer_lock);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously in the itimer event callback, we checked the timeout of the timer based on the value entered when the event was installed. Since we have a single global timer anyway, this check makes no sense.

See https://github.com/gramineproject/gramine/pull/1741#pullrequestreview-1859415462 for details.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1749)
<!-- Reviewable:end -->
