### PR TITLE
[PAL/Linux-SGX] Fix Trusted Files degenerating to Allowed Files on fork

### DIFF
--- a/common/include/arch/x86_64/cpu.h
+++ b/common/include/arch/x86_64/cpu.h
@@ -102,7 +102,10 @@ static inline void wrfsbase(uint64_t addr) {
         :: "D"(addr) : "memory");
 }
 
-static inline noreturn void die_or_inf_loop(void) {
+/* This function must be breakable for debugging and GDB integration scripts (e.g. see
+ * `fork_and_access_file.gdb` in LibOS regression tests). */
+__attribute__((__noinline__)) __attribute__((unused))
+static noreturn void die_or_inf_loop(void) {
     __asm__ volatile (
         "1: \n"
         "ud2 \n"

--- a/libos/test/regression/fork_and_access_file.c
+++ b/libos/test/regression/fork_and_access_file.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation */
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "rw_file.h"
+
+#define FILENAME     "fork_and_access_file_testfile"
+#define MAX_BUF_SIZE 256
+
+char g_parent_buf[MAX_BUF_SIZE];
+char g_child_buf[MAX_BUF_SIZE];
+
+int main(void) {
+    int fd = CHECK(open(FILENAME, O_RDONLY));
+
+    ssize_t parent_read_ret = CHECK(posix_fd_read(fd, g_parent_buf, sizeof(g_parent_buf)));
+    CHECK(lseek(fd, 0, SEEK_SET));
+
+    pid_t p = CHECK(fork());
+    if (p == 0) {
+        ssize_t child_read_ret = CHECK(posix_fd_read(fd, g_child_buf, sizeof(g_child_buf)));
+        if (child_read_ret != parent_read_ret ||
+                memcmp(g_child_buf, g_parent_buf, child_read_ret)) {
+            errx(1, "child read data different from what parent read");
+        }
+        exit(0);
+    }
+
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        errx(1, "child died with status: %#x", status);
+
+    CHECK(close(fd));
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/fork_and_access_file.gdb
+++ b/libos/test/regression/fork_and_access_file.gdb
@@ -1,0 +1,32 @@
+set breakpoint pending on
+set pagination off
+set backtrace past-main on
+
+# We want to check what happens in the child process after fork()
+set follow-fork-mode child
+
+# Cannot detach after fork because of some bug in SGX version of GDB (GDB would segfault)
+set detach-on-fork off
+
+tbreak fork
+commands
+  echo BREAK ON FORK\n
+
+  shell echo "WRITING NEW CONTENT IN FORK_AND_ACCESS_FILE_TESTFILE" > fork_and_access_file_testfile
+
+  tbreak die_or_inf_loop
+  commands
+    echo EXITING GDB WITH A GRAMINE ERROR\n
+    quit
+  end
+
+  tbreak exit
+  commands
+    echo EXITING GDB WITHOUT A GRAMINE ERROR\n
+    quit
+  end
+
+  continue
+end
+
+run

--- a/libos/test/regression/fork_and_access_file.manifest.template
+++ b/libos/test/regression/fork_and_access_file.manifest.template
@@ -1,0 +1,20 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '16' }}
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+  "file:fork_and_access_file_testfile",
+]

--- a/libos/test/regression/fork_and_access_file_testfile
+++ b/libos/test/regression/fork_and_access_file_testfile
@@ -1,0 +1,1 @@
+fork_and_access_file_testfile

--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -36,6 +36,7 @@ tests = {
     'file_size': {},
     'flock_lock': {},
     'fopen_cornercases': {},
+    'fork_and_access_file': {},
     'fork_and_exec': {},
     'fp_multithread': {
         'c_args': '-fno-builtin',  # see comment in the test's source

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -39,6 +39,7 @@ manifests = [
   "file_size",
   "flock_lock",
   "fopen_cornercases",
+  "fork_and_access_file",
   "fork_and_exec",
   "fork_disallowed",
   "fp_multithread",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -41,6 +41,7 @@ manifests = [
   "file_size",
   "flock_lock",
   "fopen_cornercases",
+  "fork_and_access_file",
   "fork_and_exec",
   "fork_disallowed",
   "fp_multithread",

--- a/pal/src/host/linux-sgx/pal_host.h
+++ b/pal/src/host/linux-sgx/pal_host.h
@@ -53,7 +53,8 @@ typedef struct {
             bool seekable;                  /* regular files are seekable, FIFO pipes are not */
             /* below fields are used only for trusted files */
             sgx_chunk_hash_t* chunk_hashes; /* array of hashes of file chunks */
-            void* umem;                     /* valid only when chunk_hashes != NULL */
+            void* umem;                     /* valid only when chunk_hashes != NULL and size > 0 */
+            bool trusted;                   /* is this a Trusted File? */
         } file;
 
         struct {

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -208,5 +208,6 @@ int _PalStreamSecureWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t l
 int _PalStreamSecureSave(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t** obuf, size_t* olen);
 
 void fixup_socket_handle_after_deserialization(PAL_HANDLE handle);
+void fixup_file_handle_after_deserialization(PAL_HANDLE handle);
 
 #endif /* IN_ENCLAVE */

--- a/pal/src/host/linux-sgx/pal_streams.c
+++ b/pal/src/host/linux-sgx/pal_streams.c
@@ -164,7 +164,9 @@ static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size,
                 free(hdl);
                 return -PAL_ERROR_NOMEM;
             }
-            hdl->file.chunk_hashes = hdl->file.umem = NULL;
+            hdl->file.chunk_hashes = hdl->file.umem = NULL; /* set up in below fixup function */
+            hdl->file.fd = host_fd;   /* correct host FD must be set for below fixup function */
+            fixup_file_handle_after_deserialization(hdl);
             break;
         }
         case PAL_TYPE_DIR: {


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, Trusted Files feature had the following bug: after fork, the metadata of currently-opened-in-parent-process TFs (SHA256 hashes for each chunk of the file) was not available in the child SGX enclave. This effectively degenerated all currently-opened TFs into Allowed Files, and thus the child enclave lost integrity guarantees in these TFs. An attacker could substitute the TF contents on the storage with arbitrary code/data, and the child enclave would not notice this.

This bug was exposed only in the child process (child SGX enclave) and only in these scenarios:
- fork without execve: the child continues reading from one of the file descriptors pointing to a trusted file opened before `fork()`;
- fork with execve: the child reads from an inherited file descriptor pointing to a trusted file.

This PR also adds a test to verify this bug is fixed.

## How to test this PR? <!-- (if applicable) -->

LibOS test (based on a GDB script) is added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1796)
<!-- Reviewable:end -->
