### PR TITLE
[PAL,mbedtls] Fix build issues on newer Ubuntu and Clang

### DIFF
--- a/pal/src/host/linux-common/topo_info.c
+++ b/pal/src/host/linux-common/topo_info.c
@@ -75,7 +75,7 @@ static int read_distances_from_file(const char* path, size_t* out_arr,
     const char* end;
     char last_separator = ' ';
     size_t node_i = 0;
-    for (size_t input_i = 0; /* no condition */; input_i++) {
+    while (true) {
         /* Find next online node (only these are listed in `distance` file). */
         while (node_i < nodes_cnt && !numa_nodes[node_i].is_online)
             node_i++;

--- a/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
+++ b/subprojects/packagefiles/mbedtls/include/mbedtls/config-pal.h
@@ -18,9 +18,11 @@
  * TODO: analyze their impact and add the applicable ones
  */
 
-#define MBEDTLS_AES_USE_HARDWARE_ONLY
 #define MBEDTLS_AESNI_C
 #define MBEDTLS_AES_C
+#define MBEDTLS_AES_USE_HARDWARE_ONLY
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
 #define MBEDTLS_BASE64_C
 #define MBEDTLS_BIGNUM_C
 #define MBEDTLS_CIPHER_C


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Two issues fixed:
- Unused for-loop variable `input_i` in `topo_info.c`
- Required ASN.1 dependencies for RSA in `mbedtls/config-pal.h`

This was detected on Ubuntu 24.04 and Clang 18. I don't know why I didn't observe this before; one of newer Ubuntu or Clang is the culprit.

Regarding the second issue, I also submitted an issue to mbedTLS team: https://github.com/Mbed-TLS/mbedtls/issues/9312


## How to test this PR? <!-- (if applicable) -->

Build with Ubuntu 24.04 and Clang 18 (default on 24.04).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1923)
<!-- Reviewable:end -->
