### PR TITLE
[python] `gramine-manifest`: error out on manifest check failure

### DIFF
--- a/Documentation/manpages/gramine-manifest.rst
+++ b/Documentation/manpages/gramine-manifest.rst
@@ -32,10 +32,6 @@ Command line arguments
    The check is enabled by default. This option serves to re-enable the check
    after :option:`--no-check`.
 
-   For the 1.7 release, only a |~| warning is issued and
-   :program:`gramine-manifest` proceeds to write the faulty manifest. In version
-   1.8 this will be a |~| hard error.
-
 .. option:: --no-check
 
    Disable schema validation, as described above in :option:`--check`.

--- a/python/gramine-manifest
+++ b/python/gramine-manifest
@@ -45,9 +45,8 @@ def main(ctx, string, define, infile, outfile, check):
         try:
             manifest.check()
         except voluptuous.MultipleInvalid as err:
-            click.echo(f'WARNING: error in manifest (after rendering): {err!s}', err=True)
-            # TODO after 1.7: make this a hard error
-            #ctx.exit(1)
+            click.echo(f'ERROR: manifest failed validation: {err!s}', err=True)
+            ctx.exit(1)
 
     manifest.dump(outfile)
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Any built-in manifest validation failure is now a hard error.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI + manual testing w/ non-compliant manifests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1975)
<!-- Reviewable:end -->
