### PR TITLE
[LibOS] test/regression: reenable `sigaltstack` test

### DIFF
--- a/libos/test/regression/sigaltstack.c
+++ b/libos/test/regression/sigaltstack.c
@@ -7,9 +7,11 @@
 #include <string.h>
 #include <unistd.h>
 
+/* default SIGSTKSZ is 8KB which is too small to hold e.g. XSAVE area (always stored by Gramine) */
+size_t sig_stack_size = 64 * 1024;
 uint8_t* sig_stack;
-size_t sig_stack_size = SIGSTKSZ;
-_Atomic int count     = 0;
+
+_Atomic int count = 0;
 
 static void handler(int signal, siginfo_t* info, void* ucontext) {
     int ret;

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -869,7 +869,6 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['munmap'])
         self.assertIn('TEST OK', stdout)
 
-    @unittest.skip('sigaltstack isn\'t correctly implemented')
     def test_060_sigaltstack(self):
         stdout, _ = self.run_binary(['sigaltstack'])
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As in title. I don't know/remember why the test was disabled, but everything works on current Gramine master. So looks like we just forgot to re-enable this test when refactoring signaling code.

Extracted from https://github.com/gramineproject/gramine/pull/1812 (completely unrelated, just noticed while working on that PR).

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1819)
<!-- Reviewable:end -->
