### PR TITLE
[common] Add encrypted-file-node-size slab into slab allocator

### DIFF
--- a/common/include/slabmgr.h
+++ b/common/include/slabmgr.h
@@ -88,14 +88,15 @@ static_assert(IS_ALIGNED(offsetof(struct slab_area, raw), 16),
              MIN_MALLOC_ALIGNMENT)
 
 #ifndef SLAB_LEVEL
-#define SLAB_LEVEL 8
+#define SLAB_LEVEL 10
 #endif
 
 #ifndef SLAB_LEVEL_SIZES
 #define SLAB_LEVEL_SIZES                                                       \
     16, 32, 64, 128 - SLAB_HDR_SIZE, 256 - SLAB_HDR_SIZE, 512 - SLAB_HDR_SIZE, \
-        1024 - SLAB_HDR_SIZE, 2048 - SLAB_HDR_SIZE
-#define SLAB_LEVELS_SUM (4080 - SLAB_HDR_SIZE * 5)
+        1024 - SLAB_HDR_SIZE, 2048 - SLAB_HDR_SIZE, 4096 - SLAB_HDR_SIZE,      \
+        8288 - SLAB_HDR_SIZE
+#define SLAB_LEVELS_SUM (16464 - SLAB_HDR_SIZE * 7)
 #else
 #ifndef SLAB_LEVELS_SUM
 #error "SLAB_LEVELS_SUM not defined"

--- a/libos/src/fs/libos_fs_mem.c
+++ b/libos/src/fs/libos_fs_mem.c
@@ -17,7 +17,12 @@ static int mem_file_resize(struct libos_mem_file* mem, size_t buf_size) {
     if (!buf)
         return -ENOMEM;
 
-    memcpy(buf, mem->buf, MIN(buf_size, (size_t)mem->size));
+    size_t min_size = MIN(buf_size, (size_t)mem->size);
+    memcpy(buf, mem->buf, min_size);
+
+    /* if the new buffer is larger, zero out the new portion */
+    if (buf_size > min_size)
+        memset(buf + min_size, 0, buf_size - min_size);
 
     free(mem->buf);
     mem->buf = buf;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Allocating the file nodes (`file_node_t`) of Gramine's encrypted files can be one source of overhead for certain workloads (e.g., RocksDB compaction). To address this performance bottleneck, this commit introduces a new slab size (8288B, considering the alignment) tailored for the size of the file node (8235B) and therefore a new free list for 8256B blocks managed by the slab allocator.

Note that while this change can improve performance for certain memory allocation patterns, it introduces internal fragmentation and may also increase memory overhead and external fragmentation if the application rarely makes allocations of the file node size.

In addition, this commit fixes an issue where in-memory files are not zeroed out when resized.

Fixes https://github.com/gramineproject/gramine/issues/1714.
Closes https://github.com/gramineproject/gramine/pull/1723.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1763)
<!-- Reviewable:end -->
