### PR TITLE
[PAL/Linux-SGX] Re-init attestation key after AESM restarted

### DIFF
--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -2187,6 +2187,45 @@ out:
     return retval;
 }
 
+int ocall_get_qe_targetinfo(bool is_epid, sgx_target_info_t* qe_targetinfo) {
+    int retval;
+    struct ocall_get_qe_targetinfo* ocall_qe_ti_args;
+
+    void* old_ustack = sgx_prepare_ustack();
+    ocall_qe_ti_args = sgx_alloc_on_ustack_aligned(sizeof(*ocall_qe_ti_args),
+                                                   alignof(*ocall_qe_ti_args));
+    if (!ocall_qe_ti_args) {
+        sgx_reset_ustack(old_ustack);
+        return -EPERM;
+    }
+
+    COPY_VALUE_TO_UNTRUSTED(&ocall_qe_ti_args->is_epid, is_epid);
+    memset(&ocall_qe_ti_args->qe_targetinfo, 0, sizeof(ocall_qe_ti_args->qe_targetinfo));
+
+    do {
+        retval = sgx_exitless_ocall(OCALL_GET_QE_TARGETINFO, ocall_qe_ti_args);
+    } while (retval == -EINTR);
+
+    if (retval < 0 && retval != -EACCES && retval != -EINVAL && retval != -ENOMEM &&
+            retval != -EPERM && retval != -EAGAIN && retval != -ECONNREFUSED) {
+        /* OCALL_GET_QE_TARGETINFO OCALL may return many error codes, but we sanitize all error
+         * codes except the above (most important ones) because PAL/LibOS logic doesn't care about
+         * specific errors */
+        retval = -EPERM;
+    }
+
+    if (!retval) {
+        if (!sgx_copy_to_enclave(qe_targetinfo, sizeof(*qe_targetinfo),
+                                 &ocall_qe_ti_args->qe_targetinfo,
+                                 sizeof(ocall_qe_ti_args->qe_targetinfo))) {
+            retval = -EPERM;
+        }
+    }
+
+    sgx_reset_ustack(old_ustack);
+    return retval;
+}
+
 int ocall_sched_setaffinity(void* tcs, unsigned long* cpu_mask, size_t cpu_mask_len) {
     int retval = 0;
     struct ocall_sched_setaffinity* ocall_sched_args;

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -129,6 +129,20 @@ int ocall_ioctl(int fd, unsigned int cmd, unsigned long arg);
 int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
                     const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len);
 
+/*!
+ * \brief Execute untrusted code in PAL to obtain Target Info of the Quoting Enclave (QE).
+ *
+ * \param      is_epid            True if EPID is used, false if DCAP/ECDSA is used.
+ * \param[out] qe_targetinfo      Retrieved Quoting Enclave's target info; buffer must be provided
+ *                                by the caller.
+ *
+ * \returns 0 on success, negative Linux error code otherwise.
+ *
+ * The obtained QE Target Info is not validated in any way (i.e., this function does not check
+ * whether Target Info contents make sense).
+ */
+int ocall_get_qe_targetinfo(bool is_epid, sgx_target_info_t* qe_targetinfo);
+
 int ocall_edmm_restrict_pages_perm(uint64_t addr, size_t count, uint64_t prot);
 int ocall_edmm_modify_pages_type(uint64_t addr, size_t count, uint64_t type);
 int ocall_edmm_remove_pages(uint64_t addr, size_t count);

--- a/pal/src/host/linux-sgx/enclave_platform.c
+++ b/pal/src/host/linux-sgx/enclave_platform.c
@@ -1,27 +1,90 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2019, Texas A&M University */
 
