### PR TITLE
[Docs] Remove limitation of tmpfs not supporting mmap

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -437,9 +437,8 @@ Gramine currently supports the following types of mount points:
 
   ``tmpfs`` is especially useful in trusted environments (like Intel SGX) for
   securely storing temporary files. This concept is similar to Linux's tmpfs.
-  Files under ``tmpfs`` mount points currently do *not* support mmap and each
-  process has its own, non-shared tmpfs (i.e., processes don't see each other's
-  files).
+  Currently there is a limitation that each process has its own, non-shared
+  tmpfs (i.e., processes don't see each other's files).
 
 Start (current working) directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The tmpfs limitation of not supporting mmap was fixed long ago, but we forgot to update the documentation.

See the implementation:
- https://github.com/gramineproject/gramine/blob/a50192cfe261854ef7dfa28f777f167d500cd3ba/libos/src/fs/tmpfs/fs.c#L319
- https://github.com/gramineproject/gramine/blob/a50192cfe261854ef7dfa28f777f167d500cd3ba/libos/src/fs/libos_fs_util.c#L135

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1782)
<!-- Reviewable:end -->
