### PR TITLE
Update README.md in RA-TLS secret provisioning example

### DIFF
--- a/CI-Examples/ra-tls-secret-prov/README.md
+++ b/CI-Examples/ra-tls-secret-prov/README.md
@@ -70,6 +70,21 @@ build time.
 
 # Quick Start
 
+> [!NOTE]
+> To obtain the values for `MRENCLAVE`, `MRSIGNER`, `ISV_PROD_ID`, and
+> `ISV_SVN`, you can run `gramine-sgx-sigstruct-view client.sig`.
+
+For testing purposes, you can set these values to `any` to skip verifying a
+particular measurement. This is useful when you want to quickly test the setup
+without worrying about the exact enclave measurements.
+
+```sh
+export RA_TLS_MRSIGNER=<MRSIGNER of the client enclave>
+export RA_TLS_MRENCLAVE=<MRENCLAVE of the client enclave>
+export RA_TLS_ISV_PROD_ID=<ISV_PROD_ID of the client enclave>
+export RA_TLS_ISV_SVN=<ISV_SVN of the client enclave>
+```
+
 For all examples, we set the following environment variables:
 ```sh
 export RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1
@@ -90,4 +105,9 @@ cd secret_prov_pf
 gramine-sgx ./client
 
 kill %%
+```
+- To run all the flows in one go, you can use the following command:
+
+```sh
+make check_dcap
 ```


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guidelines:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Updated `README.md` in `CI-Examples/ra-tls-secret-prov` to include:

- Setup instructions and commands for `RA_TLS_MRSIGNER`, `RA_TLS_MRENCLAVE`, `RA_TLS_ISV_PROD_ID`, and `RA_TLS_ISV_SVN` environment variables.
- Added `make check_dcap` command.

For more details, refer https://github.com/gramineproject/gramine/pull/1870

If this measurement variables are not set, you may face issues such as:
```
Allowing quote status SW_HARDENING_NEEDED
getenv_critical: ERROR: A required environment variable RA_TLS_MRSIGNER is not set.
client_connection: Secret Provisioning failed during mbedtls_ssl_handshake with error -12288
client_connection: ra_tls_verify_callback_results:
    attestation_scheme=2, err_loc=5, 
client_connection:     dcap.func_verify_quote_result=0x0, dcap.quote_verification_result=0xa007
make: *** [Makefile:189: check_dcap] Error 1
```
Following this [README](https://github.com/gramineproject/gramine/blob/master/CI-Examples/ra-tls-mbedtls/README.md)

## How to test this PR? <!-- (if applicable) -->
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2071)
<!-- Reviewable:end -->