+#include "api.h"
+#include "enclave_api.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
+#include "sgx_arch.h"
+
+static sgx_target_info_t g_qe_targetinfo; /* received from untrusted host, use carefully */
+static spinlock_t g_qe_targetinfo_lock = INIT_SPINLOCK_UNLOCKED;
+
+int init_qe_targetinfo(void* uptr_qe_targetinfo) {
+    /* no need to acquire g_qe_targetinfo_lock at this point since there is only a single thread */
+    if (!sgx_copy_to_enclave(&g_qe_targetinfo,
+                             sizeof(g_qe_targetinfo),
+                             uptr_qe_targetinfo,
+                             sizeof(sgx_target_info_t))) {
+        return -PAL_ERROR_DENIED;
+    }
+    return 0;
+}
 
 int sgx_get_quote(const sgx_spid_t* spid, const sgx_quote_nonce_t* nonce,
                   const sgx_report_data_t* report_data, bool linkable, char** quote,
                   size_t* quote_len) {
-    /* must align all arguments to sgx_report() so that EREPORT doesn't complain */
-    __sgx_mem_aligned sgx_report_t report;
-    __sgx_mem_aligned sgx_target_info_t targetinfo = g_pal_linuxsgx_state.qe_targetinfo;
-    __sgx_mem_aligned sgx_report_data_t _report_data = *report_data;
+    int ret;
+    int retries = 0;
+    while (retries < 5) {
+        /* must align all arguments to sgx_report() so that EREPORT doesn't complain */
+        __sgx_mem_aligned sgx_target_info_t targetinfo;
+        __sgx_mem_aligned sgx_report_data_t _report_data;
+        __sgx_mem_aligned sgx_report_t report;
 
-    int ret = sgx_report(&targetinfo, &_report_data, &report);
-    if (ret) {
-        log_error("Failed to get enclave report");
-        return -PAL_ERROR_DENIED;
+        bool new_qe_targetinfo = false;
+        if (retries) {
+            /* new attempt, need to update QE target info */
+            ret = ocall_get_qe_targetinfo(/*is_epid=*/!!spid, &targetinfo);
+            if (ret < 0) {
+                log_error("Failed to get QE target info (error code=%d)", ret);
+                return unix_to_pal_error(ret);
+            }
+            new_qe_targetinfo = true;
+        }
+
+        spinlock_lock(&g_qe_targetinfo_lock);
+        if (new_qe_targetinfo) {
+            /* got new QE target info into the local stack var, also update the global var */
+            g_qe_targetinfo = targetinfo;
+        } else {
+            /* use old QE target info stored in global var, copy it into local stack var */
+            targetinfo = g_qe_targetinfo;
+        }
+        spinlock_unlock(&g_qe_targetinfo_lock);
+
+        _report_data = *report_data;
+        ret = sgx_report(&targetinfo, &_report_data, &report);
+        if (ret) {
+            log_error("Failed to get enclave report (error code=%d)", ret);
+            return -PAL_ERROR_DENIED;
+        }
+
+        /*
+         * In DCAP, retrieving the SGX quote may return error AESM_ATT_KEY_NOT_INITIALIZED (42),
+         * which means that the attestation key is not available and AESM service must re-generate
+         * the key. When Gramine sees such error, it must perform a new INIT_QUOTE_REQUEST and then
+         * re-try retrieving the SGX quote. Note that after INIT_QUOTE_REQUEST, the targetinfo of
+         * Quoting Enclave (QE) may change and must be updated in SGX enclave (in g_qe_targetinfo).
+         *
+         * In our OCALLs, AESM_ATT_KEY_NOT_INITIALIZED is transformed into EAGAIN, and
+         * INIT_QUOTE_REQUEST corresponds to ocall_get_qe_targetinfo().
+         */
+        ret = ocall_get_quote(spid, linkable, &report, nonce, quote, quote_len);
+        if (ret < 0 && ret != -EAGAIN) {
+            log_error("Failed to get quote (error code=%d)", ret);
+            return unix_to_pal_error(ret);
+        }
+
+        if (!ret) {
+            /* success */
+            return 0;
+        }
+
+        assert(ret == -EAGAIN);
+        retries++;
     }
 
-    ret = ocall_get_quote(spid, linkable, &report, nonce, quote, quote_len);
-    if (ret < 0) {
-        log_error("Failed to get quote");
-        return unix_to_pal_error(ret);
-    }
-    return 0;
+    log_error("Failed to get quote after %d attempts", retries);
+    return -PAL_ERROR_DENIED;
 }

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -722,6 +722,12 @@ static long sgx_ocall_get_quote(void* args) {
                           &ocall_quote_args->quote_len);
 }
 
