### PR TITLE
[python] Stop using deprecated cryptography.io's `backend` argument

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Depends:
  python3,
  python3 (>= 3.10) | python3-pkg-resources,
  python3-click (>= 6.7),
- python3-cryptography,
+ python3-cryptography (>= 3.1),
  python3-jinja2,
  python3-pyelftools,
  python3-tomli (>= 1.1.0),

--- a/gramine.spec
+++ b/gramine.spec
@@ -34,7 +34,7 @@ BuildRequires: python3-sphinx_rtd_theme
 %endif
 
 Requires: python3-click >= 6.7
-Requires: python3-cryptography
+Requires: python3-cryptography >= 3.1
 Requires: python3-jinja2
 Requires: python3-protobuf
 Requires: python3-pyelftools

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -37,7 +37,7 @@ makedepends="
     "
 depends="
     py3-click>=6.7
-    py3-cryptography
+    py3-cryptography>=3.1
     py3-elftools
     py3-jinja2
     py3-tomli

--- a/python/graminelibos/sgx_sign.py
+++ b/python/graminelibos/sgx_sign.py
@@ -14,7 +14,6 @@ import struct
 
 import click
 
-from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
@@ -25,10 +24,6 @@ from .manifest import Manifest
 from .sigstruct import Sigstruct
 
 import _graminelibos_offsets as offs # pylint: disable=import-error,wrong-import-order
-
-# TODO after deprecating 20.04: remove backend wrt
-# https://cryptography.io/en/latest/faq/#what-happened-to-the-backend-argument
-_cryptography_backend = backends.default_backend()
 
 # Default / Architectural Options
 
@@ -587,8 +582,7 @@ class InvalidKeyError(Exception):
 
 def load_private_key_from_pem_file(file, passphrase=None):
     with file:
-        private_key = serialization.load_pem_private_key(
-            file.read(), password=passphrase, backend=_cryptography_backend)
+        private_key = serialization.load_pem_private_key(file.read(), password=passphrase)
 
     if not isinstance(private_key, rsa.RSAPrivateKey):
         raise InvalidKeyError(
@@ -714,8 +708,7 @@ def generate_private_key():
     """
     return rsa.generate_private_key(
         public_exponent=SGX_RSA_PUBLIC_EXPONENT,
-        key_size=SGX_RSA_KEY_SIZE,
-        backend=_cryptography_backend)
+        key_size=SGX_RSA_KEY_SIZE)
 
 
 def generate_private_key_pem():

--- a/tests/test_sgx_sign.py
+++ b/tests/test_sgx_sign.py
@@ -12,15 +12,14 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 @pytest.fixture
 def tmp_rsa_key(tmpdir):
-    from graminelibos.sgx_sign import (SGX_RSA_KEY_SIZE, SGX_RSA_PUBLIC_EXPONENT,
-        _cryptography_backend)
+    from graminelibos.sgx_sign import SGX_RSA_KEY_SIZE, SGX_RSA_PUBLIC_EXPONENT
     def gen_rsa_key(passphrase=None, key_size=SGX_RSA_KEY_SIZE):
         # TODO: use `tmp_path` fixture after we drop support for distros (RHEL 8, CentOS Stream 8)
         # that have old pytest version (< 3.9.0) installed
         key_path = tmpdir.join('key.pem')
         with open(key_path, 'wb') as pfile:
             key = rsa.generate_private_key(public_exponent=SGX_RSA_PUBLIC_EXPONENT,
-                key_size=key_size, backend=_cryptography_backend)
+                key_size=key_size)
 
             encryption_algorithm = serialization.NoEncryption()
             if passphrase is not None:
@@ -35,9 +34,7 @@ def tmp_rsa_key(tmpdir):
 
 # pylint: disable=too-many-arguments
 def verify_signature(data, exponent, modulus, signature, key_file, passphrase=None):
-    from graminelibos.sgx_sign import _cryptography_backend
-    private_key = serialization.load_pem_private_key(key_file.read(), password=passphrase,
-        backend=_cryptography_backend)
+    private_key = serialization.load_pem_private_key(key_file.read(), password=passphrase)
 
     public_key = private_key.public_key()
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As in the title.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2053)
<!-- Reviewable:end -->
