### PR TITLE
[CI-Examples] Fix wrong throughput unit in benchmark-http.sh

### DIFF
--- a/CI-Examples/rust/README.md
+++ b/CI-Examples/rust/README.md
@@ -9,6 +9,9 @@ The bind address and port are hardcoded in `src/main.rs`.
 
 # Quick Start
 
+NOTE: The "benchmark-http.sh" script uses the wrk benchmark (wrk2) under the
+hood. Please refer to https://github.com/giltene/wrk2.
+
 ```sh
 # build the program and the final manifest
 make SGX=1


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, we were printing the throughput in bytes, but wrk2 gives "Req/Sec" and the throughput in bytes doesn't really make sense.

Additionally, this commit adds a note in the README of our rust example stating the need of `wrk2` when using the benchmark script.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1821)
<!-- Reviewable:end -->
