### PR TITLE
[LibOS] Add missing locks around dentry->inode dereference 

### DIFF
--- a/libos/include/libos_process.h
+++ b/libos/include/libos_process.h
@@ -62,6 +62,8 @@ struct libos_process {
     LISTP_TYPE(libos_child_process) zombies;
 
     struct libos_lock children_lock;
+
+    /* If g_dcache_lock is also required, acquire g_dcache_lock first and then fs_lock */
     struct libos_lock fs_lock;
 
     /* Complete command line for the process, as reported by /proc/[pid]/cmdline; currently filled

--- a/libos/src/bookkeep/libos_handle.c
+++ b/libos/src/bookkeep/libos_handle.c
@@ -499,16 +499,6 @@ int set_new_fd_handle_above_fd(uint32_t fd, struct libos_handle* hdl, int fd_fla
     return __set_new_fd_handle(fd, hdl, fd_flags, handle_map, /*find_first=*/true);
 }
 
-static inline __attribute__((unused)) const char* __handle_name(struct libos_handle* hdl) {
-    if (hdl->uri)
-        return hdl->uri;
-    if (hdl->dentry && hdl->dentry->name[0] != '\0')
-        return hdl->dentry->name;
-    if (hdl->fs)
-        return hdl->fs->name;
-    return "(unknown)";
-}
-
 void get_handle(struct libos_handle* hdl) {
     refcount_inc(&hdl->ref_count);
 }

--- a/libos/src/sys/libos_open.c
+++ b/libos/src/sys/libos_open.c
@@ -373,12 +373,12 @@ static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getden
         goto out_no_unlock;
     }
 
+    lock(&g_dcache_lock);
     if (!hdl->dentry->inode) {
         ret = -ENOENT;
-        goto out_no_unlock;
+        goto out_unlock_only_dcache_lock;
     }
 
-    lock(&g_dcache_lock);
     maybe_lock_pos_handle(hdl);
     lock(&hdl->lock);
 
@@ -467,6 +467,7 @@ static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getden
 out:
     unlock(&hdl->lock);
     maybe_unlock_pos_handle(hdl);
+out_unlock_only_dcache_lock:
     unlock(&g_dcache_lock);
 out_no_unlock:
     put_handle(hdl);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This fixes two cases where a dentry->inode derefernce was not lock-protected.  It also adds a missing call to `put_handle` during error handling and (in a separate commit) removes an unused function.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Usual regression tests ...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1978)
<!-- Reviewable:end -->
