### PR TITLE
[tools/RA-TLS] Copy quote from X.509 cert into a separate object

### DIFF
--- a/tools/sgx/ra-tls/ra_tls_attest.c
+++ b/tools/sgx/ra-tls/ra_tls_attest.c
@@ -133,7 +133,8 @@ static int generate_x509(mbedtls_pk_context* pk, const uint8_t* quote, size_t qu
         goto out;
 
     /* finally, embed the quote into the generated certificate (as X.509 extension) */
-    ret = mbedtls_x509write_crt_set_extension(writecrt, (const char*)g_quote_oid, g_quote_oid_size,
+    ret = mbedtls_x509write_crt_set_extension(writecrt, (const char*)g_quote_oid,
+                                              sizeof(g_quote_oid),
                                               /*critical=*/0, quote, quote_size);
     if (ret < 0)
         goto out;

--- a/tools/sgx/ra-tls/ra_tls_common.h
+++ b/tools/sgx/ra-tls/ra_tls_common.h
@@ -24,7 +24,6 @@
 #define OID(N) \
     { 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF8, 0x4D, 0x8A, 0x39, (N) }
 static const uint8_t g_quote_oid[] = OID(0x06);
-static const size_t g_quote_oid_size = sizeof(g_quote_oid);
 
 bool getenv_allow_outdated_tcb(void);
 bool getenv_allow_hw_config_needed(void);

--- a/tools/sgx/ra-tls/ra_tls_verify_dcap.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_dcap.c
@@ -99,6 +99,7 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
     struct ra_tls_verify_callback_results* results = (struct ra_tls_verify_callback_results*)data;
 
     int ret;
+    sgx_quote_t* quote = NULL;
 
     uint8_t* supplemental_data      = NULL;
     uint32_t supplemental_data_size = 0;
@@ -124,7 +125,6 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         results->err_loc = AT_EXTRACT_QUOTE;
 
     /* extract SGX quote from "quote" OID extension from crt */
-    sgx_quote_t* quote;
     size_t quote_size;
     ret = extract_quote_and_verify_pubkey(crt, &quote, &quote_size);
     if (ret < 0) {
@@ -263,6 +263,7 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         results->err_loc = AT_NONE;
     ret = 0;
 out:
+    free(quote);
     free(supplemental_data);
     return ret;
 }

--- a/tools/sgx/ra-tls/ra_tls_verify_epid.c
+++ b/tools/sgx/ra-tls/ra_tls_verify_epid.c
@@ -121,6 +121,8 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
     struct ra_tls_verify_callback_results* results = (struct ra_tls_verify_callback_results*)data;
 
     int ret;
+    sgx_quote_t* quote = NULL;
+
     struct ias_context_t* ias = NULL;
     char* ias_pub_key_pem     = NULL;
 
@@ -168,7 +170,6 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
         results->err_loc = AT_EXTRACT_QUOTE;
 
     /* extract SGX quote from "quote" OID extension from crt */
-    sgx_quote_t* quote;
     size_t quote_size;
     ret = extract_quote_and_verify_pubkey(crt, &quote, &quote_size);
     if (ret < 0) {
@@ -281,6 +282,7 @@ out:
     if (ias)
         ias_cleanup(ias);
 
+    free(quote);
     free(ias_pub_key_pem);
     free(quote_from_ias);
     free(report_data);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `extract_quote_and_verify_pubkey()` returned a pointer to the SGX quote located inside the X.509 certificate. This is a confusing pattern, so this commit introduces a copy operation, to copy the SGX quote into a newly allocated object whose ownership is passed to the callers of this func.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1947)
<!-- Reviewable:end -->
