### PR TITLE
[LibOS] Fix bug of `RLIMIT_STACK` being overwritten in child

### DIFF
--- a/libos/test/regression/meson.build
+++ b/libos/test/regression/meson.build
@@ -104,6 +104,7 @@ tests = {
     'rename_unlink': {},
     'rename_unlink_fchown': {},
     'rlimit_nofile': {},
+    'rlimit_stack': {},
     'run_test': {
         'include_directories': include_directories(
             # for `gramine_entry_api.h`

--- a/libos/test/regression/rlimit_stack.c
+++ b/libos/test/regression/rlimit_stack.c
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+int main(void) {
+    struct rlimit rlim;
+
+    CHECK(getrlimit(RLIMIT_STACK, &rlim));
+    printf("old RLIMIT_STACK soft limit: %lu\n", (uint64_t)rlim.rlim_cur);
+
+    /* make sure we can increase the current soft limit */
+    if (rlim.rlim_cur >= rlim.rlim_max)
+        CHECK(-1);
+
+    rlim.rlim_cur++;
+    CHECK(setrlimit(RLIMIT_STACK, &rlim));
+    printf("new RLIMIT_STACK soft limit: %lu\n", (uint64_t)rlim.rlim_cur);
+
+    fflush(stdout);
+
+    int pid = CHECK(fork());
+    if (pid == 0) {
+        /* verify that STACK limit is correctly migrated to the child process */
+        CHECK(getrlimit(RLIMIT_STACK, &rlim));
+        printf("(in child, after setrlimit) RLIMIT_STACK soft limit: %lu\n",
+               (uint64_t)rlim.rlim_cur);
+
+        /* NOTE: we currently don't test that the stack limit is indeed enforced */
+        exit(0);
+    }
+
+    int status = 0;
+    CHECK(wait(&status));
+    if (!WIFEXITED(status) || WEXITSTATUS(status))
+        errx(1, "child wait status: %#x", status);
+
+    CHECK(getrlimit(RLIMIT_STACK, &rlim));
+    printf("(in parent, after setrlimit) RLIMIT_STACK soft limit: %lu\n", (uint64_t)rlim.rlim_cur);
+
+    /* NOTE: we currently don't test that the stack limit is indeed enforced */
+    puts("TEST OK");
+    return 0;
+}

--- a/libos/test/regression/rlimit_stack.manifest.template
+++ b/libos/test/regression/rlimit_stack.manifest.template
@@ -1,0 +1,20 @@
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib"
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir(libc) }}" },
+  { path = "/{{ entrypoint }}", uri = "file:{{ binary_dir }}/{{ entrypoint }}" },
+]
+
+# we specify any non-standard stack size just for testing
+sys.stack.size = "1M"
+
+sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
+sgx.debug = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+sgx.trusted_files = [
+  "file:{{ gramine.runtimedir(libc) }}/",
+  "file:{{ binary_dir }}/{{ entrypoint }}",
+]

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1100,6 +1100,15 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn("(after setrlimit) opened fd: 4096", stdout)
         self.assertIn("TEST OK", stdout)
 
+    def test_162_rlimit_stack(self):
+        # rlimit_stack.manifest.template specifies 1MB (= 1048576B) stack size
+        stdout, _ = self.run_binary(['rlimit_stack'])
+        self.assertIn("old RLIMIT_STACK soft limit: 1048576", stdout)
+        self.assertIn("new RLIMIT_STACK soft limit: 1048577", stdout)
+        self.assertIn("(in child, after setrlimit) RLIMIT_STACK soft limit: 1048577", stdout)
+        self.assertIn("(in parent, after setrlimit) RLIMIT_STACK soft limit: 1048577", stdout)
+        self.assertIn("TEST OK", stdout)
+
 class TC_31_Syscall(RegressionTestCase):
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])

--- a/libos/test/regression/tests.toml
+++ b/libos/test/regression/tests.toml
@@ -104,6 +104,7 @@ manifests = [
   "rename_unlink_fchown",
   "rlimit_nofile",
   "rlimit_nofile_4k",
+  "rlimit_stack",
   "run_test",
   "rwlock",
   "sched",

--- a/libos/test/regression/tests_musl.toml
+++ b/libos/test/regression/tests_musl.toml
@@ -106,6 +106,7 @@ manifests = [
   "rename_unlink_fchown",
   "rlimit_nofile",
   "rlimit_nofile_4k",
+  "rlimit_stack",
   "run_test",
   "rwlock",
   "sched",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the resource limit `RLIMIT_STACK` (maximum size of the process stack, in bytes) was overwritten in the child process, after fork. Thus, if the parent used `setrlimit(RLIMIT_STACK)`, the effect of this was lost in the child. This PR fixes this bug, and adds a LibOS test to verify the correct behavior.

Fixes #1974 

Noticed while reviewing #1973.

## How to test this PR? <!-- (if applicable) -->

New LibOS test was added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1976)
<!-- Reviewable:end -->
