### PR TITLE
[PAL/Linux-SGX] Error out on enclave_dbginfo allocation failure

### DIFF
--- a/pal/src/host/linux-sgx/host_main.c
+++ b/pal/src/host/linux-sgx/host_main.c
@@ -603,7 +603,9 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
                                                     /*fd=*/-1,
                                                     /*offset=*/0);
     if (IS_PTR_ERR(dbg)) {
-        log_warning("Cannot allocate debug information (GDB will not work)");
+        log_error("Cannot allocate debug information for GDB");
+        ret = -ENOMEM;
+        goto out;
     } else {
         assert(dbg == (void*)DBGINFO_ADDR);
         dbg->pid            = g_host_pid;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We're modifying this structure dynamically since we introduced support for dynamic TCS. The modification code in `add_dynamic_tcs()` has no way of knowing whether the allocation failed or succeeded, thus it has no way to decide whether writing there is legal or not.

This PR guarantees that the stucture is always allocated.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1968)
<!-- Reviewable:end -->
