### PR TITLE
[PAL,LibOS,common] Add file recovery support for encrypted files

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -1088,7 +1088,7 @@ Encrypted files
 ::
 
     fs.mounts = [
-      { type = "encrypted", path = "[PATH]", uri = "[URI]", key_name = "[KEY_NAME]" },
+      { type = "encrypted", path = "[PATH]", uri = "[URI]", key_name = "[KEY_NAME]", enable_recovery = [true|false] },
     ]
 
     fs.insecure__keys.[KEY_NAME] = "[32-character hex value]"
@@ -1153,6 +1153,12 @@ Gramine:
    and using the same key obtained via ``/dev/attestation/keys/_sgx_mrenclave``
    in the application is insecure. If you need to derive encryption keys from
    such a "doubly-used" key, you must apply a KDF.
+
+The ``enable_recovery`` mount parameter determines whether file recovery is
+enabled for the mount. If omitted, it defaults to ``false``. This feature allows
+selective enabling or disabling of recovery for different mounted files or
+directories. Note that enabling this feature can negatively impact performance,
+as it writes to a second shadow file for later recovery purposes on each flush.
 
 .. _untrusted-shared-memory:
 

--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -372,3 +372,6 @@ random bits, to obtain an attestation report and quote, etc.
 
 .. doxygenfunction:: PalFreeThenLazyReallocCommittedPages
    :project: pal
+
+.. doxygenfunction:: PalEncryptedFileRecovery
+   :project: pal

--- a/common/src/protected_files/protected_files.c
+++ b/common/src/protected_files/protected_files.c
@@ -429,6 +429,85 @@ static bool ipf_update_metadata_node(pf_context_t* pf) {
     return true;
 }
 
