### PR TITLE
[PAL/Linux-SGX] Remove symmetry check for NUMA distances

### DIFF
--- a/pal/src/host/linux-sgx/pal_main.c
+++ b/pal/src/host/linux-sgx/pal_main.c
@@ -211,13 +211,13 @@ static int sanitize_topo_info(struct pal_topo_info* topo_info) {
 
     for (size_t i = 0; i < topo_info->numa_nodes_cnt; i++) {
         /* Note: distance i -> i is 10 according to the ACPI 2.0 SLIT spec, but to accomodate for
-         * weird BIOS settings we aren't checking this. */
+         * weird BIOS settings we aren't checking this. Additionally, we do not check for symmetry
+         * of node distances within the NUMA distance matrix (i.e., equal distances in both
+         * directions) to accommodate valid asymmetric NUMA distances on hosts with Sub-NUMA
+         * Clustering (SNC) and UPI affinity enabled in the BIOS. */
         for (size_t j = 0; j < topo_info->numa_nodes_cnt; j++) {
             if ((!topo_info->numa_nodes[i].is_online || !topo_info->numa_nodes[j].is_online) &&
                     topo_info->numa_distance_matrix[i*topo_info->numa_nodes_cnt + j] != 0)
-                return PAL_ERROR_INVAL;
-            if (   topo_info->numa_distance_matrix[i*topo_info->numa_nodes_cnt + j]
-                != topo_info->numa_distance_matrix[j*topo_info->numa_nodes_cnt + i])
                 return PAL_ERROR_INVAL;
         }
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

An example of a valid NUMA distance matrix on a host w/ with SNC and UPI affinity enabled is shown below (note the asymmetric distances between nodes, e.g., <0,4> - <4,0> and <1,3> - <3,1>):

```
$ cat /sys/devices/system/node/node*/distance
node   0   1   2   3   4   5
  0:  10  15  17  21  28  26
  1:  15  10  15  23  26  23
  2:  17  15  10  26  23  21
  3:  21  28  26  10  15  17
  4:  23  26  23  15  10  15
  5:  26  23  21  17  15  10
```

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine/2122)
<!-- Reviewable:end -->
