### PR TITLE
[PAL/Linux-SGX] AEX-Notify 4/5: Do not clobber RBX reg in stage-1 signal handler

### DIFF
--- a/pal/src/host/linux-sgx/enclave_entry.S
+++ b/pal/src/host/linux-sgx/enclave_entry.S
@@ -531,8 +531,8 @@ enclave_entry:
     movq %rdi, SGX_GPR_RIP(%rbx)
 
     # copy the whole SSA[0].XSAVE region to the CPU context's XSAVE on stack;
-    # __restore_xregs / __save_xregs clobber RDX so need to stash it in RBX
-    movq %rdx, %rbx
+    # __restore_xregs / __save_xregs clobber RDX so need to stash it in R10
+    movq %rdx, %r10
     movq %gs:SGX_SSA, %rdi
     leaq 1f(%rip), %r11
     jmp __restore_xregs
@@ -541,7 +541,7 @@ enclave_entry:
     leaq 2f(%rip), %r11
     jmp __save_xregs
 2:
-    movq %rbx, %rdx
+    movq %r10, %rdx
 
 .Lcssa1_exception_eexit:
     # .Lcssa0_ocall_or_cssa1_exception_eexit has an ABI that uses RSI, RDI, RSP; clear the relevant


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

**Part 4 in AEX-Notify series.**

If the enclave is entered with CSSA=1, then the enclave starts executing the stage-1 signal handler asssembly code. This assembly code prepares the context for the stage-2 signal handler, which will be executed in regular context with CSSA=0 and using C code.

This stage-1 signal handler uses the RBX register as a base pointer to the SSA[0].GPRSGX region. Closer to the end of the stage-1 handler flow, in particular before the `.Lcssa1_exception_eexit` label, this SSA[0] base pointer is not needed anymore, so the RBX register is used for other purposes. In particular, RBX is used to hold the stashed RDX value (where-to-exit address in untrusted runtime).

However, a future commit that will introduce AEX-Notify flows inside the enclave needs to access the SSA[0].GPRSGX region at this stage (in the `.Lcssa1_exception_eexit` label). So the RBX register must not be overwritten. Thus, this preparatory commit does not clobber RBX, but instead stashes RDX into another unused register, R10.

See also related PRs and discussions:
- #1530 
- #1531 
- #1948 

## How to test this PR? <!-- (if applicable) -->

CI is enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2036)
<!-- Reviewable:end -->