+static long sgx_ocall_get_qe_targetinfo(void* args) {
+    struct ocall_get_qe_targetinfo* ocall_qe_ti_args = args;
+    return init_quoting_enclave_targetinfo(ocall_qe_ti_args->is_epid,
+                                           &ocall_qe_ti_args->qe_targetinfo);
+}
+
 static long sgx_ocall_edmm_modify_pages_type(void* _args) {
     struct ocall_edmm_modify_pages_type* args = _args;
     return edmm_modify_pages_type(args->addr, args->count, args->type);
@@ -784,6 +790,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_EVENTFD]                  = sgx_ocall_eventfd,
     [OCALL_IOCTL]                    = sgx_ocall_ioctl,
     [OCALL_GET_QUOTE]                = sgx_ocall_get_quote,
+    [OCALL_GET_QE_TARGETINFO]        = sgx_ocall_get_qe_targetinfo,
     [OCALL_EDMM_MODIFY_PAGES_TYPE]   = sgx_ocall_edmm_modify_pages_type,
     [OCALL_EDMM_REMOVE_PAGES]        = sgx_ocall_edmm_remove_pages,
     [OCALL_EDMM_RESTRICT_PAGES_PERM] = sgx_ocall_edmm_restrict_pages_perm,

--- a/pal/src/host/linux-sgx/host_platform.c
+++ b/pal/src/host/linux-sgx/host_platform.c
@@ -17,6 +17,8 @@
 #define AESM_SOCKET_NAME_LEGACY "sgx_aesm_socket_base"
 #define AESM_SOCKET_NAME_NEW    "/var/run/aesmd/aesm.socket"
 
+#define AESM_ATT_KEY_NOT_INITIALIZED 42
+
 /* hard-coded production attestation key of Intel reference QE (the only supported one) */
 /* FIXME: should allow other attestation keys from non-Intel QEs */
 static const sgx_ql_att_key_id_t g_default_ecdsa_p256_att_key_id = {
@@ -254,6 +256,11 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
         }
 
         Response__GetQuoteExResponse* r = res->getquoteexres;
