### PR TITLE
[PAL/Linux-SGX] Re-init attestation key after AESM restarted

### DIFF
--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -112,14 +112,18 @@ int ocall_ioctl(int fd, unsigned int cmd, unsigned long arg);
 /*!
  * \brief Execute untrusted code in PAL to obtain a quote from the Quoting Enclave.
  *
- * \param      spid       Software provider ID (SPID); if NULL then DCAP/ECDSA is used.
- * \param      linkable   Quote type (linkable vs unlinkable); ignored if DCAP/ECDSA is used.
- * \param      report     Enclave report to be sent to the Quoting Enclave.
- * \param      nonce      16B nonce to be included in the quote for freshness; ignored if
- *                        DCAP/ECDSA is used.
- * \param[out] quote      Quote returned by the Quoting Enclave (allocated via malloc() in this
- *                        function; the caller gets the ownership of the quote).
- * \param[out] quote_len  Length of the quote returned by the Quoting Enclave.
+ * \param      spid               Software provider ID (SPID); if NULL then DCAP is used.
+ * \param      linkable           Quote type (linkable vs unlinkable); ignored if DCAP is used.
+ * \param      report             Enclave report to be sent to the Quoting Enclave.
+ * \param      nonce              16B nonce to be included in the quote for freshness; ignored if
+ *                                DCAP is used.
+ * \param[out] quote              Quote returned by the Quoting Enclave (allocated via mmap() in
+ *                                this function; the caller gets the ownership of the quote).
+ * \param[out] quote_len          Length of the quote returned by the Quoting Enclave.
+ * \param[out] qe_targetinfo      Retrieved Quoting Enclave's target info; buffer must be submitted
+ *                                by the caller.
+ * \param[out] qe_targetinfo_set  Whether Quoting Enclave's target info (above) was set; if true the
+ *                                caller must update the corresponding qe_targetinfo global var.
  *
  * \returns 0 on success, negative Linux error code otherwise.
  *
@@ -127,7 +131,8 @@ int ocall_ioctl(int fd, unsigned int cmd, unsigned long arg);
  * returned quote corresponds to this enclave or whether its contents make sense).
  */
 int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
-                    const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len);
+                    const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len,
+                    sgx_target_info_t* qe_targetinfo, bool* qe_targetinfo_set);
 
 int ocall_edmm_restrict_pages_perm(uint64_t addr, size_t count, uint64_t prot);
 int ocall_edmm_modify_pages_type(uint64_t addr, size_t count, uint64_t type);

--- a/pal/src/host/linux-sgx/host_platform.c
+++ b/pal/src/host/linux-sgx/host_platform.c
@@ -17,6 +17,11 @@
 #define AESM_SOCKET_NAME_LEGACY "sgx_aesm_socket_base"
 #define AESM_SOCKET_NAME_NEW    "/var/run/aesmd/aesm.socket"
 
+/* retrieving the SGX quote may return error 42, which means that the attestation key is not
+ * available and AESM service must re-generate the key; when Gramine sees such error, it performs a
+ * dummy INIT_QUOTE_REQUEST and then re-tries retrieving the SGX quote */
+#define AESM_ATT_KEY_NOT_INITIALIZED 42
+
 /* hard-coded production attestation key of Intel reference QE (the only supported one) */
 /* FIXME: should allow other attestation keys from non-Intel QEs */
 static const sgx_ql_att_key_id_t g_default_ecdsa_p256_att_key_id = {
@@ -254,6 +259,11 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
         }
 
         Response__GetQuoteExResponse* r = res->getquoteexres;
+        if (r->errorcode == AESM_ATT_KEY_NOT_INITIALIZED) {
+            /* special case, the caller must perform init_quoting_enclave_targetinfo() and retry */
+            ret = -EAGAIN;
+            goto out;
+        }
         if (r->errorcode != 0) {
             log_error("AESM service returned error %d", r->errorcode);
             goto out;
@@ -292,6 +302,11 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
         }
 
         Response__GetQuoteResponse* r = res->getquoteres;
+        if (r->errorcode == AESM_ATT_KEY_NOT_INITIALIZED) {
+            /* special case, the caller must perform init_quoting_enclave_targetinfo() and retry */
+            ret = -EAGAIN;
+            goto out;
+        }
         if (r->errorcode != 0) {
             log_error("AESM service returned error %d", r->errorcode);
             goto out;

--- a/pal/src/host/linux-sgx/host_platform.c
+++ b/pal/src/host/linux-sgx/host_platform.c
@@ -17,9 +17,6 @@
 #define AESM_SOCKET_NAME_LEGACY "sgx_aesm_socket_base"
 #define AESM_SOCKET_NAME_NEW    "/var/run/aesmd/aesm.socket"
 
-/* retrieving the SGX quote may return error 42, which means that the attestation key is not
- * available and AESM service must re-generate the key; when Gramine sees such error, it performs a
- * dummy INIT_QUOTE_REQUEST and then re-tries retrieving the SGX quote */
 #define AESM_ATT_KEY_NOT_INITIALIZED 42
 
 /* hard-coded production attestation key of Intel reference QE (the only supported one) */
@@ -302,11 +299,6 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
         }
 
         Response__GetQuoteResponse* r = res->getquoteres;
