### PR TITLE
Add log_trace for raw syscalls

### DIFF
--- a/pal/src/host/linux-sgx/pal_exception.c
+++ b/pal/src/host/linux-sgx/pal_exception.c
@@ -229,6 +229,9 @@ static bool handle_ud(sgx_cpu_context_t* uc, int* out_event_num) {
             log_always("Emulating a raw syscall instruction. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }
+        char buf[LOCATION_BUF_SIZE];
+        pal_describe_location(uc->rip, buf, sizeof(buf));
+        log_trace("Emulating raw syscall instruction with number %lu at address %s", uc->rax, buf);
         return false;
     } else if (is_in_out(instr) && !has_lock_prefix(instr)) {
         /*

--- a/pal/src/host/linux/pal_exception.c
+++ b/pal/src/host/linux/pal_exception.c
@@ -91,6 +91,10 @@ static void handle_sync_signal(int signum, siginfo_t* info, struct ucontext* uc)
             log_always("Emulating a raw system/supervisor call. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }
+        char buf[LOCATION_BUF_SIZE];
+        pal_describe_location(ucontext_get_ip(uc), buf, sizeof(buf));
+        log_trace("Emulating raw syscall instruction with number %d at address %s",
+                  info->si_syscall, buf);
     }
 
     enum pal_event event = signal_to_pal_event(signum);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guidelines:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

- Logging every raw syscall helps identify how often they occur. If it's too many, then that might cause performance issues, but if it's rare, we can ignore the performance angle
- Printing messages for every syscall captures information about multiple raw syscalls rather than just the first one.
- Printing the syscall address helps to find the library to which the syscall belongs without modifying Gramine code
 

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
- To build gramine, use meson and ninja commands. Then, for any workload (eg tested on pytorch), modify the manifest file to change log_level to trace, and you will see the raw syscalls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1991)
<!-- Reviewable:end -->
