### PR TITLE
[Docs] Stop using `|nbsp|` on pages rendered by GitHub

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,16 +1,10 @@
 Contributing to Gramine
 =======================
 
-.. highlight:: sh
-
-.. see Documentation/howto-doc.rst about |nbsp| versus |~|
-.. |nbsp| unicode:: 0xa0
-   :trim:
-
 First off, thank you for your interest in contributing to Gramine!
 
 In general, code contributions should be submitted to the Gramine project
-using a |nbsp| `pull request <https://github.com/gramineproject/gramine/pulls>`__.
+using a `pull request <https://github.com/gramineproject/gramine/pulls>`__.
 
 To learn more about the knowledge required to start contributing to this project
 as well as some advice on contributing high-quality PRs, read through `the
@@ -20,7 +14,7 @@ onboarding guide
 Reporting Bugs
 --------------
 
-In order to report a |nbsp| problem, please open an issue in the `issue tracker
+In order to report a problem, please open an issue in the `issue tracker
 <https://github.com/gramineproject/gramine/issues>`__.
 
 Reporting Security Vulnerabilities
@@ -52,22 +46,21 @@ newcomers.
 Branch Names
 ------------
 
-For work in progress (for team members), please use your name/userid as
-a |nbsp| prefix in the branch name.  For example, if user ``jane`` is adding
-feature ``foo``, the branch should be named: ``jane/foo``.
+For work in progress (for team members), please use your name/userid as a prefix
+in the branch name. For example, if user ``jane`` is adding feature ``foo``,
+the branch should be named: ``jane/foo``.
 
-For new contributors, the branch will likely be on a |nbsp| fork of the
-repository.
+For new contributors, the branch will likely be on a fork of the repository.
 
-Otherwise, branches without this prefix should only be created for
-a |nbsp| specific purpose, as approved by the maintainers.
+Otherwise, branches without this prefix should only be created for a specific
+purpose, as approved by the maintainers.
 
 Pull Requests
 -------------
 
 The primary mechanism for submitting code changes is with a pull request (PR).
 
-In general, a |nbsp| PR should:
+In general, a PR should:
 
 #. Address a single problem.
 #. Clearly explain the problem and solution in the PR and commit messages, using
@@ -131,7 +124,7 @@ Before a pull request is merged, it must:
    - 3 approving maintainers
    - 2 approving maintainers and 5 days since the PR was created
 
-   If the author is a |nbsp| maintainer the limits are lowered by 1.
+   If the author is a maintainer the limits are lowered by 1.
 
 Additional reviews from anyone are welcome.
 
@@ -191,7 +184,9 @@ We also have (and are actively growing) PAL and LibOS unit tests.
 
 In order to run tests, Gramine must be installed. The test binaries, which are
 also built by Meson, must be installed as well. To do that, configure your build
-directory with ``-Dtests=enabled`` and install Gramine::
+directory with ``-Dtests=enabled`` and install Gramine:
+
+.. code-block:: sh
 
    # add -Dsgx=enabled and SGX options if necessary
    meson setup build/ --werror -Dtests=enabled -Ddirect=enabled
@@ -199,17 +194,23 @@ directory with ``-Dtests=enabled`` and install Gramine::
    ninja -C build/
    sudo ninja -C build/ install
 
-To run the PAL tests::
+To run the PAL tests:
+
+.. code-block:: sh
 
    cd pal/regression
    gramine-test pytest -v
 
-For SGX, one needs to do the following::
+For SGX, one needs to do the following:
+
+.. code-block:: sh
 
    cd pal/regression
    gramine-test --sgx pytest -v
 
-It is also possible to run a subset of tests::
+It is also possible to run a subset of tests:
+
+.. code-block:: sh
 
    gramine-test pytest -v -k TC_01_Bootstrap
    gramine-test pytest -v -k test_100_basic_boostrapping
