### PR TITLE
[LibOS] Introduce `refresh_mappings_on_file()` convenience func

### DIFF
--- a/libos/include/libos_vma.h
+++ b/libos/include/libos_vma.h
@@ -134,11 +134,10 @@ int msync_range(uintptr_t begin, uintptr_t end);
 /* Call `msync` for file mappings of `hdl` */
 int msync_handle(struct libos_handle* hdl);
 
-/* Reload file mappings of `hdl` */
-int reload_mmaped_from_file_handle(struct libos_handle* hdl);
-
-/* Refresh page protections of file mappings of `hdl` when the file size has changed */
-int prot_refresh_mmaped_from_file_handle(struct libos_handle* hdl, size_t file_size);
+/* Refresh page protections and optionally reload file contents of file mappings of `hdl`. Reloading
+ * of file contents is performed by reading data from `hdl` and only on MAP_SHARED mappings. */
+void refresh_mappings_on_file(struct libos_handle* hdl, size_t new_file_size,
+                              bool reload_file_contents);
 
 void debug_print_all_vmas(void);
 

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -491,23 +491,7 @@ static ssize_t chroot_encrypted_write(struct libos_handle* hdl, const void* buf,
     size_t new_size = hdl->inode->size;
     unlock(&hdl->inode->lock);
 
-    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
-        /* There are mappings for the file, refresh their access protections. */
-        ret = prot_refresh_mmaped_from_file_handle(hdl, new_size);
-        if (ret < 0) {
-            log_error("refreshing page protections of mmapped regions of file failed: %s",
-                      unix_strerror(ret));
-            BUG();
-        }
-
-        /* There are mappings for the file, read data from `enc` (only for MAP_SHARED mappings). */
-        ret = reload_mmaped_from_file_handle(hdl);
-        if (ret < 0) {
-            log_error("reload mmapped regions of file failed: %s", unix_strerror(ret));
-            BUG();
-        }
-    }
-
+    refresh_mappings_on_file(hdl, new_size, /*reload_file_contents=*/true);
     return (ssize_t)actual_count;
 }
 
@@ -532,16 +516,7 @@ static int chroot_encrypted_truncate(struct libos_handle* hdl, file_off_t size) 
     hdl->inode->size = size;
     unlock(&hdl->inode->lock);
 
-    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
-        /* There are mappings for the file, refresh their access protections. */
-        ret = prot_refresh_mmaped_from_file_handle(hdl, size);
-        if (ret < 0) {
-            log_error("refreshing page protections of mmapped regions of file failed: %s",
-                      unix_strerror(ret));
-            BUG();
-        }
-    }
-
+    refresh_mappings_on_file(hdl, size, /*reload_file_contents=*/false);
     return 0;
 }
 

--- a/libos/src/fs/chroot/fs.c
+++ b/libos/src/fs/chroot/fs.c
@@ -246,23 +246,7 @@ static ssize_t chroot_write(struct libos_handle* hdl, const void* buf, size_t co
         unlock(&hdl->inode->lock);
     }
 
-    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
-        /* There are mappings for the file, refresh their access protections. */
-        ret = prot_refresh_mmaped_from_file_handle(hdl, new_size);
-        if (ret < 0) {
-            log_error("refreshing page protections of mmapped regions of file failed: %s",
-                      unix_strerror(ret));
-            BUG();
-        }
-
-        /* There are mappings for the file, read data from `hdl` (only for MAP_SHARED mappings). */
-        ret = reload_mmaped_from_file_handle(hdl);
-        if (ret < 0) {
-            log_error("reload mmapped regions of file failed: %s", unix_strerror(ret));
-            BUG();
-        }
-    }
-
+    refresh_mappings_on_file(hdl, new_size, /*reload_file_contents=*/true);
     return (ssize_t)actual_count;
 }
 

--- a/libos/src/fs/libos_fs_util.c
+++ b/libos/src/fs/libos_fs_util.c
@@ -270,15 +270,6 @@ int generic_truncate(struct libos_handle* hdl, file_off_t size) {
     hdl->inode->size = size;
     unlock(&hdl->inode->lock);
 
-    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
-        /* There are mappings for the file, refresh their access protections. */
-        ret = prot_refresh_mmaped_from_file_handle(hdl, size);
-        if (ret < 0) {
-            log_error("refreshing page protections of mmapped regions of file failed: %s",
-                      unix_strerror(ret));
-            BUG();
-        }
-    }
-
+    refresh_mappings_on_file(hdl, size, /*reload_file_contents=*/false);
     return 0;
 }

--- a/libos/src/fs/tmpfs/fs.c
+++ b/libos/src/fs/tmpfs/fs.c
@@ -274,23 +274,7 @@ static ssize_t tmpfs_write(struct libos_handle* hdl, const void* buf, size_t siz
     size_t new_size = inode->size;
     unlock(&inode->lock);
 
-    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
-        /* There are mappings for the file, refresh their access protections. */
-        int refresh_ret = prot_refresh_mmaped_from_file_handle(hdl, new_size);
-        if (refresh_ret < 0) {
-            log_error("refreshing page protections of mmapped regions of file failed: %s",
-                      unix_strerror(refresh_ret));
-            BUG();
-        }
-
-        /* There are mappings for the file, read data from `hdl` (only for MAP_SHARED mappings). */
-        int reload_ret = reload_mmaped_from_file_handle(hdl);
-        if (reload_ret < 0) {
-            log_error("reload mmapped regions of file failed: %s", unix_strerror(reload_ret));
-            BUG();
-        }
-    }
-
+    refresh_mappings_on_file(hdl, new_size, /*reload_file_contents=*/true);
     return ret;
 }
 
@@ -314,16 +298,7 @@ static int tmpfs_truncate(struct libos_handle* hdl, file_off_t size) {
     hdl->inode->size = size;
     unlock(&hdl->inode->lock);
 
-    if (__atomic_load_n(&hdl->inode->num_mmapped, __ATOMIC_ACQUIRE) != 0) {
-        /* There are mappings for the file, refresh their access protections. */
-        ret = prot_refresh_mmaped_from_file_handle(hdl, size);
-        if (ret < 0) {
-            log_error("refreshing page protections of mmapped regions of file failed: %s",
-                      unix_strerror(ret));
-            BUG();
-        }
-    }
-
+    refresh_mappings_on_file(hdl, size, /*reload_file_contents=*/false);
     return 0;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit refactors repetitive invocations of file-mapping related functions `prot_refresh_mmaped_from_file_handle()` and `reload_mmaped_from_file_handle()` into a new convenience function.

Fixes #1931.

~~Applies on top of #1818.~~

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1956)
<!-- Reviewable:end -->
