### PR TITLE
[python] Add nice error message for ENOENT when measuring trusted files

### DIFF
--- a/python/gramine-sgx-sign
+++ b/python/gramine-sgx-sign
@@ -129,7 +129,10 @@ def main(ctx, with_, output, libpal, manifest_file, date, sigfile, depfile, verb
 
     manifest = Manifest.load(manifest_file)
 
-    expanded = manifest.expand_all_trusted_files(chroot=chroot)
+    try:
+        expanded = manifest.expand_all_trusted_files(chroot=chroot)
+    except FileNotFoundError as err:
+        ctx.fail(f'Missing trusted file: {err.filename!r}')
 
     with open(output, 'wb') as f:
         manifest.dump(f)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
See commit
## How to test this PR? <!-- (if applicable) -->

CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1880)
<!-- Reviewable:end -->
