### PR TITLE
Enable C23 when available and nodiscard feature

### DIFF
--- a/common/include/nodiscard.h
+++ b/common/include/nodiscard.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation
+ *                    Mariusz Zaborski <oshogbo@invisiblethingslab.com>
+ */
+
+/*
+ * This file contains a definition for NODISCARD, a macro that wraps
+ * the nodiscard attribute introduced in C23. However, because Gramine supports
+ * older systems that might not have support for C23, we have to wrap it on our
+ * own and change it to a no-op on systems that don't support it.
+ * TODO: Remove the macros and use [[nodiscard]] directly, after dropping *EL8
+ *       and Ubuntu 20.04 support.
+ */
+
+#pragma once
+
+#if defined(__has_c_attribute)
+#if __has_c_attribute(nodiscard)
+#define NODISCARD [[nodiscard]]
+#endif
+#endif
+
+#ifndef NODISCARD
+#define NODISCARD
+#endif

--- a/common/include/pal_error.h
+++ b/common/include/pal_error.h
@@ -7,9 +7,10 @@
 
 #pragma once
 
+#include <nodiscard.h>
 #include <stddef.h>
 
-typedef enum _pal_error_t {
+typedef enum NODISCARD {
     PAL_ERROR_SUCCESS = 0,
     PAL_ERROR_NOTIMPLEMENTED,
     PAL_ERROR_NOTDEFINED,

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,18 @@ project(
     ],
 )
 
+# If C23 (or experimetal C23 - C2x) is available, use it.
+# TODO: Gramine supports older versions of gcc, so newer versions of compilers
+#       may not be available.
+#       We can change to c2x when we drop *EL8 and Ubuntu 20.04.
+#       We can't change to c23 for any supported versions yet (requires at
+#       least gcc 14).
+if meson.get_compiler('c').has_argument('-std=c23')
+  add_project_arguments('-std=c23', language: 'c')
+elif meson.get_compiler('c').has_argument('-std=c2x')
+  add_project_arguments('-std=c2x', language: 'c')
+endif
+
 # we need this subdir() early, because we need scripts defined there for setting up global vars
 subdir('scripts')
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Change the build system to use C23 or C2x (the experimental version of C23 used before the official release). We plan to convert functions to return pal_error_t instead of int. This will be implemented in separate commits, each making small, incremental changes.

This commit is done also to enforce a new policy on a new code.

## Why __has_c_attribute

The `__has_c_attribute` is used to check the availability of new attributes. It was added simultaneously with `nodiscard` in the experimental version: https://gcc.gnu.org/gcc-11/changes.html.

Documentation for __has_c_attribute can be found at: https://en.cppreference.com/w/c/language/attributes.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1879)
<!-- Reviewable:end -->
