### PR TITLE
WIP [LibOS,PAL] Print stats of internal-memory allocators

### DIFF
--- a/common/include/slabmgr.h
+++ b/common/include/slabmgr.h
@@ -88,14 +88,15 @@ static_assert(IS_ALIGNED(offsetof(struct slab_area, raw), 16),
              MIN_MALLOC_ALIGNMENT)
 
 #ifndef SLAB_LEVEL
-#define SLAB_LEVEL 8
+#define SLAB_LEVEL 10
 #endif
 
 #ifndef SLAB_LEVEL_SIZES
 #define SLAB_LEVEL_SIZES                                                       \
     16, 32, 64, 128 - SLAB_HDR_SIZE, 256 - SLAB_HDR_SIZE, 512 - SLAB_HDR_SIZE, \
-        1024 - SLAB_HDR_SIZE, 2048 - SLAB_HDR_SIZE
-#define SLAB_LEVELS_SUM (4080 - SLAB_HDR_SIZE * 5)
+        1024 - SLAB_HDR_SIZE, 2048 - SLAB_HDR_SIZE, 4096 - SLAB_HDR_SIZE,      \
+        8288 - SLAB_HDR_SIZE
+#define SLAB_LEVELS_SUM (16464 - SLAB_HDR_SIZE * 7)
 #else
 #ifndef SLAB_LEVELS_SUM
 #error "SLAB_LEVELS_SUM not defined"

--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -975,3 +975,6 @@ int chroot_dentry_uri(struct libos_dentry* dent, mode_t type, char** out_uri);
 
 int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void* arg);
 int chroot_unlink(struct libos_dentry* dent);
+
+void dump_dentry_alloc_stats(void);
+void dump_mount_alloc_stats(void);

--- a/libos/include/libos_handle.h
+++ b/libos/include/libos_handle.h
@@ -291,3 +291,5 @@ int get_file_size(struct libos_handle* file, uint64_t* size);
 
 ssize_t do_handle_read(struct libos_handle* hdl, void* buf, size_t count);
 ssize_t do_handle_write(struct libos_handle* hdl, const void* buf, size_t count);
+
+void dump_handle_alloc_stats(void);

