### PR TITLE
[LibOS] Fix `ENOENT` error in `fchown` on unlinked file

### DIFF
--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -99,6 +99,7 @@ tests = {
     'pthread_set_get_affinity': {},
     'readdir': {},
     'rename_unlink': {},
+    'rename_unlink_fchown': {},
     'run_test': {
         'include_directories': include_directories(
             # for `gramine_entry_api.h`

--- a/libos/test/regression/rename_unlink_fchown.c
+++ b/libos/test/regression/rename_unlink_fchown.c
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation
+ *                    Michael Steiner <michael.steiner@intel.com>
+ */
+
+/*
+ * Tests for fchown after renaming and deleting files. Mostly focused on cases where a file is still
+ * open. These tests are separate from other renaming/deleting tests in `rename_unlink.c` because
+ * these tests require a root user to perform fchown with arbitrary user/group.
+ */
+
+#define _DEFAULT_SOURCE /* fchmod */
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "rw_file.h"
+
+static const char message[] = "first message\n";
+static const size_t message_len = sizeof(message) - 1;
+
+static void should_not_exist(const char* path) {
+    struct stat statbuf;
+
+    if (stat(path, &statbuf) == 0)
+        errx(1, "%s unexpectedly exists", path);
+    if (errno != ENOENT)
+        err(1, "stat %s", path);
+}
+
+static void check_statbuf(const char* desc, struct stat* statbuf, size_t size) {
+    assert(!OVERFLOWS(off_t, size));
+
+    if (!S_ISREG(statbuf->st_mode))
+        errx(1, "%s: wrong mode (0o%o)", desc, statbuf->st_mode);
+    if (statbuf->st_size != (off_t)size)
+        errx(1, "%s: wrong size (%lu)", desc, statbuf->st_size);
+}
+
+static void check_ownership_and_permissions(const char* path, struct stat* statbuf, uid_t uid,
+                                            gid_t gid, mode_t permissions) {
+    if (statbuf->st_uid != uid || statbuf->st_gid != gid)
+        errx(1, "wrong ownership of file %s", path);
+    if ((statbuf->st_mode & 0777) != permissions)
+        errx(1, "wrong permissions of file %s", path);
+}
+
+static void should_exist(const char* path, size_t size) {
+    struct stat statbuf;
+    CHECK(stat(path, &statbuf));
+    check_statbuf(path, &statbuf, size);
+}
+
+static int create_file(const char* path, const char* str, size_t len) {
+    int fd = CHECK(open(path, O_RDWR | O_CREAT | O_TRUNC, 0600));
+
+    ssize_t n = posix_fd_write(fd, str, len);
+    if (n < 0)
+        errx(1, "posix_fd_write %s", path);
+    if ((size_t)n != len)
+        errx(1, "written less bytes than expected into %s", path);
+
+    return fd;
+}
+
+static void test_rename_fchown_fchmod(const char* path1, const char* path2) {
+    printf("%s...\n", __func__);
+
+    int fd = create_file(path1, message, message_len);
+
+    if (fchown(fd, /*owner=*/123, /*group=*/123) != 0) /* dummy owner/group just for testing */
+        err(1, "fchown before rename");
+    if (fchmod(fd, 0660) != 0) /* note: no "other users" mode bits */
+        err(1, "fchmod before rename");
+
+    struct stat st;
+    CHECK(stat(path1, &st));
+    check_ownership_and_permissions(path1, &st, /*uid=*/123, /*gid=*/123, /*permissions=*/0660);
+
+    CHECK(rename(path1, path2));
+
+    should_not_exist(path1);
+    should_exist(path2, message_len);
+
+    if (fchown(fd, /*owner=*/321, /*group=*/321) != 0) /* different dummy owner/group */
+        err(1, "fchown after rename");
+    if (fchmod(fd, 0666) != 0) /* note: now with "other users" mode bits */
+        err(1, "fchmod after rename");
+
+    CHECK(stat(path2, &st));
+    check_ownership_and_permissions(path2, &st, /*uid=*/321, /*gid=*/321, /*permissions=*/0666);
+
+    CHECK(close(fd));
+    CHECK(unlink(path2));
+}
+
+static void test_unlink_fchown(const char* path) {
+    printf("%s...\n", __func__);
+
+    int fd = create_file(path, /*message=*/NULL, /*len=*/0);
+
+    CHECK(unlink(path));
+    should_not_exist(path);
+
+    if (fchown(fd, /*owner=*/123, /*group=*/123) != 0) /* dummy owner/group just for testing */
+        err(1, "fchown after file removal");
+
+    /* note that file was created with permissions 0600, see create_file() */
+    struct stat st;
+    CHECK(fstat(fd, &st));
+    check_ownership_and_permissions(path, &st, /*uid=*/123, /*gid=*/123, /*permissions=*/0600);
+
+    CHECK(close(fd));
+}
+
+int main(int argc, char* argv[]) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+
+    if (argc != 3)
+        errx(1, "Usage: %s <path1> <path2>", argv[0]);
+
+    const char* path1 = argv[1];
+    const char* path2 = argv[2];
+
+    test_rename_fchown_fchmod(path1, path2);
+    test_unlink_fchown(path1);
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -705,7 +705,7 @@ class TC_30_Syscall(RegressionTestCase):
 
         self.assertIn('TEST OK', stdout)
 
-    def test_033_rename_unlink_chroot(self):
+    def test_033a_rename_unlink_chroot(self):
         file1 = 'tmp/file1'
         file2 = 'tmp/file2'
         try:
@@ -716,7 +716,7 @@ class TC_30_Syscall(RegressionTestCase):
                     os.unlink(path)
         self.assertIn('TEST OK', stdout)
 
-    def test_034_rename_unlink_pf(self):
+    def test_033b_rename_unlink_pf(self):
         os.makedirs('tmp/pf', exist_ok=True)
         file1 = 'tmp/pf/file1'
         file2 = 'tmp/pf/file2'
@@ -728,7 +728,7 @@ class TC_30_Syscall(RegressionTestCase):
                     os.unlink(path)
         self.assertIn('TEST OK', stdout)
 
-    def test_035_rename_unlink_enc(self):
+    def test_033c_rename_unlink_enc(self):
         os.makedirs('tmp_enc', exist_ok=True)
         file1 = 'tmp_enc/file1'
         file2 = 'tmp_enc/file2'
@@ -744,10 +744,55 @@ class TC_30_Syscall(RegressionTestCase):
                     os.unlink(path)
         self.assertIn('TEST OK', stdout)
 
-    def test_036_rename_unlink_tmpfs(self):
+    def test_033d_rename_unlink_tmpfs(self):
         file1 = '/mnt/tmpfs/file1'
         file2 = '/mnt/tmpfs/file2'
         stdout, _ = self.run_binary(['rename_unlink', file1, file2])
+        self.assertIn('TEST OK', stdout)
+
+    def test_034a_rename_unlink_fchown_chroot(self):
+        file1 = 'tmp/file1'
+        file2 = 'tmp/file2'
+        try:
+            stdout, _ = self.run_binary(['rename_unlink_fchown', file1, file2])
+        finally:
+            for path in [file1, file2]:
+                if os.path.exists(path):
+                    os.unlink(path)
+        self.assertIn('TEST OK', stdout)
+
+    def test_034b_rename_unlink_fchown_pf(self):
+        os.makedirs('tmp/pf', exist_ok=True)
+        file1 = 'tmp/pf/file1'
+        file2 = 'tmp/pf/file2'
+        try:
+            stdout, _ = self.run_binary(['rename_unlink_fchown', file1, file2])
+        finally:
+            for path in [file1, file2]:
+                if os.path.exists(path):
+                    os.unlink(path)
+        self.assertIn('TEST OK', stdout)
+
+    def test_034c_rename_unlink_fchown_enc(self):
+        os.makedirs('tmp_enc', exist_ok=True)
+        file1 = 'tmp_enc/file1'
+        file2 = 'tmp_enc/file2'
+        # Delete the files: the test overwrites them anyway, but it may fail if they are malformed.
+        for path in [file1, file2]:
+            if os.path.exists(path):
+                os.unlink(path)
+        try:
+            stdout, _ = self.run_binary(['rename_unlink_fchown', file1, file2])
+        finally:
+            for path in [file1, file2]:
+                if os.path.exists(path):
+                    os.unlink(path)
+        self.assertIn('TEST OK', stdout)
+
+    def test_034d_rename_unlink_fchown_tmpfs(self):
+        file1 = '/mnt/tmpfs/file1'
+        file2 = '/mnt/tmpfs/file2'
+        stdout, _ = self.run_binary(['rename_unlink_fchown', file1, file2])
         self.assertIn('TEST OK', stdout)
 
     def test_040_futex_bitset(self):

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -98,6 +98,7 @@ manifests = [
   "pthread_set_get_affinity",
   "readdir",
   "rename_unlink",
+  "rename_unlink_fchown",
   "run_test",
   "rwlock",
   "sched",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -100,6 +100,7 @@ manifests = [
   "pthread_set_get_affinity",
   "readdir",
   "rename_unlink",
+  "rename_unlink_fchown",
   "run_test",
   "rwlock",
   "sched",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is conceptually similar to the commit ["[LibOS] Fix `ENOENT` error in `fchmod` on unlinked file"](https://github.com/gramineproject/gramine/commit/ac8fc770d1004dbcaf43a5b805a7928b7c4fb90f).

This PR was created while reviewing #1874.

## How to test this PR? <!-- (if applicable) -->

Added a sub-test to the `rename_unlink` LibOS regression test.

If you want to run this sub-test on vanilla Linux, change UID and GID in `fchown()` to some reasonable IDs available on your system.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1875)
<!-- Reviewable:end -->