+static bool ipf_write_recovery_node(pf_context_t* pf, uint64_t physical_node_number,
+                                    const void* buffer, uint64_t offset) {
+    assert(pf->host_recovery_file_handle);
+
+    recovery_node_t recovery_node = { .physical_node_number = physical_node_number };
+    memcpy(recovery_node.bytes, buffer, PF_NODE_SIZE);
+
+    pf_status_t status = g_cb_write(pf->host_recovery_file_handle, (void*)&recovery_node, offset,
+                                    sizeof(recovery_node));
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    return true;
+}
+
+static bool ipf_write_recovery_file(pf_context_t* pf) {
+    assert(pf->host_recovery_file_handle);
+
+    uint64_t offset = 0;
+
+    pf_status_t status = g_cb_truncate(pf->host_recovery_file_handle, 0);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    void* node;
+    for (node = lruc_get_first(pf->cache); node != NULL; node = lruc_get_next(pf->cache)) {
+        file_node_t* file_node = (file_node_t*)node;
+        if (!file_node->need_writing)
+            continue;
+
+        if (!ipf_write_recovery_node(pf, file_node->physical_node_number, &file_node->encrypted,
+                                     offset))
+            return false;
+
+        offset += sizeof(recovery_node_t);
+    }
+
+    if (!ipf_write_recovery_node(pf, /*physical_node_number=*/1, &pf->root_mht_node.encrypted,
+                                 offset))
+        return false;
+
+    offset += sizeof(recovery_node_t);
+
+    if (!ipf_write_recovery_node(pf, /*physical_node_number=*/0, &pf->metadata_node, offset))
+        return false;
+
+    return true;
+}
+
+static bool ipf_set_update_flag(pf_context_t* pf) {
+    pf->metadata_node.plaintext_part.update_flag = 1;
+    bool ret = ipf_write_node(pf, /*physical_node_number=*/0, &pf->metadata_node);
+
+    /* Unset the `update_flag` in memory, which will be cleared on disk at the end of the flush when
+     * we write the metadata to disk. */
+    pf->metadata_node.plaintext_part.update_flag = 0;
+
+    return ret;
+}
+
+static bool ipf_clear_update_flag(pf_context_t* pf) {
+    assert(pf->metadata_node.plaintext_part.update_flag == 0);
+
+    if (!ipf_write_node(pf, /*physical_node_number=*/0, &pf->metadata_node))
+        return false;
+
+    pf_status_t status = g_cb_fsync(pf->host_file_handle);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    return true;
+}
+
 static bool ipf_internal_flush(pf_context_t* pf) {
     if (!pf->need_writing) {
         DEBUG_PF("no need to write");
@@ -436,11 +515,25 @@ static bool ipf_internal_flush(pf_context_t* pf) {
     }
 
     if (pf->metadata_decrypted.file_size > MD_USER_DATA_SIZE && pf->root_mht_node.need_writing) {
+        if (pf->host_recovery_file_handle) {
+            if (!ipf_write_recovery_file(pf)) {
+                pf->file_status = PF_STATUS_FLUSH_ERROR;
+                DEBUG_PF("failed to write changes to the recovery file");
+                return false;
+            }
+
+            if (!ipf_set_update_flag(pf)) {
+                pf->file_status = PF_STATUS_FLUSH_ERROR;
+                DEBUG_PF("failed to set the update flag");
+                return false;
+            }
+        }
+
         if (!ipf_update_all_data_and_mht_nodes(pf)) {
             // this is something that shouldn't happen, can't fix this...
             pf->file_status = PF_STATUS_CRYPTO_ERROR;
             DEBUG_PF("failed to update data and MHT nodes");
-            return false;
+            goto unrecoverable_error;
         }
     }
 
@@ -448,17 +541,23 @@ static bool ipf_internal_flush(pf_context_t* pf) {
         // this is something that shouldn't happen, can't fix this...
         pf->file_status = PF_STATUS_CRYPTO_ERROR;
         DEBUG_PF("failed to update metadata node");
-        return false;
+        goto unrecoverable_error;
     }
 
     if (!ipf_write_all_changes_to_disk(pf)) {
         pf->file_status = PF_STATUS_WRITE_TO_DISK_FAILED;
         DEBUG_PF("failed to write changes to disk");
-        return false;
+        goto recoverable_error;
     }
 
     pf->need_writing = false;
     return true;
+
+unrecoverable_error:
+    if (pf->host_recovery_file_handle)
+        (void)ipf_clear_update_flag(pf);
+recoverable_error:
+    return false;
 }
 
 static file_node_t* ipf_get_mht_node(pf_context_t* pf, uint64_t offset) {
@@ -751,6 +850,7 @@ static bool ipf_init_fields(pf_context_t* pf) {
     ipf_init_root_mht(&pf->root_mht_node);
 
     pf->host_file_handle = NULL;
+    pf->host_recovery_file_handle = NULL;
     pf->need_writing     = false;
     pf->file_status      = PF_STATUS_UNINITIALIZED;
     pf->last_error       = PF_STATUS_SUCCESS;
@@ -852,7 +952,8 @@ static void ipf_try_clear_error(pf_context_t* pf) {
 }
 
 static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create, pf_handle_t file,
-                              uint64_t real_size, const pf_key_t* kdk_key, pf_status_t* status) {
+                              uint64_t real_size, const pf_key_t* kdk_key,
+                              pf_handle_t recovery_file_handle, pf_status_t* status) {
     *status = PF_STATUS_NO_MEMORY;
     pf_context_t* pf = calloc(1, sizeof(*pf));
 
@@ -891,6 +992,8 @@ static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create
 
     pf->host_file_handle = file;
     pf->mode = mode;
+
+    pf->host_recovery_file_handle = recovery_file_handle;
 
     if (!create) {
         if (!ipf_init_existing_file(pf, path))
@@ -1126,12 +1229,14 @@ void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_fsync_f fsync_f,
 }
 
 pf_status_t pf_open(pf_handle_t handle, const char* path, uint64_t underlying_size,
-                    pf_file_mode_t mode, bool create, const pf_key_t* key, pf_context_t** context) {
+                    pf_file_mode_t mode, bool create, const pf_key_t* key,
+                    pf_handle_t recovery_file_handle, pf_context_t** context) {
     if (!g_initialized)
         return PF_STATUS_UNINITIALIZED;
 
     pf_status_t status;
-    *context = ipf_open(path, mode, create, handle, underlying_size, key, &status);
+    *context = ipf_open(path, mode, create, handle, underlying_size, key, recovery_file_handle,
+                        &status);
     return status;
 }
 
@@ -1294,6 +1399,26 @@ pf_status_t pf_flush(pf_context_t* pf) {
         pf->last_error = status;
         return pf->last_error;
     }
+
+    return PF_STATUS_SUCCESS;
+}
+
+pf_status_t pf_get_recovery_info(pf_context_t* pf, bool* recovery_needed, size_t* pos_size,
+                                 size_t* node_size) {
+    if (recovery_needed) {
+        // read metadata node
+        if (!ipf_read_node(pf, /*physical_node_number=*/0, (uint8_t*)&pf->metadata_node))
+            return pf->last_error;
+
+        *recovery_needed = (pf->metadata_node.plaintext_part.update_flag == 1);
+    }
+
+    if (pos_size)
+        *pos_size = sizeof(((recovery_node_t*)0)->physical_node_number);
+
+
+    if (node_size)
+        *node_size = sizeof(((recovery_node_t*)0)->bytes);
 
     return PF_STATUS_SUCCESS;
 }

--- a/common/src/protected_files/protected_files.h
+++ b/common/src/protected_files/protected_files.h
@@ -212,19 +212,21 @@ const char* pf_strerror(int err);
 /*!
  * \brief Open a protected file.
  *
- * \param      handle           Open underlying file handle.
- * \param      path             Path to the file. If NULL and \p create is false, don't check path
- *                              for validity.
- * \param      underlying_size  Underlying file size.
- * \param      mode             Access mode.
- * \param      create           Overwrite file contents if true.
- * \param      key              Wrap key.
- * \param[out] context          PF context for later calls.
+ * \param      handle                Open underlying file handle.
+ * \param      path                  Path to the file. If NULL and \p create is false, don't check path
+ *                                   for validity.
+ * \param      underlying_size       Underlying file size.
+ * \param      mode                  Access mode.
+ * \param      create                Overwrite file contents if true.
+ * \param      key                   Wrap key.
+ * \param      recovery_file_handle  (optional)Underlying recovery file handle.
+ * \param[out] context               PF context for later calls.
  *
  * \returns PF status.
  */
 pf_status_t pf_open(pf_handle_t handle, const char* path, uint64_t underlying_size,
-                    pf_file_mode_t mode, bool create, const pf_key_t* key, pf_context_t** context);
+                    pf_file_mode_t mode, bool create, const pf_key_t* key,
+                    pf_handle_t recovery_file_handle, pf_context_t** context);
 
 /*!
  * \brief Close a protected file and commit all changes to disk.
@@ -302,3 +304,16 @@ pf_status_t pf_rename(pf_context_t* pf, const char* new_path);
  * \returns PF status.
  */
 pf_status_t pf_flush(pf_context_t* pf);
+
+/*!
+ * \brief Check whether a PF needs recovery.
+ *
+ * \param      pf               PF context.
+ * \param[out] recovery_needed  (optional)Whether recovery is needed for \p pf.
+ * \param[out] pos_size         (optional)Size of the \p pf node position.
+ * \param[out] node_size        (optional)Size of the \p pf node data.
+ *
+ * \returns PF status.
+ */
+pf_status_t pf_get_recovery_info(pf_context_t* pf, bool* recovery_needed, size_t* pos_size,
+                                 size_t* node_size);

--- a/common/src/protected_files/protected_files_format.h
+++ b/common/src/protected_files/protected_files_format.h
@@ -56,6 +56,7 @@ typedef struct {
     uint8_t    minor_version;
     pf_nonce_t metadata_key_nonce;
     pf_mac_t   metadata_mac; /* GCM mac */
+    uint8_t    update_flag; /* for file recovery */
 } metadata_plaintext_t;
 
 typedef struct {
@@ -94,6 +95,11 @@ typedef struct {
     uint8_t bytes[PF_NODE_SIZE];
 } encrypted_node_t;
 static_assert(sizeof(encrypted_node_t) == PF_NODE_SIZE, "sizeof(encrypted_node_t)");
+
+typedef struct {
+    uint64_t physical_node_number;
+    uint8_t bytes[PF_NODE_SIZE];
+} recovery_node_t;
 
 static_assert(sizeof(mht_node_t) == sizeof(data_node_t), "sizes of MHT and data nodes differ");
 

--- a/common/src/protected_files/protected_files_internal.h
+++ b/common/src/protected_files/protected_files_internal.h
@@ -17,6 +17,9 @@ struct pf_context {
     pf_file_mode_t mode;           // read-only, write-only or read-write
     bool need_writing;             // whether file was modified and thus needs writing to storage
 
+    pf_handle_t host_recovery_file_handle;  // opaque recovery file handle (e.g. PAL handle) used by
+                                            // callbacks
+
     pf_status_t file_status;       // PF_STATUS_SUCCESS, PF_STATUS_CRYPTO_ERROR, etc.
     pf_status_t last_error;        // FIXME: unclear why this is needed
 

--- a/libos/include/libos_fs.h
+++ b/libos/include/libos_fs.h
@@ -62,6 +62,10 @@ struct libos_mount_params {
 
     /* Key name (used by `chroot_encrypted` filesystem), or NULL if not applicable */
     const char* key_name;
+
+    /* Whether to enable file recovery (used by `chroot_encrypted` filesystem), false if not
+     * applicable */
+    bool enable_recovery;
 };
 
 struct libos_fs_ops {
@@ -531,6 +535,8 @@ struct libos_mount {
     struct libos_dentry* root;
 
     void* data;
+
+    bool enable_recovery;
 
     void* cpdata;
     size_t cpsize;

--- a/libos/include/libos_fs_encrypted.h
+++ b/libos/include/libos_fs_encrypted.h
@@ -17,7 +17,10 @@
 #include "libos_types.h"
 #include "list.h"
 #include "pal.h"
+#include "perm.h"
 #include "protected_files.h"
+
+#define RECOVERY_FILE_PERM_RW PERM_rw_rw_rw_
 
 /*
  * Represents a named key for opening files. The key might not be set yet: value of a key can be
@@ -49,6 +52,11 @@ struct libos_encrypted_file {
     /* `pf` and `pal_handle` are non-null as long as `use_count` is greater than 0 */
     pf_context_t* pf;
     PAL_HANDLE pal_handle;
+
+    /* `recovery_file_pal_handle` is non-null as long as `enable_recovery` is true and `use_count`
+     * is greater than 0 */
+    bool enable_recovery;
+    PAL_HANDLE recovery_file_pal_handle;
 };
 
 /*
@@ -109,31 +117,33 @@ void update_encrypted_files_key(struct libos_encrypted_files_key* key, const pf_
 /*
  * \brief Open an existing encrypted file.
  *
- * \param      uri      PAL URI to open, has to begin with "file:".
- * \param      key      Key, has to be already set.
- * \param[out] out_enc  On success, set to a newly created `libos_encrypted_file` object.
+ * \param      uri              PAL URI to open, has to begin with "file:".
+ * \param      key              Key, has to be already set.
+ * \param      enable_recovery  Whether to enable file recovery.
+ * \param[out] out_enc          On success, set to a newly created `libos_encrypted_file` object.
  *
  * `uri` has to correspond to an existing file that can be decrypted with `key`.
  *
  * The newly created `libos_encrypted_file` object will have `use_count` set to 1.
  */
 int encrypted_file_open(const char* uri, struct libos_encrypted_files_key* key,
-                        struct libos_encrypted_file** out_enc);
+                        bool enable_recovery, struct libos_encrypted_file** out_enc);
 
 /*
  * \brief Create a new encrypted file.
  *
- * \param      uri      PAL URI to open, has to begin with "file:".
- * \param      perm     Permissions for the new file.
- * \param      key      Key, has to be already set.
- * \param[out] out_enc  On success, set to a newly created `libos_encrypted_file` object.
+ * \param      uri              PAL URI to open, has to begin with "file:".
+ * \param      perm             Permissions for the new file.
+ * \param      key              Key, has to be already set.
+ * \param      enable_recovery  Whether to enable file recovery.
+ * \param[out] out_enc          On success, set to a newly created `libos_encrypted_file` object.
  *
  * `uri` must not correspond to an existing file.
  *
  * The newly created `libos_encrypted_file` object will have `use_count` set to 1.
  */
 int encrypted_file_create(const char* uri, mode_t perm, struct libos_encrypted_files_key* key,
-                          struct libos_encrypted_file** out_enc);
+                          bool enable_recovery, struct libos_encrypted_file** out_enc);
 
 /*
  * \brief Deallocate an encrypted file.

--- a/libos/src/fs/chroot/encrypted.c
+++ b/libos/src/fs/chroot/encrypted.c
@@ -154,7 +154,7 @@ static int chroot_encrypted_lookup(struct libos_dentry* dent) {
         file_off_t size;
 
         struct libos_encrypted_files_key* key = dent->mount->data;
-        ret = encrypted_file_open(uri, key, &enc);
+        ret = encrypted_file_open(uri, key, dent->mount->enable_recovery, &enc);
         if (ret < 0) {
             if (ret == -EACCES) {
                 /* allow the inode to be created even if the underlying encrypted file is corrupted;
@@ -233,7 +233,7 @@ static int chroot_encrypted_creat(struct libos_handle* hdl, struct libos_dentry*
 
     struct libos_encrypted_files_key* key = dent->mount->data;
     struct libos_encrypted_file* enc;
-    ret = encrypted_file_create(uri, HOST_PERM(perm), key, &enc);
+    ret = encrypted_file_create(uri, HOST_PERM(perm), key, dent->mount->enable_recovery, &enc);
     if (ret < 0)
         goto out;
 

--- a/libos/src/fs/libos_fs_encrypted.c
+++ b/libos/src/fs/libos_fs_encrypted.c
@@ -165,6 +165,8 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
 
     int ret;
     char* normpath = NULL;
+    PAL_HANDLE recovery_file_pal_handle = NULL;
+    bool maybe_recovery_needed = !create && enc->enable_recovery && !pal_handle;
 
     if (!pal_handle) {
         enum pal_create_mode create_mode = create ? PAL_CREATE_ALWAYS : PAL_CREATE_NEVER;
@@ -174,7 +176,32 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
             log_warning("PalStreamOpen failed: %s", pal_strerror(ret));
             return pal_to_unix_errno(ret);
         }
+
+        if (enc->enable_recovery) {
+            const char* recovery_file_suffix = "_gramine_recovery";
+            size_t uri_len = strlen(enc->uri);
+            size_t suffix_len = strlen(recovery_file_suffix);
+            size_t recovery_file_uri_len = uri_len + suffix_len + 1;
+            char* recovery_file_uri = malloc(recovery_file_uri_len);
+            if (!recovery_file_uri) {
+                ret = -ENOMEM;
+                goto out;
+            }
+            memcpy(recovery_file_uri, enc->uri, uri_len);
+            memcpy(recovery_file_uri + uri_len, recovery_file_suffix, suffix_len);
+            recovery_file_uri[uri_len + suffix_len] = '\0';
+
+            ret = PalStreamOpen(recovery_file_uri, PAL_ACCESS_RDWR, RECOVERY_FILE_PERM_RW,
+                                PAL_CREATE_TRY, /*options=*/0, &recovery_file_pal_handle);
+            free(recovery_file_uri);
+            if (ret < 0) {
+                log_warning("PalStreamOpen failed: %s", pal_strerror(ret));
+                ret = pal_to_unix_errno(ret);
+                goto out;
+            }
+        }
     }
