### PR TITLE
[CI-Examples] Drop hacks in Makefiles for old Make versions

### DIFF
--- a/CI-Examples/README.md
+++ b/CI-Examples/README.md
@@ -1,7 +1,7 @@
 # Example Integrations
 
-This folder contains application integration examples. They were tested on
-Ubuntu 18.04 and 20.04.
+This folder contains application integration examples. They are tested on
+Ubuntu 24.04 and 22.04.
 
 For instructions how to build and run each application under Gramine, please
 see the README.md in each subdirectory.

--- a/CI-Examples/blender/Makefile
+++ b/CI-Examples/blender/Makefile
@@ -50,13 +50,7 @@ blender.manifest: blender.manifest.template $(BLENDER_DIR)/blender | $(RUN_DIR)
 		-Dblender_ver=$(BLENDER_VER) \
 		$< >$@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-blender.sig blender.manifest.sgx: sgx_outputs
-	@:
-
-.INTERMEDIATE: sgx_outputs
-sgx_outputs: blender.manifest | $(RUN_DIR)
+blender.sig blender.manifest.sgx &: blender.manifest | $(RUN_DIR)
 	gramine-sgx-sign \
 		--output blender.manifest.sgx \
 		--manifest blender.manifest

--- a/CI-Examples/busybox/Makefile
+++ b/CI-Examples/busybox/Makefile
@@ -28,13 +28,7 @@ busybox.manifest: busybox.manifest.template
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< > $@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-busybox.manifest.sgx busybox.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: busybox.manifest
+busybox.manifest.sgx busybox.sig &: busybox.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/helloworld/Makefile
+++ b/CI-Examples/helloworld/Makefile
@@ -27,24 +27,7 @@ helloworld.manifest: helloworld.manifest.template helloworld
 		$< $@
 	gramine-manifest-check $@
 
-# gramine-sgx-sign generates both a .sig file and a .manifest.sgx file. This is somewhat
-# hard to express properly in Make. The simple solution would be to use
-# "Rules with Grouped Targets" (`&:`), however make on Ubuntu <= 20.04 doesn't support it.
-#
-# Simply using a normal rule with "two targets" is equivalent to creating separate rules
-# for each of the targets, and when using `make -j`, this might cause two instances
-# of gramine-sgx-sign to get launched simultaneously, potentially breaking the build.
-#
-# As a workaround, we use a dummy intermediate target, and mark both files as depending on it, to
-# get the dependency graph we want. We mark this dummy target as .INTERMEDIATE, which means
-# that make will consider the source tree up-to-date even if the sgx_sign file doesn't exist,
-# as long as the other dependencies check out. This is in contrast to .PHONY, which would
-# be rebuilt on every invocation of make.
-helloworld.sig helloworld.manifest.sgx: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: helloworld.manifest
+helloworld.sig helloworld.manifest.sgx &: helloworld.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/lighttpd/Makefile
+++ b/CI-Examples/lighttpd/Makefile
@@ -54,13 +54,7 @@ lighttpd.manifest: lighttpd.manifest.template $(INSTALL_DIR)/sbin/lighttpd
 		-Dinstall_dir=$(abspath $(INSTALL_DIR)) \
 		$< >$@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-lighttpd.manifest.sgx lighttpd.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: lighttpd.manifest
+lighttpd.manifest.sgx lighttpd.sig &: lighttpd.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/lighttpd/README.md
+++ b/CI-Examples/lighttpd/README.md
@@ -6,7 +6,7 @@ the Makefile and a template for generating the manifest.
 # Building lighttpd source
 
 For this example, we build lighttpd from source instead of using an existing
-binary. To build lighttpd on Ubuntu 20.04, please make sure that the following
+binary. To build lighttpd on Ubuntu 24.04, please make sure that the following
 packages are installed:
 
     sudo apt-get install -y build-essential libssl-dev zlib1g-dev

--- a/CI-Examples/memcached/Makefile
+++ b/CI-Examples/memcached/Makefile
@@ -39,13 +39,7 @@ memcached.manifest: memcached.manifest.template memcached
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< > $@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-memcached.manifest.sgx memcached.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: memcached.manifest
+memcached.manifest.sgx memcached.sig &: memcached.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/nginx/Makefile
+++ b/CI-Examples/nginx/Makefile
@@ -73,13 +73,7 @@ nginx.manifest: nginx.manifest.template $(INSTALL_DIR)/sbin/nginx \
 		-Dinstall_dir_abspath=$(abspath $(INSTALL_DIR)) \
 		$< >$@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-nginx.manifest.sgx nginx.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: nginx.manifest
