### PR TITLE
[meson] Install libcbor static lib together with RA-TLS libs

### DIFF
--- a/debian/gramine.install
+++ b/debian/gramine.install
@@ -8,6 +8,7 @@ usr/lib/${DEB_HOST_MULTIARCH}/gramine/direct/loader
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/libsysdb.so
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/sgx/libpal.so
 usr/lib/${DEB_HOST_MULTIARCH}/gramine/sgx/loader
+usr/lib/${DEB_HOST_MULTIARCH}/libcbor.a*
 usr/lib/${DEB_HOST_MULTIARCH}/libmbed*_gramine.*
 usr/lib/${DEB_HOST_MULTIARCH}/libra_tls_attest.so*
 usr/lib/${DEB_HOST_MULTIARCH}/libra_tls_verify.a
@@ -16,6 +17,7 @@ usr/lib/${DEB_HOST_MULTIARCH}/libsecret_prov_verify.a
 usr/lib/${DEB_HOST_MULTIARCH}/libsgx_util.a*
 usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig/*.pc
 
+usr/include/gramine/cbor.h
 usr/include/gramine/mbedtls/*.h
 usr/include/gramine/psa/*.h
 usr/include/gramine/ra_tls.h

--- a/gramine.spec
+++ b/gramine.spec
@@ -113,6 +113,7 @@ install -t %{buildroot}/%{_licensedir}/%{name} LICENSE*.txt
 
 %{_libdir}/libmbed{crypto,tls,x509}_%{name}.{so*,a}
 
+%{_libdir}/libcbor.a
 %{_libdir}/libra_tls*.so*
 %{_libdir}/libra_tls_verify.a
 %{_libdir}/libsecret_prov*.so*

--- a/subprojects/packagefiles/libcbor-0.11.0/meson.build
+++ b/subprojects/packagefiles/libcbor-0.11.0/meson.build
@@ -19,7 +19,9 @@ libcbor_lib = custom_target('libcbor',
     ],
 
     console: true,
-    install: false,
+
+    install: true,
+    install_dir: [get_option('libdir'), get_option('includedir') / 'gramine'],
 )
 
 # We can't use `include_directories('include')` because the `include/` dir is generated in the


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit ["[tools/sgx] Modify RA-TLS to adhere to Interoperable RA-TLS standard"](https://github.com/gramineproject/gramine/commit/71fa288885d3fd8d8d23ca88156c69957c055c43) introduced libcbor static lib as a new dependency of RA-TLS libraries. However, the commit forgot to install this static lib. Installation is required so that RA-TLS plugins can re-use this libcbor library together with RA-TLS libs. Moreover, Meson v1.5.1 spits an error if libcbor is not installed.

Fixes #1962.

## How to test this PR? <!-- (if applicable) -->

Try to build & install Gramine on a system with latest Meson (v1.5.1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1963)
<!-- Reviewable:end -->