+    assert(enc->enable_recovery == (recovery_file_pal_handle != NULL));
 
     PAL_STREAM_ATTR pal_attr;
     ret = PalStreamAttributesQueryByHandle(pal_handle, &pal_attr);
@@ -209,7 +236,7 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
         goto out;
     }
     pf_status_t pfs = pf_open(pal_handle, normpath, size, PF_FILE_MODE_READ | PF_FILE_MODE_WRITE,
-                              create, &enc->key->pf_key, &pf);
+                              create, &enc->key->pf_key, recovery_file_pal_handle, &pf);
     unlock(&g_keys_lock);
     if (PF_FAILURE(pfs)) {
         log_warning("pf_open failed: %s", pf_strerror(pfs));
@@ -217,13 +244,56 @@ static int encrypted_file_internal_open(struct libos_encrypted_file* enc, PAL_HA
         goto out;
     }
 
+    if (maybe_recovery_needed) {
+        bool recovery_needed;
+        size_t node_size;
+        size_t pos_size;
+        pfs = pf_get_recovery_info(pf, &recovery_needed, &pos_size, &node_size);
+        if (PF_FAILURE(pfs)) {
+            log_warning("get file recovery info failed: %s", pf_strerror(pfs));
+            ret = -EACCES;
+            goto out;
+        }
+
+        if (recovery_needed) {
+            log_debug("starting file recovery");
+
+            ret = PalEncryptedFileRecovery(pal_handle, recovery_file_pal_handle, pos_size,
+                                           node_size);
+            if (ret < 0) {
+                log_warning("PalEncryptedFileRecovery failed: %s", pal_strerror(ret));
+                ret = pal_to_unix_errno(ret);
+                goto out;
+            }
+
+            pfs = pf_get_recovery_info(pf, &recovery_needed, /*pos_size=*/NULL, /*node_size=*/NULL);
+            if (PF_FAILURE(pfs)) {
+                log_warning("get file recovery info: %s", pf_strerror(pfs));
+                ret = -EACCES;
+                goto out;
+            }
+
+            if (recovery_needed) {
+                log_warning("file recovery needed but failed");
+                ret = -EACCES;
+                goto out;
+            }
+
+            log_debug("file recovery completed");
+        }
+    }
+
     enc->pf = pf;
     enc->pal_handle = pal_handle;
+    enc->recovery_file_pal_handle = recovery_file_pal_handle;
     ret = 0;
 out:
     free(normpath);
-    if (ret < 0)
+    if (ret < 0) {
         PalObjectDestroy(pal_handle);
+        if (recovery_file_pal_handle)
+            PalObjectDestroy(recovery_file_pal_handle);
+    }
     return ret;
 }
 
