### PR TITLE
[PAL/Linux-SGX] Add locking around read/write on encrypted pipes

### DIFF
--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -88,6 +88,7 @@ tests = {
     'pipe': {},
     'pipe_nonblocking': {},
     'pipe_ocloexec': {},
+    'pipe_race': {},
     'poll': {},
     'poll_closed_fd': {},
     'poll_many_types': {},

--- a/libos/test/regression/pipe_race.c
+++ b/libos/test/regression/pipe_race.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation */
+
+/*
+ * Pipes in e.g. Linux-SGX PAL are automatically encrypted using mbedTLS's SSL/TLS sessions (aka
+ * contexts). By design, an mbedTLS SSL/TLS context is assumed to be used within a single thread and
+ * thus does not use any locking. In Gramine, though, the pipe and its associated SSL/TLS context
+ * can be used in multiple threads. Without protecting pipe read/write operations with a lock,
+ * mbedTLS internal handling of the context would exhibit data races, leading to e.g. -EACCES in
+ * Gramine. This test checks that locking is correct and that no data races occur.
+ */
+
+#define _XOPEN_SOURCE 700
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#define WRITER_THREADS 4
+#define ITERATIONS     100000
+#define BUF_SIZE       64 /* must be safe to not overflow, see users of this macro */
+
+static uint32_t threads_started  = 0;
+static uint32_t threads_finished = 0;
+
+static void pthread_check(int x) {
+    if (x) {
+        errx(1, "pthread failed with %d", x);
+    }
+}
+
+static void* writer_thread_func(void* arg) {
+    int* pipefds = arg;
+    uint32_t writer_thread_idx = __atomic_fetch_add(&threads_started, 1, __ATOMIC_SEQ_CST);
+
+    char buf[BUF_SIZE] = {0};
+    CHECK(sprintf(buf, "WRITER THREAD %u\n", writer_thread_idx));
+
+    for (uint64_t i = 0; i < ITERATIONS; i++)
+        CHECK(write(pipefds[1], buf, strlen(buf)));
+
+    if (__atomic_add_fetch(&threads_finished, 1, __ATOMIC_SEQ_CST) == WRITER_THREADS) {
+        /* last writer thread closes the write end of pipe */
+        CHECK(close(pipefds[1]));
+    }
+    return NULL;
+}
+
+int main(int argc, char** argv) {
+    int pipefds[2];
+    CHECK(pipe(pipefds));
+
+    pthread_t th[WRITER_THREADS];
+    for (int i = 0; i < WRITER_THREADS; i++)
+        pthread_check(pthread_create(&th[i], NULL, writer_thread_func, pipefds));
+
+    while (__atomic_load_n(&threads_started, __ATOMIC_SEQ_CST) != WRITER_THREADS)
+        ;
+
+    char buf[BUF_SIZE] = {0};
+    while (true) {
+        ssize_t bytes_read = CHECK(read(pipefds[0], buf, sizeof(buf) - 1));
+        if (!bytes_read)
+            break;
+#ifdef DEBUG_TEST /* declare to see the test output during debugging */
+        printf("%s", buf);
+#endif
+    }
+    CHECK(close(pipefds[0]));
+
+    for (int i = 0; i < WRITER_THREADS; i++)
+        pthread_check(pthread_join(th[i], NULL));
+
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1504,6 +1504,10 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['pipe_ocloexec'])
         self.assertIn('TEST OK', stdout)
 
+    def test_093_pipe_race(self):
+        stdout, _ = self.run_binary(['pipe_race'])
+        self.assertIn('TEST OK', stdout)
+
     def test_095_mkfifo(self):
         try:
             stdout, _ = self.run_binary(['mkfifo'], timeout=60)

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -87,6 +87,7 @@ manifests = [
   "pipe",
   "pipe_nonblocking",
   "pipe_ocloexec",
+  "pipe_race",
   "poll",
   "poll_closed_fd",
   "poll_many_types",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -89,6 +89,7 @@ manifests = [
   "pipe",
   "pipe_nonblocking",
   "pipe_ocloexec",
+  "pipe_race",
   "poll",
   "poll_closed_fd",
   "poll_many_types",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Pipes in Linux-SGX PAL are automatically encrypted using mbedTLS's SSL/TLS sessions (aka contexts). By design, an mbedTLS SSL/TLS context is assumed to be used within a single thread and thus does not use any locking. In Gramine, though, the pipe and its associated SSL/TLS context can be used in multiple threads. Without protecting pipe read/write operations with a lock, mbedTLS internal handling of the context would exhibit data races, leading to e.g. -EACCES in Gramine.

This bug was detected on a private workload. This bug can be considered a regression, introduced in [commit "[LibOS] Do not perform lock(&hdl->pos_lock) on non-seekable handles"](https://github.com/gramineproject/gramine/commit/ec06c32366672b3dfc19f539d16d37c6449ab4ca). That commit, among other things, removed the locking around LibOS-level pipe read/write operations; the locks were supposed to guard only "file position", which is meaningless for pipes and that's why that commit removed the locking. However, that locking (by accident) also protected the mbedTLS SSL/TLS context, and removing it resulted in some workloads failing (pipe reads/writes returning -EACCES) due to internal mbedTLS data races.

See for the mbedTLS threading discussion e.g. this thread: https://github.com/Mbed-TLS/mbedtls/issues/564

## How to test this PR? <!-- (if applicable) -->

Detected on a private workload. ~~I don't know if it's worth it to write a LibOS test that stresses the data race.~~

Added a new LibOS test:
- without this PR:
```
~/gramineproject/gramine/libos/test/regression$ gramine-sgx pipe_race
pipe_race: error at write(pipefds[1], buf, strlen(buf)) (line 45): Permission denied: Permission denied
```

- with this PR:
```
~/gramineproject/gramine/libos/test/regression$ gramine-sgx pipe_race
TEST OK
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1934)
<!-- Reviewable:end -->
