### PR TITLE
[LibOS] Add `stat()` and `hstat()` callbacks to FIFOs

### DIFF
--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -1596,9 +1596,6 @@ must-pass =
 [quotactl*]
 skip = yes
 
-[read03]
-skip = yes
-
 [readahead01]
 skip = yes
 

--- a/libos/test/regression/mkfifo.c
+++ b/libos/test/regression/mkfifo.c
@@ -14,9 +14,19 @@
 int main(int argc, char** argv) {
     int fd;
     char buffer[1024];
+    struct stat stat_buf;
 
     if (mkfifo(FIFO_PATH, S_IRWXU) < 0) {
         perror("mkfifo error");
+        return 1;
+    }
+
+    if (stat(FIFO_PATH, &stat_buf) < 0) {
+        perror("stat error");
+        return 1;
+    }
+    if (!S_ISFIFO(stat_buf.st_mode)) {
+        fprintf(stderr, "stat returned a non-FIFO mode");
         return 1;
     }
 
@@ -30,6 +40,15 @@ int main(int argc, char** argv) {
         fd = open(FIFO_PATH, O_NONBLOCK | O_RDONLY);
         if (fd < 0) {
             perror("[child] open error");
+            return 1;
+        }
+
+        if (fstat(fd, &stat_buf) < 0) {
+            perror("fstat error");
+            return 1;
+        }
+        if (!S_ISFIFO(stat_buf.st_mode)) {
+            fprintf(stderr, "fstat returned a non-FIFO mode");
             return 1;
         }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, FIFO pseudo-files (named pipes) did not have callbacks of `stat()` (used on FIFO filenames) and `hstat()` (used on FIFO handles/FDs). This breaks some apps that want to double-check that the file they have opened or want to open is a FIFO, using the `stat()` or `fstat()` syscalls. There was no good reason to skip those callbacks, so this commit adds their dummy implementations.

Fixes #1896.

## How to test this PR? <!-- (if applicable) -->

Added some sub-tests in LibOS, and activated `read03` in LTP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1897)
<!-- Reviewable:end -->
