### PR TITLE
[tools/RA-TLS] Drop deprecated `RA_TLS_*` env semantics

### DIFF
--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -119,6 +119,10 @@ stage('test-sgx') {
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
             cd CI-Examples/ra-tls-mbedtls
+            export RA_TLS_MRSIGNER=any
+            export RA_TLS_MRENCLAVE=any
+            export RA_TLS_ISV_PROD_ID=any
+            export RA_TLS_ISV_SVN=any
             if [ "${RA_TYPE}" = "epid" ]; then \
                 if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
                 then \
@@ -142,6 +146,10 @@ stage('test-sgx') {
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
             cd CI-Examples/ra-tls-secret-prov
+            export RA_TLS_MRSIGNER=any
+            export RA_TLS_MRENCLAVE=any
+            export RA_TLS_ISV_PROD_ID=any
+            export RA_TLS_ISV_SVN=any
             if [ "${RA_TYPE}" = "epid" ]; then \
                 if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
                 then \
@@ -162,6 +170,10 @@ stage('test-sgx') {
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
             cd CI-Examples/ra-tls-nginx
+            export RA_TLS_MRSIGNER=any
+            export RA_TLS_MRENCLAVE=any
+            export RA_TLS_ISV_PROD_ID=any
+            export RA_TLS_ISV_SVN=any
             if [ "${RA_TYPE}" = "epid" ]; then \
                 if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
                 then \

--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -314,10 +314,8 @@ SGX measurements:
 - ``RA_TLS_ISV_SVN`` -- verify that the attesting enclave has this or higher
   ``ISV_SVN``. This is a decimal string.
 
-For each of these settings, you may specify the special value ``any`` to skip
-verifying a particular measurement. This used to be the default, which would
-be used if a particular environment variable wasn't present. This behavior
-has been deprecated and will become a hard error in the future.
+Each of these variables has to be explicitly set, but you may specify the
+special value ``any`` to skip verifying a particular measurement.
 
 The four SGX measurements above may be also verified via a user-specified
 callback with the signature ``int (*callback)(char* mrenclave, char* mrsigner,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Omitting any of the measurement variables is now a hard error.

## How to test this PR? <!-- (if applicable) -->

Try RA-TLS examples without setting some of these variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1870)
<!-- Reviewable:end -->