--- a/libos/include/libos_utils.h
+++ b/libos/include/libos_utils.h
@@ -25,6 +25,7 @@ static inline uint64_t hash64(uint64_t key) {
 
 /* heap allocation functions */
 int init_slab(void);
+void dump_slab_alloc_stats(void);
 
 void* malloc(size_t size);
 void free(void* mem);

--- a/libos/include/libos_vma.h
+++ b/libos/include/libos_vma.h
@@ -140,3 +140,5 @@ size_t get_peak_memory_usage(void);
 
 /* Returns total memory usage */
 size_t get_total_memory_usage(void);
+
+void dump_vma_alloc_stats(void);

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -136,11 +136,15 @@ int init_handle(void) {
     if (!create_lock(&handle_mgr_lock)) {
         return -ENOMEM;
     }
-    handle_mgr = create_mem_mgr(init_align_up(HANDLE_MGR_ALLOC));
+    handle_mgr = create_mem_mgr(init_align_up(HANDLE_MGR_ALLOC), "libos handles");
     if (!handle_mgr) {
         return -ENOMEM;
     }
     return 0;
+}
+
+void dump_handle_alloc_stats(void) {
+    dump_mem_mgr_stats(handle_mgr);
 }
 
 int init_std_handles(void) {

--- a/libos/src/bookkeep/libos_vma.c
+++ b/libos/src/bookkeep/libos_vma.c
@@ -661,7 +661,7 @@ int init_vma(void) {
         log_error("Failed to add tmp vma to cache!");
         BUG();
     }
-    vma_mgr = create_mem_mgr(DEFAULT_VMA_COUNT);
+    vma_mgr = create_mem_mgr(DEFAULT_VMA_COUNT, "VMAs");
     if (!vma_mgr) {
         log_error("Failed to create VMA memory manager!");
         return -ENOMEM;
@@ -699,6 +699,12 @@ int init_vma(void) {
     }
 
     return 0;
+}
+
+void dump_vma_alloc_stats(void) {
+    lock(&vma_mgr_lock);
+    dump_mem_mgr_stats(vma_mgr);
+    unlock(&vma_mgr_lock);
 }
 
 static void _add_unmapped_vma(uintptr_t begin, uintptr_t end, struct libos_vma* vma) {

--- a/libos/src/fs/libos_dcache.c
+++ b/libos/src/fs/libos_dcache.c
@@ -56,7 +56,7 @@ int init_dcache(void) {
         return -ENOMEM;
     }
 
-    dentry_mgr = create_mem_mgr(init_align_up(DCACHE_MGR_ALLOC));
+    dentry_mgr = create_mem_mgr(init_align_up(DCACHE_MGR_ALLOC), "FS dentries");
 
     if (g_pal_public_state->parent_process) {
         /* In a child process, `g_dentry_root` will be restored from a checkpoint. */
@@ -91,6 +91,10 @@ int init_dcache(void) {
     g_dentry_root->name_len = 0;
 
     return 0;
+}
+
+void dump_dentry_alloc_stats(void) {
+    dump_mem_mgr_stats(dentry_mgr);
 }
 
 /* Increment the reference count for a dentry */

--- a/libos/src/fs/libos_fs.c
+++ b/libos/src/fs/libos_fs.c
@@ -59,7 +59,7 @@ int init_fs(void) {
         goto err;
     }
 
-    g_mount_mgr = create_mem_mgr(init_align_up(MOUNT_MGR_ALLOC));
+    g_mount_mgr = create_mem_mgr(init_align_up(MOUNT_MGR_ALLOC), "FS mounts");
     if (!g_mount_mgr) {
         ret = -ENOMEM;
         goto err;
@@ -91,6 +91,10 @@ err:
     if (lock_created(&g_mount_list_lock))
         destroy_lock(&g_mount_list_lock);
     return ret;
+}
+
+void dump_mount_alloc_stats(void) {
+    dump_mem_mgr_stats(g_mount_mgr);
 }
 
 static struct libos_mount* alloc_mount(void) {

--- a/libos/src/libos_malloc.c
+++ b/libos/src/libos_malloc.c
@@ -83,6 +83,10 @@ int init_slab(void) {
     return 0;
 }
 
+void dump_slab_alloc_stats(void) {
+    dump_slab_mgr_stats(slab_mgr);
+}
+
 void* malloc(size_t size) {
     void* mem = slab_alloc(slab_mgr, size);
 

--- a/libos/src/sys/libos_exit.c
+++ b/libos/src/sys/libos_exit.c
@@ -15,6 +15,7 @@
 #include "libos_table.h"
 #include "libos_thread.h"
 #include "libos_utils.h"
+#include "libos_vma.h"
 #include "pal.h"
 
 static noreturn void libos_clean_and_exit(int exit_code) {
@@ -56,6 +57,12 @@ static noreturn void libos_clean_and_exit(int exit_code) {
     terminate_ipc_worker();
 
     log_debug("process %u exited with status %d", g_process_ipc_ids.self_vmid, exit_code);
+
+    dump_dentry_alloc_stats();
+    dump_mount_alloc_stats();
+    dump_handle_alloc_stats();
+    dump_vma_alloc_stats();
+    dump_slab_alloc_stats();
 
     /* TODO: We exit whole libos, but there are some objects that might need cleanup - we should do
      * a proper cleanup of everything. */

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -287,6 +287,8 @@ int pal_internal_memory_free(void* addr, size_t size);
 void pal_disable_early_memory_bookkeeping(void);
 
 void init_slab_mgr(void);
+void dump_slab_stats(void);
+
 void* malloc(size_t size);
 void* calloc(size_t num, size_t size);
 void free(void* mem);

--- a/pal/src/pal_process.c
+++ b/pal/src/pal_process.c
@@ -19,5 +19,6 @@ int PalProcessCreate(const char** args, uintptr_t (*reserved_mem_ranges)[2],
 }
 
 noreturn void PalProcessExit(int exitcode) {
+    dump_slab_stats();
     _PalProcessExit(exitcode);
 }

--- a/pal/src/slab.c
+++ b/pal/src/slab.c
@@ -70,6 +70,10 @@ void init_slab_mgr(void) {
         INIT_FAIL("cannot initialize slab manager");
 }
 
+void dump_slab_stats(void) {
+    dump_slab_mgr_stats(g_slab_mgr);
+}
+
 void* malloc(size_t size) {
     void* ptr = slab_alloc(g_slab_mgr, size);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

On process/enclave termination, statistics of the MEMMGR and SLAB allocators are written to stderr.

This is a draft PR, not intended for merge. If we decide this is valuable, then this should be hidden under a new manifest option and beautified.

See https://github.com/gramineproject/gramine/issues/1767 for context.

## How to test this PR? <!-- (if applicable) -->

Just run any workload. If workload runs infinitely (e.g. Redis server), don't forget to kill it gracefully via SIGTERM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1768)
<!-- Reviewable:end -->
