### PR TITLE
[tests] Increase timeout of `fork06` LTP test

### DIFF
--- a/libos/test/ltp/ltp.cfg
+++ b/libos/test/ltp/ltp.cfg
@@ -551,6 +551,10 @@ skip = yes
 [fork05]
 skip = yes
 
+# performs 1,000 forks, which may be slow on ASan builds and wimpy VMs
+[fork06]
+timeout = 60
+
 # sometimes fails with "x/100 children didn't read correctly from an inheritted fd"
 [fork07]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `fork06` LTP test had a default timeout of 30 seconds, which translated to 60 seconds under AddressSanitizer builds (due to scaling factor of 2). However, our new Jenkins CI is based on wimpy VMs, and the default timeout of 60 is not enough for ASan-enabled CI jobs anymore.

Found while working on #1984.

## How to test this PR? <!-- (if applicable) -->

CI is enough.

Without this PR, our current CI prints errors like this on `Jenkins-Direct-Sanitizers`:
```
_______________________________ test_ltp[fork06] _______________________________
[gw3] linux -- Python 3.8.10 /usr/bin/python3
test_ltp.py:196: in test_ltp
returncode, stdout, _stderr = run_command(full_cmd, timeout=timeout, can_fail=True)
../../../usr/lib/python3.8/site-packages/graminelibos/regression.py:157: in run_command
    raise AssertionError('Command {} timed out after {} s'.format(cmd, timeout))
E   AssertionError: Command ['gramine-direct', 'fork06'] timed out after 60 s
------------------------------ Captured log call -------------------------------
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1985)
<!-- Reviewable:end -->
