### PR TITLE
[Scripts] Add activate.sh

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -311,3 +311,14 @@ if enable_libgomp
 endif
 
 run_target('clang-format', command: [meson_clang_format_prog])
+
+conf = configuration_data()
+conf.set('PATH', get_option('prefix') / get_option('bindir'))
+conf.set('LD_LIBRARY_PATH', get_option('prefix') / get_option('libdir'))
+conf.set('PKG_CONFIG_PATH', get_option('prefix') / get_option('libdir') / 'pkgconfig')
+conf.set('PYTHONPATH', python3_platlib)
+configure_file(
+    input: 'scripts/activate.sh.in',
+    output: 'activate.sh',
+    configuration: conf,
+)

--- a/scripts/activate.sh.in
+++ b/scripts/activate.sh.in
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -xe
+
+case "@PATH@" in
+@*)
+    echo this script is intended for running from builddir >&2
+    exit 1
+    ;;
+esac
+
+pathmunge() {
+    eval "var=\$$1"
+    case "$var" in *"$2"*) return;; esac
+    eval "$1=\$2\${$1:+:\$$1}"
+    eval "export $1"
+}
+
+pathmunge PATH "@PATH@"
+pathmunge LD_LIBRARY_PATH "@LD_LIBRARY_PATH@"
+pathmunge PKG_CONFIG_PATH "@PKG_CONFIG_PATH@"
+pathmunge PYTHONPATH "@PYTHONPATH@"
+
+exec $SHELL


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is mostly QoL feature for Gramine developers. If you setup the build with nonstandard `--prefix`, like you do for development, it's quite a chore to set all environment variables for Gramine to work. This script does this automatically.

The script is never installed, but is present in meson's build directory. After you install gramine, you can just run this script to get a valid environment. 

Until we can do something about devenv (which would not need even installing; cf. #1183), this should be a reasonably convenient way to reliably get a testing environment.

## How to test this PR? <!-- (if applicable) -->

```sh
meson setup build/ --prefix ... -Dsgx=enabled -Ddirect=enabled <other options>
meson compile -C build/
meson install -C build/
build/activate.sh
cd CI-Examples/helloworld
make SGX=1
gramine-sgx helloworld # gramine-sgx should be in $PATH after activate.sh
```