### PR TITLE
[python] `gramine-manifest`: print warning to stderr

### DIFF
--- a/python/graminelibos/manifest.py
+++ b/python/graminelibos/manifest.py
@@ -15,6 +15,7 @@ import hashlib
 import os
 import pathlib
 import posixpath
+import sys
 
 import tomli
 import tomli_w
@@ -346,8 +347,8 @@ class Manifest:
         # found deprecated `loader.entrypoint = "file:..."`; replace with loader.entrypoint.uri
         # TODO: remove this in Gramine v1.9
         if isinstance(loader_entrypoint, str):
-            print(f'WARNING: `loader.entrypoint = "file:..."` manifest syntax is deprecated, '
-                   'please switch to `loader.entrypoint.uri = "file:..."`')
+            print('WARNING: `loader.entrypoint = "file:..."` manifest syntax is deprecated, '
+                  'please switch to `loader.entrypoint.uri = "file:..."`', file=sys.stderr)
             loader_entrypoint = { 'uri': loader_entrypoint }
             loader['entrypoint'] = loader_entrypoint
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit "[PAL] Validate entrypoint ELF file separately" introduced a warning message during invocation of `gramine-manifest` if the manifest template has a deprecated `loader.entrypoint = "file:..."` syntax.

This warning message was erroneously printed to stdout, but stdout is used in `gramine-manifest` tool to output the rendered manifest file itself. This commit fixes that blooper by printing to stderr.

Fixes gramineproject/examples#103

## How to test this PR? <!-- (if applicable) -->

See https://github.com/gramineproject/examples/issues/103

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1953)
<!-- Reviewable:end -->
