### PR TITLE
[common] Add explicit fsync callback to Protected Files

### DIFF
--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -92,6 +92,15 @@ typedef pf_status_t (*pf_write_f)(pf_handle_t handle, const void* buffer, uint64
                                   size_t size);
 
 /*!
+ * \brief File sync callback.
+ *
+ * \param handle  File handle.
+ *
+ * \returns PF status.
+ */
+typedef pf_status_t (*pf_fsync_f)(pf_handle_t handle);
+
+/*!
  * \brief File truncate callback.
  *
  * \param handle  File handle.
@@ -172,6 +181,7 @@ typedef pf_status_t (*pf_random_f)(uint8_t* buffer, size_t size);
  *
  * \param read_f             File read callback.
  * \param write_f            File write callback.
+ * \param fsync_f            File sync callback.
  * \param truncate_f         File truncate callback.
  * \param aes_cmac_f         AES-CMAC callback.
  * \param aes_gcm_encrypt_f  AES-GCM encrypt callback.
@@ -181,8 +191,9 @@ typedef pf_status_t (*pf_random_f)(uint8_t* buffer, size_t size);
  *
  * Must be called before any actual APIs.
  */
-void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_truncate_f truncate_f,
-                      pf_aes_cmac_f aes_cmac_f, pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
+void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_fsync_f fsync_f,
+                      pf_truncate_f truncate_f, pf_aes_cmac_f aes_cmac_f,
+                      pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
                       pf_aes_gcm_decrypt_f aes_gcm_decrypt_f, pf_random_f random_f,
                       pf_debug_f debug_f);
 

--- a/tools/sgx/common/pf_util.c
+++ b/tools/sgx/common/pf_util.c
@@ -97,6 +97,18 @@ static pf_status_t linux_write(pf_handle_t handle, const void* buffer, uint64_t 
     return PF_STATUS_SUCCESS;
 }
 
+static pf_status_t linux_fsync(pf_handle_t handle) {
+    int fd = *(int*)handle;
+    DBG("linux_fsync: fd %d\n", fd);
+    int ret = fsync(fd);
+    if (ret < 0) {
+        ERROR("fsync failed: %s\n", strerror(errno));
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+
+    return PF_STATUS_SUCCESS;
+}
+
 static pf_status_t linux_truncate(pf_handle_t handle, uint64_t size) {
     int fd = *(int*)handle;
     DBG("linux_truncate: fd %d, size %zu\n", fd, size);
@@ -214,7 +226,7 @@ static int pf_set_linux_callbacks(pf_debug_f debug_f) {
         return -1;
     }
 
-    pf_set_callbacks(linux_read, linux_write, linux_truncate, mbedtls_aes_cmac,
+    pf_set_callbacks(linux_read, linux_write, linux_fsync, linux_truncate, mbedtls_aes_cmac,
                      mbedtls_aes_gcm_encrypt, mbedtls_aes_gcm_decrypt, mbedtls_random, debug_f);
     return 0;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Protected Files didn't have a way to ensure that the data is physically stored on disk (aka fsync). This is in contrast to the "file flush" operation, which only flushes user-space buffers to the OS kernel buffers. (Gramine confusingly uses the term "flush" to mean flush and fsync, depending on the context.)

This explicit fsync is important in e.g. persistent database workloads. It was detected on a RocksDB workload.

## How to test this PR? <!-- (if applicable) -->

Unfortunately I don't know how to test this, without failing the system somehow...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1753)
<!-- Reviewable:end -->
