### PR TITLE
[common] Refactor Protected Files, part 6

### DIFF
--- a/common/src/protected_files/protected_files_format.h
+++ b/common/src/protected_files/protected_files_format.h
@@ -104,7 +104,7 @@ typedef struct _file_node {
     bool need_writing;
     struct _file_node* parent;
 
-    uint64_t node_number;
+    uint64_t logical_node_number;
     uint64_t physical_node_number;
 
     encrypted_node_t encrypted; // encrypted data from storage (bounce buffer)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit refactors PF code without changing functionality (part 6 in a series of commits). In particular, this commit renames ambiguous `node_number` fields/variables to `physical_node_number` or `logical_node_number`, depending on the context.

This PR supersedes https://github.com/gramineproject/gramine/pull/1894.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1907)
<!-- Reviewable:end -->
