### PR TITLE
[LibOS] Do not reuse `chroot_unlink()` in `shm` filesystem

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -978,4 +978,3 @@ int synthetic_setup_dentry(struct libos_dentry* dent, mode_t type, mode_t perm);
 int fifo_setup_dentry(struct libos_dentry* dent, mode_t perm, int fd_read, int fd_write);
 
 int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void* arg);
-int chroot_unlink(struct libos_dentry* dent);

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -292,8 +292,6 @@ out:
     return ret;
 }
 
-/* NOTE: this function is different from generic `chroot_unlink` only to add PAL_OPTION_PASSTHROUGH.
- * Once that option is removed, we can safely go back to using `chroot_unlink`. */
 static int chroot_encrypted_unlink(struct libos_dentry* dent) {
     assert(locked(&g_dcache_lock));
     assert(dent->inode);

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -333,7 +333,7 @@ out:
     return ret;
 }
 
-int chroot_unlink(struct libos_dentry* dent) {
+static int chroot_unlink(struct libos_dentry* dent) {
     assert(locked(&g_dcache_lock));
     assert(dent->inode);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It is a bad smell to reuse functions intended for another subsystem. Also, a future commit will modify `chroot_unlink()` such that `shm` FS won't be able to reuse it.

Extracted from #1812.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1815)
<!-- Reviewable:end -->
