### PR TITLE
[PAL] Validate entrypoint ELF file separately

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -69,19 +69,30 @@ Loader entrypoint
 
 ::
 
-   loader.entrypoint = "[URI]"
+   loader.entrypoint.uri = "[URI]"
    (Default: "<path to libsysdb.so>")
 
-This specifies the LibOS component that Gramine will load and run before loading
-the first executable of the user application. **Note**: currently, there is only
-one LibOS implementation: ``libsysdb.so``, and there is no need to specify this
-option explicitly.
+   loader.entrypoint.sha256 = "[HASH]"
+
+``loader.entrypoint.uri`` specifies the LibOS component that Gramine will load
+and run before loading the first executable of the user application. **Note**:
+currently, there is only one LibOS implementation: ``libsysdb.so``, and there is
+no need to specify this option explicitly.
+
+Additionally, the loader entrypoint is cryptographically hashed at build time.
+At startup, Gramine verifies that the entrypoint's hash matches what is stored
+in the manifest in ``loader.entrypoint.sha256``. The signer tool will
+automatically generate the hash of this file and add it to the SGX-specific
+manifest (``.manifest.sgx``). The manifest writer may also explicitly specify
+the hash; in this case, hashing of the file will be skipped by the signer tool
+and the value in ``loader.entrypoint.sha256`` will be used instead.
 
 Note that the loader (the PAL binary) loads the LibOS binary specified in
 ``loader.entrypoint`` and passes control to this binary. Next, the LibOS binary
 loads the actual executable (the user application) specified in
 ``libos.entrypoint``. Also note that, in contrast to ``libos.entrypoint``, the
-``loader.entrypoint`` option specifies a PAL URI (with the ``file:`` prefix).
+``loader.entrypoint.uri`` option specifies a PAL URI (with the ``file:``
+prefix).
 
 .. _libos-entrypoint:
 
@@ -1359,3 +1370,15 @@ In addition, the application manifest must also contain ``sgx.debug = true``.
    independently.
 
 See :ref:`vtune-sgx-profiling` for more information.
+
+Deprecated options
+------------------
+
+Loader entrypoint (deprecated syntax)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   loader.entrypoint = "[URI]"
+
+This syntax was renamed to ``loader.entrypoint.uri``.

--- a/libos/test/abi/x86_64/manifest.template
+++ b/libos/test/abi/x86_64/manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 fs.mounts = [
@@ -10,6 +9,5 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/abi/x86_64/stack_arg.manifest.template
+++ b/libos/test/abi/x86_64/stack_arg.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 # The argv source file must set argv[0] as the basename of the entrypoint. This is crucial for
@@ -15,7 +14,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]
 

--- a/libos/test/abi/x86_64/stack_env.manifest.template
+++ b/libos/test/abi/x86_64/stack_env.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.foo = "bar"
@@ -15,6 +14,5 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/fs/manifest.template
+++ b/libos/test/fs/manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -29,7 +28,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/libgcc_s.so.1",

--- a/libos/test/ltp/manifest.template
+++ b/libos/test/ltp/manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/lib64"
@@ -36,7 +35,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/ld-linux-x86-64.so.2",
   "file:{{ gramine.runtimedir() }}/libc.so.6",

