### PR TITLE
[PAL/Linux-SGX] Read exitless-OCALL result before resetting the stack

### DIFF
--- a/pal/src/host/linux-sgx/enclave_ocalls.c
+++ b/pal/src/host/linux-sgx/enclave_ocalls.c
@@ -136,8 +136,12 @@ static long sgx_exitless_ocall(uint64_t code, void* ocall_args) {
         }
     }
 
+    /* important to copy req->result before resetting the stack, otherwise it may be overwritten;
+     * this enclave's stack is also used in AEX flows, see host_entry.S:async_exit_pointer() */
+    long result = COPY_UNTRUSTED_VALUE(&req->result);
     sgx_reset_ustack(old_ustack);
-    return COPY_UNTRUSTED_VALUE(&req->result);
+
+    return result;
 }
 
 __attribute_no_sanitize_address


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, there was a data race that the exitless-OCALL logic read the result of the OCALL from the stack *after* the code reset the stack. However, this stack is shared with the AEX flows. As of now, the AEX flows use the stack only in debug mode, so this data race flew under the radar for a long time. What can happen is that right-before reading the result of the exitless OCALL, the enclave thread is interrupted, an AEX logic is executed and modifies the values on the stack, then the exitless-OCALL logic is resumed, and the enclave thread reads an AEX-modified OCALL result value.

Future commits (e.g., AEX-Notify) will introduce more AEX flows and expose this data race. So let's fix it now.

This was detected while working on #1857 and #1944. The same problem is exhibited also in AEX-Notify PR: #1531. 

## How to test this PR? <!-- (if applicable) -->

Run PAL and LibOS regression tests in a loop on e.g. PR #1944 (commenting out this fix first). They have Exitless tests, so they fail periodically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1955)
<!-- Reviewable:end -->
