### PR TITLE
[Docs] Add explicit path to conf.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,5 @@ python:
         - requirements: Documentation/requirements.txt
 
 sphinx:
-  fail_on_warning: true
+    configuration: Documentation/conf.py
+    fail_on_warning: true


### PR DESCRIPTION
See announcement:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

## How to test this PR? <!-- (if applicable) -->

Needs to build correctly in RTD, see https://readthedocs.org/projects/gramine/builds/

## Special considerations

This PR needs to be merged before 6.01.2024, or we risk failing documentation builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2077)
<!-- Reviewable:end -->
