### PR TITLE
[PAL/Linux-SGX] Add diagnostics to error message about sigstruct size

### DIFF
--- a/pal/src/host/linux-sgx/host_internal.h
+++ b/pal/src/host/linux-sgx/host_internal.h
@@ -69,7 +69,7 @@ bool is_wrfsbase_supported(void);
 
 int read_enclave_token(int token_file, sgx_arch_token_t* out_token);
 int create_dummy_enclave_token(sgx_sigstruct_t* sig, sgx_arch_token_t* out_token);
-int read_enclave_sigstruct(int sigfile, sgx_sigstruct_t* sig);
+int read_enclave_sigstruct(char* sig_path, sgx_sigstruct_t* sig);
 
 int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Inspired by #1997, maybe in the future it will save one round trip while debugging other people's computers. 

## How to test this PR? <!-- (if applicable) -->

```
cd helloworld
make SGX=1
truncate -s 0 helloworld.sig  # or any number != 1808
gramine-sgx helloworld
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/1998)
<!-- Reviewable:end -->
