### PR TITLE
[docker] Add test scripts

### DIFF
--- a/packaging/docker/Dockerfile.test
+++ b/packaging/docker/Dockerfile.test
@@ -1,0 +1,35 @@
+ARG GRAMINE_IMAGE=gramineproject/gramine:stable-focal
+
+FROM ${GRAMINE_IMAGE}
+
+# ARGs cannot be grouped since each FROM in a Dockerfile initiates a new build
+# stage, resulting in the loss of ARG values from earlier stages.
+ARG GRAMINE_URL=https://github.com/gramineproject/gramine.git
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
+    autoconf bison gawk git meson nasm libunwind-dev ninja-build pkg-config python3 \
+    python3-click python3-jinja2 python3-pip python3-pyelftools python3-pytest \
+    wget && \
+    python3 -m pip install 'meson>=0.56' 'tomli>=1.1.0' 'tomli-w>=0.4.0' && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+
+RUN git clone --depth 1 --branch v$(gramine-direct --version | cut -d' ' -f2) \
+    ${GRAMINE_URL} gramine && \
+    cd gramine && \
+    meson setup \
+        build/ \
+	--prefix=/usr \
+        -Ddirect=disabled \
+        -Dsgx=disabled \
+        -Dtests=enabled \
+        -Dforce_sgx_tests=enabled && \
+    meson compile -C build/ && \
+    meson install -C build/
+
+RUN gramine-sgx-gen-private-key
+
+ENTRYPOINT ["/usr/bin/gramine-test"]

--- a/packaging/docker/test.sh
+++ b/packaging/docker/test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+usage() {
+    echo "Usage: test.sh [ubuntu20,ubuntu22]"
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+image=""
+codename=""
+
+case "$1" in
+    ubuntu20)
+        codename="focal"
+        ;;
+    ubuntu22)
+        codename="jammy"
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+EXTRA_ARGS=""
+if [ -n "${GRAMINE_URL}" ]; then
+    EXTRA_ARGS="--build-arg GRAMINE_URL=${GRAMINE_URL}"
+fi
+
+tag="gramineproject/gramine:testing-stable-${codename}"
+docker build \
+    --build-arg GRAMINE_IMAGE="gramineproject/gramine:stable-${codename}" \
+    ${EXTRA_ARGS} \
+    -t "${tag}" \
+    -f Dockerfile.test \
+    . || exit 1
+
+docker run \
+    --rm \
+    -ti \
+    --device /dev/sgx_enclave \
+    --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+    --cap-add SYS_ADMIN \
+    --cap-add SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    "${tag}" \
+    -C /root/gramine/libos/test/regression pytest
+
+docker run \
+    --rm \
+    -ti \
+    --device /dev/sgx_enclave \
+    --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+    "${tag}" \
+    -C /root/gramine/libos/test/regression --sgx pytest


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This pull request is related to https://github.com/gramineproject/gramine/pull/1913 and it adds the scripts for automatically testing Docker images before releasing them to Docker Hub.

## How to test this PR? <!-- (if applicable) -->

```shell
GRAMINE_URL=https://github.com/oshogbo/gramine-wips.git ./test.sh ubuntu20
```