### PR TITLE
DONTMERGE [common] Update ciphersuite used for securing pipe/UDS connections

### DIFF
--- a/common/src/crypto/adapters/mbedtls_adapter.c
+++ b/common/src/crypto/adapters/mbedtls_adapter.c
@@ -343,7 +343,7 @@ int lib_SSLInit(LIB_SSL_CONTEXT* ssl_ctx, int stream_fd, bool is_server, const u
 
     memset(ssl_ctx, 0, sizeof(*ssl_ctx));
 
-    ssl_ctx->ciphersuites[0] = MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256;
+    ssl_ctx->ciphersuites[0] = MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256;
     memset(&ssl_ctx->ciphersuites[1], 0, sizeof(ssl_ctx->ciphersuites[1]));
 
     ssl_ctx->pal_recv_cb = pal_recv_cb;

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
@@ -38,7 +38,6 @@
 #define MBEDTLS_HAVE_X86_64
 #endif
 #define MBEDTLS_HKDF_C
-#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 #define MBEDTLS_MD_C
 #define MBEDTLS_NET_C
 #define MBEDTLS_NO_PLATFORM_ENTROPY
@@ -49,9 +48,18 @@
 #define MBEDTLS_PLATFORM_ZEROIZE_ALT
 #define MBEDTLS_RSA_C
 #define MBEDTLS_SHA256_C
-#define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256
 #define MBEDTLS_SSL_CLI_C
 #define MBEDTLS_SSL_CONTEXT_SERIALIZATION
 #define MBEDTLS_SSL_PROTO_TLS1_2
 #define MBEDTLS_SSL_SRV_C
 #define MBEDTLS_SSL_TLS_C
+
+/* below features are to implement ECDHE-PSK based secure-pipe sessions */
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ECP_DP_SECP521R1_ENABLED
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+/* AES-128 with CBC and SHA256 is the strongest combination that current version of mbedTLS can
+ * offer with ephemeral key exchange for PSK; there is no GCM or CCM support for ECDHE-PSK yet */
+#define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Gramine-SGX used MBEDTLS_TLS_PSK_WITH_AES_128_GCM_SHA256 ciphersuite when creating TLS-secured pipes and Unix Domain Sockets. This ciphersuite is considered deprecated, thus we switch to MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256 (with Elliptic Curve DHE key exchange). This is recommended for Forward Security.

Unfortunately mbedTLS v3.6.0 doesn't provide an ECDHE PSK based ciphersuite that has AES-GCM, but only the one with AES-CBC. For the lack of options, we use the AES-CBC one.

**DONTMERGE:**
- This hampers performance of applications that use pipes/UDSes a lot.
- Serialization of TLS sessions (during fork) is broken because our patch only works for GCM mode (only checkpoints CTR counter).

There is an alternative PR that uses DHE: https://github.com/gramineproject/gramine/pull/1918

More info see also in https://github.com/Mbed-TLS/mbedtls/issues/8170

## How to test this PR? <!-- (if applicable) -->

CI is enough.

CI currently fails on forking apps, because serialization of TLS sessions doesn't work correctly. That's because of our [minimalistic patch](https://github.com/gramineproject/gramine/blob/master/subprojects/packagefiles/mbedtls/gramine.patch).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1911)
<!-- Reviewable:end -->
