### PR TITLE
[LibOS] Make all pipe and UDS names Gramine-instance-specific

### DIFF
--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -548,8 +548,7 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
 
     while (true) {
         if (use_vmid_for_name) {
-            len = snprintf(pipename, sizeof(pipename), "%lu/%u", g_pal_public_state->instance_id,
-                           g_process_ipc_ids.self_vmid);
+            len = snprintf(pipename, sizeof(pipename), "%u", g_process_ipc_ids.self_vmid);
             if (len >= sizeof(pipename))
                 return -ERANGE;
         } else {
@@ -560,8 +559,10 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
                 return ret;
         }
 
-        log_debug("Creating pipe: " URI_PREFIX_PIPE_SRV "%s", pipename);
-        len = snprintf(uri, size, URI_PREFIX_PIPE_SRV "%s", pipename);
+        log_debug("Creating pipe: " URI_PREFIX_PIPE_SRV "%lu/%s", g_pal_public_state->instance_id,
+                  pipename);
+        len = snprintf(uri, size, URI_PREFIX_PIPE_SRV "%lu/%s", g_pal_public_state->instance_id,
+                       pipename);
         if (len >= size)
             return -ERANGE;
 
@@ -580,7 +581,10 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, bool use_vm
 
     /* output generated pipe handle, URI, and name */
     *hdl = pipe;
-    len = snprintf(uri, size, URI_PREFIX_PIPE "%s", pipename);
+    len = snprintf(uri, size, URI_PREFIX_PIPE "%lu/%s", g_pal_public_state->instance_id, pipename);
+    static_assert(static_strlen(URI_PREFIX_PIPE) < static_strlen(URI_PREFIX_PIPE_SRV),
+                  "without this condition the assert below should be changed into an `if`");
+    assert(len < size); /* must hold because above we did the same but with longer prefix */
     if (name)
         memcpy(name, pipename, sizeof(pipename));
     return 0;

--- a/libos/src/net/unix.c
+++ b/libos/src/net/unix.c
@@ -72,8 +72,14 @@ static int unaddr_to_sockname(void* addr, size_t* addrlen_ptr, char* sock_name,
     if (ret < 0) {
         return -ENOMEM;
     }
-    assert(sock_name_size >= 2 * sizeof(hash) + 1);
-    bytes2hex(hash, sizeof(hash), sock_name, sock_name_size);
+
+    char hash_str[64 + 1] = {0};
+    bytes2hex(hash, sizeof(hash), hash_str, sizeof(hash_str));
+
+    size_t len = snprintf(sock_name, sock_name_size, "%lu/%s", g_pal_public_state->instance_id,
+                          hash_str);
+    if (len >= sock_name_size)
+        return -ERANGE;
     return 0;
 }
 
@@ -125,7 +131,7 @@ static int bind(struct libos_handle* handle, void* addr, size_t addrlen) {
     struct libos_sock_handle* sock = &handle->info.sock;
     assert(locked(&sock->lock));
 
-    char pipe_name[static_strlen(URI_PREFIX_PIPE_SRV) + 64 + 1] = URI_PREFIX_PIPE_SRV;
+    char pipe_name[static_strlen(URI_PREFIX_PIPE_SRV) + 96 + 1] = URI_PREFIX_PIPE_SRV;
     int ret = unaddr_to_sockname(addr, &addrlen,
                                  pipe_name + static_strlen(URI_PREFIX_PIPE_SRV),
                                  sizeof(pipe_name) - static_strlen(URI_PREFIX_PIPE_SRV));
@@ -222,7 +228,7 @@ static int connect(struct libos_handle* handle, void* addr, size_t addrlen, bool
         return -EINVAL;
     }
 
-    char pipe_name[static_strlen(URI_PREFIX_PIPE) + 64 + 1] = URI_PREFIX_PIPE;
+    char pipe_name[static_strlen(URI_PREFIX_PIPE) + 96 + 1] = URI_PREFIX_PIPE;
     int ret = unaddr_to_sockname(addr, &addrlen,
                                  pipe_name + static_strlen(URI_PREFIX_PIPE),
                                  sizeof(pipe_name) - static_strlen(URI_PREFIX_PIPE));


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit ["[LibOS,PAL] Move assigning name to a pipe/UDS from PAL to LibOS"](https://github.com/gramineproject/gramine/commit/dd1d3dca50359d3a842cea7fb536896772438c12) had a small bug: the new LibOS logic lost the Gramine-instance-specific part of the name for some pipes and all UNIX Domain Sockets (UDSes).

This led to a benign but annoying bug of e.g. two `gramine-direct` Gramine instances being able to establish a common UDS. This could have been considered a feature, but two `gramine-sgx` Gramine instances would (correctly) fail to establish a common UDS, because each `gramine-sgx` instance has its own encryption key, and thus two UDSes would not be able to establish a secure TLS channel (even though they see each other because of this bug).

To make behavior of `gramine-direct` and `gramine-sgx` uniform, this commit forces all pipe names and UDS names to have the Gramine-instance-specific part in the name. I.e., previously UDSes had names on the host Linux like `@/gramine/<hash-of-uds-name>` and now they have names like `@/gramine/<gramine-instance-id>/<hash-of-uds-name>`.

References:
- https://github.com/gramineproject/gramine/blob/master/pal/src/host/linux-common/gramine_unix_socket_addr.c
- https://github.com/gramineproject/gramine/blob/master/libos/src/net/unix.c
- https://github.com/gramineproject/gramine/blob/master/libos/src/libos_init.c
- https://github.com/gramineproject/gramine/commit/dd1d3dca50359d3a842cea7fb536896772438c12

## How to test this PR? <!-- (if applicable) -->

Run two Gramine instances, one creating and listening on the UDS, another connecting to the same UDS.
- Without this PR, two `gramine-direct` instances will establish a connection. (`gramine-sgx` instances won't because of failed TLS handshake.)
- With this PR, two `gramine-direct` instances will **not** be able to establish a connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1761)
<!-- Reviewable:end -->
