### PR TITLE
[PAL] Fix `attestation` LibOS regression test for UBSan

### DIFF
--- a/pal/src/host/linux-sgx/pal_misc.c
+++ b/pal/src/host/linux-sgx/pal_misc.c
@@ -702,7 +702,7 @@ int _PalAttestationQuote(const void* user_report_data, size_t user_report_data_s
 
     enum sgx_attestation_type attestation_type;
     sgx_spid_t spid;
-    bool linkable;
+    bool linkable = false;
 
     ret = parse_attestation_type(g_pal_public_state.manifest_root, &attestation_type);
     if (ret < 0) {


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

UBSan detects an uninitialized boolean variable on a DCAP SGX machine on the remote attestation example, failing with the message:

    error: ubsan: load of invalid value for bool or enum: 100
    error: ubsan: ../pal/src/host/linux-sgx/pal_misc.c:724:43

This happens because `bool linkable` variable is assigned only in the EPID attestation scheme, but left unassigned in the DCAP scheme. This commit fixes this (though it's not a bug since DCAP never uses `linkable` anyway). Hence, UBSan doesn't complain anymore.

Reported by @woju 

## How to test this PR? <!-- (if applicable) -->

Run LibOS regression test `attestation` on Ubuntu 24.04 + UBSan enabled + DCAP attestation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2004)
<!-- Reviewable:end -->
