### PR TITLE
[curl] Upgrade libcurl to version 8.7.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -229,7 +229,7 @@ mbedtls_proj = subproject('mbedtls-mbedtls-3.5.2')
 mbedtls_static_dep = mbedtls_proj.get_variable('mbedtls_static_dep')
 mbedtls_pal_dep = mbedtls_proj.get_variable('mbedtls_pal_dep')
 
-curl_proj = subproject('curl-8.5.0')
+curl_proj = subproject('curl-8.7.1')
 cjson_proj = subproject('cJSON-1.7.12')
 
 if sgx

--- a/subprojects/curl-8.5.0.wrap
+++ b/subprojects/curl-8.5.0.wrap
@@ -1,7 +1,0 @@
-[wrap-file]
-directory = curl-8.5.0
-source_url = https://curl.se/download/curl-8.5.0.tar.gz
-source_fallback_url = https://packages.gramineproject.io/distfiles/curl-8.5.0.tar.gz
-source_filename = curl-8.5.0.tar.gz
-source_hash = 05fc17ff25b793a437a0906e0484b82172a9f4de02be5ed447e0cab8c3475add
-patch_directory = curl-8.5.0

--- a/subprojects/curl-8.7.1.wrap
+++ b/subprojects/curl-8.7.1.wrap
@@ -1,0 +1,7 @@
+[wrap-file]
+directory = curl-8.7.1
+source_url = https://curl.se/download/curl-8.7.1.tar.gz
+source_fallback_url = https://packages.gramineproject.io/distfiles/curl-8.7.1.tar.gz
+source_filename = curl-8.7.1.tar.gz
+source_hash = f91249c87f68ea00cf27c44fdfa5a78423e41e71b7d408e5901a9896d905c495
+patch_directory = curl-8.7.1

--- a/subprojects/packagefiles/curl-8.7.1/compile.sh
+++ b/subprojects/packagefiles/curl-8.7.1/compile.sh
@@ -27,7 +27,7 @@ cp -ar "$CURRENT_SOURCE_DIR" "$PRIVATE_DIR"
 
     log "running configure..."
     # The list of configure options is selected based on:
-    # https://github.com/curl/curl/blob/curl-8_5_0/docs/INSTALL.md#reducing-size
+    # https://github.com/curl/curl/blob/curl-8_7_1/docs/INSTALL.md#reducing-size
     ./configure                                     \
         --enable-proxy                              \
         --disable-alt-svc                           \
@@ -39,9 +39,11 @@ cp -ar "$CURRENT_SOURCE_DIR" "$PRIVATE_DIR"
         --disable-dnsshuffle                        \
         --disable-doh                               \
         --disable-file                              \
+        --disable-form-api                          \
         --disable-ftp                               \
         --disable-get-easy-options                  \
         --disable-gopher                            \
+        --disable-headers-api                       \
         --disable-hsts                              \
         --disable-http-auth                         \
         --disable-imap                              \
@@ -49,8 +51,10 @@ cp -ar "$CURRENT_SOURCE_DIR" "$PRIVATE_DIR"
         --disable-ldaps                             \
         --disable-libcurl-option                    \
         --disable-manual                            \
+        --disable-mime                              \
         --disable-mqtt                              \
         --disable-netrc                             \
+        --disable-ntlm                              \
         --disable-ntlm-wb                           \
         --disable-pop3                              \
         --disable-progress-meter                    \

--- a/subprojects/packagefiles/curl-8.7.1/meson.build
+++ b/subprojects/packagefiles/curl-8.7.1/meson.build
@@ -1,4 +1,4 @@
-project('curl', 'c', version: '8.5.0')
+project('curl', 'c', version: '8.7.1')
 
 curl_libs_output = [
     'libcurl.a',


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This upgrade includes fixes for several CVEs affecting libcurl, specifically:
* CVE-2024-0853 (fixed in v8.6.0);
* CVE-2024-2004, CVE-2024-2398, CVE-2024-2379, CVE-2024-2466 (fixed in v8.7.0/v8.7.1).

This commit also updates the (disabled) libcurl feature list in Gramine based on the updated minimal binary size configuration recommendations from curl.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1833)
<!-- Reviewable:end -->
