### PR TITLE
[LibOS] Add `post_poll()` callback to network sockets

### DIFF
--- a/libos/src/fs/socket/fs.c
+++ b/libos/src/fs/socket/fs.c
@@ -224,6 +224,15 @@ static int checkin(struct libos_handle* handle) {
     return 0;
 }
 
+static void post_poll(struct libos_handle* hdl, pal_wait_flags_t* pal_ret_events) {
+    assert(hdl->type == TYPE_SOCK);
+
+    if (*pal_ret_events & (PAL_WAIT_READ | PAL_WAIT_WRITE)) {
+        bool error_event = !!(*pal_ret_events & (PAL_WAIT_ERROR | PAL_WAIT_HANG_UP));
+        check_connect_inprogress_on_poll(hdl, error_event);
+    }
+}
+
 static struct libos_fs_ops socket_fs_ops = {
     .close    = close,
     .read     = read,
@@ -235,6 +244,7 @@ static struct libos_fs_ops socket_fs_ops = {
     .ioctl    = ioctl,
     .checkout = checkout,
     .checkin  = checkin,
+    .post_poll = &post_poll,
 };
 
 struct libos_fs socket_builtin_fs = {

--- a/libos/src/sys/libos_epoll.c
+++ b/libos/src/sys/libos_epoll.c
@@ -679,13 +679,6 @@ static int do_epoll_wait(int epfd, struct epoll_event* events, int maxevents, in
                 this_item_events |= items[i]->events & (EPOLLOUT | EPOLLWRNORM);
             }
 
-            /* TODO: move this to socket FS's post_poll() callback */
-            if (items[i]->handle->type == TYPE_SOCK &&
-                    (pal_ret_events[i] & (PAL_WAIT_READ | PAL_WAIT_WRITE))) {
-                bool error_event = !!(pal_ret_events[i] & (PAL_WAIT_ERROR | PAL_WAIT_HANG_UP));
-                check_connect_inprogress_on_poll(items[i]->handle, error_event);
-            }
-
             if (!this_item_events) {
                 /* This handle is not interested in events that were detected - epoll item was
                  * probably updated asynchronously. */

--- a/libos/src/sys/libos_poll.c
+++ b/libos/src/sys/libos_poll.c
@@ -221,13 +221,6 @@ static long do_poll(struct pollfd* fds, size_t fds_len, uint64_t* timeout_us) {
         if (ret_events[i] & PAL_WAIT_WRITE)
             fds[i].revents |= fds[i].events & (POLLOUT | POLLWRNORM);
 
-        /* TODO: move this to socket FS's post_poll() callback */
-        if (libos_handles[i]->type == TYPE_SOCK &&
-                (ret_events[i] & (PAL_WAIT_READ | PAL_WAIT_WRITE))) {
-            bool error_event = !!(ret_events[i] & (PAL_WAIT_ERROR | PAL_WAIT_HANG_UP));
-            check_connect_inprogress_on_poll(libos_handles[i], error_event);
-        }
-
         if (fds[i].revents)
             ret_events_count++;
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit ["[LibOS] Add secure implementation of eventfd"](https://github.com/gramineproject/gramine/pull/1728) introduced a `post_poll()` callback which can be used to trigger additional events on specific events returned from select/poll/epoll. This commit refactors the LibOS code such that sockets-specific handling of EINPROGRESS is moved from select/poll/epoll code into this `post_poll()` callback.

## How to test this PR? <!-- (if applicable) -->

CI must pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1844)
<!-- Reviewable:end -->
