### PR TITLE
Flush profile data on demand using `SIGUSR1` signal

### DIFF
--- a/Documentation/performance.rst
+++ b/Documentation/performance.rst
@@ -630,6 +630,14 @@ prematurely. Killing the application abruptly via SIGKILL will result in incorre
 perf data. Instead, add ``sys.enable_sigterm_injection = true`` to manifest and
 terminate the application using command ``kill <pid>`` (i.e. send SIGTERM).
 
+It is also possible to flush the collected profile data in a file interactively,
+using the ``SIGUSR1`` signal. This helps to collect profile data only for a
+particular period, e.g., skipping the Gramine startup and application
+initialization time and concentrating only on the actual application processing.
+Send ``SIGUSR1`` using command ``kill -SIGUSR1 -<PGID>`` (note the minus sign
+before <PGID>). Sending multiple ``SIGUSR1`` will create multiple files, each
+containing profile data collected after the previous ``SIGUSR1``.
+
 *Note*: The accuracy of this tool is unclear (though we had positive experiences
 using the tool so far). The SGX profiling works by measuring the value of
 instruction pointer on each asynchronous enclave exit (AEX), which happen on

--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -50,13 +50,17 @@ struct pal_enclave {
     /* profiling */
     bool profile_enable;
     int profile_mode;
-    char profile_filename[64];
     bool profile_with_stack;
     int profile_frequency;
 #endif
 };
 
 extern struct pal_enclave g_pal_enclave;
+
+#ifdef DEBUG
+extern bool g_trigger_profile_reinit;
+extern char g_profile_filename[128];
+#endif /* DEBUG */
 
 void* realloc(void* ptr, size_t new_size);
 
@@ -144,10 +148,6 @@ enum {
     SGX_PROFILE_MODE_OCALL_OUTER = 3,
 };
 
-/* Filenames for saved data */
-#define SGX_PROFILE_FILENAME "sgx-perf.data"
-#define SGX_PROFILE_FILENAME_WITH_PID "sgx-perf-%d.data"
-
 /* Initialize based on g_pal_enclave settings */
 int sgx_profile_init(void);
 
@@ -174,8 +174,10 @@ void sgx_profile_report_elf(const char* filename, void* addr);
 struct perf_data;
 
 struct perf_data* pd_open(const char* file_name, bool with_stack);
+int pd_open_file(struct perf_data* pd, const char* file_name);
 
 /* Finalize and close; returns resulting file size */
+ssize_t pd_close_file(struct perf_data* pd);
 ssize_t pd_close(struct perf_data* pd);
 
 /* Write PERF_RECORD_COMM (report command name) */

--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -798,20 +798,15 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info,
 
 #ifdef DEBUG
     enclave_info->profile_enable = false;
