### PR TITLE
[LibOS] Move `print_warnings_on_insecure_configs()` to LibOS

### DIFF
--- a/libos/include/libos_internal.h
+++ b/libos/include/libos_internal.h
@@ -30,6 +30,8 @@ extern struct pal_public_state* g_pal_public_state;
 void libos_log(int level, const char* file, const char* func, uint64_t line,
                const char* fmt, ...) __attribute__((format(printf, 5, 6)));
 
+int print_warnings_on_insecure_configs(bool parent_process);
+
 /*!
  * \brief High-level syscall emulation entrypoint.
  *

--- a/libos/src/fs/dev/attestation.c
+++ b/libos/src/fs/dev/attestation.c
@@ -327,6 +327,13 @@ static int init_sgx_attestation(struct pseudo_node* attestation, struct pseudo_n
     if (strcmp(g_pal_public_state->host_type, "Linux-SGX"))
         return 0;
 
+    /* FIXME: Make all SGX-related names and constants more generic, based on
+     *        g_pal_public_state->confidential_computing == true */
+    if (!g_pal_public_state->confidential_computing) {
+        log_error("host is Linux-SGX but 'confidential_computing' flag is false, impossible");
+        return -EINVAL;
+    }
+
     if (!g_pal_public_state->attestation_type) {
         log_error("Cannot determine remote attestation type during init of /dev/attestation/");
         return -EINVAL;

--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -371,6 +371,8 @@ static int read_environs(const char* const* envp) {
     } while (0)
 
 noreturn void libos_init(const char* const* argv, const char* const* envp) {
+    int ret;
+
     g_pal_public_state = PalGetPalPublicState();
     assert(g_pal_public_state);
 
@@ -410,12 +412,18 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     RUN_INIT(init_dcache);
     RUN_INIT(init_handle);
 
+    ret = print_warnings_on_insecure_configs(!!g_pal_public_state->parent_process);
+    if (ret < 0) {
+        log_error("Cannot parse the manifest (while checking for insecure configurations)");
+        PalProcessExit(1);
+    }
+
     log_debug("LibOS loaded at %p, ready to initialize", &__load_address);
 
     if (g_pal_public_state->parent_process) {
         struct checkpoint_hdr hdr;
 
-        int ret = read_exact(g_pal_public_state->parent_process, &hdr, sizeof(hdr));
+        ret = read_exact(g_pal_public_state->parent_process, &hdr, sizeof(hdr));
         if (ret < 0) {
             log_error("libos_init: failed to read the whole checkpoint header: %s",
                       unix_strerror(ret));
@@ -469,7 +477,7 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     RUN_INIT(init_ipc_worker);
 
     if (g_pal_public_state->parent_process) {
-        int ret = connect_to_process(g_process_ipc_ids.parent_vmid);
+        ret = connect_to_process(g_process_ipc_ids.parent_vmid);
         if (ret < 0) {
             log_error("libos_init: failed to establish IPC connection to parent: %s",
                       unix_strerror(ret));

--- a/libos/src/meson.build
+++ b/libos/src/meson.build
@@ -108,6 +108,7 @@ libos_sources = files(
     'sys/libos_wait.c',
     'sys/libos_wrappers.c',
     'utils/log.c',
+    'utils/warn.c',
 )
 
 # Arch-specific meson.build must define the following Meson variables:

--- a/libos/src/utils/warn.c
+++ b/libos/src/utils/warn.c
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation */
+
+#include "api.h"
+#include "libos_internal.h"
+#include "toml.h"
+#include "toml_utils.h"
+
+static bool warn_about_allowed_files_usage(void) {
+    toml_table_t* manifest_sgx = toml_table_in(g_pal_public_state->manifest_root, "sgx");
+    if (!manifest_sgx)
+        return false;
+    toml_array_t* toml_allowed_files = toml_array_in(manifest_sgx, "allowed_files");
+    if (!toml_allowed_files)
+        return false;
+
+    return true;
+}
+
+static bool warn_about_fs_insecure_keys(void) {
+    toml_table_t* manifest_fs = toml_table_in(g_pal_public_state->manifest_root, "fs");
+    if (!manifest_fs)
+        return false;
+    toml_table_t* manifest_fs_keys = toml_table_in(manifest_fs, "insecure__keys");
+    if (!manifest_fs_keys)
+        return false;
+    int ret = toml_table_nkval(manifest_fs_keys);
+    if (ret <= 0)
+        return false;
+
+    return true;
+}
+
+int print_warnings_on_insecure_configs(bool parent_process) {
+    int ret;
+
+    if (!g_pal_public_state->confidential_computing) {
+        /* Warn only in confidential-computing environments. */
+        return 0;
+    }
+
+    if (parent_process) {
+        /* Warn only in the first process. */
+        return 0;
+    }
+
+    bool verbose_log_level    = false;
+    bool sgx_debug            = false;
+    bool use_cmdline_argv     = false;
+    bool use_host_env         = false;
+    bool disable_aslr         = false;
+    bool allow_eventfd        = false;
+    bool experimental_flock   = false;
+    bool allow_all_files      = false;
+    bool use_allowed_files    = warn_about_allowed_files_usage();
+    bool encrypted_files_keys = warn_about_fs_insecure_keys();
+    bool memfaults_without_exinfo_allowed = false;
+
+    char* log_level_str = NULL;
+    char* file_check_policy_str = NULL;
+
+    ret = toml_string_in(g_pal_public_state->manifest_root, "loader.log_level", &log_level_str);
+    if (ret < 0)
+        goto out;
+    if (log_level_str && strcmp(log_level_str, "none") && strcmp(log_level_str, "error"))
+        verbose_log_level = true;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root, "sgx.debug",
+                       /*defaultval=*/false, &sgx_debug);
+    if (ret < 0)
+        goto out;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root, "loader.insecure__use_cmdline_argv",
+                       /*defaultval=*/false, &use_cmdline_argv);
+    if (ret < 0)
+        goto out;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root, "loader.insecure__use_host_env",
+                       /*defaultval=*/false, &use_host_env);
+    if (ret < 0)
+        goto out;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root, "loader.insecure__disable_aslr",
+                       /*defaultval=*/false, &disable_aslr);
+    if (ret < 0)
+        goto out;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root, "sys.insecure__allow_eventfd",
+                       /*defaultval=*/false, &allow_eventfd);
+    if (ret < 0)
+        goto out;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root, "sys.experimental__enable_flock",
+                       /*defaultval=*/false, &experimental_flock);
+    if (ret < 0)
+        goto out;
+
+    ret = toml_string_in(g_pal_public_state->manifest_root, "sgx.file_check_policy",
+                         &file_check_policy_str);
+    if (ret < 0)
+        goto out;
+    if (file_check_policy_str && !strcmp(file_check_policy_str, "allow_all_but_log"))
+        allow_all_files = true;
+
+    ret = toml_bool_in(g_pal_public_state->manifest_root,
+                       "sgx.insecure__allow_memfaults_without_exinfo",
+                       /*defaultval=*/false, &memfaults_without_exinfo_allowed);
+    if (ret < 0)
+        goto out;
+
+    if (!verbose_log_level && !sgx_debug && !use_cmdline_argv && !use_host_env && !disable_aslr &&
+            !allow_eventfd && !experimental_flock && !allow_all_files && !use_allowed_files &&
+            !encrypted_files_keys && !memfaults_without_exinfo_allowed) {
+        /* there are no insecure configurations, skip printing */
+        ret = 0;
+        goto out;
+    }
+
+    log_always("-------------------------------------------------------------------------------"
+               "----------------------------------------");
+    log_always("Gramine detected the following insecure configurations:\n");
+
+    if (sgx_debug)
+        log_always("  - sgx.debug = true                           "
+                   "(this is a debug enclave)");
+
+    if (verbose_log_level)
+        log_always("  - loader.log_level = warning|debug|trace|all "
+                   "(verbose log level, may leak information)");
+
+    if (use_cmdline_argv)
+        log_always("  - loader.insecure__use_cmdline_argv = true   "
+                   "(forwarding command-line args from untrusted host to the app)");
+
+    if (use_host_env)
+        log_always("  - loader.insecure__use_host_env = true       "
+                   "(forwarding environment vars from untrusted host to the app)");
+
+    if (disable_aslr)
+        log_always("  - loader.insecure__disable_aslr = true       "
+                   "(Address Space Layout Randomization is disabled)");
+
+    if (allow_eventfd)
+        log_always("  - sys.insecure__allow_eventfd = true         "
+                   "(host-based eventfd is enabled)");
+
+    if (experimental_flock)
+        log_always("  - sys.experimental__enable_flock = true      "
+                   "(flock syscall is enabled; still under development and may contain bugs)");
+
+    if (memfaults_without_exinfo_allowed)
+        log_always("  - sgx.insecure__allow_memfaults_without_exinfo "
+                   "(allow memory faults even when SGX EXINFO is not supported by CPU)");
+
+    if (allow_all_files)
+        log_always("  - sgx.file_check_policy = allow_all_but_log  "
+                   "(all files are passed through from untrusted host without verification)");
+
+    if (use_allowed_files)
+        log_always("  - sgx.allowed_files = [ ... ]                "
+                   "(some files are passed through from untrusted host without verification)");
+
+    if (encrypted_files_keys)
+        log_always("  - fs.insecure__keys.* = \"...\"                "
+                   "(keys hardcoded in manifest)");
+
+
+    log_always("\nGramine will continue application execution, but this configuration must not be "
+               "used in production!");
+    log_always("-------------------------------------------------------------------------------"
+               "----------------------------------------\n");
+
+    ret = 0;
+out:
+    free(file_check_policy_str);
+    free(log_level_str);
+    return ret;
+}
+

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -130,12 +130,16 @@ struct pal_dns_host_conf {
 struct pal_public_state {
     uint64_t instance_id;
     const char* host_type;
-    const char* attestation_type; /* currently only for Linux-SGX */
+
+    /*
+     * Related to confidential computing (currently only for Linux-SGX PAL)
+     */
+    bool confidential_computing;
+    const char* attestation_type;
 
     /*
      * Handles and executables
      */
-
     toml_table_t* manifest_root; /*!< program manifest */
     PAL_HANDLE parent_process;   /*!< handle of parent process */
     PAL_HANDLE first_thread;     /*!< handle of first thread */

--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -408,168 +408,6 @@ extern void* g_enclave_top;
 extern uint64_t g_tsc_hz;
 extern size_t g_unused_tcs_pages_num;
 
-static bool warn_about_allowed_files_usage(void) {
-    if (g_pal_common_state.parent_process) {
-        /* only warn in the master process, not in children */
-        return false;
-    }
-    toml_table_t* manifest_sgx = toml_table_in(g_pal_public_state.manifest_root, "sgx");
-    if (!manifest_sgx)
-        return false;
-    toml_array_t* toml_allowed_files = toml_array_in(manifest_sgx, "allowed_files");
-    if (!toml_allowed_files)
-        return false;
-    return true;
-}
-
-static int print_warnings_on_insecure_configs(PAL_HANDLE parent_process) {
-    int ret;
-
-    if (parent_process) {
-        /* Warn only in the first process. */
-        return 0;
-    }
-
-    bool verbose_log_level    = false;
-    bool sgx_debug            = false;
-    bool use_cmdline_argv     = false;
-    bool use_host_env         = false;
-    bool disable_aslr         = false;
-    bool allow_eventfd        = false;
-    bool experimental_flock   = false;
-    bool allow_all_files      = false;
-    bool use_allowed_files    = warn_about_allowed_files_usage();
-    bool encrypted_files_keys = false;
-    bool memfaults_without_exinfo_allowed = g_pal_linuxsgx_state.memfaults_without_exinfo_allowed;
-
-    char* log_level_str = NULL;
-    char* file_check_policy_str = NULL;
-
-    ret = toml_string_in(g_pal_public_state.manifest_root, "loader.log_level", &log_level_str);
-    if (ret < 0)
-        goto out;
-    if (log_level_str && strcmp(log_level_str, "none") && strcmp(log_level_str, "error"))
-        verbose_log_level = true;
-
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "sgx.debug",
-                       /*defaultval=*/false, &sgx_debug);
-    if (ret < 0)
-        goto out;
-
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "loader.insecure__use_cmdline_argv",
-                       /*defaultval=*/false, &use_cmdline_argv);
-    if (ret < 0)
-        goto out;
-
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "loader.insecure__use_host_env",
-                       /*defaultval=*/false, &use_host_env);
-    if (ret < 0)
-        goto out;
-
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "loader.insecure__disable_aslr",
-                       /*defaultval=*/false, &disable_aslr);
-    if (ret < 0)
-        goto out;
-
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "sys.insecure__allow_eventfd",
-                       /*defaultval=*/false, &allow_eventfd);
-    if (ret < 0)
-        goto out;
-
-    ret = toml_bool_in(g_pal_public_state.manifest_root, "sys.experimental__enable_flock",
-                       /*defaultval=*/false, &experimental_flock);
-    if (ret < 0)
-        goto out;
-
-    ret = toml_string_in(g_pal_public_state.manifest_root, "sgx.file_check_policy",
-                         &file_check_policy_str);
-    if (ret < 0)
-        goto out;
-    if (file_check_policy_str && !strcmp(file_check_policy_str, "allow_all_but_log"))
-        allow_all_files = true;
-
-    toml_table_t* manifest_fs = toml_table_in(g_pal_public_state.manifest_root, "fs");
-    if (manifest_fs) {
-        toml_table_t* manifest_fs_keys = toml_table_in(manifest_fs, "insecure__keys");
-        if (manifest_fs_keys) {
-            ret = toml_table_nkval(manifest_fs_keys);
-            if (ret < 0)
-                goto out;
-
-            if (ret > 0)
-                encrypted_files_keys = true;
-        }
-    }
-
-    if (!verbose_log_level && !sgx_debug && !use_cmdline_argv && !use_host_env && !disable_aslr &&
-            !allow_eventfd && !experimental_flock && !allow_all_files && !use_allowed_files &&
-            !encrypted_files_keys && !memfaults_without_exinfo_allowed) {
-        /* there are no insecure configurations, skip printing */
-        ret = 0;
-        goto out;
-    }
-
-    log_always("-------------------------------------------------------------------------------"
-               "----------------------------------------");
-    log_always("Gramine detected the following insecure configurations:\n");
-
-    if (sgx_debug)
-        log_always("  - sgx.debug = true                           "
-                   "(this is a debug enclave)");
-
-    if (verbose_log_level)
-        log_always("  - loader.log_level = warning|debug|trace|all "
-                   "(verbose log level, may leak information)");
-
-    if (use_cmdline_argv)
-        log_always("  - loader.insecure__use_cmdline_argv = true   "
-                   "(forwarding command-line args from untrusted host to the app)");
-
-    if (use_host_env)
-        log_always("  - loader.insecure__use_host_env = true       "
-                   "(forwarding environment vars from untrusted host to the app)");
-
-    if (disable_aslr)
-        log_always("  - loader.insecure__disable_aslr = true       "
-                   "(Address Space Layout Randomization is disabled)");
-
-    if (allow_eventfd)
-        log_always("  - sys.insecure__allow_eventfd = true         "
-                   "(host-based eventfd is enabled)");
-
-    if (experimental_flock)
-        log_always("  - sys.experimental__enable_flock = true      "
-                   "(flock syscall is enabled; still under development and may contain bugs)");
-
-    if (memfaults_without_exinfo_allowed)
-        log_always("  - sgx.insecure__allow_memfaults_without_exinfo "
-                   "(allow memory faults even when SGX EXINFO is not supported by CPU)");
-
-    if (allow_all_files)
-        log_always("  - sgx.file_check_policy = allow_all_but_log  "
-                   "(all files are passed through from untrusted host without verification)");
-
-    if (use_allowed_files)
-        log_always("  - sgx.allowed_files = [ ... ]                "
-                   "(some files are passed through from untrusted host without verification)");
-
-    if (encrypted_files_keys)
-        log_always("  - fs.insecure__keys.* = \"...\"                "
-                   "(keys hardcoded in manifest)");
-
-
-    log_always("\nGramine will continue application execution, but this configuration must not be "
-               "used in production!");
-    log_always("-------------------------------------------------------------------------------"
-               "----------------------------------------\n");
-
-    ret = 0;
-out:
-    free(file_check_policy_str);
-    free(log_level_str);
-    return ret;
-}
-
 static void print_warning_on_invariant_tsc(PAL_HANDLE parent_process) {
     if (!parent_process && !g_tsc_hz) {
         /* Warn only in the first process. */
@@ -594,11 +432,6 @@ static void print_warnings_on_invalid_dns_host_conf(PAL_HANDLE parent_process) {
 }
 
 static void post_callback(void) {
-    if (print_warnings_on_insecure_configs(g_pal_common_state.parent_process) < 0) {
-        log_error("Cannot parse the manifest (while checking for insecure configurations)");
-        ocall_exit(1, /*is_exitgroup=*/true);
-    }
-
     print_warning_on_invariant_tsc(g_pal_common_state.parent_process);
 
     print_warnings_on_invalid_dns_host_conf(g_pal_common_state.parent_process);
@@ -641,6 +474,8 @@ noreturn void pal_linux_main(void* uptr_libpal_uri, size_t libpal_uri_len, void*
     }
 
     call_init_array();
+
+    g_pal_public_state.confidential_computing = true;
 
     /* Initialize alloc_align as early as possible, a lot of PAL APIs depend on this being set. */
     g_pal_public_state.alloc_align = g_page_size;

--- a/pal/src/host/linux/pal_main.c
+++ b/pal/src/host/linux/pal_main.c
@@ -183,6 +183,8 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
 
     call_init_array();
 
+    g_pal_public_state.confidential_computing = false;
+
     /* Initialize alloc_align as early as possible, a lot of PAL APIs depend on this being set. */
     g_pal_public_state.alloc_align = g_page_size;
     assert(IS_POWER_OF_2(g_pal_public_state.alloc_align));


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `print_warnings_on_insecure_configs()` function was in Linux-SGX PAL. However, since almost all insecure manifest configurations are processed in the LibOS layer, it makes sense to move the printing of warnings about these configs from PAL to LibOS. This has an additional benefit of deduplicating this printing across all "confidential computing" PALs (currently there is only SGX, but in future Gramine may have TDX, AMD-SEV, etc.).

Based on top of #1812.

Fixes #1981 

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1984)
<!-- Reviewable:end -->
