### PR TITLE
[glibc] Fix redefinition of `_FORTIFY_SOURCE`

### DIFF
--- a/subprojects/packagefiles/glibc-2.39/fix-fortify-source.patch
+++ b/subprojects/packagefiles/glibc-2.39/fix-fortify-source.patch
@@ -1,0 +1,126 @@
+From 73302ea9454b816d5e0a4f02bbd68df1bf2bb53d Mon Sep 17 00:00:00 2001
+From: Matthias Klose <matthias.klose@canonical.com>
+Date: Thu, 28 Mar 2024 13:16:23 +0100
+Subject: [PATCH] Fix non-standard redefinition of _FORTIFIY_SOURCE
+
+---
+ configure             |  4 ++--
+ configure.ac          |  4 ++--
+ debug/Makefile        | 18 +++++++++---------
+ stdio-common/Makefile |  2 +-
+ wcsmbs/Makefile       |  2 +-
+ 5 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/configure b/configure
+index 59ff1e415d..d392c0b797 100755
+--- a/configure
++++ b/configure
+@@ -7471,7 +7471,7 @@ printf "%s\n" "#define HAVE_LIBCAP 1" >>confdefs.h
+ fi
+ 
+ 
+-no_fortify_source="-Wp,-U_FORTIFY_SOURCE"
++no_fortify_source="-U_FORTIFY_SOURCE"
+ fortify_source="${no_fortify_source}"
+ 
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for maximum supported _FORTIFY_SOURCE level" >&5
+@@ -7523,7 +7523,7 @@ esac
+ 
+ if test "$libc_cv_fortify_source" = yes
+ then :
+-  fortify_source="${fortify_source},-D_FORTIFY_SOURCE=${enable_fortify_source}"
++  fortify_source="${fortify_source} -D_FORTIFY_SOURCE=${enable_fortify_source}"
+ 
+ fi
+ 
+diff --git a/configure.ac b/configure.ac
+index 65799e5685..a91781d290 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1500,7 +1500,7 @@ dnl If not, then don't use it.
+ dnl Note that _FORTIFY_SOURCE may have been set through FLAGS too.
+ dnl _FORTIFY_SOURCE value will be selectively disabled for function that can't
+ dnl support it
+-no_fortify_source="-Wp,-U_FORTIFY_SOURCE"
++no_fortify_source="-U_FORTIFY_SOURCE"
+ fortify_source="${no_fortify_source}"
+ 
+ AC_CACHE_CHECK([for maximum supported _FORTIFY_SOURCE level],
+@@ -1519,7 +1519,7 @@ AS_CASE([$enable_fortify_source],
+         [libc_cv_fortify_source=no])
+ 
+ AS_IF([test "$libc_cv_fortify_source" = yes],
+-      [fortify_source="${fortify_source},-D_FORTIFY_SOURCE=${enable_fortify_source}"]
++      [fortify_source="${fortify_source} -D_FORTIFY_SOURCE=${enable_fortify_source}"]
+       )
+ 
+ AC_SUBST(enable_fortify_source)
+diff --git a/debug/Makefile b/debug/Makefile
+index 3903cc97a3..2ad5ef7cdc 100644
+--- a/debug/Makefile
++++ b/debug/Makefile
+@@ -171,16 +171,16 @@ CFLAGS-recvfrom_chk.c += -fexceptions -fasynchronous-unwind-tables
+ # set up for us, so keep the CFLAGS/CPPFLAGS split logical as the order is:
+ # <user CFLAGS> <test CFLAGS> <user CPPFLAGS> <test CPPFLAGS>
+ CFLAGS-tst-longjmp_chk.c += -fexceptions -fasynchronous-unwind-tables
+-CPPFLAGS-tst-longjmp_chk.c += $(no-fortify-source),-D_FORTIFY_SOURCE=1
++CPPFLAGS-tst-longjmp_chk.c += $(no-fortify-source) -D_FORTIFY_SOURCE=1
+ CFLAGS-tst-longjmp_chk2.c += -fexceptions -fasynchronous-unwind-tables
+-CPPFLAGS-tst-longjmp_chk2.c += $(no-fortify-source),-D_FORTIFY_SOURCE=1
++CPPFLAGS-tst-longjmp_chk2.c += $(no-fortify-source) -D_FORTIFY_SOURCE=1
+ CFLAGS-tst-longjmp_chk3.c += -fexceptions -fasynchronous-unwind-tables
+-CPPFLAGS-tst-longjmp_chk3.c += $(no-fortify-source),-D_FORTIFY_SOURCE=1
+-CPPFLAGS-tst-realpath-chk.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
+-CPPFLAGS-tst-chk-cancel.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
+-CFLAGS-tst-sprintf-fortify-rdonly.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
+-CFLAGS-tst-fortify-syslog.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
+-CFLAGS-tst-fortify-wide.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
++CPPFLAGS-tst-longjmp_chk3.c += $(no-fortify-source) -D_FORTIFY_SOURCE=1
++CPPFLAGS-tst-realpath-chk.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
++CPPFLAGS-tst-chk-cancel.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
++CFLAGS-tst-sprintf-fortify-rdonly.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
++CFLAGS-tst-fortify-syslog.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
++CFLAGS-tst-fortify-wide.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
+ 
+ # _FORTIFY_SOURCE tests.
+ # Auto-generate tests for _FORTIFY_SOURCE for different levels, compilers and
+@@ -218,7 +218,7 @@ src-chk-nongnu = \#undef _GNU_SOURCE
+ # cannot be disabled via pragmas, so require -Wno-error to be used.
+ define gen-chk-test
+ tests-$(1)-$(4)-chk += tst-fortify-$(1)-$(2)-$(3)-$(4)
+-CFLAGS-tst-fortify-$(1)-$(2)-$(3)-$(4).$(1) += $(no-fortify-source),-D_FORTIFY_SOURCE=$(3) -Wno-format \
++CFLAGS-tst-fortify-$(1)-$(2)-$(3)-$(4).$(1) += $(no-fortify-source) -D_FORTIFY_SOURCE=$(3) -Wno-format \
+ 					  -Wno-deprecated-declarations \
+ 					  -Wno-error
+ $(eval $(call cflags-$(2),$(1),$(3),$(4)))
+diff --git a/stdio-common/Makefile b/stdio-common/Makefile
+index e312565f3b..c1b1a779e0 100644
+--- a/stdio-common/Makefile
++++ b/stdio-common/Makefile
+@@ -486,7 +486,7 @@ CFLAGS-tst-gets.c += -Wno-deprecated-declarations
+ 
+ # BZ #11319 was first fixed for regular vdprintf, then reopened because
+ # the fortified version had the same bug.
+-CFLAGS-tst-bz11319-fortify2.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
++CFLAGS-tst-bz11319-fortify2.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
+ 
+ CFLAGS-tst-memstream-string.c += -fno-builtin-fprintf
+ 
+diff --git a/wcsmbs/Makefile b/wcsmbs/Makefile
+index 65173e28aa..6b9297e80c 100644
+--- a/wcsmbs/Makefile
++++ b/wcsmbs/Makefile
+@@ -258,7 +258,7 @@ CFLAGS-wcstod_l.c += $(strtox-CFLAGS) $(config-cflags-wno-ignored-attributes)
+ CFLAGS-wcstold_l.c += $(strtox-CFLAGS) $(config-cflags-wno-ignored-attributes)
+ CFLAGS-wcstof128_l.c += $(strtox-CFLAGS)
+ CFLAGS-wcstof_l.c += $(strtox-CFLAGS) $(config-cflags-wno-ignored-attributes)
+-CPPFLAGS-tst-wchar-h.c += $(no-fortify-source),-D_FORTIFY_SOURCE=2
++CPPFLAGS-tst-wchar-h.c += $(no-fortify-source) -D_FORTIFY_SOURCE=2
+ 
+ CFLAGS-wcschr.c += $(config-cflags-wno-ignored-attributes)
+ CFLAGS-wmemchr.c += $(config-cflags-wno-ignored-attributes)
+
+base-commit: 983f34a1252de3ca6f2305c211d86530ea42010e
+-- 
+2.43.0
+

--- a/subprojects/packagefiles/glibc-2.39/meson.build
+++ b/subprojects/packagefiles/glibc-2.39/meson.build
@@ -71,6 +71,7 @@ glibc = custom_target('glibc',
 
     input: [
         'glibc-2.39/configure',
+        'fix-fortify-source.patch',
         'gramine-syscall.patch',
         'hp-timing.patch',
     ],


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The new Ubuntu release, Noble, includes a version of GCC with a spec that defines `_FORTIFY_SOURCE` when optimization is enabled:
```
$ gcc -dumpspecs | grep _FORTIFY_SOURCE
 %{!O0:%{O*:%{!D_FORTIFY_SOURCE=*:%{!U_FORTIFY_SOURCE:-D_FORTIFY_SOURCE=3}}}
```

However, some files in glibc need to be built without `_FORTIFY_SOURCE`, such as `vprintf.c`. The patch from Ubuntu Noble changes the method of undefining _FORTIFY_SOURCE to -U_FORTIFY_SOURCE. Previously it was limited only to the preprocessor (-Wp,-U_FORTIFY_SOURCE). The new method also undefines the definition from the spec.
The patch addresses some other non-standard redefinitions of _FORTIFY_SOURCE as well.

## Some useful things

### Get logs from the ubuntu/debian build (depends on the machine)
```
getbuildlog glibc last amd64
```

### Patch obtained from
- http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/glibc_2.39-0ubuntu8.1.debian.tar.xz

### Ubuntu change log
https://changelogs.ubuntu.com/changelogs/pool/main/g/glibc/glibc_2.39-0ubuntu8.1/changelog

```
glibc (2.39-0ubuntu7) noble; urgency=medium

[...]
  * d/p/fix-fortify-source.patch: Fix FTBFS on Noble
[...]
 -- Simon Chopin <schopin@ubuntu.com>  Thu, 28 Mar 2024 15:16:51 +0100
```

## How to test this PR? <!-- (if applicable) -->

Test suite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1865)
<!-- Reviewable:end -->
