### PR TITLE
[tests] Add `-Wno-implicit-function-declaration` for LTP build

### DIFF
--- a/libos/test/ltp/Makefile
+++ b/libos/test/ltp/Makefile
@@ -6,6 +6,11 @@ BUILDDIR = $(ROOTDIR)/build
 INSTALLDIR = $(ROOTDIR)/install
 TESTCASEDIR = $(INSTALLDIR)/testcases/bin
 
+# Without the below flag, LTP's clone301 test fails on Clang 18 (e.g. on Ubuntu 24.04) with
+# "error: implicit declaration of function pidfd_send_signal".
+# TODO: Remove this flag when LTP is updated to the latest release (where this is fixed).
+EXTRA_CFLAGS = -Wno-implicit-function-declaration
+
 clean-extra += clean-build
 
 .PHONY: all
@@ -24,7 +29,7 @@ $(BUILDDIR)/BUILD_SUCCESS: $(SRCDIR)/configure
 	mkdir -p $(BUILDDIR)
 	# Kernel module tests are not meaningful for our LibOS and building them causes troubles on
 	# incompatible host kernels.
-	cd $(BUILDDIR) && $(SRCDIR)/configure --without-modules --prefix $(INSTALLDIR)
+	cd $(BUILDDIR) && $(SRCDIR)/configure CFLAGS=$(EXTRA_CFLAGS) --without-modules --prefix $(INSTALLDIR)
 	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) all
 	touch $@
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Currently used version of LTP has a bug that results in the following build error, e.g. when using Clang v18 on Ubuntu 24.04:

    clone301.c:136:8: error: call to undeclared function 'pidfd_send_signal'

This is because Clang promoted "implicit function declaration" check from a warning to an error starting from Clang v16. This commit adds `-Wno-implicit-function-declaration` flag to CFLAGS during LTP build.

Newer LTP releases fixed this bug, so in the future, when Gramine uses newer LTP, this commit should be reverted.

Reported by @woju.

## How to test this PR? <!-- (if applicable) -->

Build LTP with Clang on Ubuntu 24.04.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2005)
<!-- Reviewable:end -->