-    enclave_info->profile_filename[0] = '\0';
 
     if (!profile_str || !strcmp(profile_str, "none")) {
         // do not enable
     } else if (!strcmp(profile_str, "main")) {
         if (enclave_info->is_first_process) {
-            snprintf(enclave_info->profile_filename, ARRAY_SIZE(enclave_info->profile_filename),
-                     SGX_PROFILE_FILENAME);
             enclave_info->profile_enable = true;
         }
     } else if (!strcmp(profile_str, "all")) {
         enclave_info->profile_enable = true;
-        snprintf(enclave_info->profile_filename, ARRAY_SIZE(enclave_info->profile_filename),
-                 SGX_PROFILE_FILENAME_WITH_PID, (int)g_host_pid);
     } else {
         log_error("Invalid 'sgx.profile.enable' "
                   "(the value must be \"none\", \"main\" or \"all\")");

--- a/pal/src/host/linux-sgx/host_perf_data.c
+++ b/pal/src/host/linux-sgx/host_perf_data.c
@@ -140,13 +140,13 @@ static int pd_write(struct perf_data* pd, const void* data, size_t size) {
     return 0;
 }
 
-struct perf_data* pd_open(const char* file_name, bool with_stack) {
+int pd_open_file(struct perf_data* pd, const char* file_name) {
     int ret;
 
     int fd = DO_SYSCALL(open, file_name, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, PERM_rw_r__r__);
     if (fd < 0) {
-        log_error("pd_open: cannot open %s for writing: %s", file_name, unix_strerror(fd));
-        return NULL;
+        log_error("pd_open_file: cannot open %s for writing: %s", file_name, unix_strerror(fd));
+        return fd;
     }
 
     /*
@@ -162,23 +162,36 @@ struct perf_data* pd_open(const char* file_name, bool with_stack) {
     if (ret < 0)
         goto fail;
 
+    assert(pd->fd == -1);
+    pd->fd = fd;
+    return 0;
+
+fail:;
+    int close_ret = DO_SYSCALL(close, fd);
+    if (close_ret < 0)
+        log_error("pd_open_file: close failed: %s", unix_strerror(close_ret));
+    return ret;
+}
+
+struct perf_data* pd_open(const char* file_name, bool with_stack) {
     struct perf_data* pd = malloc(sizeof(*pd));
     if (!pd) {
         log_error("pd_open: out of memory");
-        goto fail;
+        return NULL;
     }
 
-    pd->fd = fd;
+    pd->fd  = -1;
+    int ret = pd_open_file(pd, file_name);
+    if (ret < 0) {
+        free(pd);
+        return NULL;
+    }
+
     pd->buf_count = 0;
     pd->with_stack = with_stack;
-    return pd;
 
-fail:
-    ret = DO_SYSCALL(close, fd);
-    if (ret < 0)
-        log_error("pd_open: close failed: %s", unix_strerror(ret));
-    return NULL;
-};
+    return pd;
+}
 
 static int write_prologue_epilogue(struct perf_data* pd) {
     int ret;
@@ -266,9 +279,8 @@ static int write_prologue_epilogue(struct perf_data* pd) {
     return 0;
 }
 
-ssize_t pd_close(struct perf_data* pd) {
-    ssize_t ret = 0;
-    int close_ret;
+ssize_t pd_close_file(struct perf_data* pd) {
+    ssize_t ret;
 
     ret = pd_flush(pd);
     if (ret < 0)
@@ -282,12 +294,20 @@ ssize_t pd_close(struct perf_data* pd) {
     if (ret < 0)
         goto out;
 
-out:
-    close_ret = DO_SYSCALL(close, pd->fd);
+out:;
+    int close_ret = DO_SYSCALL(close, pd->fd);
+    pd->fd = -1;
     if (close_ret < 0)
-        log_error("pd_close: close failed: %s", unix_strerror(close_ret));
+        log_error("pd_close_file: close failed: %s", unix_strerror(close_ret));
 
+    /* Returns the size of the finalized perf-data file on success */
+    return ret;
+}
+
+ssize_t pd_close(struct perf_data* pd) {
+    ssize_t ret = pd_close_file(pd);
     free(pd);
+
     return ret;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Currently Gramine don't support flushing sgx profiling data if user wants to collect only for a particular duraion (e.g., only during perf benchmarking runs). This PR add feature to flush the profile data on demand using `SIGUSR1` signal. That way user can collect data only for a particular duration. This also eliminates the noise added in profile data duing start and stop of the process.

Partially fixes issue #1711

## How to test this PR? <!-- (if applicable) -->

Please follow the instruction [here](https://gramine.readthedocs.io/en/latest/performance.html#sgx-profiling) to enable SGX profiling. Now execute the workload in Gramine SGX. Send `SIGUSR1` signal using command `kill -SIGUSR1 <pid>` to flush the profile data. This should create a sgx profile data file which can be opened using `perf report` command.

Example:

1. Add below manifest options to `gramine/CI-Examples/redis/redis-server.manifest.template`.
        `sgx.profile.enable = "main"`
        `sgx.profile.with_stack = true`
2.  Build the redis example: `make clean && make SGX=1`
3. Run redis server: `gramine-sgx redis-server &`
4. Get the redis server pid and run `kill -SIGUSR1 <pid>` to flush. Gramine flush the profile data in a file as indicated by below log line:
        `Profile data written to sgx-perf-1707196865.data (161042 bytes)`
5. Run the benchmarks using command `src/src/redis-benchmark`
6. Once benchmark run is complete issue the send `SIGUSR1` signal to flush profile data using command `kill -SIGUSR1 <pid>`.  Again profile data is written to a new file as indicated by below log line:
        `Profile data written to sgx-perf-1707196952.data (15096242 bytes)`
7. `sgx-perf-1707196952.data` have the profile data collected during benchmarks run.
8. Open the profile data: `perf report --no-children -i sgx-perf-1707196952.data`

Same steps can be tried with MongoDB, MySQL etc..

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1751)
<!-- Reviewable:end -->
