### PR TITLE
[CI-Examples] Add Nginx test data files measurements within the manifest

### DIFF
--- a/CI-Examples/nginx/Makefile
+++ b/CI-Examples/nginx/Makefile
@@ -17,6 +17,18 @@ LISTEN_HOST ?= 127.0.0.1
 LISTEN_PORT ?= 8002
 LISTEN_SSL_PORT ?= 8444
 
+# HTTP docs: Generating random HTML files in $(INSTALL_DIR)/html/random
+RANDOM_DIR = $(INSTALL_DIR)/html/random
+RANDOM_FILES = \
+	$(foreach n,1 2 3 4 5 6 7 8 9 10,2K.$n.html) \
+	$(foreach n,1 2 3 4 5,10K.$n.html) \
+	$(foreach n,1 2 3 4 5,100K.$n.html) \
+	$(foreach n,1 2 3,1M.$n.html) \
+	$(foreach n,1 2 3,10M.$n.html) \
+	$(foreach n,1 2 3,100.$n.html)
+
+TEST_DATA = $(addprefix $(RANDOM_DIR)/,$(RANDOM_FILES))
+
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -81,18 +93,6 @@ $(INSTALL_DIR)/conf/nginx-gramine.conf: nginx-gramine.conf.template $(INSTALL_DI
 		-e 's|$$(LISTEN_SSL_PORT)|'"$(LISTEN_SSL_PORT)"'|g' \
 		-e 's|$$(LISTEN_HOST)|'"$(LISTEN_HOST)"'|g' \
 	$< > $@
-
-# HTTP docs: Generating random HTML files in $(INSTALL_DIR)/html/random
-RANDOM_DIR = $(INSTALL_DIR)/html/random
-RANDOM_FILES = \
-	$(foreach n,1 2 3 4 5 6 7 8 9 10,2K.$n.html) \
-	$(foreach n,1 2 3 4 5,10K.$n.html) \
-	$(foreach n,1 2 3 4 5,100K.$n.html) \
-	$(foreach n,1 2 3,1M.$n.html) \
-	$(foreach n,1 2 3,10M.$n.html) \
-	$(foreach n,1 2 3,100.$n.html)
-
-TEST_DATA = $(addprefix $(RANDOM_DIR)/,$(RANDOM_FILES))
 
 # We need to first build and install nginx, otherwise nginx' makefiles think that they already
 # filled $(INSTALL_DIR)/html and skip copying installation files.


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
### Description of the problem

Commit aef087f "[[LibOS] Move trusted and allowed files logic to LibOS]" modified the Nginx `Makefile` after which it was observed that all the test data files (`install/html/random`) are generated after the manifest file generation and hence were not added as `sgx.trusted_files` in manifest.sgx file. 

Fixes #2016 
<!--
    If your PR fixes an issue, please remember to add "Fixes #2016"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
1. Git clone gramine repo `git clone https://github.com/gramineproject/gramine.git`.
2. Go to `CI-Examples/nginx` folder.
3. Execute `make SGX=1` command.
4. The test data files will be added as part of `sgx.trusted_files` within the manifest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2018)
<!-- Reviewable:end -->
