### PR TITLE
[common] Refactor Protected Files, part 7

### DIFF
--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -29,7 +29,7 @@
 typedef uint8_t pf_iv_t[PF_IV_SIZE];
 typedef uint8_t pf_mac_t[PF_MAC_SIZE];
 typedef uint8_t pf_key_t[PF_KEY_SIZE];
-typedef uint8_t pf_keyid_t[PF_NONCE_SIZE];
+typedef uint8_t pf_nonce_t[PF_NONCE_SIZE];
 
 typedef enum _pf_status_t {
     PF_STATUS_SUCCESS              = 0,

--- a/common/src/protected_files/protected_files_format.h
+++ b/common/src/protected_files/protected_files_format.h
@@ -54,7 +54,7 @@ typedef struct _metadata_plain {
     uint64_t   file_id;
     uint8_t    major_version;
     uint8_t    minor_version;
-    pf_keyid_t metadata_key_id;
+    pf_nonce_t metadata_key_nonce;
     pf_mac_t   metadata_gmac; /* GCM mac */
 } metadata_plain_t;
 
@@ -118,7 +118,7 @@ typedef struct _file_node {
 typedef struct {
     uint32_t counter;           // always "1"
     char label[MAX_LABEL_SIZE]; // must be NULL terminated
-    pf_keyid_t nonce;           // nonce for key derivation from KDK, stored in metadata node
+    pf_nonce_t nonce;           // nonce for key derivation from KDK, stored in metadata node
     uint32_t output_len;        // in bits; always 128
 } kdf_input_t;
 

--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -13,22 +13,22 @@
 #include "protected_files_format.h"
 
 struct pf_context {
-    pf_handle_t file; // opaque file handle (e.g. PAL handle) used by callbacks
-    pf_file_mode_t mode; // read-only, write-only or read-write
-    bool need_writing; // whether file was modified and thus needs writing to storage
+    pf_handle_t host_file_handle;  // opaque file handle (e.g. PAL handle) used by callbacks
+    pf_file_mode_t mode;           // read-only, write-only or read-write
+    bool need_writing;             // whether file was modified and thus needs writing to storage
 
-    pf_status_t file_status; // PF_STATUS_SUCCESS, PF_STATUS_CRYPTO_ERROR, etc.
-    pf_status_t last_error;  // FIXME: unclear why this is needed
+    pf_status_t file_status;       // PF_STATUS_SUCCESS, PF_STATUS_CRYPTO_ERROR, etc.
+    pf_status_t last_error;        // FIXME: unclear why this is needed
 
-    pf_key_t user_kdk_key; // KDK installed by user of PF (e.g. from Gramine manifest)
+    pf_key_t user_kdk_key;         // KDK installed by user of PF (e.g. from Gramine manifest)
 
-    metadata_node_t file_metadata; // plaintext and encrypted metadata from storage (bounce buffer)
-    metadata_encrypted_t encrypted_part_plain; // contains file path, size, etc.
+    metadata_node_t metadata_node; // plaintext and encrypted metadata from storage (bounce buffer)
+    metadata_encrypted_t metadata_decrypted; // contains file path, size, etc.
 
-    file_node_t root_mht; // root MHT node is needed for files bigger than MD_USER_DATA_SIZE bytes
+    file_node_t root_mht_node;     // needed for files bigger than MD_USER_DATA_SIZE bytes
 
-    lruc_context_t* cache; // up to MAX_NODES_IN_CACHE nodes are cached for each file
+    lruc_context_t* cache;         // up to MAX_NODES_IN_CACHE nodes are cached for each file
 #ifdef DEBUG
-    char* debug_buffer; // buffer for debug output
+    char* debug_buffer;            // buffer for debug output
 #endif
 };


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit refactors PF code without changing functionality (part 7 in a series of commits). In particular, this commit renames:
- "key_id" to a more correct "nonce"
- "encrypted_part_plain" to "metadata_decrypted" (i.e. decrypted conents of the encrypted part of the metadata node)
- "file" to a more specific "host_file_handle"
- "file_metadata" to a more correct "metadata_node"
- "root_mht" to a more specific "root_mht_node"

This PR supersedes https://github.com/gramineproject/gramine/pull/1894.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1908)
<!-- Reviewable:end -->
