### PR TITLE
[python] Print nicer errors in `gramine-manifest`

### DIFF
--- a/python/gramine-manifest
+++ b/python/gramine-manifest
@@ -6,6 +6,11 @@
 import click
 import voluptuous
 
+try:
+    from tomllib import TOMLDecodeError
+except ImportError:
+    from tomli import TOMLDecodeError
+
 from graminelibos import Manifest
 
 def validate_define(_ctx, _param, values):
@@ -28,9 +33,13 @@ def validate_define(_ctx, _param, values):
 @click.pass_context
 def main(ctx, string, define, infile, outfile, check):
     if not bool(string) ^ bool(infile):
-        click.get_current_context().fail('specify exactly one of (infile, -c)')
+        ctx.fail('specify exactly one of (infile, -c)')
     template = infile.read() if infile else string
-    manifest = Manifest.from_template(template, define)
+    try:
+        manifest = Manifest.from_template(template, define)
+    except TOMLDecodeError as err:
+        click.echo(f'ERROR: failed to parse manifest template: {err!s}', err=True)
+        ctx.exit(1)
 
     if check:
         try:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See the analogous problem and discussion for `gramine-manifest-check`: https://reviewable.io/reviews/gramineproject/gramine/1726#-Nw79aKICx9Ai1ujL3Hk.

## How to test this PR? <!-- (if applicable) -->

Corrupt a manifest template and try to build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1862)
<!-- Reviewable:end -->
