### PR TITLE
Retire Dmitrii Kuvaiskii from active maintainers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Dmitrii Kuvaiskii <dmitrii.kuvaiskii@gmail.com> <dmitrii.kuvaiskii@intel.com>

--- a/Documentation/management-team.rst
+++ b/Documentation/management-team.rst
@@ -4,7 +4,6 @@ Management Team (Maintainers)
 The currently active members of the management team are:
 
 * Michał Kowalczyk (Invisible Things Lab/Intel)
-* Dmitrii Kuvaiskii (Intel)
 * Borys Popławski (Invisible Things Lab/Intel)
 * Wojtek Porczyk (Invisible Things Lab/Intel)
 * Don Porter (UNC)
@@ -14,6 +13,7 @@ The currently active members of the management team are:
 
 The past (inactive) members of the management team are:
 
+* Dmitrii Kuvaiskii
 * Paweł Marczewski
 * Rafał Wojdyła
 * Isaku Yamahata


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See commit message.

This PR should be merged at or around Friday, when Dmitrii's maintainership ends, WRT decision #2043 (proposed by Dmitrii himself).

The commit dates were doctored to 01.11.2024 00:00 UTC, please don't break that accidentally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2046)
<!-- Reviewable:end -->