--- a/libos/test/regression/argv_from_file.manifest.template
+++ b/libos/test/regression/argv_from_file.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -19,7 +18,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/argv_from_manifest.manifest.template
+++ b/libos/test/regression/argv_from_manifest.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -22,7 +21,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/attestation.manifest.template
+++ b/libos/test/regression/attestation.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -19,7 +18,6 @@ sgx.ra_client_spid = "{{ env.get('RA_CLIENT_SPID', '') }}"
 sgx.ra_client_linkable = {{ 'true' if env.get('RA_CLIENT_LINKABLE', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/bootstrap_cpp.manifest.template
+++ b/libos/test/regression/bootstrap_cpp.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -18,7 +17,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ arch_libdir }}/libgcc_s.so.1",
   "file:/usr{{ arch_libdir }}/libstdc++.so.6",

--- a/libos/test/regression/debug_log_file.manifest.template
+++ b/libos/test/regression/debug_log_file.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -17,7 +16,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/debug_log_inline.manifest.template
+++ b/libos/test/regression/debug_log_inline.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -16,7 +15,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/device_ioctl.manifest.template
+++ b/libos/test/regression/device_ioctl.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -12,7 +11,6 @@ fs.mounts = [
 sgx.debug = true
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/device_ioctl_fail.manifest.template
+++ b/libos/test/regression/device_ioctl_fail.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "device_ioctl" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -14,7 +13,6 @@ fs.mounts = [
 sgx.debug = true
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/device_ioctl_parse_fail.manifest.template
+++ b/libos/test/regression/device_ioctl_parse_fail.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -12,7 +11,6 @@ fs.mounts = [
 sgx.debug = true
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/device_passthrough.manifest.template
+++ b/libos/test/regression/device_passthrough.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -13,7 +12,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/env_from_file.manifest.template
+++ b/libos/test/regression/env_from_file.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -19,7 +18,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/env_from_host.manifest.template
+++ b/libos/test/regression/env_from_host.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -15,7 +14,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/env_passthrough.manifest.template
+++ b/libos/test/regression/env_passthrough.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "bootstrap" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -20,7 +19,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/eventfd_fork.manifest.template
+++ b/libos/test/regression/eventfd_fork.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -14,7 +13,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/eventfd_fork_allowed_failing.manifest.template
+++ b/libos/test/regression/eventfd_fork_allowed_failing.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "eventfd_fork" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "warning"  # to print the warning about eventfd usage in child process
@@ -20,7 +19,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/fcntl_lock_child_only.manifest.template
+++ b/libos/test/regression/fcntl_lock_child_only.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -16,7 +15,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/libos/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "file_check_policy" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -18,9 +17,9 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.file_check_policy = "allow_all_but_log"
 
-# there are no "file:{{ gramine.libos }}" and "file:{{ gramine.runtimedir() }}/"
-# entries in `sgx.trusted_files` -- this is on purpose; we want to test that
-# `allow_all_but_log` also applies to Gramine-runtime files (e.g., LibOS binary)
+# there is no "file:{{ gramine.runtimedir() }}/" entry in `sgx.trusted_files` -- this is on purpose;
+# we want to test that `allow_all_but_log` also applies to Gramine-runtime files (e.g., libc
+# binaries)
 
 sgx.trusted_files = [
   "file:{{ binary_dir }}/{{ entrypoint }}",

--- a/libos/test/regression/file_check_policy_strict.manifest.template
+++ b/libos/test/regression/file_check_policy_strict.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "file_check_policy" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -19,7 +18,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.file_check_policy = "strict"
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
 
   # test TOML inline table syntax without `sha256`

--- a/libos/test/regression/fork_and_access_file.manifest.template
+++ b/libos/test/regression/fork_and_access_file.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -13,7 +12,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:fork_and_access_file_testfile",

--- a/libos/test/regression/fork_disallowed.manifest.template
+++ b/libos/test/regression/fork_disallowed.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "fork_and_exec" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "warning"
@@ -18,7 +17,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/host_root_fs.manifest.template
+++ b/libos/test/regression/host_root_fs.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ binary_dir }}/{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -15,7 +14,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/hostname_extra_runtime_conf.manifest.template
+++ b/libos/test/regression/hostname_extra_runtime_conf.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "hostname"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -15,7 +14,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/hostname",
 ]

--- a/libos/test/regression/init_fail.manifest.template
+++ b/libos/test/regression/init_fail.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -14,7 +13,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/init_fail2.manifest.template
+++ b/libos/test/regression/init_fail2.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "init_fail" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -18,7 +17,6 @@ sgx.enclave_size = "256M"
 sys.brk.max_size = "512M"
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/large_mmap.manifest.template
+++ b/libos/test/regression/large_mmap.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -21,7 +20,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/manifest.template
+++ b/libos/test/regression/manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -33,7 +32,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ arch_libdir }}/libgcc_s.so.1",
   "file:/usr{{ arch_libdir }}/libstdc++.so.6",

--- a/libos/test/regression/multi_pthread.manifest.template
+++ b/libos/test/regression/multi_pthread.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -16,7 +15,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enable_stats = true
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/multi_pthread_exitless.manifest.template
+++ b/libos/test/regression/multi_pthread_exitless.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "multi_pthread"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -17,7 +16,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.enable_stats = true
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/multi_pthread",
 ]

