### PR TITLE
[LibOS] Fix `R_OK` and `X_OK` macros for file permissions

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -504,10 +504,10 @@ struct libos_mount {
 
 extern struct libos_dentry* g_dentry_root;
 
-#define F_OK 0
-#define R_OK        001
-#define W_OK        002
-#define X_OK        004
+#define F_OK   0
+#define X_OK 001
+#define W_OK 002
+#define R_OK 004
 #define MAY_EXEC  001
 #define MAY_WRITE 002
 #define MAY_READ  004


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

These macros were mixed up. However, they were used only in the syscall parser so this mix up didn't lead to any functionality issues. Noticed when analyzing Gramine logs; kudos to Jinen Gandhi and Anjali Rai.

Here are the links how it's implemented in Musl and Glibc, for cross reference:
- https://github.com/bminor/musl/blob/f314e133929b6379eccc632bef32eaebb66a7335/include/fcntl.h#L115-L118
- https://github.com/bminor/glibc/blob/bbd248ac0d75efdef8fe61ea69b1fb25fb95b6e7/posix/unistd.h#L281-L284

And this is the only place where these macros are used: https://github.com/gramineproject/gramine/blob/1cf1f46646646a3b9c6b371e67c80e945577456a/libos/src/libos_parser.c#L734-L747

Fixes #1755 

## How to test this PR? <!-- (if applicable) -->

Look at Gramine logs in the `access()` syscall.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1752)
<!-- Reviewable:end -->
