### PR TITLE
[PAL/Linux-SGX] Remove unused `dummy_debug_variable`

### DIFF
--- a/pal/src/host/linux-sgx/pal_tcb.h
+++ b/pal/src/host/linux-sgx/pal_tcb.h
@@ -49,10 +49,6 @@ struct pal_enclave_tcb {
     struct untrusted_area untrusted_area_cache;
 };
 
-#ifndef DEBUG
-extern uint64_t dummy_debug_variable;
-#endif
-
 #ifdef IN_ENCLAVE
 
 static inline struct pal_enclave_tcb* pal_get_enclave_tcb(void) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

No idea why it was used and who introduced it. Git history ends in our infamous "First commit".

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1954)
<!-- Reviewable:end -->