-        if (r->errorcode == AESM_ATT_KEY_NOT_INITIALIZED) {
-            /* special case, the caller must perform init_quoting_enclave_targetinfo() and retry */
-            ret = -EAGAIN;
-            goto out;
-        }
         if (r->errorcode != 0) {
             log_error("AESM service returned error %d", r->errorcode);
             goto out;

--- a/pal/src/host/linux-sgx/pal_ocall_types.h
+++ b/pal/src/host/linux-sgx/pal_ocall_types.h
@@ -343,6 +343,8 @@ struct ocall_get_quote {
     sgx_quote_nonce_t nonce;
     char*             quote;
     size_t            quote_len;
+    sgx_target_info_t qe_targetinfo;
+    bool              qe_targetinfo_set;
 };
 
 struct ocall_edmm_restrict_pages_perm {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine uses the AESM daemon to request SGX Quotes from the Quoting Enclave. AESM runs in the background and may be restarted. For some reason, after a restart AESM "forgets" the platform's attestation key and requires an additional INIT_QUOTE_REQUEST before it is able to generate SGX Quotes again. This behavior is documented in Intel SGX PSW/DCAP software, but Gramine didn't implement this and thus failed with "AESM service returned error 42".

This PR complies with the SGX PSW/DCAP documentation and adds the send of INIT_QUOTE_REQUEST + retry of SGX quote retrieval.

For documentation, see e.g. this comment: https://github.com/intel/linux-sgx/blob/80a6625c497056c43e78d993e414ca99a9efed5c/common/inc/sgx_uae_quote_ex.h#L139-L140

## How to test this PR? <!-- (if applicable) -->

This was detected by a customer.

A simple reproducer is like this:
```diff
diff --git a/CI-Examples/python/scripts/sgx-quote.py b/CI-Examples/python/scripts/sgx-quote.py
index 8a79b4f1..3c979553 100644
--- a/CI-Examples/python/scripts/sgx-quote.py
+++ b/CI-Examples/python/scripts/sgx-quote.py
@@ -5,27 +5,32 @@

 import os
 import sys
+import time

-if not os.path.exists("/dev/attestation/quote"):
-    print("Cannot find `/dev/attestation/quote`; "
-          "are you running under SGX, with remote attestation enabled?")
-    sys.exit(1)
-
-with open('/dev/attestation/attestation_type') as f:
-    print(f"Detected attestation type: {f.read()}")
-
-with open("/dev/attestation/user_report_data", "wb") as f:
-    f.write(b'\0'*64)
-
-with open("/dev/attestation/quote", "rb") as f:
-    quote = f.read()
-
-print(f"Extracted SGX quote with size = {len(quote)} and the following fields:")
-print(f"  ATTRIBUTES.FLAGS: {quote[96:104].hex()}  [ Debug bit: {quote[96] & 2 > 0} ]")
-print(f"  ATTRIBUTES.XFRM:  {quote[104:112].hex()}")
-print(f"  MRENCLAVE:        {quote[112:144].hex()}")
-print(f"  MRSIGNER:         {quote[176:208].hex()}")
-print(f"  ISVPRODID:        {quote[304:306].hex()}")
-print(f"  ISVSVN:           {quote[306:308].hex()}")
-print(f"  REPORTDATA:       {quote[368:400].hex()}")
-print(f"                    {quote[400:432].hex()}")
+while True:
+    if not os.path.exists("/dev/attestation/quote"):
+        print("Cannot find `/dev/attestation/quote`; "
+                "are you running under SGX, with remote attestation enabled?")
+        sys.exit(1)
+
+    with open('/dev/attestation/attestation_type') as f:
+        print(f"Detected attestation type: {f.read()}")
+
+    with open("/dev/attestation/user_report_data", "wb") as f:
+        f.write(b'\0'*64)
+
+    with open("/dev/attestation/quote", "rb") as f:
+        quote = f.read()
+
+    print(f"Extracted SGX quote with size = {len(quote)} and the following fields:")
+    print(f"  ATTRIBUTES.FLAGS: {quote[96:104].hex()}  [ Debug bit: {quote[96] & 2 > 0} ]")
+    print(f"  ATTRIBUTES.XFRM:  {quote[104:112].hex()}")
+    print(f"  MRENCLAVE:        {quote[112:144].hex()}")
+    print(f"  MRSIGNER:         {quote[176:208].hex()}")
+    print(f"  ISVPRODID:        {quote[304:306].hex()}")
+    print(f"  ISVSVN:           {quote[306:308].hex()}")
+    print(f"  REPORTDATA:       {quote[368:400].hex()}")
+    print(f"                    {quote[400:432].hex()}")
+
+    sys.stdout.flush()
+    time.sleep(5)
```

Apply the above patch, run it in one terminal, and in another terminal do `sudo systemctl restart aesmd`. Without this PR, Gramine will fail. With this PR, Gramine will continue execution of the endless loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1877)
<!-- Reviewable:end -->
