### PR TITLE
[LibOS] Move `init_r_debug()` before `init_fs()`

### DIFF
--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -398,6 +398,7 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     }
 
     RUN_INIT(init_vma);
+    RUN_INIT(init_r_debug);
     RUN_INIT(init_slab);
     RUN_INIT(read_environs, envp);
     RUN_INIT(init_rlimit);
@@ -405,7 +406,6 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     RUN_INIT(init_fs_lock);
     RUN_INIT(init_dcache);
     RUN_INIT(init_handle);
-    RUN_INIT(init_r_debug);
 
     log_debug("LibOS loaded at %p, ready to initialize", &__load_address);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Many subsystems rely on debug metadata (in particular, the lock for debug info) to be already initialized. This is especially true for error handling paths, which may want to remove the debug info.

Extracted from #1812.

Fixes #1813.

## How to test this PR? <!-- (if applicable) -->

See #1813.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1814)
<!-- Reviewable:end -->