@@ -251,11 +321,19 @@ static void encrypted_file_internal_close(struct libos_encrypted_file* enc) {
     pf_status_t pfs = pf_close(enc->pf);
     if (PF_FAILURE(pfs)) {
         log_warning("pf_close failed: %s", pf_strerror(pfs));
+        goto out;
     }
 
+    if (enc->recovery_file_pal_handle)
+        (void)PalStreamDelete(enc->recovery_file_pal_handle, PAL_DELETE_ALL);
+
+out:
     enc->pf = NULL;
     PalObjectDestroy(enc->pal_handle);
     enc->pal_handle = NULL;
+    if (enc->recovery_file_pal_handle)
+        PalObjectDestroy(enc->recovery_file_pal_handle);
+    enc->recovery_file_pal_handle = NULL;
     return;
 }
 
@@ -446,7 +524,7 @@ void update_encrypted_files_key(struct libos_encrypted_files_key* key, const pf_
 }
 
 static int encrypted_file_alloc(const char* uri, struct libos_encrypted_files_key* key,
-                                struct libos_encrypted_file** out_enc) {
+                                bool enable_recovery, struct libos_encrypted_file** out_enc) {
     assert(strstartswith(uri, URI_PREFIX_FILE));
 
     if (!key) {
@@ -467,14 +545,18 @@ static int encrypted_file_alloc(const char* uri, struct libos_encrypted_files_ke
     enc->use_count = 0;
     enc->pf = NULL;
     enc->pal_handle = NULL;
+
+    enc->enable_recovery = enable_recovery;
+    enc->recovery_file_pal_handle = NULL;
+
     *out_enc = enc;
     return 0;
 }
 
 int encrypted_file_open(const char* uri, struct libos_encrypted_files_key* key,
-                        struct libos_encrypted_file** out_enc) {
+                        bool enable_recovery, struct libos_encrypted_file** out_enc) {
     struct libos_encrypted_file* enc;
-    int ret = encrypted_file_alloc(uri, key, &enc);
+    int ret = encrypted_file_alloc(uri, key, enable_recovery, &enc);
     if (ret < 0)
         return ret;
 
@@ -490,9 +572,9 @@ int encrypted_file_open(const char* uri, struct libos_encrypted_files_key* key,
 }
 
 int encrypted_file_create(const char* uri, mode_t perm, struct libos_encrypted_files_key* key,
-                          struct libos_encrypted_file** out_enc) {
+                          bool enable_recovery, struct libos_encrypted_file** out_enc) {
     struct libos_encrypted_file* enc;
-    int ret = encrypted_file_alloc(uri, key, &enc);
+    int ret = encrypted_file_alloc(uri, key, enable_recovery, &enc);
     if (ret < 0)
         return ret;
 
@@ -510,6 +592,7 @@ void encrypted_file_destroy(struct libos_encrypted_file* enc) {
     assert(enc->use_count == 0);
     assert(!enc->pf);
     assert(!enc->pal_handle);
+    assert(!enc->recovery_file_pal_handle);
     free(enc->uri);
     free(enc);
 }
@@ -762,6 +845,8 @@ BEGIN_CP_FUNC(encrypted_file) {
     new_enc = (struct libos_encrypted_file*)(base + off);
 
     new_enc->use_count = enc->use_count;
+    new_enc->enable_recovery = enc->enable_recovery;
+
     DO_CP_MEMBER(str, enc, new_enc, uri);
 
     lock(&g_keys_lock);
@@ -775,6 +860,12 @@ BEGIN_CP_FUNC(encrypted_file) {
         struct libos_palhdl_entry* entry;
         DO_CP(palhdl_ptr, &enc->pal_handle, &entry);
         entry->phandle = &new_enc->pal_handle;
+    }
+
+    if (enc->recovery_file_pal_handle) {
+        struct libos_palhdl_entry* entry;
+        DO_CP(palhdl_ptr, &enc->recovery_file_pal_handle, &entry);
+        entry->phandle = &new_enc->recovery_file_pal_handle;
     }
     ADD_CP_FUNC_ENTRY(off);
 

--- a/libos/test/fs/manifest.template
+++ b/libos/test/fs/manifest.template
@@ -11,7 +11,7 @@ fs.mounts = [
   { path = "/mounted", uri = "file:tmp" },
 
   { type = "encrypted", path = "/tmp/enc_input", uri = "file:tmp/enc_input" },
-  { type = "encrypted", path = "/tmp/enc_output", uri = "file:tmp/enc_output" },
+  { type = "encrypted", path = "/tmp/enc_output", uri = "file:tmp/enc_output", enable_recovery = true },
   { type = "encrypted", path = "/mounted/enc_input", uri = "file:tmp/enc_input" },
   { type = "encrypted", path = "/mounted/enc_output", uri = "file:tmp/enc_output" },
   { type = "tmpfs", path = "/mnt-tmpfs" },

--- a/pal/include/host/linux-common/linux_utils.h
+++ b/pal/include/host/linux-common/linux_utils.h
@@ -55,3 +55,5 @@ void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat);
 int create_reserved_mem_ranges_fd(void* reserved_mem_ranges, size_t reserved_mem_ranges_size);
 
 void probe_stack(size_t pages_count);
+
+int encrypted_file_recovery(int file_fd, int recovery_file_fd, size_t pos_size, size_t node_size);

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -1043,4 +1043,17 @@ void PalGetLazyCommitPages(uintptr_t addr, size_t size, uint8_t* bitvector);
  */
 int PalFreeThenLazyReallocCommittedPages(void* addr, size_t size);
 
+/*!
+ * \brief Recover an encrypted file.
+ *
+ * \param handle     Handle to the file.
+ * \param handle     Handle to the recovery file.
+ * \param pos_size   Size of the pf node position.
+ * \param node_size  Size of the pf node data.
+ *
+ * \returns 0 on success, negative error code on failure.
+ */
+int PalEncryptedFileRecovery(PAL_HANDLE file_handle, PAL_HANDLE recovery_file_handle,
+                             size_t pos_size, size_t node_size);
+
 #undef INSIDE_PAL_H

--- a/pal/include/pal_internal.h
+++ b/pal/include/pal_internal.h
@@ -318,3 +318,6 @@ extern int (*g_mem_bkeep_get_vma_info_upcall)(uintptr_t addr, pal_prot_flags_t* 
 
 void _PalGetLazyCommitPages(uintptr_t addr, size_t size, uint8_t* bitvector);
 int _PalFreeThenLazyReallocCommittedPages(void* addr, uint64_t size);
+
+int _PalEncryptedFileRecovery(PAL_HANDLE file_handle, PAL_HANDLE recovery_file_handle,
+                              size_t pos_size, size_t node_size);

--- a/pal/src/host/linux-sgx/enclave_ocalls.h
+++ b/pal/src/host/linux-sgx/enclave_ocalls.h
@@ -140,3 +140,5 @@ int ocall_get_qe_targetinfo(sgx_target_info_t* qe_targetinfo);
 int ocall_edmm_restrict_pages_perm(uint64_t addr, size_t count, uint64_t prot);
 int ocall_edmm_modify_pages_type(uint64_t addr, size_t count, uint64_t type);
 int ocall_edmm_remove_pages(uint64_t addr, size_t count);
+
+int ocall_encrypted_file_recovery(int fd, int recovery_fd, size_t pos_size, size_t node_size);

--- a/pal/src/host/linux-sgx/host_ocalls.c
+++ b/pal/src/host/linux-sgx/host_ocalls.c
@@ -737,6 +737,11 @@ static long sgx_ocall_edmm_restrict_pages_perm(void* _args) {
     return edmm_restrict_pages_perm(args->addr, args->count, args->prot);
 }
 
+static long sgx_ocall_encrypted_file_recovery(void* _args) {
+    struct ocall_encrypted_file_recovery* args = _args;
+    return encrypted_file_recovery(args->fd, args->recovery_fd, args->pos_size, args->node_size);
+}
+
 sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_EXIT]                     = sgx_ocall_exit,
     [OCALL_MMAP_UNTRUSTED]           = sgx_ocall_mmap_untrusted,
@@ -788,6 +793,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_EDMM_MODIFY_PAGES_TYPE]   = sgx_ocall_edmm_modify_pages_type,
     [OCALL_EDMM_REMOVE_PAGES]        = sgx_ocall_edmm_remove_pages,
     [OCALL_EDMM_RESTRICT_PAGES_PERM] = sgx_ocall_edmm_restrict_pages_perm,
+    [OCALL_ENCRYPTED_FILE_RECOVERY]  = sgx_ocall_encrypted_file_recovery,
 };
 
 static int rpc_thread_loop(void* arg) {

--- a/pal/src/host/linux-sgx/pal_misc.c
+++ b/pal/src/host/linux-sgx/pal_misc.c
@@ -897,3 +897,13 @@ int _PalFreeThenLazyReallocCommittedPages(void* addr, uint64_t size) {
 
     return 0;
 }
+
+int _PalEncryptedFileRecovery(PAL_HANDLE file_handle, PAL_HANDLE recovery_file_handle,
+                              size_t pos_size, size_t node_size) {
+    int ret = ocall_encrypted_file_recovery(file_handle->file.fd, recovery_file_handle->file.fd,
+                                            pos_size, node_size);
+    if (ret < 0)
+        return unix_to_pal_error(ret);
+
+    return 0;
+}

--- a/pal/src/host/linux-sgx/pal_ocall_types.h
+++ b/pal/src/host/linux-sgx/pal_ocall_types.h
@@ -74,6 +74,7 @@ enum {
     OCALL_EDMM_RESTRICT_PAGES_PERM,
     OCALL_EDMM_MODIFY_PAGES_TYPE,
     OCALL_EDMM_REMOVE_PAGES,
+    OCALL_ENCRYPTED_FILE_RECOVERY,
     OCALL_NR,
 };
 
@@ -361,6 +362,13 @@ struct ocall_edmm_modify_pages_type {
 struct ocall_edmm_remove_pages {
     uint64_t addr;
     size_t count;
+};
+
+struct ocall_encrypted_file_recovery {
+    int fd;
+    int recovery_fd;
+    size_t pos_size;
+    size_t node_size;
 };
 
 #pragma pack(pop)

--- a/pal/src/host/linux/pal_misc.c
+++ b/pal/src/host/linux/pal_misc.c
@@ -101,3 +101,13 @@ int _PalFreeThenLazyReallocCommittedPages(void* addr, size_t size) {
     int ret = DO_SYSCALL(madvise, addr, size, MADV_DONTNEED);
     return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
+
+int _PalEncryptedFileRecovery(PAL_HANDLE file_handle, PAL_HANDLE recovery_file_handle,
+                              size_t pos_size, size_t node_size) {
+    int ret = encrypted_file_recovery(file_handle->file.fd, recovery_file_handle->file.fd, pos_size,
+                                      node_size);
+    if (ret < 0)
+        return unix_to_pal_error(ret);
+
+    return 0;
+}

--- a/pal/src/host/skeleton/pal_misc.c
+++ b/pal/src/host/skeleton/pal_misc.c
@@ -82,3 +82,12 @@ int _PalFreeThenLazyReallocCommittedPages(void* addr, uint64_t size) {
     __UNUSED(size);
     return PAL_ERROR_NOTIMPLEMENTED;
 }
+
+int _PalEncryptedFileRecovery(PAL_HANDLE file_handle, PAL_HANDLE recovery_file_handle,
+                              size_t pos_size, size_t node_size) {
+    __UNUSED(file_handle);
+    __UNUSED(recovery_file_handle);
+    __UNUSED(pos_size);
+    __UNUSED(node_size);
+    return 0;
+}

--- a/pal/src/pal_misc.c
+++ b/pal/src/pal_misc.c
@@ -67,3 +67,10 @@ int PalFreeThenLazyReallocCommittedPages(void* addr, size_t size) {
 
     return _PalFreeThenLazyReallocCommittedPages(addr, size);
 }
+
+int PalEncryptedFileRecovery(PAL_HANDLE file_handle, PAL_HANDLE recovery_file_handle,
+                             size_t pos_size, size_t node_size) {
+    assert(file_handle && recovery_file_handle);
+
+    return _PalEncryptedFileRecovery(file_handle, recovery_file_handle, pos_size, node_size);
+}

--- a/pal/src/pal_symbols
+++ b/pal/src/pal_symbols
@@ -54,3 +54,4 @@ PalDebugLog
 PalGetPalPublicState
 PalGetLazyCommitPages
 PalFreeThenLazyReallocCommittedPages
+PalEncryptedFileRecovery

--- a/python/graminelibos/manifest_check.py
+++ b/python/graminelibos/manifest_check.py
@@ -30,6 +30,7 @@ _fs_base = (
         Required('type'): 'encrypted',
         Required('uri'): _uri,
         'key_name': str,
+        'enable_recovery': bool,
     },
     {
         Required('type'): 'tmpfs',

--- a/tools/sgx/common/pf_util.c
+++ b/tools/sgx/common/pf_util.c
@@ -330,7 +330,7 @@ int pf_encrypt_file(const char* input_path, const char* output_path, const pf_ke
 
     pf_handle_t handle = (pf_handle_t)&output;
     pf_status_t pfs = pf_open(handle, norm_output_path, /*size=*/0, PF_FILE_MODE_WRITE,
-                              /*create=*/true, wrap_key, &pf);
+                              /*create=*/true, wrap_key, /*recovery_file_handle=*/NULL, &pf);
     if (PF_FAILURE(pfs)) {
         ERROR("Failed to open output PF: %s\n", pf_strerror(pfs));
         goto out;
@@ -438,7 +438,7 @@ int pf_decrypt_file(const char* input_path, const char* output_path, bool verify
     }
 
     pf_status_t pfs = pf_open((pf_handle_t)&input, norm_input_path, input_size, PF_FILE_MODE_READ,
-                              /*create=*/false, wrap_key, &pf);
+                              /*create=*/false, wrap_key, /*recovery_file_handle=*/NULL, &pf);
     if (PF_FAILURE(pfs)) {
         ERROR("Opening protected input file failed: %s\n", pf_strerror(pfs));
         goto out;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously, a fatal error during writes to encrypted files could cause file corruption due to incorrect GMACs and/or encryption keys.

To address this, we introduce a file recovery mechanism using a "shadow" recovery file that stores data about to change and an update flag in the metadata node indicating the start of a write transaction. During file flush, all cached blocks that are about to change are saved to the recovery file in the format of physical node numbers (offsets) plus encrypted block data. Before saving the main file contents, the `update_flag` is set in the file's metadata node and cleared only when the transaction is complete. If an encrypted file is opened and the `update_flag` is set, a recovery process starts to revert partial changes using the recovery file, returning to the last known good state. The "shadow" recovery file is cleaned up on file close.

This commit adds a new mount parameter `enable_recovery = [true|false]` for encrypted files mounts to optionally enable this feature. We extend the file flush logic of protected files (pf) to include the recovery file dump and the setting/unsetting of the update flag. We make changes to the public pf APIs: the `pf_open()` API is extended to make the pf aware of the underlying recovery file managed by the LibOS, and recovery information (e.g., whether the pf needs recovery) is exposed back to the LibOS via a new `pf_get_recovery_info()` API. To facilitate the LibOS to initiate a file recovery process on file open, a new PAL API `PalEncryptedFileRecovery()` is introduced.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI + manual testing.

