### PR TITLE
[Docs] Fix `--branch` magic to not collide variable with sphinx tags

### DIFF
--- a/.ci/docs.jenkinsfile
+++ b/.ci/docs.jenkinsfile
@@ -5,7 +5,14 @@ pipeline {
     stages {
         stage('build') {
             steps {
-                sh 'make -C Documentation html SPHINXOPTS="-W"'
+                sh '''
+                    cd Documentation
+                    git tag vTEST-FOR-DOCS-PIPELINE
+                    READTHEDOCS=1 READTHEDOCS_VERSION=stable make html SPHINXOPTS="-W"'
+                    make clean
+                    git tag -d vTEST-FOR-DOCS-PIPELINE
+                    make html SPHINXOPTS="-W"'
+                '''
             }
         }
     }

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -89,10 +89,10 @@ if 'READTHEDOCS' in os.environ:
     elif rtd_current_version == 'stable':
         # we don't have a version, we may be able to check from git
         try:
-            tags = [tag for tag in subprocess.check_output(
+            git_tags = [tag for tag in subprocess.check_output(
                     ['git', 'tag', '--points-at']).decode().strip().split()
                 if tag.startswith('v')]
-            rst_stable_checkout = f'--branch {tags.pop()}'
+            rst_stable_checkout = f'--branch {git_tags.pop()}'
         except (subprocess.CalledProcessError, IndexError):
             pass
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See commit message.
Fixes: #2066

## How to test this PR? <!-- (if applicable) -->

```sh
READTHEDOCS=1 READTHEDOCS_VERSION=stable make -C Documentation html
firefox Documentation/_build/html/run-sample-application.html
```
and look at the `git clone` invocation in the first listing. `make html` should be successful, but no `--branch` in the listing. Now:
```sh
make -C Documentation clean
git tag v123456-do-not-push
READTHEDOCS=1 READTHEDOCS_VERSION=stable make -C Documentation html
firefox Documentation/_build/html/run-sample-application.html
```
should succeed and have `--branch v123456-do-not-push` in the listing.

Remember to
```sh
git tag -d v123456-do-not-push
```
before you push.

(Before this commit `READTHEDOCS=... make` will fail as in https://readthedocs.org/projects/gramine/builds/26350000/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2073)
<!-- Reviewable:end -->
