### PR TITLE
[LibOS] Allow `stat()` and `chmod()` on encrypted-files dirs

### DIFF
--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -359,7 +359,7 @@ static int chroot_encrypted_chmod(struct libos_dentry* dent, mode_t perm) {
     assert(locked(&g_dcache_lock));
     assert(dent->inode);
 
-    if (!dent->inode->data)
+    if (dent->inode->type == S_IFREG && !dent->inode->data)
         return -EACCES;
 
     char* uri = NULL;
@@ -528,7 +528,7 @@ static int chroot_encrypted_stat(struct libos_dentry* dent, struct stat* buf) {
     assert(locked(&g_dcache_lock));
     assert(dent->inode);
 
-    if (!dent->inode->data)
+    if (dent->inode->type == S_IFREG && !dent->inode->data)
         return -EACCES;
 
     return generic_inode_stat(dent, buf);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit ["[LibOS] Allow `unlink()` on corrupted encrypted files"](https://github.com/gramineproject/gramine/commit/4dae6b0d1131dab890747cf91534a8c2fdd86357) introduced checks `if (!dent->inode->data) return -EACCES` for all encrypted-files callbacks. However, these callbacks are also used for directories of encrypted files (FS mounts in manifest file and their sub-dirs), and directories never have `inode->data` anyway. Therefore, that commit introduced a bug that encrypted-files dirs returned EACCES error on `stat()` and `chmod()`.

This PR fixes this bug by additionally checking that the inode is of "regular file" type.

Fixes https://github.com/gramineproject/contrib/issues/85.

## How to test this PR? <!-- (if applicable) -->

A sub-test is added in `sealed_file` LibOS test. Also see https://github.com/gramineproject/contrib/issues/85 for reproducers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1840)
<!-- Reviewable:end -->
