### PR TITLE
[common] Refactor Protected Files, part 5

### DIFF
--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -14,14 +14,14 @@
 
 #define PF_NODE_SIZE 4096U
 
-/*! Size of the AES-GCM encryption key */
-#define PF_KEY_SIZE 16
-
 /*! Size of IV for AES-GCM */
 #define PF_IV_SIZE 12
 
 /*! Size of MAC fields */
 #define PF_MAC_SIZE 16
+
+/*! Size of the AES-GCM encryption key */
+#define PF_KEY_SIZE 16
 
 /*! Size of the nonce used in KDF (Key Derivation Function) */
 #define PF_NONCE_SIZE 32

--- a/common/src/protected_files/protected_files_format.h
+++ b/common/src/protected_files/protected_files_format.h
@@ -44,6 +44,7 @@ typedef struct _data_node_crypto {
 } gcm_crypto_data_t;
 
 // for PF_NODE_SIZE == 4096, we have 96 attached data nodes and 32 mht child nodes
+// 3/4 of the node is dedicated to data nodes, 1/4 to MHT nodes
 #define ATTACHED_DATA_NODES_COUNT ((PF_NODE_SIZE / sizeof(gcm_crypto_data_t)) * 3 / 4)
 #define CHILD_MHT_NODES_COUNT ((PF_NODE_SIZE / sizeof(gcm_crypto_data_t)) * 1 / 4)
 static_assert(ATTACHED_DATA_NODES_COUNT == 96, "ATTACHED_DATA_NODES_COUNT");
@@ -59,7 +60,7 @@ typedef struct _metadata_plain {
 
 typedef struct _metadata_encrypted {
     char     path[PATH_MAX_SIZE];
-    uint64_t size;
+    uint64_t size; /* file size after decryption */
     pf_key_t mht_key;
     pf_mac_t mht_gmac;
     uint8_t  data[MD_USER_DATA_SIZE];

--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -25,7 +25,7 @@ struct pf_context {
     metadata_node_t file_metadata; // plaintext and encrypted metadata from storage (bounce buffer)
     metadata_encrypted_t encrypted_part_plain; // contains file path, size, etc.
 
-    file_node_t root_mht; // root MHT node is needed for files bigger than 3KB
+    file_node_t root_mht; // root MHT node is needed for files bigger than MD_USER_DATA_SIZE bytes
 
     lruc_context_t* cache; // up to MAX_NODES_IN_CACHE nodes are cached for each file
 #ifdef DEBUG


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit refactors PF code without changing functionality (part 5 in a series of commits). In particular, this commit moves code around, rephrases some comments, removes useless comments and empty lines, as well as renames vague `data` and `block` words to more specific `node`.

This PR supersedes #1894.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1899)
<!-- Reviewable:end -->
