### PR TITLE
[tests] Fix signature length calculation in sgx_sign tests

### DIFF
--- a/tests/test_sgx_sign.py
+++ b/tests/test_sgx_sign.py
@@ -44,7 +44,7 @@ def verify_signature(data, exponent, modulus, signature, key_file, passphrase=No
     numbers = public_key.public_numbers()
     assert numbers.e == exponent
     assert numbers.n == modulus
-    signature_bytes = signature.to_bytes((signature.bit_length() + 7) // 8, byteorder='big')
+    signature_bytes = signature.to_bytes((modulus.bit_length() + 7) // 8, byteorder='big')
     # This will raise a `cryptography.exceptions.InvalidSignature` exception
     # if signature verification fails.
     public_key.verify(signature_bytes, data, padding.PKCS1v15(), hashes.SHA256())


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Incorrect signature length calculation could cause an `InvalidSignature` exception if the signature happened to start with a 0x00 byte, resulting in random CI failures.

Fixes #1689.

## How to test this PR? <!-- (if applicable) -->

Run `while true; python3 -m pytest -v -k 'test_sign_from_pem_path' tests/; or break; end` in Gramine root and wait. Without this PR it fails after ~64 loop iterations with:
```
tests/test_sgx_sign.py:64: in test_sign_from_pem_path
    verify_signature(data, exponent, modulus, signature, key_file)
tests/test_sgx_sign.py:50: in verify_signature
    public_key.verify(signature_bytes, data, padding.PKCS1v15(), hashes.SHA256())
/usr/local/lib/python3.8/dist-packages/cryptography/hazmat/backends/openssl/rsa.py:550: in verify
    _rsa_sig_verify(
/usr/local/lib/python3.8/dist-packages/cryptography/hazmat/backends/openssl/rsa.py:325: in _rsa_sig_verify
    raise InvalidSignature
E   cryptography.exceptions.InvalidSignature
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1864)
<!-- Reviewable:end -->