+        if (r->errorcode == AESM_ATT_KEY_NOT_INITIALIZED) {
+            /* special case, the caller must perform init_quoting_enclave_targetinfo() and retry */
+            ret = -EAGAIN;
+            goto out;
+        }
         if (r->errorcode != 0) {
             log_error("AESM service returned error %d", r->errorcode);
             goto out;

--- a/pal/src/host/linux-sgx/pal_linux.h
+++ b/pal/src/host/linux-sgx/pal_linux.h
@@ -35,7 +35,6 @@ extern struct pal_linuxsgx_state {
     bool enclave_initialized;        /* thread creation ECALL is allowed only after this is set */
     bool edmm_enabled;
     bool memfaults_without_exinfo_allowed;
-    sgx_target_info_t qe_targetinfo; /* received from untrusted host, use carefully */
     sgx_report_body_t enclave_info;  /* cached self-report result, trusted */
 
     /* remaining heap usable by application */

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -693,12 +693,8 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
     /* Now that we have `libpal_path`, set name for PAL map */
     set_pal_binary_name(libpal_path + URI_PREFIX_FILE_LEN);
 
-    /* We can't verify the following arguments from the host. So we copy them directly but need to
-     * be careful when we use them. */
-    if (!sgx_copy_to_enclave(&g_pal_linuxsgx_state.qe_targetinfo,
-                             sizeof(g_pal_linuxsgx_state.qe_targetinfo),
-                             uptr_qe_targetinfo,
-                             sizeof(sgx_target_info_t))) {
+    ret = init_qe_targetinfo(uptr_qe_targetinfo);
+    if (ret < 0) {
         log_error("Copying qe_targetinfo into the enclave failed");
         ocall_exit(1, /*is_exitgroup=*/true);
     }

--- a/pal/src/host/linux-sgx/pal_ocall_types.h
+++ b/pal/src/host/linux-sgx/pal_ocall_types.h
@@ -70,6 +70,7 @@ enum {
     OCALL_EVENTFD,
     OCALL_IOCTL,
     OCALL_GET_QUOTE,
+    OCALL_GET_QE_TARGETINFO,
     OCALL_EDMM_RESTRICT_PAGES_PERM,
     OCALL_EDMM_MODIFY_PAGES_TYPE,
     OCALL_EDMM_REMOVE_PAGES,
@@ -343,6 +344,11 @@ struct ocall_get_quote {
     sgx_quote_nonce_t nonce;
     char*             quote;
     size_t            quote_len;
+};
+
+struct ocall_get_qe_targetinfo {
+    bool              is_epid;
+    sgx_target_info_t qe_targetinfo;
 };
 
 struct ocall_edmm_restrict_pages_perm {

--- a/pal/src/host/linux-sgx/sgx_attest.h
+++ b/pal/src/host/linux-sgx/sgx_attest.h
@@ -93,4 +93,6 @@ int sgx_get_quote(const sgx_spid_t* spid, const sgx_quote_nonce_t* nonce,
                   const sgx_report_data_t* report_data, bool linkable, char** quote,
                   size_t* quote_len);
 
+int init_qe_targetinfo(void* uptr_qe_targetinfo);
+
 #pragma pack(pop)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine uses the AESM daemon to request SGX Quotes from the Quoting Enclave. AESM runs in the background and may be restarted. For some reason, after a restart AESM "forgets" the platform's attestation key and requires an additional INIT_QUOTE_REQUEST before it is able to generate SGX Quotes again. Moreover, the Quoting Enclave's Target Info may change at this point, so Gramine must update its cached QE Target Info. This behavior is applicable only to DCAP attestation and is documented in Intel SGX PSW/DCAP software. Gramine didn't implement this behavior and thus failed with "AESM service returned error 42".

This PR complies with the SGX PSW/DCAP documentation and adds the send of INIT_QUOTE_REQUEST + update of QE Target Info + retry of SGX quote retrieval.

This is a re-creation of #1877, with a better design. Closes #1877.

## How to test this PR? <!-- (if applicable) -->

Change `CI-Examples/python/scripts/sgx-quote.py` to this:
```python
import os
import sys
import time

while True:
    if not os.path.exists("/dev/attestation/quote"):
        print("Cannot find `/dev/attestation/quote`; "
                "are you running under SGX, with remote attestation enabled?")
        sys.exit(1)

    with open('/dev/attestation/attestation_type') as f:
        print(f"Detected attestation type: {f.read()}")

    with open("/dev/attestation/user_report_data", "wb") as f:
        f.write(b'\0'*64)

    with open("/dev/attestation/quote", "rb") as f:
        quote = f.read()

    print(f"Extracted SGX quote with size = {len(quote)} and the following fields:")
    print(f"  ATTRIBUTES.FLAGS: {quote[96:104].hex()}  [ Debug bit: {quote[96] & 2 > 0} ]")
    print(f"  ATTRIBUTES.XFRM:  {quote[104:112].hex()}")
    print(f"  MRENCLAVE:        {quote[112:144].hex()}")
    print(f"  MRSIGNER:         {quote[176:208].hex()}")
    print(f"  ISVPRODID:        {quote[304:306].hex()}")
    print(f"  ISVSVN:           {quote[306:308].hex()}")
    print(f"  REPORTDATA:       {quote[368:400].hex()}")
    print(f"                    {quote[400:432].hex()}")

    sys.stdout.flush()
    time.sleep(5)
```

Apply the above Python script, run it in one terminal, and in another terminal do `sudo systemctl restart aesmd`. Without this PR, Gramine will fail. With this PR, Gramine will continue execution of the endless loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1881)
<!-- Reviewable:end -->