--- a/libos/test/regression/openmp.manifest.template
+++ b/libos/test/regression/openmp.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 # Gramine optionally provides patched OpenMP runtime library that runs faster inside SGX enclaves
@@ -27,7 +26,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/rwlock.manifest.template
+++ b/libos/test/regression/rwlock.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -14,7 +13,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/shadow_pseudo_fs.manifest.template
+++ b/libos/test/regression/shadow_pseudo_fs.manifest.template
@@ -1,6 +1,5 @@
 {% set entrypoint = "open_file" -%}
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -18,7 +17,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:{{ gramine.runtimedir(libc) }}/",
 ]

--- a/libos/test/regression/shebang_test_script.manifest.template
+++ b/libos/test/regression/shebang_test_script.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "shebang_test_script.sh"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -15,7 +14,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:/bin/sh",
   "file:shebang_test_script.sh",

--- a/libos/test/regression/shm.manifest.template
+++ b/libos/test/regression/shm.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -17,7 +16,6 @@ sgx.allowed_files = [
 ]
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/sigterm_multithread.manifest.template
+++ b/libos/test/regression/sigterm_multithread.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -15,7 +14,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/socket_ioctl.manifest.template
+++ b/libos/test/regression/socket_ioctl.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -13,7 +12,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/sysfs_common.manifest.template
+++ b/libos/test/regression/sysfs_common.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -12,7 +11,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/libos/test/regression/toml_parsing.manifest.template
+++ b/libos/test/regression/toml_parsing.manifest.template
@@ -2,7 +2,9 @@
 
 {% set entrypoint = "helloworld" -%}
 
+# test deprecated loader.entrypoint syntax, TODO: remove in v1.9
 loader.entrypoint = "file:{{ gramine.libos }}"
+
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -24,9 +26,6 @@ sgx.seal_key.xfrm_mask  = "0xfffffffffff9ff1b"
 sgx.seal_key.misc_mask  = "0xffffffff"
 
 # below format of sgx.trusted_files is to test TOML-table syntax without `sha256`
-[[sgx.trusted_files]]
-uri = "file:{{ gramine.libos }}"
-
 [[sgx.trusted_files]]
 uri = "file:{{ gramine.runtimedir(libc) }}/"
 

--- a/libos/test/regression/uid_gid.manifest.template
+++ b/libos/test/regression/uid_gid.manifest.template
@@ -1,4 +1,3 @@
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -15,7 +14,6 @@ sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir(libc) }}/",
   "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -294,6 +294,8 @@ void free(void* mem);
 int _PalInitDebugStream(const char* path);
 int _PalDebugLog(const void* buf, size_t size);
 
+int _PalValidateEntrypoint(const void* buf, size_t size);
+
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
 void pal_log(int level, const char* file, const char* func, uint64_t line,

--- a/pal/regression/Bootstrap6.manifest.template
+++ b/pal/regression/Bootstrap6.manifest.template
@@ -1,10 +1,8 @@
 {% set entrypoint = "Bootstrap" -%}
 
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
 
 sgx.enclave_size = "8192M"
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-
-sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]

--- a/pal/regression/Bootstrap7.manifest.template
+++ b/pal/regression/Bootstrap7.manifest.template
@@ -1,6 +1,5 @@
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 
-sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pal/regression/File.manifest.template
+++ b/pal/regression/File.manifest.template
@@ -1,11 +1,10 @@
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.allowed_files = [
-  "file:{{ binary_dir }}/{{ entrypoint }}",
   "file:{{ entrypoint }}.manifest",
   "file:../regression/{{ entrypoint }}.manifest",
   "file:file_nonexist.tmp",

--- a/pal/regression/Thread2.manifest.template
+++ b/pal/regression/Thread2.manifest.template
@@ -1,8 +1,6 @@
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '2' }}
 sgx.enable_stats = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-
-sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]

--- a/pal/regression/Thread2_edmm.manifest.template
+++ b/pal/regression/Thread2_edmm.manifest.template
@@ -1,9 +1,7 @@
 {% set entrypoint = "Thread2" -%}
 
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 
 sgx.max_threads = 1
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-
-sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]

--- a/pal/regression/Thread2_exitless.manifest.template
+++ b/pal/regression/Thread2_exitless.manifest.template
@@ -1,11 +1,9 @@
 {% set entrypoint = "Thread2" -%}
 
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '2' }}
 sgx.insecure__rpc_thread_num = 2
 sgx.enable_stats = true
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-
-sgx.trusted_files = [ "file:{{ binary_dir }}/{{ entrypoint }}" ]

--- a/pal/regression/manifest.template
+++ b/pal/regression/manifest.template
@@ -1,4 +1,4 @@
-loader.entrypoint = "file:{{ binary_dir }}/{{ entrypoint }}"
+loader.entrypoint.uri = "file:{{ binary_dir }}/{{ entrypoint }}"
 loader.log_level = "debug"
 loader.insecure__use_cmdline_argv = true
 
@@ -11,8 +11,4 @@ sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.allowed_files = [
   "file:test.txt", # for File2 test
   "file:to_send.tmp", # for PalSendHandle test
-]
-
-sgx.trusted_files = [
-  "file:{{ binary_dir }}/{{ entrypoint }}",
 ]

--- a/pal/src/host/linux/pal_misc.c
+++ b/pal/src/host/linux/pal_misc.c
@@ -79,3 +79,9 @@ int _PalGetSpecialKey(const char* name, void* key, size_t* key_size) {
     __UNUSED(key_size);
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
+
+int _PalValidateEntrypoint(const void* buf, size_t size) {
+    __UNUSED(buf);
+    __UNUSED(size);
+    return 0; /* no need to validate entrypoint; this PAL doesn't provide security */
+}

--- a/pal/src/host/skeleton/pal_misc.c
+++ b/pal/src/host/skeleton/pal_misc.c
@@ -59,6 +59,12 @@ int _PalGetSpecialKey(const char* name, void* key, size_t* key_size) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
+int _PalValidateEntrypoint(const void* buf, size_t size) {
+    __UNUSED(buf);
+    __UNUSED(size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
 double _PalGetBogomips(void) {
     /* this has to be implemented */
     return 0.0;

--- a/python/graminelibos/manifest_check.py
+++ b/python/graminelibos/manifest_check.py
@@ -58,7 +58,8 @@ GramineManifestSchema = Schema({
     },
 
     Required('loader'): {
-        Required('entrypoint'): str,
+        # TODO: validator for sha256
+        Required('entrypoint'): {Required('uri'): _uri, 'sha256': str},
         'argv': [str],
         'argv_src_file': str,
         'env': {str: Any(str, {'value': str}, {'passthrough': True})},


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the entrypoint ELF file (`loader.entrypoint` in manifest) contents were validated during file read and file mmap, just like with all other files. In particular, Linux-SGX PAL expects the entrypoint to be marked as `sgx.trusted_files` and validates its SHA256 hash during file read/mmap.

However, future commits will move handling of `sgx.trusted_files` to the LibOS layer. Thus, file read/mmap at the PAL layer will lose validation guarantees. This commit introduces a separate `loader.entrypoint_sha256` manifest option and a corresponding logic to validate the (only required) entrypoint file. A new assumption is made now, that the only file to be loaded by PAL (and not by LibOS) is this entrypoint file; this assumption can be made because the entrypoint has no dependencies.

Extracted from #1812.

Related to https://github.com/gramineproject/gramine/pull/1716 (ideally both should be merged one after another).

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1820)
<!-- Reviewable:end -->