+nginx.manifest.sgx nginx.sig &: nginx.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/nginx/README.md
+++ b/CI-Examples/nginx/README.md
@@ -4,7 +4,7 @@ This directory contains the Makefile and the template manifest for the most
 recent version of Nginx web server (as of this writing, version 1.16.1).
 
 We build Nginx from the source code instead of using an existing installation.
-On Ubuntu 20.04, please make sure that the following packages are installed:
+On Ubuntu 24.04, please make sure that the following packages are installed:
 ```sh
 sudo apt-get install -y build-essential libssl-dev zlib1g-dev
 ```

--- a/CI-Examples/python/Makefile
+++ b/CI-Examples/python/Makefile
@@ -29,13 +29,7 @@ python.manifest: python.manifest.template
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< >$@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-python.manifest.sgx python.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: python.manifest
+python.manifest.sgx python.sig &: python.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/ra-tls-mbedtls/Makefile
+++ b/CI-Examples/ra-tls-mbedtls/Makefile
@@ -65,13 +65,7 @@ server.manifest: server.manifest.template server
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$< > $@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-server.manifest.sgx server.sig: sgx_sign_server
-	@:
-
-.INTERMEDIATE: sgx_sign_server
-sgx_sign_server: server.manifest
+server.manifest.sgx server.sig &: server.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/ra-tls-secret-prov/Makefile
+++ b/CI-Examples/ra-tls-secret-prov/Makefile
@@ -87,13 +87,7 @@ secret_prov_minimal/client.manifest: secret_prov_minimal/client.manifest.templat
 		-Dra_client_linkable=$(RA_CLIENT_LINKABLE) \
 		$(notdir $<) > $(notdir $@)
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-secret_prov_minimal/client.manifest.sgx secret_prov_minimal/client.sig: sgx_sign_secret_prov_minimal_client
-	@:
-
-.INTERMEDIATE: sgx_sign_secret_prov_minimal_client
-sgx_sign_secret_prov_minimal_client: secret_prov_minimal/client.manifest
+secret_prov_minimal/client.manifest.sgx secret_prov_minimal/client.sig &: secret_prov_minimal/client.manifest
 	cd secret_prov_minimal && \
 	gramine-sgx-sign \
 		--manifest $(notdir $<) \

--- a/CI-Examples/redis/Makefile
+++ b/CI-Examples/redis/Makefile
@@ -79,16 +79,10 @@ redis-server.manifest: redis-server.manifest.template $(SRCDIR)/src/redis-server
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< > $@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-redis-server.sig redis-server.manifest.sgx: sgx_outputs
-	@:
-
 # Manifest for Gramine-SGX requires special "gramine-sgx-sign" procedure. This
 # procedure creates the final manifest.sgx file and an SGX-specific
 # redis-server.sig file (SIGSTRUCT object).
-.INTERMEDIATE: sgx_outputs
-sgx_outputs: redis-server.manifest
+redis-server.sig redis-server.manifest.sgx &: redis-server.manifest
 	gramine-sgx-sign \
 		--manifest redis-server.manifest \
 		--output redis-server.manifest.sgx

--- a/CI-Examples/rust/Makefile
+++ b/CI-Examples/rust/Makefile
@@ -32,13 +32,7 @@ rust-hyper-http-server.manifest: rust-hyper-http-server.manifest.template $(SELF
 		-Dself_exe=$(SELF_EXE) \
 		$< $@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-rust-hyper-http-server.manifest.sgx rust-hyper-http-server.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: rust-hyper-http-server.manifest
+rust-hyper-http-server.manifest.sgx rust-hyper-http-server.sig &: rust-hyper-http-server.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/CI-Examples/sqlite/Makefile
+++ b/CI-Examples/sqlite/Makefile
@@ -22,13 +22,7 @@ sqlite3.manifest: manifest.template
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< >$@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
-sqlite3.manifest.sgx sqlite3.sig: sgx_sign
-	@:
-
-.INTERMEDIATE: sgx_sign
-sgx_sign: sqlite3.manifest
+sqlite3.manifest.sgx sqlite3.sig &: sqlite3.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Part of the 20.04 deprecation - we can finally use modern and less buggy tools!

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2050)
<!-- Reviewable:end -->
