### PR TITLE
[LibOS] Return `0` on zero-sized `read()` syscalls on sockets

### DIFF
--- a/libos/include/libos_socket.h
+++ b/libos/include/libos_socket.h
@@ -128,7 +128,7 @@ extern struct libos_sock_ops sock_ip_ops;
 
 ssize_t do_recvmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
                    void* msg_control, size_t* msg_controllen_ptr, void* addr, size_t* addrlen_ptr,
-                   unsigned int* flags);
+                   unsigned int* flags, bool emulate_recv_error_semantics);
 ssize_t do_sendmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_len,
                    void* msg_control, size_t msg_controllen, void* addr, size_t addrlen,
                    unsigned int flags);

--- a/libos/src/fs/socket/fs.c
+++ b/libos/src/fs/socket/fs.c
@@ -36,7 +36,8 @@ static ssize_t read(struct libos_handle* handle, void* buf, size_t size, file_of
     };
     unsigned int flags = 0;
     return do_recvmsg(handle, &iov, /*iov_len=*/1, /*msg_control=*/NULL,
-                      /*msg_controllen_ptr=*/NULL, /*addr=*/NULL, /*addrlen_ptr=*/NULL, &flags);
+                      /*msg_controllen_ptr=*/NULL, /*addr=*/NULL, /*addrlen_ptr=*/NULL, &flags,
+                      /*emulate_recv_error_semantics=*/false);
 }
 
 static ssize_t write(struct libos_handle* handle, const void* buf, size_t size, file_off_t* pos) {
@@ -54,7 +55,8 @@ static ssize_t readv(struct libos_handle* handle, struct iovec* iov, size_t iov_
     __UNUSED(pos);
     unsigned int flags = 0;
     return do_recvmsg(handle, iov, iov_len, /*msg_control=*/NULL, /*msg_controllen_ptr=*/NULL,
-                      /*addr=*/NULL, /*addrlen_ptr=*/NULL, &flags);
+                      /*addr=*/NULL, /*addrlen_ptr=*/NULL, &flags,
+                      /*emulate_recv_error_semantics=*/false);
 }
 
 static ssize_t writev(struct libos_handle* handle, struct iovec* iov, size_t iov_len,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

On Linux, `read(socket-fd, buf, /*count=*/0)` has a special case of returning zero, after all checks. Same applies for `readv()`. However, this does *not* apply to `recvfrom()`, `recvmsg()`, `recvmmsg()`.

Linux code simply says "Match SYS5 behavior" in this corner case: https://github.com/torvalds/linux/blob/99bd3cb0d12e85/net/socket.c#L1136-L1136

Apparently some applications/libraries rely on this behavior. Without this corner case, these apps would hang (if the socket is blocking) or unexpectedly return -EAGAIN (if the socket is non-blocking). Note that the underlying PalSocketRecv() uses `recvmsg()` syscall, at least on Linux-based PALs, so a simple fall-through to PAL would change the semantics of `read()`/`readv()` issued by the app.

## How to test this PR? <!-- (if applicable) -->

Found on a closed-source app.

Not sure if this deserves a separate regression test. If anyone wants, I can add one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1760)
<!-- Reviewable:end -->
