### PR TITLE
[LibOS] VMA bookkeep calls Pal `mprotect` per VMA

### DIFF
--- a/libos/src/bookkeep/libos_thread.c
+++ b/libos/src/bookkeep/libos_thread.c
@@ -97,7 +97,7 @@ int alloc_thread_libos_stack(struct libos_thread* thread) {
     need_mem_free = true;
 
     /* Create a stack guard page. */
-    ret = PalVirtualMemoryProtect(addr, PAGE_SIZE, /*prot=*/0);
+    ret = bkeep_mprotect(addr, PAGE_SIZE, /*prot=*/0, /*is_internal=*/true);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
         goto unmap;

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -132,10 +132,6 @@ static void* allocate_stack(size_t size, size_t protect_size, bool user) {
         goto out_fail;
     }
 
-    if (PalVirtualMemoryProtect(stack + protect_size, size, PAL_PROT_READ | PAL_PROT_WRITE) < 0) {
-        goto out_fail;
-    }
-
     return stack + protect_size;
 
 out_fail:;


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
VMA bookkeeping records prot of each VMA. However, `mprotect` syscall always calls Pal `mprotect` no matter prot changed or not, because `prot` recorded in VMA bookkeeping is not used during the syscall. 

This PR updates VMA bookkeep `mprotect` to walk through VMAs and only call Pal `mprotect` when prot is not same as current prot in corresponding VMAs, and also fixes prot mismatch exceptions in libos_thread.c.

Partial fixes #1708. In future PR, Pal `mprotect` will take a new parameter `old_prot` to extend/retstrict protection accordingly.
## How to test this PR? <!-- (if applicable) -->

existing tests since all changes are internal.