### PR TITLE
[PAL/Linux-SGX] Remove redundant checks

### DIFF
--- a/pal/src/host/linux-sgx/enclave_framework.c
+++ b/pal/src/host/linux-sgx/enclave_framework.c
@@ -115,9 +115,6 @@ void* sgx_alloc_on_ustack(size_t size) {
 }
 
 void* sgx_copy_to_ustack(const void* ptr, size_t size) {
-    if (!sgx_is_completely_within_enclave(ptr, size)) {
-        return NULL;
-    }
     void* uptr = sgx_alloc_on_ustack(size);
     if (uptr) {
         sgx_copy_from_enclave_verified(uptr, ptr, size);
@@ -202,11 +199,8 @@ void sgx_copy_to_enclave_verified(void* ptr, const void* uptr, size_t size) {
 }
 
 bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize) {
-    if (usize > maxsize ||
-        !sgx_is_valid_untrusted_ptr(uptr, usize, /*alignment=*/1) ||
-        !sgx_is_completely_within_enclave(ptr, maxsize)) {
+    if (usize > maxsize)
         return false;
-    }
 
     sgx_copy_to_enclave_verified(ptr, uptr, usize);
     return true;
@@ -266,11 +260,6 @@ void sgx_copy_from_enclave_verified(void* uptr, const void* ptr, size_t size) {
 }
 
 bool sgx_copy_from_enclave(void* uptr, const void* ptr, size_t size) {
-    if (!sgx_is_valid_untrusted_ptr(uptr, size, /*alignment=*/1)
-            || !sgx_is_completely_within_enclave(ptr, size)) {
-        return false;
-    }
-
     sgx_copy_from_enclave_verified(uptr, ptr, size);
     return true;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There are redundant checks performed inside the `sgx_copy_from_enclave_verified` and `sgx_copy_to_enclave_verified` functions as well as by the caller of these functions.

1-3% of performance improvement is seen with `Nginx` and `MySQL` workloads after removing the redundant checks.

This PR removes the redundant checks from caller.

## How to test this PR? <!-- (if applicable) -->

Jenkins test should be enough

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1778)
<!-- Reviewable:end -->
