### PR TITLE
[PAL] Print a nice error if enclave range collides with other regions

### DIFF
--- a/common/include/api.h
+++ b/common/include/api.h
@@ -407,6 +407,16 @@ int buf_flush(struct print_buf* buf);
 #define TIME_NS_IN_US 1000ul
 #define TIME_NS_IN_S (TIME_NS_IN_US * TIME_US_IN_S)
 
+/* ranges are inclusive-exclusive - [start, end) */
+static inline bool ranges_overlap(uintptr_t a_start, uintptr_t a_end,
+                                  uintptr_t b_start, uintptr_t b_end) {
+    assert(a_start <= a_end);
+    assert(b_start <= b_end);
+    if (a_start == a_end || b_start == b_end)
+        return false; // an empty range doesn't overlap with anything
+    return !(a_end <= b_start || b_end <= a_start);
+}
+
 #ifdef __x86_64__
 static inline bool __range_not_ok(uintptr_t addr, size_t size) {
     addr += size;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, if enclave size was very large (e.g. 2TB) its collision with some hardcoded memory regions in untrusted memory (ASan shadow map, debug info area, untrusted shared memory) caused allocation failures, leading to cryptic errors.
This commit fixes that and checks all the ranges for collisions.

The lack of these checks was _not_ a security issue, because:
- ASan range is used only in debug builds
- debug range is used also in release, but only by the untrusted PAL
- shared memory range allocation would fail in ocall_mmap_untrusted() before leaving the enclave (on pointer check)

Fixes #1787.

## How to test this PR? <!-- (if applicable) -->

Modify some enclave size to e.g. 2TB. Outputs from my runs:

debug, 2TB, no fix:
```
> gramine-sgx helloworld
Gramine is starting. Parsing TOML manifest file, this may take some time...
fish: Job 1, 'gramine-sgx helloworld' terminated by signal SIGKILL (Forced quit)
```

asan, 2TB, no fix:

```
> gramine-sgx helloworld
Gramine is starting. Parsing TOML manifest file, this may take some time...
error: Allocation of EPC memory failed: File exists (EEXIST)
```

debug, 2TB, fix:

```
> gramine-sgx helloworld
Gramine is starting. Parsing TOML manifest file, this may take some time...
error: Enclave range collides with shared memory or debug range. This is most likely caused by too large enclave size.
error: load_enclave() failed with error: Invalid argument (EINVAL)
```

asan, 2TB, fix:

same as debug, because ASan range is checked afterwards and it's further in memory than debug range. After commenting out debug and shared range checks:

```
> gramine-sgx helloworld
Gramine is starting. Parsing TOML manifest file, this may take some time...
error: Enclave range collides with ASan range. This is most likely caused by too large enclave size.
error: load_enclave() failed with error: Invalid argument (EINVAL)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1826)
<!-- Reviewable:end -->
