### PR TITLE
[PAL] Do not describe RIP location on syscall instruction

### DIFF
--- a/pal/src/host/linux-sgx/pal_exception.c
+++ b/pal/src/host/linux-sgx/pal_exception.c
@@ -232,9 +232,10 @@ static bool handle_ud(sgx_cpu_context_t* uc, int* out_event_num) {
             log_always("Emulating a raw syscall instruction. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }
-        char buf[LOCATION_BUF_SIZE];
-        pal_describe_location(uc->rip, buf, sizeof(buf));
-        log_trace("Emulating raw syscall instruction with number %lu at address %s", uc->rax, buf);
+        /* FIXME: better to use `pal_describe_location()` (see example below), but it leads to a
+         * non-deterministic bug on some workloads */
+        log_trace("Emulating raw syscall instruction with number %lu at address %p",
+                  uc->rax, (void*)uc->rip);
         return false;
     } else if (is_in_out(instr) && !has_lock_prefix(instr)) {
         /*

--- a/pal/src/host/linux/pal_exception.c
+++ b/pal/src/host/linux/pal_exception.c
@@ -91,10 +91,10 @@ static void handle_sync_signal(int signum, siginfo_t* info, struct ucontext* uc)
             log_always("Emulating a raw system/supervisor call. This degrades performance, consider"
                        " patching your application to use Gramine syscall API.");
         }
-        char buf[LOCATION_BUF_SIZE];
-        pal_describe_location(ucontext_get_ip(uc), buf, sizeof(buf));
-        log_trace("Emulating raw syscall instruction with number %d at address %s",
-                  info->si_syscall, buf);
+        /* FIXME: better to use `pal_describe_location()` (see example below), but it leads to a
+         * non-deterministic bug on some workloads */
+        log_trace("Emulating raw syscall instruction with number %d at address %p", info->si_syscall,
+                  info->si_call_addr);
     }
 
     enum pal_event event = signal_to_pal_event(signum);


### PR DESCRIPTION
## Description of the Changes

PR #1991 exposes a segmentation fault with the use of `pal_describe_location` as in below error log:
 
```
(host_exception.c:141:handle_sync_signal) error: Unexpected segmentation fault (SIGSEGV) occurred inside untrusted PAL (libc-2.31.so+0x22941 (addr = 0x7f62e5f98941))
```
 
Using the above addresses we could find the functions abort->hlt from objdump of libc.
 
We tried to debug the issue using GDB to figure out the cause of abort call inside libc but issue did not reproduced with GDB even after multiple tries.
 
Issue is consistent with Pytorch workload using curated apps (with debug build) without GDB, on a Azure VM, rarely on our lab servers.
 
Also tested by increasing the ENCLAVE_SIG_STACK_SIZE and ALT_STACK_SIZE size to 256KB but that also did not help.
 
Likely some race in Gramine when using `pal_describe_location` which we are not hitting with GDB as GDB makes the execution slow.
 
We want to remove this function call in coming release and analyze this issue after the release.

Fixes gramineproject/contrib#87

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2017)
<!-- Reviewable:end -->
