### PR TITLE
[LibOS] Fix memmgr free list performance bug

### DIFF
--- a/common/include/list.h
+++ b/common/include/list.h
@@ -280,6 +280,7 @@
          (CURSOR) != (HEAD)->first && (HEAD)->first; (CURSOR) = (TMP), (TMP) = (TMP)->FIELD.next)
 
 /* Assertion code written in Gramine project */
+#ifdef DEBUG
 #define CHECK_LIST_HEAD(TYPE, HEAD, FIELD)                               \
     do {                                                                 \
         TYPE pos;                                                        \
@@ -290,6 +291,9 @@
             assert(pos->FIELD.next->FIELD.prev == pos);                  \
         }                                                                \
     } while (0)
+#else
+#define CHECK_LIST_HEAD(TYPE, HEAD, FIELD) ((void)0)
+#endif
 
 // Add NEW to OLD at position first (assuming first is all we need for now)
 // Can probably drop TYPE with some preprocessor smarts


### PR DESCRIPTION
[LibOS] Fix memmgr free list performance bug

Fixes the memmgr performance bug described in #2033 by changing the `CHECK_LIST_HEAD` macro in `common/include/list.h` in release mode to `(void)0`.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

To fix the issue described in #2033, this PR surrounds the `CHECK_LIST_HEAD` macro defined in 
[common/include/list.h](https://github.com/gramineproject/gramine/blob/a08a455d7910dff7c202d61a19466cb049fc72fb/common/include/list.h) 
with `#ifdef DEBUG`. In release mode, the macro is now replaced with `(void)0`.

This macro is currently only used in `memmgr.h`. Thus, changing it directly was the simplest fix of the performance bug.

Fixes #2033

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2052)
<!-- Reviewable:end -->
