### PR TITLE
[LibOS] Rename `chroot_dentry_uri()` into `dentry_uri()`

### DIFF
--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -837,6 +837,14 @@ int dentry_abs_path(struct libos_dentry* dent, char** path, size_t* size);
  */
 int dentry_rel_path(struct libos_dentry* dent, char** path, size_t* size);
 
+/*
+ * Calculate the URI for a dentry. The URI scheme is determined by file type (`type` field). It
+ * needs to be passed separately (instead of using `dent->inode->type`) because the dentry might not
+ * have inode associated yet: we might be creating a new file, or looking up a file we don't know
+ * yet.
+ */
+int dentry_uri(struct libos_dentry* dent, mode_t type, char** out_uri);
+
 ino_t dentry_ino(struct libos_dentry* dent);
 
 /*!
@@ -968,14 +976,6 @@ int generic_truncate(struct libos_handle* hdl, file_off_t size);
 int synthetic_setup_dentry(struct libos_dentry* dent, mode_t type, mode_t perm);
 
 int fifo_setup_dentry(struct libos_dentry* dent, mode_t perm, int fd_read, int fd_write);
-
-/*
- * Calculate the URI for a dentry. The URI scheme is determined by file type (`type` field). It
- * needs to be passed separately (instead of using `dent->inode->type`) because the dentry might not
- * have inode associated yet: we might be creating a new file, or looking up a file we don't know
- * yet.
- */
-int chroot_dentry_uri(struct libos_dentry* dent, mode_t type, char** out_uri);
 
 int chroot_readdir(struct libos_dentry* dent, readdir_callback_t callback, void* arg);
 int chroot_unlink(struct libos_dentry* dent);

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -115,7 +115,7 @@ static int chroot_encrypted_lookup(struct libos_dentry* dent) {
      * See also the comment in `fs.c:chroot_lookup` (but note that this case is simpler, because we
      * don't allow "dev:" mounts).
      */
-    int ret = chroot_dentry_uri(dent, S_IFREG, &uri);
+    int ret = dentry_uri(dent, S_IFREG, &uri);
     if (ret < 0)
         goto out;
 
@@ -221,7 +221,7 @@ static int chroot_encrypted_creat(struct libos_handle* hdl, struct libos_dentry*
     __UNUSED(flags);
 
     char* uri;
-    int ret = chroot_dentry_uri(dent, S_IFREG, &uri);
+    int ret = dentry_uri(dent, S_IFREG, &uri);
     if (ret < 0)
         return ret;
 
@@ -266,7 +266,7 @@ static int chroot_encrypted_mkdir(struct libos_dentry* dent, mode_t perm) {
 
     char* uri = NULL;
 
-    int ret = chroot_dentry_uri(dent, S_IFDIR, &uri);
+    int ret = dentry_uri(dent, S_IFDIR, &uri);
     if (ret < 0)
         goto out;
 
@@ -299,7 +299,7 @@ static int chroot_encrypted_unlink(struct libos_dentry* dent) {
     assert(dent->inode);
 
     char* uri;
-    int ret = chroot_dentry_uri(dent, dent->inode->type, &uri);
+    int ret = dentry_uri(dent, dent->inode->type, &uri);
     if (ret < 0)
         return ret;
 
@@ -331,7 +331,7 @@ static int chroot_encrypted_rename(struct libos_dentry* old, struct libos_dentry
     int ret;
     char* new_uri = NULL;
 
-    ret = chroot_dentry_uri(new, old->inode->type, &new_uri);
+    ret = dentry_uri(new, old->inode->type, &new_uri);
     if (ret < 0)
         return ret;
 
@@ -364,7 +364,7 @@ static int chroot_encrypted_chmod(struct libos_dentry* dent, mode_t perm) {
 
     char* uri = NULL;
 
-    int ret = chroot_dentry_uri(dent, dent->inode->type, &uri);
+    int ret = dentry_uri(dent, dent->inode->type, &uri);
     if (ret < 0)
         goto out;
 

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -44,76 +44,6 @@ static int chroot_mount(struct libos_mount_params* params, void** mount_data) {
     return 0;
 }
 
-static const char* strip_prefix(const char* uri) {
-    const char* s = strchr(uri, ':');
-    assert(s);
-    return s + 1;
-}
-
-int chroot_dentry_uri(struct libos_dentry* dent, mode_t type, char** out_uri) {
-    assert(dent->mount);
-    assert(dent->mount->uri);
-
-    int ret;
-
-    const char* root = strip_prefix(dent->mount->uri);
-
-    const char* prefix;
-    size_t prefix_len;
-    switch (type) {
-        case S_IFREG:
-            prefix = URI_PREFIX_FILE;
-            prefix_len = static_strlen(URI_PREFIX_FILE);
-            break;
-        case S_IFDIR:
-            prefix = URI_PREFIX_DIR;
-            prefix_len = static_strlen(URI_PREFIX_DIR);
-            break;
-        case S_IFCHR:
-            prefix = URI_PREFIX_DEV;
-            prefix_len = static_strlen(URI_PREFIX_DEV);
-            break;
-        default:
-            BUG();
-    }
-
-    char* rel_path;
-    size_t rel_path_size;
-    ret = dentry_rel_path(dent, &rel_path, &rel_path_size);
-    if (ret < 0)
-        return ret;
-
-    /* Treat empty path as "." */
-    if (*root == '\0')
-        root = ".";
-
-    size_t root_len = strlen(root);
-
-    /* Allocate buffer for "<prefix:><root>/<rel_path>" (if `rel_path` is empty, we don't need the
-     * space for `/`, but overallocating 1 byte doesn't hurt us, and keeps the code simple) */
-    char* uri = malloc(prefix_len + root_len + 1 + rel_path_size);
-    if (!uri) {
-        ret = -ENOMEM;
-        goto out;
-    }
-    memcpy(uri, prefix, prefix_len);
-    memcpy(uri + prefix_len, root, root_len);
-    if (rel_path_size == 1) {
-        /* this is the mount root, the URI is "<prefix:><root>"*/
-        uri[prefix_len + root_len] = '\0';
-    } else {
-        /* this is not the mount root, the URI is "<prefix:><root>/<rel_path>" */
-        uri[prefix_len + root_len] = '/';
-        memcpy(uri + prefix_len + root_len + 1, rel_path, rel_path_size);
-    }
-    *out_uri = uri;
-    ret = 0;
-
-out:
-    free(rel_path);
-    return ret;
-}
-
 static int chroot_setup_dentry(struct libos_dentry* dent, mode_t type, mode_t perm,
                                file_off_t size) {
     assert(locked(&g_dcache_lock));
@@ -138,7 +68,7 @@ static int chroot_lookup(struct libos_dentry* dent) {
      * and report the right file type.
      */
     char* uri = NULL;
-    ret = chroot_dentry_uri(dent, S_IFREG, &uri);
+    ret = dentry_uri(dent, S_IFREG, &uri);
     if (ret < 0)
         goto out;
 
@@ -184,7 +114,7 @@ out:
 /* Open a temporary read-only PAL handle for a file (used by `unlink` etc.) */
 static int chroot_temp_open(struct libos_dentry* dent, PAL_HANDLE* out_palhdl) {
     char* uri;
-    int ret = chroot_dentry_uri(dent, dent->inode->type, &uri);
+    int ret = dentry_uri(dent, dent->inode->type, &uri);
     if (ret < 0)
         return ret;
 
@@ -202,7 +132,7 @@ static int chroot_do_open(struct libos_handle* hdl, struct libos_dentry* dent, m
     int ret;
 
     char* uri;
-    ret = chroot_dentry_uri(dent, type, &uri);
+    ret = dentry_uri(dent, type, &uri);
     if (ret < 0)
         return ret;
 
@@ -429,7 +359,7 @@ static int chroot_rename(struct libos_dentry* old, struct libos_dentry* new) {
     int ret;
     char* new_uri = NULL;
 
-    ret = chroot_dentry_uri(new, old->inode->type, &new_uri);
+    ret = dentry_uri(new, old->inode->type, &new_uri);
     if (ret < 0)
         goto out;
 

--- a/libos/src/fs/shm/fs.c
+++ b/libos/src/fs/shm/fs.c
@@ -57,7 +57,7 @@ static int shm_do_open(struct libos_handle* hdl, struct libos_dentry* dent, mode
     assert(locked(&g_dcache_lock));
 
     char* uri;
-    int ret = chroot_dentry_uri(dent, type, &uri);
+    int ret = dentry_uri(dent, type, &uri);
     if (ret < 0)
         return ret;
 
@@ -109,7 +109,7 @@ static int shm_lookup(struct libos_dentry* dent) {
      * However, "file:" prefix is good enough here: `PalStreamAttributesQuery` will access the file
      * and report the right file type.
      */
-    int ret = chroot_dentry_uri(dent, S_IFREG, &uri);
+    int ret = dentry_uri(dent, S_IFREG, &uri);
     if (ret < 0)
         goto out;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Function `chroot_dentry_uri()` is a generic function to extract the URI out of the dentry (by concatenating the URI prefix, the dentry's mount point path and the dentry relative name). Thus this function must have a generic name and must be moved to a generic dentry file.

Extracted from https://github.com/gramineproject/gramine/pull/1812.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1817)
<!-- Reviewable:end -->
