### PR TITLE
[common] Update ASan to be compatible with Clang 18

### DIFF
--- a/common/include/asan.h
+++ b/common/include/asan.h
@@ -255,6 +255,9 @@ void __asan_register_globals(struct __asan_global* globals, size_t n);
  * implementation does nothing (and we don't even handle `.fini_array`). */
 void __asan_unregister_globals(struct __asan_global* globals, size_t n);
 
+void __asan_register_elf_globals(uintptr_t* flag, void* start, void* stop);
+void __asan_unregister_elf_globals(uintptr_t* flag, void* start, void* stop);
+
 /* Callbacks for setting the shadow memory to specific values. As with load/store callbacks, LLVM
  * normally generates inline stores and calls these functions only for bigger areas. This is
  * controlled by `-mllvm -asan-max-inline-poisoning-size=N`. */

--- a/common/src/asan.c
+++ b/common/src/asan.c
@@ -359,6 +359,28 @@ void __asan_unregister_globals(struct __asan_global* globals, size_t n) {
     __UNUSED(n);
 }
 
+void __asan_register_elf_globals(uintptr_t* flag, void* start, void* stop) {
+    if (*flag || start == stop)
+        return;
+
+    assert(IS_ALIGNED((uintptr_t)stop - (uintptr_t)start, sizeof(struct __asan_global)));
+    struct __asan_global* globals_start = start;
+    struct __asan_global* globals_stop  = stop;
+    __asan_register_globals(globals_start, globals_stop - globals_start);
+    *flag = 1;
+}
+
+void __asan_unregister_elf_globals(uintptr_t* flag, void* start, void* stop) {
+    if (!*flag || start == stop)
+        return;
+
+    assert(IS_ALIGNED((uintptr_t)stop - (uintptr_t)start, sizeof(struct __asan_global)));
+    struct __asan_global* globals_start = start;
+    struct __asan_global* globals_stop  = stop;
+    __asan_unregister_globals(globals_start, globals_stop - globals_start);
+    *flag = 0;
+}
+
 #define DEFINE_ASAN_SET_SHADOW(name, value)                         \
     __attribute__((noinline))                                       \
     void __asan_set_shadow_ ## name (uintptr_t addr, size_t size) { \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Newer Clang versions added more ASan callbacks, in particular `__asan_register_elf_globals()` and `__asan_unregister_elf_globals()`. Our code replicates exactly what the Clang/LLVM code does for these two callbacks.

See:
- https://github.com/llvm/llvm-project/blob/8f63d154ec996cba590a83a4542dd545c78af85c/compiler-rt/lib/asan/asan_globals.cpp#L346-L364

Why these callbacks were added exactly, I am not sure. All I understand is that in some mode, on ELF-based platforms, these callbacks are called instead of a more generic `__asan_register_globals()`. See these links, maybe someone will get a better understanding of this change:
- https://github.com/llvm/llvm-project/commit/4094d9a1276e7d31324cd0c075fc40890befc3ac
- https://github.com/llvm/llvm-project/pull/96529
- https://github.com/rust-lang/rust/issues/113404

## How to test this PR? <!-- (if applicable) -->

CI is enough for older ASan versions. To test newer ASan versions, run on Ubuntu 24.04 (and default Clang version there, which is v18).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1930)
<!-- Reviewable:end -->