@@ -235,11 +236,14 @@ The LibOS unit tests work similarly, and are under
 
 LTP
 ^^^
-Gramine passes a |nbsp| subset of the LTP tests. New changes should not break
-currently passing LTP tests (and, ideally, might add new passing tests). LTP is
-currently tested only on the Linux PAL; it may or may not work on Linux-SGX PAL.
 
-To run these tests::
+Gramine passes a subset of the LTP tests. New changes should not break currently
+passing LTP tests (and, ideally, might add new passing tests). LTP is currently
+tested only on the Linux PAL; it may or may not work on Linux-SGX PAL.
+
+To run these tests:
+
+.. code-block:: sh
 
    cd libos/test/ltp
    # consider -j$(nproc) or similar to parallelize and improve the build time.

--- a/Documentation/devel/howto-doc.rst
+++ b/Documentation/devel/howto-doc.rst
@@ -129,15 +129,10 @@ Preferred reST style
 
       This is a |~| function.
 
-  This substitution is added to all documents processed by Sphinx. For files
-  processed also by other software (like ``README.rst``, which is both rendered
-  by GitHub and included in ``index.rst``), use ``|nbsp|`` after adding this
-  substitution yourself::
-
-      .. |nbsp| unicode:: 0xa0
-         :trim:
-
-      This is a |nbsp| README.
+  This substitution is added to all documents processed by Sphinx. Don't use
+  this for files processed also by other software (like ``README.rst``, which
+  is both rendered by GitHub and included in ``index.rst``) - GitHub renders
+  those spaces incorrectly.
 
 Documentation of the code should be organized into files by logical concepts,
 as they fit into programmer's mind. Ideally, this should match the source files,

--- a/README.rst
+++ b/README.rst
@@ -12,29 +12,24 @@ Gramine Library OS with Intel SGX Support
 
 *A Linux-compatible Library OS for Multi-Process Applications*
 
-.. This is not |~|, because that is in rst_prolog in conf.py, which GitHub cannot parse.
-   GitHub doesn't appear to use it correctly anyway...
-.. |nbsp| unicode:: 0xa0
-   :trim:
-
 
 What is Gramine?
 ================
 
-Gramine (formerly called *Graphene*) is a |nbsp| lightweight library OS,
-designed to run a single application with minimal host requirements. Gramine can
-run applications in an isolated environment with benefits comparable to running
-a |nbsp| complete OS in a |nbsp| virtual machine -- including guest
-customization, ease of porting to different OSes, and process migration.
+Gramine (formerly called *Graphene*) is a lightweight library OS, designed to
+run a single application with minimal host requirements. Gramine can run
+applications in an isolated environment with benefits comparable to running a
+complete OS in a virtual machine -- including guest customization, ease of
+porting to different OSes, and process migration.
 
 Gramine supports native, unmodified Linux binaries on any platform. Currently,
 Gramine runs on Linux and Intel SGX enclaves on Linux platforms.
 
-In untrusted cloud and edge deployments, there is a |nbsp| strong desire to
-shield the whole application from rest of the infrastructure. Gramine supports
-this “lift and shift” paradigm for bringing unmodified applications into
-Confidential Computing with Intel SGX. Gramine can protect applications from a
-|nbsp| malicious system stack with minimal porting effort.
+In untrusted cloud and edge deployments, there is a strong desire to shield the
+whole application from rest of the infrastructure. Gramine supports this “lift
+and shift” paradigm for bringing unmodified applications into Confidential
+Computing with Intel SGX. Gramine can protect applications from a malicious
+system stack with minimal porting effort.
 
 Gramine is a growing project and we have a growing contributor and maintainer
 community. The code and overall direction of the project are determined by a


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

GitHub misrenders it, effectively leaving a triple-space which looks really ugly.

## How to test this PR? <!-- (if applicable) -->

Look at the rich diff on GitHub.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1892)
<!-- Reviewable:end -->
