### PR TITLE
[LibOS] test/regression: Use unresponsive IPv4 address `203.0.113.0`

### DIFF
--- a/libos/test/regression/tcp_einprogress.c
+++ b/libos/test/regression/tcp_einprogress.c
@@ -23,8 +23,7 @@
 
 static void usage(const char* prog_name) {
     fprintf(stderr, "usage: %s <IP address> poll|epoll\n", prog_name);
-    fprintf(stderr, "(use 127.0.0.1 for responsive peer and 10.255.255.255 for unresponsive "
-                    "peer)\n");
+    fprintf(stderr, "(use 127.0.0.1 for responsive peer and 203.0.113.0 for unresponsive peer)\n");
 }
 
 int main(int argc, const char** argv) {

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1482,11 +1482,11 @@ class TC_80_Socket(RegressionTestCase):
     # Two tests for an unresponsive peer: first connect() returns EINPROGRESS, then poll/epoll
     # times out because the connection cannot be established
     def test_307_socket_tcp_einprogress_unresponsive_poll(self):
-        stdout, _ = self.run_binary(['tcp_einprogress', '10.255.255.255', 'poll'])
+        stdout, _ = self.run_binary(['tcp_einprogress', '203.0.113.0', 'poll'])
         self.assertIn('TEST OK (connection timed out)', stdout)
 
     def test_308_socket_tcp_einprogress_unresponsive_epoll(self):
-        stdout, _ = self.run_binary(['tcp_einprogress', '10.255.255.255', 'epoll'])
+        stdout, _ = self.run_binary(['tcp_einprogress', '203.0.113.0', 'epoll'])
         self.assertIn('TEST OK (connection timed out)', stdout)
 
     def test_310_socket_tcp_ipv6_v6only(self):


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously the EINPROGRESS tests used a supposedly-unresponsive address `10.255.255.255`, but this address may be used in the private network. This commit switches to the address from the reserved "Documentation" range, which should never be used in networks.

Fixes #1850.

## How to test this PR? <!-- (if applicable) -->

Run in a network that either actually uses 10.255.255.255, or that explicitly refuses connections to it.