### PR TITLE
[Docs] Remove highlight directive from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,6 @@ Gramine Library OS with Intel SGX Support
 .. |nbsp| unicode:: 0xa0
    :trim:
 
-.. highlight:: sh
-
 
 What is Gramine?
 ================
@@ -90,6 +88,7 @@ For bug reports and feature requests, `post an issue on our GitHub repository
 
 If you prefer emails, please send them to users@gramineproject.io
 (`public archive <https://groups.google.com/g/gramine-users>`__).
+
 
 Reporting security issues
 =========================


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

see commit message

## How to test this PR? <!-- (if applicable) -->

Please check that this does not happen anymore:
![image](https://github.com/gramineproject/gramine/assets/1550337/dc29d319-4f71-4c14-848b-735341b89fdf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1854)
<!-- Reviewable:end -->
